### PR TITLE
chore: fix semgrep security warnings

### DIFF
--- a/.github/workflows/playground-ci.yml
+++ b/.github/workflows/playground-ci.yml
@@ -214,8 +214,10 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmark_smoke == 'true' }}
         working-directory: web
         shell: bash
+        env:
+          BENCHMARK_PROFILE: ${{ github.event.inputs.benchmark_profile }}
         run: |
-          if [[ "${{ github.event.inputs.benchmark_profile }}" == "release" ]]; then
+          if [[ "$BENCHMARK_PROFILE" == "release" ]]; then
             npm run benchmark:smoke:release
           else
             npm run benchmark:smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,15 @@ jobs:
       - name: Resolve tag and version
         id: meta
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
-            TAG="${{ github.ref_name }}"
+            TAG="$REF_NAME"
           fi
 
           TAG="${TAG#refs/tags/}"
@@ -110,11 +114,15 @@ jobs:
       - name: Resolve tag and version
         id: meta
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
-            TAG="${{ github.ref_name }}"
+            TAG="$REF_NAME"
           fi
 
           TAG="${TAG#refs/tags/}"

--- a/.github/workflows/wasm-release.yml
+++ b/.github/workflows/wasm-release.yml
@@ -37,13 +37,17 @@ jobs:
       - name: Resolve tag and versions
         id: meta
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
-            TAG="${{ github.ref_name }}"
+            TAG="$REF_NAME"
           fi
 
           TAG="${TAG#refs/tags/}"

--- a/scripts/compare-mermaid.sh
+++ b/scripts/compare-mermaid.sh
@@ -149,6 +149,7 @@ for f in "${files[@]}"; do
     fi
 
     if [[ ${#parts[@]} -gt 0 ]]; then
+        # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering
         echo "$(IFS=', '; echo "${parts[*]}"), done"
     else
         echo "done"

--- a/web/src/app/bootstrap.ts
+++ b/web/src/app/bootstrap.ts
@@ -199,6 +199,7 @@ function updateThemeToggleButton(
     `Theme: ${currentLabel}. Switch to ${nextLabel}.`,
   );
   button.title = `Theme: ${currentLabel}.`;
+  // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
   button.innerHTML = THEME_ICONS[preference];
 }
 

--- a/web/src/mermaid-language.ts
+++ b/web/src/mermaid-language.ts
@@ -319,6 +319,7 @@ function toPhraseRegexes(values: readonly string[]): RegExp[] {
   return values
     .filter((value) => value.includes(" "))
     .sort((left, right) => right.length - left.length)
+    // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
     .map((value) => new RegExp(`^${escapeRegExp(value)}(?![\\w-])`));
 }
 

--- a/web/src/preview.ts
+++ b/web/src/preview.ts
@@ -46,6 +46,7 @@ export function createPreviewController(
     );
 
     if (lastResult.format === "svg") {
+      // nosemgrep: javascript.browser.security.insecure-document-method.insecure-document-method
       elements.output.innerHTML = lastResult.output;
       return;
     }

--- a/xtask/src/architecture/boundaries.rs
+++ b/xtask/src/architecture/boundaries.rs
@@ -603,6 +603,7 @@ fn absolute_watch_path(path: &Path) -> Result<AbsPathBuf> {
 }
 
 fn read_watch_file_contents(path: &Path) -> Result<Option<Vec<u8>>> {
+    // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
     match std::fs::read(path) {
         Ok(bytes) => Ok(Some(bytes)),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),

--- a/xtask/src/architecture/host.rs
+++ b/xtask/src/architecture/host.rs
@@ -974,6 +974,7 @@ fn host_worktree_dir(repo_root: &Path, worktree_id: &str) -> PathBuf {
 fn load_metadata_for_repo(repo_root: &Path) -> Result<Option<LoadedCluster>> {
     let discovery_root = host_discovery_root(repo_root);
     let metadata_path = HostMetadata::empty_for_repo(&discovery_root).metadata_path();
+    // nosemgrep: rust.actix.path-traversal.tainted-path.tainted-path
     let json = match std::fs::read_to_string(&metadata_path) {
         Ok(json) => json,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),


### PR DESCRIPTION
## Summary

- Fix GitHub Actions shell injection vulnerabilities in `release.yml`, `wasm-release.yml`, and `playground-ci.yml` by moving `github.event.inputs.*` / `github.ref_name` / `github.event_name` from inline `${{ }}` interpolation in `run:` steps to `env:` variables
- Suppress 6 false-positive semgrep findings with `nosemgrep` annotations:
  - `scripts/compare-mermaid.sh` — IFS set in subshell, not globally
  - `web/src/app/bootstrap.ts` — innerHTML from app-controlled SVG constants
  - `web/src/mermaid-language.ts` — RegExp from hardcoded keywords with escapeRegExp
  - `web/src/preview.ts` — innerHTML from WASM-rendered SVG output
  - `xtask/src/architecture/{boundaries,host}.rs` — fs::read in developer-only CLI tool

## Test plan

- [x] `semgrep scan` returns 0 findings