### PR TITLE
refactor: remove MermaidLayeredEngine text output support

### DIFF
--- a/src/diagrams/flowchart/engine.rs
+++ b/src/diagrams/flowchart/engine.rs
@@ -320,11 +320,26 @@ pub struct MermaidLayeredEngine {
     mode: MeasurementMode,
 }
 
+impl Default for MermaidLayeredEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MermaidLayeredEngine {
-    /// Create with text-grid measurement mode.
-    pub fn text() -> Self {
+    /// Create with default SVG measurement mode.
+    ///
+    /// MermaidLayeredEngine only supports SVG and MMDS output (not text/ascii),
+    /// matching Mermaid.js which only renders to SVG.
+    pub fn new() -> Self {
+        let defaults = crate::render::SvgOptions::default();
+        let metrics = super::render::svg_metrics::SvgTextMetrics::new(
+            defaults.font_size,
+            defaults.node_padding_x,
+            defaults.node_padding_y,
+        );
         Self {
-            mode: MeasurementMode::Text,
+            mode: MeasurementMode::Svg(metrics),
         }
     }
 
@@ -355,6 +370,19 @@ impl GraphEngine for MermaidLayeredEngine {
     ) -> Result<GraphSolveResult, RenderError> {
         use crate::diagram::EdgeRouting;
         use crate::render::SvgOptions;
+
+        // MermaidLayeredEngine only supports SVG and MMDS output.
+        // Mermaid.js itself only renders to SVG; text/ascii output should use
+        // FluxLayeredEngine (which produces identical text layout anyway).
+        if matches!(
+            request.output_format,
+            OutputFormat::Text | OutputFormat::Ascii
+        ) {
+            return Err(RenderError {
+                message: "mermaid-layered does not support text output; use flux-layered instead"
+                    .to_string(),
+            });
+        }
 
         // Build a transient Mermaid-compatible view that normalizes per-subgraph
         // direction semantics to match Mermaid dagre behavior.

--- a/src/engines/graph/registry.rs
+++ b/src/engines/graph/registry.rs
@@ -49,7 +49,7 @@ impl Default for GraphEngineRegistry {
         );
         registry.register_solver(
             EngineAlgorithmId::new(EngineId::Mermaid, AlgorithmId::Layered),
-            Box::new(MermaidLayeredEngine::text()),
+            Box::new(MermaidLayeredEngine::new()),
         );
 
         registry

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -458,6 +458,8 @@ fn cli_accepts_flux_layered_engine() {
 fn cli_accepts_mermaid_layered_engine() {
     mmdflux()
         .args([
+            "--format",
+            "svg",
             "--layout-engine",
             "mermaid-layered",
             "tests/fixtures/flowchart/simple.mmd",

--- a/tests/engine_registry.rs
+++ b/tests/engine_registry.rs
@@ -73,33 +73,8 @@ fn cose_bilkent_rejected_at_parse_boundary() {
 }
 
 // =============================================================================
-// Flux vs Mermaid routing: text-mode invariant
+// Flux vs Mermaid routing: SVG-divergent test
 // =============================================================================
-
-#[test]
-fn flux_vs_mermaid_text_output_identical_for_simple() {
-    let input = std::fs::read_to_string("tests/fixtures/flowchart/simple.mmd").unwrap();
-    let mut instance = FlowchartInstance::new();
-    instance.parse(&input).unwrap();
-
-    let flux_config = RenderConfig {
-        layout_engine: Some(EngineAlgorithmId::parse("flux-layered").unwrap()),
-        ..RenderConfig::default()
-    };
-    let mermaid_config = RenderConfig {
-        layout_engine: Some(EngineAlgorithmId::parse("mermaid-layered").unwrap()),
-        ..RenderConfig::default()
-    };
-
-    let flux_out = instance.render(OutputFormat::Text, &flux_config).unwrap();
-    let mermaid_out = instance
-        .render(OutputFormat::Text, &mermaid_config)
-        .unwrap();
-    assert_eq!(
-        flux_out, mermaid_out,
-        "text output should be routing-independent"
-    );
-}
 
 #[test]
 fn flux_vs_mermaid_svg_output_may_diverge_for_cycle() {
@@ -490,7 +465,7 @@ fn flux_layered_solve_routed_level_has_routed_geometry() {
 
 #[test]
 fn mermaid_layered_engine_id() {
-    let engine = MermaidLayeredEngine::text();
+    let engine = MermaidLayeredEngine::new();
     assert_eq!(
         engine.id(),
         EngineAlgorithmId::new(EngineId::Mermaid, AlgorithmId::Layered)
@@ -499,7 +474,7 @@ fn mermaid_layered_engine_id() {
 
 #[test]
 fn mermaid_layered_capabilities_are_hint_driven() {
-    let engine = MermaidLayeredEngine::text();
+    let engine = MermaidLayeredEngine::new();
     let caps = engine.capabilities();
     assert_eq!(caps.route_ownership, RouteOwnership::HintDriven);
     assert!(caps.supports_subgraphs);
@@ -508,9 +483,9 @@ fn mermaid_layered_capabilities_are_hint_driven() {
 #[test]
 fn mermaid_layered_solve_layout_level_has_no_routed_geometry() {
     let diagram = build_simple_diagram();
-    let engine = MermaidLayeredEngine::text();
+    let engine = MermaidLayeredEngine::new();
     let request = GraphSolveRequest {
-        output_format: OutputFormat::Text,
+        output_format: OutputFormat::Mmds,
         geometry_level: GeometryLevel::Layout,
         path_simplification: PathSimplification::None,
         routing_style: None,
@@ -531,7 +506,7 @@ fn mermaid_layered_layout_matches_flux_layered_layout() {
     let diagram = build_simple_diagram();
     let config = EngineConfig::Layered(mmdflux::layered::types::LayoutConfig::default());
     let layout_req = GraphSolveRequest {
-        output_format: OutputFormat::Text,
+        output_format: OutputFormat::Mmds,
         geometry_level: GeometryLevel::Layout,
         path_simplification: PathSimplification::None,
         routing_style: None,
@@ -540,7 +515,7 @@ fn mermaid_layered_layout_matches_flux_layered_layout() {
     let flux = FluxLayeredEngine::text()
         .solve(&diagram, &config, &layout_req)
         .unwrap();
-    let mermaid = MermaidLayeredEngine::text()
+    let mermaid = MermaidLayeredEngine::new()
         .solve(&diagram, &config, &layout_req)
         .unwrap();
 
@@ -561,9 +536,9 @@ fn mermaid_layered_layout_matches_flux_layered_layout() {
 #[test]
 fn mermaid_layered_solve_routed_level_has_routed_geometry() {
     let diagram = build_simple_diagram();
-    let engine = MermaidLayeredEngine::text();
+    let engine = MermaidLayeredEngine::new();
     let request = GraphSolveRequest {
-        output_format: OutputFormat::Text,
+        output_format: OutputFormat::Mmds,
         geometry_level: GeometryLevel::Routed,
         path_simplification: PathSimplification::None,
         routing_style: None,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3511,14 +3511,10 @@ fn td_backward_entry_face_followup_parity_matches_text_for_decision_and_complex(
             full_edge.path, orthogonal_edge.path
         );
 
-        // Text output should still match between edge routings (backward edge
-        // face differences only affect SVG path geometry, not text grid).
-        let full_text = render_text_with_engine(&input, "mermaid-layered");
-        let orthogonal_text = render_text_with_engine(&input, "flux-layered");
-        assert_eq!(
-            orthogonal_text, full_text,
-            "fixture {fixture} orthogonal text should match polyline text"
-        );
+        // Text output is routing-independent (backward edge face differences
+        // only affect SVG path geometry, not text grid). Verify flux-layered
+        // renders successfully for each fixture.
+        let _text = render_text_with_engine(&input, "flux-layered");
     }
 }
 
@@ -3656,12 +3652,8 @@ fn lr_backward_spacing_followup_matches_text_parity_for_git_and_http() {
             orthogonal_edge.path
         );
 
-        let full_text = render_text_with_engine(&input, "mermaid-layered");
-        let orthogonal_text = render_text_with_engine(&input, "flux-layered");
-        assert_eq!(
-            orthogonal_text, full_text,
-            "fixture {fixture} orthogonal text should match polyline text once LR backward channel spacing parity is satisfied"
-        );
+        // Verify flux-layered text renders successfully for this fixture.
+        let _text = render_text_with_engine(&input, "flux-layered");
     }
 
     {
@@ -3742,12 +3734,8 @@ fn lr_backward_spacing_followup_matches_text_parity_for_git_and_http() {
             orthogonal_edge.path
         );
 
-        let full_text = render_text_with_engine(&input, "mermaid-layered");
-        let orthogonal_text = render_text_with_engine(&input, "flux-layered");
-        assert_eq!(
-            orthogonal_text, full_text,
-            "fixture {fixture} orthogonal text should match polyline text once right-side backward clearance parity is satisfied"
-        );
+        // Verify flux-layered text renders successfully for this fixture.
+        let _text = render_text_with_engine(&input, "flux-layered");
     }
 }
 
@@ -3755,7 +3743,7 @@ fn lr_backward_spacing_followup_matches_text_parity_for_git_and_http() {
 fn polyline_route_rollback_is_stable_for_text_and_svg() {
     let input = load_fixture("simple_cycle.mmd");
 
-    let render_with = |format: OutputFormat| {
+    let render_svg = || {
         let registry = default_registry();
         let mut instance = registry
             .create("flowchart")
@@ -3763,7 +3751,7 @@ fn polyline_route_rollback_is_stable_for_text_and_svg() {
         instance.parse(&input).expect("fixture should parse");
         instance
             .render(
-                format,
+                OutputFormat::Svg,
                 &RenderConfig {
                     layout_engine: Some(EngineAlgorithmId::parse("mermaid-layered").unwrap()),
                     edge_preset: Some(EdgePreset::Polyline),
@@ -3773,15 +3761,8 @@ fn polyline_route_rollback_is_stable_for_text_and_svg() {
             .expect("render should succeed")
     };
 
-    let baseline_text = render_with(OutputFormat::Text);
-    let baseline_svg = render_with(OutputFormat::Svg);
-
-    let text = render_with(OutputFormat::Text);
-    let svg = render_with(OutputFormat::Svg);
-    assert_eq!(
-        text, baseline_text,
-        "text rollback should be stable across repeated renders"
-    );
+    let baseline_svg = render_svg();
+    let svg = render_svg();
     assert_eq!(
         svg, baseline_svg,
         "svg rollback should be stable across repeated renders"
@@ -3792,31 +3773,23 @@ fn polyline_route_rollback_is_stable_for_text_and_svg() {
 fn text_label_revalidation_fixtures_match_between_orthogonal_route_and_polyline_route_modes() {
     let fixtures = ["labeled_edges.mmd", "inline_label_flowchart.mmd"];
 
-    let render_with_engine = |input: &str, engine: &str| {
+    for fixture in fixtures {
+        let input = load_fixture(fixture);
         let registry = default_registry();
         let mut instance = registry
             .create("flowchart")
             .expect("flowchart instance should exist");
-        instance.parse(input).expect("fixture should parse");
-        instance
+        instance.parse(&input).expect("fixture should parse");
+        // Verify flux-layered text renders successfully for label fixtures.
+        let _text = instance
             .render(
                 OutputFormat::Text,
                 &RenderConfig {
-                    layout_engine: EngineAlgorithmId::parse(engine).ok(),
+                    layout_engine: EngineAlgorithmId::parse("flux-layered").ok(),
                     ..RenderConfig::default()
                 },
             )
-            .expect("text render should succeed")
-    };
-
-    for fixture in fixtures {
-        let input = load_fixture(fixture);
-        let mermaid_layered = render_with_engine(&input, "mermaid-layered");
-        let flux_layered = render_with_engine(&input, "flux-layered");
-        assert_eq!(
-            flux_layered, mermaid_layered,
-            "Label revalidation text parity guard failed for fixture {fixture}: flux-layered text output diverged from mermaid-layered"
-        );
+            .expect("text render should succeed");
     }
 }
 


### PR DESCRIPTION
## Summary

- MermaidLayeredEngine now only supports SVG and MMDS output, matching Mermaid.js which only renders to SVG
- Text/ASCII output uses FluxLayeredEngine exclusively (both engines share the same layered kernel and produce identical text output)
- Replace `MermaidLayeredEngine::text()` with `::new()` (default SVG measurement mode)
- `MermaidLayeredEngine::solve()` returns a clear error for text/ascii requests

## Test plan

- [x] 1927 tests pass (1 redundant text parity test removed)
- [x] `just lint` clean
- [x] CLI test updated to verify mermaid-layered with `--format svg`
- [x] Engine registry tests updated to use MMDS format
- [x] Integration tests stripped of mermaid-layered text comparisons