### PR TITLE
fix(web): map path detail config to wasm pathSimplification

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -198,6 +198,21 @@ function isPathDetail(value: string): value is SharePathDetail {
   );
 }
 
+function pathSimplificationForDetail(
+  detail: SharePathDetail,
+): "lossless" | "lossy" | "minimal" | null {
+  switch (detail) {
+    case "full":
+      return null;
+    case "compact":
+      return "lossless";
+    case "simplified":
+      return "lossy";
+    case "endpoints":
+      return "minimal";
+  }
+}
+
 function parsePersistedPlaygroundState(
   rawValue: string | null,
 ): EffectivePlaygroundState | null {
@@ -1012,15 +1027,18 @@ export function renderApp(
       if (renderSettings.edgePreset !== "auto") {
         config.edgePreset = renderSettings.edgePreset;
       }
-      if (renderSettings.pathDetail !== "full") {
-        config.pathDetail = renderSettings.pathDetail;
-      }
     }
 
     if (selectedFormat === "mmds") {
       config.geometryLevel = "routed";
-      if (renderSettings.pathDetail !== "full") {
-        config.pathDetail = renderSettings.pathDetail;
+    }
+
+    if (selectedFormat === "svg" || selectedFormat === "mmds") {
+      const pathSimplification = pathSimplificationForDetail(
+        renderSettings.pathDetail,
+      );
+      if (pathSimplification) {
+        config.pathSimplification = pathSimplification;
       }
     }
 

--- a/web/tests/examples.test.ts
+++ b/web/tests/examples.test.ts
@@ -438,7 +438,7 @@ describe("playground examples", () => {
     expect(JSON.parse(payload?.configJson ?? "{}")).toEqual({
       layoutEngine: "mermaid-layered",
       edgePreset: "bezier",
-      pathDetail: "endpoints",
+      pathSimplification: "minimal",
     });
   });
 });

--- a/web/tests/state-persistence.test.ts
+++ b/web/tests/state-persistence.test.ts
@@ -259,4 +259,49 @@ describe("playground state persistence", () => {
       history.replaceState(null, "", window.location.pathname);
     }
   });
+
+  it("maps MMDS path detail to pathSimplification config", async () => {
+    const shareHash = encodeShareState({
+      input: "graph TD\nA-->B",
+      format: "mmds",
+      renderSettings: {
+        layoutEngine: "auto",
+        edgePreset: "auto",
+        geometryLevel: "layout",
+        pathDetail: "compact",
+      },
+    });
+    const renderClient = createFakeRenderClient();
+
+    try {
+      history.replaceState(null, "", `#${shareHash}`);
+
+      const root = document.createElement("div");
+      renderApp(root, {
+        renderClientFactory: () => renderClient,
+        debounceMs: 0,
+        stateStorage: createMemoryStorage(),
+      });
+
+      await Promise.resolve();
+
+      expect(renderClient.render).toHaveBeenCalledTimes(1);
+      const request = renderClient.render.mock.calls[0]?.[0] as {
+        format: string;
+        configJson?: string;
+      };
+      expect(request.format).toBe("mmds");
+      const config = JSON.parse(request.configJson ?? "{}") as Record<
+        string,
+        string
+      >;
+      expect(config).toMatchObject({
+        geometryLevel: "routed",
+        pathSimplification: "lossless",
+      });
+      expect(config.pathDetail).toBeUndefined();
+    } finally {
+      history.replaceState(null, "", window.location.pathname);
+    }
+  });
 });


### PR DESCRIPTION
## Fix
The playground was sending `pathDetail` in `configJson`, but wasm config parsing expects `pathSimplification` (camelCase). This caused runtime render errors like:

`invalid config_json: unknown field "pathDetail"`

## Changes
- map UI `pathDetail` values to wasm `pathSimplification` values:
  - `full` -> omit (default)
  - `compact` -> `lossless`
  - `simplified` -> `lossy`
  - `endpoints` -> `minimal`
- keep MMDS forced `geometryLevel: "routed"` behavior
- add regression coverage for MMDS mapping and update SVG config expectation tests

## Validation
- `cd /Users/kevin/src/mmdflux/worktrees/web-playground-redesign/web && npx vitest run`
- `cd /Users/kevin/src/mmdflux/worktrees/web-playground-redesign/web && npm run build`
