### PR TITLE
Hide ELK engines from public API until implemented

### DIFF
--- a/src/engines/graph/selection.rs
+++ b/src/engines/graph/selection.rs
@@ -155,25 +155,20 @@ impl EngineAlgorithmId {
         match normalize_enum_token(s).as_str() {
             "flux-layered" => Ok(Self::FLUX_LAYERED),
             "mermaid-layered" => Ok(Self::MERMAID_LAYERED),
+            #[cfg(feature = "engine-elk")]
             "elk-layered" => Ok(Self::ELK_LAYERED),
+            #[cfg(feature = "engine-elk")]
             "elk-mrtree" => Ok(Self::ELK_MRTREE),
-            "dagre" => Err(RenderError {
-                message: "\"dagre\" is no longer a valid engine ID. \
+            #[cfg(not(feature = "engine-elk"))]
+            "elk-layered" | "elk-mrtree" | "elk" => Err(RenderError {
+                message: "ELK engines are not available in this build. \
                           Use \"flux-layered\" (recommended) or \"mermaid-layered\"."
                     .into(),
-            }),
-            "elk" => Err(RenderError {
-                message: "\"elk\" is no longer a valid engine ID. \
-                          Use \"elk-layered\" or \"elk-mrtree\"."
-                    .into(),
-            }),
-            "cose" | "cose-bilkent" => Err(RenderError {
-                message: "\"cose\" is no longer supported. Use \"flux-layered\".".into(),
             }),
             other => Err(RenderError {
                 message: format!(
                     "unknown engine: {other:?}. Valid options: \
-                     flux-layered, mermaid-layered, elk-layered, elk-mrtree"
+                     flux-layered, mermaid-layered"
                 ),
             }),
         }
@@ -198,21 +193,12 @@ impl EngineAlgorithmId {
     pub fn check_available(self) -> Result<(), RenderError> {
         match self.descriptor().required_feature {
             None => Ok(()),
-            Some(feature) => {
-                if feature == "engine-elk" {
-                    #[cfg(feature = "engine-elk")]
-                    {
-                        return Ok(());
-                    }
-                }
-
-                Err(RenderError {
-                    message: format!(
-                        "{} is not available; rebuild with the `{feature}` feature flag enabled",
-                        self
-                    ),
-                })
-            }
+            Some(_) => Err(RenderError {
+                message: format!(
+                    "{self} is not yet implemented. \
+                     Use \"flux-layered\" (recommended) or \"mermaid-layered\"."
+                ),
+            }),
         }
     }
 

--- a/src/engines/graph/solve.rs
+++ b/src/engines/graph/solve.rs
@@ -20,6 +20,7 @@ pub(crate) fn solve_graph_family(
     config: &EngineConfig,
     request: &GraphSolveRequest,
 ) -> Result<GraphSolveResult, RenderError> {
+    engine_id.check_available()?;
     let registry = GraphEngineRegistry::default();
     let engine = registry.get_solver(engine_id).ok_or_else(|| RenderError {
         message: format!("no engine registered for: {engine_id}"),

--- a/src/engines/graph/tests.rs
+++ b/src/engines/graph/tests.rs
@@ -272,12 +272,11 @@ fn registry_resolves_mermaid_layered() {
 
 #[cfg(not(feature = "engine-elk"))]
 #[test]
-fn registry_does_not_have_elk_solver_without_feature() {
-    let registry = GraphEngineRegistry::default();
-    let id = EngineAlgorithmId::parse("elk-layered").unwrap();
+fn elk_engine_parse_rejected_without_feature() {
+    let result = EngineAlgorithmId::parse("elk-layered");
     assert!(
-        registry.get_solver(id).is_none(),
-        "elk-layered should not be registered without engine-elk feature"
+        result.is_err(),
+        "elk-layered should not be parseable without engine-elk feature"
     );
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,7 @@ struct Cli {
     #[arg(long)]
     svg_diagram_padding: Option<f64>,
 
-    /// Layout engine (flux-layered, mermaid-layered, elk-layered, elk-mrtree)
+    /// Layout engine (flux-layered, mermaid-layered)
     #[arg(long)]
     layout_engine: Option<String>,
 

--- a/tests/architecture_guards.rs
+++ b/tests/architecture_guards.rs
@@ -805,7 +805,6 @@ fn engine_taxonomy_uses_explicit_engine_and_algorithm_namespaces() {
             .join("src/engines/graph/algorithms/layered")
             .exists()
     );
-    assert!(!repo_root.join("src/engines/graph/cose.rs").exists());
     assert!(
         !repo_root
             .join("src/engines/graph/layered_engine.rs")

--- a/tests/class_instance.rs
+++ b/tests/class_instance.rs
@@ -161,19 +161,12 @@ fn class_instance_unknown_engine_rejected_at_parse_boundary() {
 
 #[cfg(not(feature = "engine-elk"))]
 #[test]
-fn class_instance_unknown_engine_errors_cleanly() {
-    let result = render_class(
-        "classDiagram\nA --> B",
-        OutputFormat::Text,
-        &RenderConfig {
-            layout_engine: Some(EngineAlgorithmId::parse("elk-layered").unwrap()),
-            ..RenderConfig::default()
-        },
-    );
+fn class_instance_elk_engine_rejected_without_feature() {
+    let result = EngineAlgorithmId::parse("elk-layered");
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(
-        err.message.contains("engine-elk") || err.message.contains("not available"),
+        err.message.contains("not available"),
         "error should be actionable: {}",
         err.message
     );

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -720,17 +720,7 @@ fn cli_layout_engine_unavailable_fails_cleanly() {
         .write_stdin("graph TD\nA-->B")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("engine-elk"));
-}
-
-#[test]
-fn cli_rejects_legacy_cose_with_migration() {
-    mmdflux()
-        .args(["--layout-engine", "cose"])
-        .write_stdin("graph TD\nA-->B")
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains("flux-layered"));
+        .stderr(predicate::str::contains("not available"));
 }
 
 // =============================================================================

--- a/tests/engine_registry.rs
+++ b/tests/engine_registry.rs
@@ -17,17 +17,15 @@ fn render_with_engine(input: &str, engine: &str) -> Result<String, RenderError> 
     mmdflux::render_diagram(input, OutputFormat::Text, &config)
 }
 
+#[cfg(not(feature = "engine-elk"))]
 #[test]
 fn unavailable_engine_returns_actionable_error() {
-    #[cfg(not(feature = "engine-elk"))]
-    {
-        let err = render_with_engine("graph TD\nA-->B", "elk-layered").unwrap_err();
-        assert!(
-            err.message.contains("engine-elk"),
-            "error should reference feature flag: {}",
-            err.message
-        );
-    }
+    let err = render_with_engine("graph TD\nA-->B", "elk-layered").unwrap_err();
+    assert!(
+        err.message.contains("not available"),
+        "error should indicate unavailability: {}",
+        err.message
+    );
 }
 
 #[test]
@@ -36,27 +34,6 @@ fn unknown_engine_returns_error() {
     assert!(
         err.message.contains("unknown engine"),
         "error should mention unknown engine: {}",
-        err.message
-    );
-}
-
-#[test]
-fn cose_rejected_at_parse_boundary() {
-    // COSE is not in the new engine+algorithm taxonomy; rejected at parse time.
-    let err = EngineAlgorithmId::parse("cose").unwrap_err();
-    assert!(
-        !err.message.is_empty(),
-        "cose should be rejected at parse boundary: {}",
-        err.message
-    );
-}
-
-#[test]
-fn cose_bilkent_rejected_at_parse_boundary() {
-    let err = EngineAlgorithmId::parse("cose-bilkent").unwrap_err();
-    assert!(
-        !err.message.is_empty(),
-        "cose-bilkent should be rejected at parse boundary: {}",
         err.message
     );
 }
@@ -108,8 +85,6 @@ fn engine_algorithm_id_parses_all_valid_ids() {
     for (input, engine, algo) in [
         ("flux-layered", EngineId::Flux, AlgorithmId::Layered),
         ("mermaid-layered", EngineId::Mermaid, AlgorithmId::Layered),
-        ("elk-layered", EngineId::Elk, AlgorithmId::Layered),
-        ("elk-mrtree", EngineId::Elk, AlgorithmId::MrTree),
     ] {
         let id = EngineAlgorithmId::parse(input).unwrap();
         assert_eq!(id.engine(), engine);
@@ -120,8 +95,8 @@ fn engine_algorithm_id_parses_all_valid_ids() {
 #[test]
 fn engine_algorithm_id_is_case_insensitive() {
     assert!(EngineAlgorithmId::parse("Flux-Layered").is_ok());
-    assert!(EngineAlgorithmId::parse("ELK-MRTREE").is_ok());
-    assert!(EngineAlgorithmId::parse("  elk-layered  ").is_ok());
+    assert!(EngineAlgorithmId::parse("MERMAID-LAYERED").is_ok());
+    assert!(EngineAlgorithmId::parse("  flux-layered  ").is_ok());
 }
 
 #[test]
@@ -138,18 +113,8 @@ fn engine_algorithm_id_rejects_legacy_dagre_with_migration() {
 fn engine_algorithm_id_rejects_legacy_elk_with_migration() {
     let err = EngineAlgorithmId::parse("elk").unwrap_err();
     assert!(
-        err.message.contains("elk-layered"),
-        "should suggest replacement: {}",
-        err
-    );
-}
-
-#[test]
-fn engine_algorithm_id_rejects_legacy_cose() {
-    let err = EngineAlgorithmId::parse("cose").unwrap_err();
-    assert!(
-        err.message.contains("no longer supported") || err.message.contains("cose"),
-        "unexpected error: {}",
+        err.message.contains("not available"),
+        "should indicate unavailability: {}",
         err
     );
 }
@@ -166,12 +131,16 @@ fn engine_algorithm_id_rejects_unknown() {
 
 #[test]
 fn engine_algorithm_id_display_roundtrips() {
-    for input in [
-        "flux-layered",
-        "mermaid-layered",
-        "elk-layered",
-        "elk-mrtree",
-    ] {
+    for input in ["flux-layered", "mermaid-layered"] {
+        let id = EngineAlgorithmId::parse(input).unwrap();
+        assert_eq!(id.to_string(), input);
+    }
+}
+
+#[cfg(feature = "engine-elk")]
+#[test]
+fn engine_algorithm_id_display_roundtrips_elk() {
+    for input in ["elk-layered", "elk-mrtree"] {
         let id = EngineAlgorithmId::parse(input).unwrap();
         assert_eq!(id.to_string(), input);
     }
@@ -202,6 +171,7 @@ fn mermaid_layered_capabilities() {
     assert_eq!(caps.supported_routing_styles, &[RoutingStyle::Polyline]);
 }
 
+#[cfg(feature = "engine-elk")]
 #[test]
 fn elk_layered_capabilities() {
     let id = EngineAlgorithmId::parse("elk-layered").unwrap();
@@ -214,6 +184,7 @@ fn elk_layered_capabilities() {
     );
 }
 
+#[cfg(feature = "engine-elk")]
 #[test]
 fn elk_mrtree_capabilities() {
     let id = EngineAlgorithmId::parse("elk-mrtree").unwrap();
@@ -241,11 +212,10 @@ fn mermaid_layered_is_always_available() {
 #[cfg(not(feature = "engine-elk"))]
 #[test]
 fn elk_layered_unavailable_without_feature() {
-    let id = EngineAlgorithmId::parse("elk-layered").unwrap();
-    let err = id.check_available().unwrap_err();
+    let err = EngineAlgorithmId::parse("elk-layered").unwrap_err();
     assert!(
-        err.message.contains("engine-elk"),
-        "should name feature flag: {}",
+        err.message.contains("not available"),
+        "should indicate unavailability: {}",
         err
     );
 }
@@ -253,11 +223,10 @@ fn elk_layered_unavailable_without_feature() {
 #[cfg(not(feature = "engine-elk"))]
 #[test]
 fn elk_mrtree_unavailable_without_feature() {
-    let id = EngineAlgorithmId::parse("elk-mrtree").unwrap();
-    let err = id.check_available().unwrap_err();
+    let err = EngineAlgorithmId::parse("elk-mrtree").unwrap_err();
     assert!(
-        err.message.contains("engine-elk"),
-        "should name feature flag: {}",
+        err.message.contains("not available"),
+        "should indicate unavailability: {}",
         err
     );
 }

--- a/tests/flowchart_instance.rs
+++ b/tests/flowchart_instance.rs
@@ -328,16 +328,10 @@ fn engine_selection_explicit_layered_matches_default() {
 #[cfg(not(feature = "engine-elk"))]
 #[test]
 fn engine_selection_unavailable_engine_errors() {
-    let config = RenderConfig {
-        layout_engine: Some(EngineAlgorithmId::parse("elk-layered").unwrap()),
-        ..Default::default()
-    };
-    let result = render_flowchart("graph TD\nA-->B", OutputFormat::Text, &config);
-    assert!(result.is_err());
-    let err = result.unwrap_err();
+    let err = EngineAlgorithmId::parse("elk-layered").unwrap_err();
     assert!(
-        err.message.contains("engine-elk") || err.message.contains("not available"),
-        "error should be actionable: {}",
+        err.message.contains("not available"),
+        "error should indicate unavailability: {}",
         err.message
     );
 }

--- a/tests/registry_regression.rs
+++ b/tests/registry_regression.rs
@@ -112,15 +112,15 @@ fn regression_engine_selection_via_registry() {
 
     assert_eq!(default_out, layered_out);
 
-    let err = render_diagram(
-        input,
-        OutputFormat::Text,
-        &RenderConfig {
-            layout_engine: Some(EngineAlgorithmId::parse("elk-layered").unwrap()),
-            ..Default::default()
-        },
-    );
-    assert!(err.is_err());
+    // ELK engine IDs are rejected at parse time when the engine-elk feature is not enabled
+    #[cfg(not(feature = "engine-elk"))]
+    {
+        let err = EngineAlgorithmId::parse("elk-layered");
+        assert!(
+            err.is_err(),
+            "elk-layered should not parse without engine-elk feature"
+        );
+    }
 }
 
 // =============================================================================

--- a/tests/render_format.rs
+++ b/tests/render_format.rs
@@ -38,7 +38,7 @@ fn routed_mmds_text_render_does_not_reenter_runtime_engine_selection() {
     let input =
         std::fs::read_to_string("tests/fixtures/mmds/positioned/routed-basic.json").unwrap();
     let config = RenderConfig {
-        layout_engine: Some(EngineAlgorithmId::parse("elk-layered").unwrap()),
+        layout_engine: Some(EngineAlgorithmId::ELK_LAYERED),
         ..RenderConfig::default()
     };
 


### PR DESCRIPTION
## Summary

- ELK engine IDs (`elk-layered`, `elk-mrtree`) are no longer parseable without the `engine-elk` feature flag — parse returns a clear "ELK engines are not available in this build" error instead of accepting then failing at runtime
- CLI help text lists only available engines (`flux-layered, mermaid-layered`)
- Legacy engine names (`dagre`, `cose`, `cose-bilkent`) no longer special-cased — handled by the generic unknown-engine error path
- Removes stale cose engine references from architecture guard tests

## Test plan

- [x] 2110 tests pass (`just check`)
- [x] clippy + fmt clean
- [x] Verify `--layout-engine elk-layered` produces the expected error message without `engine-elk` feature
- [x] Verify `--layout-engine flux-layered` and `mermaid-layered` still work as expected