### PR TITLE
feat(xtask): add contract-based architecture rules engine

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,7 +54,7 @@
     "mmdflux-local": {
       "source": {
         "source": "directory",
-        "path": "../mmdflux-plugin-marketplace"
+        "path": "./mmdflux-plugin-marketplace"
       },
       "autoUpdate": true
     }

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: test
+description: Run tests with optional nextest filter expression
+---
+
+Run project tests using cargo-nextest.
+
+If `$ARGUMENTS` is provided, pass it as a nextest filter expression:
+
+```bash
+just test -E '$ARGUMENTS'
+```
+
+If no arguments are provided, run all tests:
+
+```bash
+just test
+```
+
+Common filter patterns:
+- `test(test_name)` — match test by name
+- `test(~keyword)` — fuzzy match
+- `package(mmdflux)` — only the main crate
+- `test(dagre_parity)` — layout parity tests against dagre.js
+
+To run a specific test file instead of a filter expression, use:
+```bash
+just test-file <name>
+```
+where `<name>` is the filename without extension (e.g., `just test-file integration_full`).

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: verify
+description: Run full project verification (lint + test + architecture boundaries)
+---
+
+Run the full project verification suite:
+
+```bash
+just check
+```
+
+This runs three stages in sequence:
+1. **Lint** — `cargo +nightly fmt -- --check` and clippy
+2. **Test** — `cargo nextest run` (all tests, parallel)
+3. **Architecture** — `cargo xtask architecture` (semantic boundary enforcement)
+
+If any stage fails, report the failure clearly and fix it before re-running. Do not skip stages.
+
+If only a specific stage needs re-checking after a fix, run it individually:
+- `just lint` — format + clippy only
+- `just test` — tests only
+- `just boundaries` — architecture boundaries only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ just test                      # Run all tests (nextest, parallel)
 just test-file integration     # Run a specific test file
 just test -E 'test(test_name)' # Run a specific test (nextest filter)
 just lint                      # clippy + fmt check
-just check                     # lint + test
+just check                     # lint + test + architecture
 just build                     # Debug build
 just release                   # Release build
 just boundaries-watch         # Watch semantic architecture boundaries
@@ -35,17 +35,12 @@ See `docs/architecture/dependency-rules.md` for the authoritative module ownersh
 
 When editing imports, top-level wiring, or ownership boundaries, run
 `cargo xtask architecture check` before finishing. During larger boundary
-refactors, consider keeping `just boundaries-watch` running in a separate
-terminal and pay attention to its output while you work. `boundaries-watch`
-runs `cargo xtask architecture host`, which watches for changes and hosts
-results for one-shot `check` reuse in the same worktree. That host reuse
-is optional: the normal one-shot command still falls back to the standalone
-local run when no host is present or when the host is incompatible. Use
-`cargo xtask architecture check --status` to inspect the warm-host state,
-or `cargo xtask architecture check --fresh` to bypass reuse and force a
-local run. Windows contributors should treat the host as optional; the
-transport shape is named-pipe based there, and one-shot client reuse still
-falls back locally today.
+refactors, keep `just boundaries-watch` running in a separate terminal.
+
+Inspection commands:
+- `just boundaries-graph` — print dependency graph as Mermaid
+- `just boundaries-explain --edge <source> <target>` — inspect a specific edge
+- `just boundaries-explain --boundary <name>` — inspect a boundary
 
 Pipeline: **Frontend → Diagrams → Engine → Render**
 
@@ -62,88 +57,6 @@ Input Text → frontends.rs (detect frontend: Mermaid or MMDS)
 1. **Runtime facade**: `render_diagram`, `detect_diagram`, `validate_diagram` + `RenderConfig`, `OutputFormat`, `RenderError` re-exported from `lib.rs`
 2. **Low-level API**: `builtins`, `registry`, `payload`, `graph`, `timeline`, `mmds` for adapter-oriented workflows
 3. **Internal implementation**: `diagrams`, `engines`, `render`, `mermaid` — documented for contributors but not part of the supported contract
-
-### Module Structure
-
-**`src/frontends.rs`** — Source-format detection (Mermaid vs MMDS)
-
-**`src/mermaid/`** — Mermaid source ingestion
-
-- `grammar.pest` — PEG grammar definition
-- `ast.rs` — Flowchart AST types (`ShapeSpec`, `Vertex`, `ConnectorSpec`, `EdgeSpec`, `Statement`)
-- `flowchart.rs` — `parse_flowchart()` entry point
-- `class/`, `sequence/` — Per-type parsers
-- `error.rs` — `ParseError`, `ParseDiagnostic`
-
-**`src/graph/`** — Graph-family IR, float-space geometry, routing, and style
-
-- `diagram.rs` — `Graph` struct (nodes, edges, subgraphs, direction)
-- `node.rs` — `Node` with `Shape` enum
-- `edge.rs` — `Edge` with `Stroke` and `Arrow`
-- `style.rs` — `NodeStyle`, `ColorToken`, style statement parsing
-- `geometry.rs` — `GraphGeometry`, `RoutedGraphGeometry` (float-space layout results)
-- `grid/` — Float-to-grid conversion, grid routing, replay geometry contracts
-- `routing/` — Shared routing helpers (orthogonal routing, float routing)
-- `attachment.rs`, `direction_policy.rs`, `measure.rs`, `projection.rs`, `space.rs`
-
-**`src/diagrams/`** — Diagram type implementations (detect, compile, build payload)
-
-- `flowchart/` — Flowchart: compiler to `graph::Graph`, validation warnings
-- `class/` — Class diagrams: compiler to `graph::Graph`
-- `sequence/` — Sequence diagrams: compiler to `timeline::Sequence`
-
-Diagrams stop at `into_payload()` — they produce a `payload::Diagram`, not rendered output.
-
-**`src/engines/`** — Engine adapters and layout algorithms
-
-- `graph/contracts.rs` — `GraphEngine` trait, `GraphSolveRequest`, `EngineConfig`
-- `graph/flux.rs` — `FluxLayeredEngine` (all formats)
-- `graph/mermaid.rs` — `MermaidLayeredEngine` (SVG/MMDS only)
-- `graph/elk.rs` — ELK subprocess adapter (behind `engine-elk` feature flag)
-- `graph/algorithms/layered/` — Sugiyama hierarchical layout (~95% dagre v0.8.5 parity)
-- `graph/algorithms/layered/kernel/` — Pure graph-agnostic layered engine (internal boundary)
-- `graph/registry.rs` — `GraphEngineRegistry` with `EngineAlgorithmId`
-
-**`src/render/`** — Output production
-
-- `graph/` — Shared graph-family text and SVG emission from `GraphGeometry`
-- `graph/text/` — Text-pipeline edge/node/subgraph rendering
-- `graph/svg/` — SVG-pipeline rendering
-- `diagram/` — Family-local renderers (sequence text)
-- `text/` — Text utilities (`Canvas`, `CharSet`)
-
-**`src/runtime/`** — Pipeline orchestration and config
-
-- `mod.rs` — `render_diagram`, `validate_diagram`, `detect_diagram` facade functions
-- `config.rs` — `RenderConfig`, `LayoutConfig`, `LayoutDirection`, `Ranker`
-- `config_input.rs` — `RuntimeConfigInput` (serde-friendly config for JSON/WASM consumers)
-- `graph_family.rs` — Graph-family solve-result dispatch
-- `mmds.rs` — MMDS replay rendering (hydrate → render dispatch)
-- `payload.rs` — Payload rendering dispatch
-
-**`src/mmds/`** — MMDS interchange format (pure — no render or engines imports)
-
-- `output.rs` — MMDS JSON serialization for graph-family output
-- `detect.rs`, `parse.rs`, `hydrate.rs`, `mermaid.rs`
-
-**Other top-level modules:**
-- `format.rs` — `OutputFormat`, `Curve`, `EdgePreset`, `RoutingStyle`, `ColorWhen`, `TextColorMode`
-- `errors.rs` — `RenderError`, `ParseDiagnostic`
-- `registry.rs` — `DiagramRegistry`, `DiagramInstance`, `ParsedDiagram`, `DiagramFamily`
-- `builtins.rs` — `default_registry()` wiring
-- `payload.rs` — `payload::Diagram` enum (`Flowchart`, `Class`, `Sequence`)
-- `simplification.rs` — Path simplification
-- `timeline/` — `timeline::Sequence` and sequence layout
-
-### Key Data Flow
-
-1. `parse_flowchart(input)` → `Flowchart` AST
-2. `compile_to_graph(&flowchart)` → `graph::Graph` with nodes/edges/subgraphs
-3. `GraphEngine::solve()` → `GraphGeometry` (float coordinates, edge topology)
-4. `route_graph_geometry()` → `RoutedGraphGeometry` (edge paths, attachment ports)
-5. Text: `geometry_to_grid_layout_with_routed()` → `GridLayout` → `route_all_edges()` → `Canvas` → String
-6. SVG: `render_svg_from_routed_geometry()` → SVG string
-7. MMDS: `mmds::output::to_mmds_json_typed_with_routing()` → structured JSON
 
 ## Testing
 

--- a/Justfile
+++ b/Justfile
@@ -87,6 +87,14 @@ boundaries:
 boundaries-watch:
     cargo xtask architecture host
 
+# Print the semantic boundary dependency graph as Mermaid.
+boundaries-graph:
+    cargo xtask architecture graph
+
+# Explain a specific edge or boundary in the semantic dependency graph.
+boundaries-explain *args:
+    cargo xtask architecture explain {{ args }}
+
 # Build size-optimized release wasm bindings for browser and bundler targets
 wasm-build-release:
     CARGO_PROFILE_RELEASE_OPT_LEVEL=z CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 CARGO_PROFILE_RELEASE_LTO=fat CARGO_PROFILE_RELEASE_PANIC=abort wasm-pack build crates/mmdflux-wasm --target web --release --out-dir ../../target/wasm-pkg-web

--- a/boundaries.toml
+++ b/boundaries.toml
@@ -1,14 +1,13 @@
-# boundaries.toml — semantic module dependency policy
+# boundaries.toml — semantic module dependency policy (v2)
 #
 # Enforces the architecture rules from docs/architecture/dependency-rules.md
-# through the repo-owned `cargo xtask architecture boundaries` checker.
+# through the repo-owned `cargo xtask architecture` checker.
 #
-# Run:   cargo xtask architecture boundaries
-# CI:    cargo run --locked --package xtask -- architecture boundaries
+# Run:   cargo xtask architecture check
+# CI:    cargo run --locked --package xtask -- architecture check
 #
-# Only modules listed in [modules] are evaluated as source boundaries. Omitting a
-# top-level module keeps it out of the source set; imports from checked modules
-# into omitted modules still show up as violations.
+# Boundaries listed below are evaluated as source boundaries. Omitting a
+# top-level module (e.g. internal_tests) keeps it out of the governed set.
 
 version = 1
 
@@ -16,35 +15,190 @@ version = 1
 # for owner-spanning regressions rather than a governed architecture boundary.
 
 [modules]
-errors = []
-format = ["errors"]
-timeline = []
+errors = {}
+format = {}
+timeline = {}
+simplification = {}
+graph = {}
+mermaid = {}
+engines = { tags = { role = "runtime-facade" } }
+render = { tags = { role = "runtime-facade" } }
+payload = {}
+registry = {}
+diagrams = {}
+builtins = { tags = { role = "runtime-facade" } }
+mmds = {}
+frontends = { tags = { role = "runtime-facade" } }
+runtime = {}
 
-simplification = ["errors", "format"]
+# --- Allow rules (one per governed source boundary) ---
+
+[[rules]]
+id = "allow-errors"
+type = "allow"
+[rules.config]
+source = "errors"
+allowed = []
+
+[[rules]]
+id = "allow-format"
+type = "allow"
+[rules.config]
+source = "format"
+allowed = ["errors"]
+
+[[rules]]
+id = "allow-timeline"
+type = "allow"
+[rules.config]
+source = "timeline"
+allowed = []
+
+[[rules]]
+id = "allow-simplification"
+type = "allow"
+[rules.config]
+source = "simplification"
+allowed = ["errors", "format"]
 
 # Must not import render, engines, diagrams, or runtime.
-graph = ["errors", "format"]
-mermaid = ["errors", "graph", "timeline"]
+[[rules]]
+id = "allow-graph"
+type = "allow"
+[rules.config]
+source = "graph"
+allowed = ["errors", "format"]
+
+[[rules]]
+id = "allow-mermaid"
+type = "allow"
+[rules.config]
+source = "mermaid"
+allowed = ["errors", "graph", "timeline"]
 
 # Must not import render, diagrams, or runtime.
-engines = ["errors", "format", "graph"]
+[[rules]]
+id = "allow-engines"
+type = "allow"
+[rules.config]
+source = "engines"
+allowed = ["errors", "format", "graph"]
 
 # Must not import diagrams, config, engines, or runtime.
-render = ["format", "graph", "simplification", "timeline"]
+[[rules]]
+id = "allow-render"
+type = "allow"
+[rules.config]
+source = "render"
+allowed = ["format", "graph", "simplification", "timeline"]
 
-payload = ["graph", "timeline"]
-registry = ["errors", "format", "payload"]
+[[rules]]
+id = "allow-payload"
+type = "allow"
+[rules.config]
+source = "payload"
+allowed = ["graph", "timeline"]
+
+[[rules]]
+id = "allow-registry"
+type = "allow"
+[rules.config]
+source = "registry"
+allowed = ["errors", "format", "payload"]
 
 # Must not import render or engines (stops at into_payload).
-diagrams = ["errors", "graph", "mermaid", "payload", "registry", "timeline"]
-builtins = ["diagrams", "format", "registry"]
+[[rules]]
+id = "allow-diagrams"
+type = "allow"
+[rules.config]
+source = "diagrams"
+allowed = ["errors", "graph", "mermaid", "payload", "registry", "timeline"]
+
+[[rules]]
+id = "allow-builtins"
+type = "allow"
+[rules.config]
+source = "builtins"
+allowed = ["diagrams", "format", "registry"]
 
 # Must not import diagrams, config, engines, render, or runtime.
-mmds = ["errors", "format", "graph", "simplification"]
-frontends = ["mermaid", "mmds"]
+[[rules]]
+id = "allow-mmds"
+type = "allow"
+[rules.config]
+source = "mmds"
+allowed = ["errors", "format", "graph", "simplification"]
 
-runtime = [
+[[rules]]
+id = "allow-frontends"
+type = "allow"
+[rules.config]
+source = "frontends"
+allowed = ["mermaid", "mmds"]
+
+[[rules]]
+id = "allow-runtime"
+type = "allow"
+[rules.config]
+source = "runtime"
+allowed = [
     "builtins", "engines", "errors",
     "format", "frontends", "graph", "mermaid", "mmds",
     "payload", "registry", "render", "simplification", "timeline",
+]
+
+# --- Layers rule (pipeline spine ordering) ---
+# Lower layers must not depend on higher layers.
+
+[[rules]]
+id = "pipeline-layers"
+type = "layers"
+[rules.config]
+order = ["errors", "format", "graph", "engines", "render", "runtime"]
+
+# --- Independence rules (peer isolation) ---
+# These frontends must not depend on each other.
+
+[[rules]]
+id = "parser-independence"
+type = "independence"
+[rules.config]
+members = ["mermaid", "mmds"]
+
+# The three pipeline pillars must not cross-depend.
+[[rules]]
+id = "pipeline-pillar-independence"
+type = "independence"
+[rules.config]
+members = ["engines", "render", "diagrams"]
+
+# --- Protected rules (facade-only access) ---
+# Boundaries tagged role=runtime-facade are only accessible through runtime.
+
+[[rules]]
+id = "protect-runtime-facades"
+type = "protected"
+[rules.config]
+targets = { tag = "role", value = "runtime-facade" }
+allowed_importers = ["runtime"]
+
+# diagrams is accessed only by builtins (which wires it into the registry).
+[[rules]]
+id = "protect-diagrams"
+type = "protected"
+[rules.config]
+targets = ["diagrams"]
+allowed_importers = ["builtins"]
+
+# --- Acyclic rule (DAG guarantee) ---
+# The full boundary graph must be cycle-free.
+
+[[rules]]
+id = "no-boundary-cycles"
+type = "acyclic"
+[rules.config]
+members = [
+    "builtins", "diagrams", "engines", "errors", "format",
+    "frontends", "graph", "mermaid", "mmds", "payload",
+    "registry", "render", "runtime", "simplification", "timeline",
 ]

--- a/xtask/docs/architecture.md
+++ b/xtask/docs/architecture.md
@@ -1,0 +1,425 @@
+# Architecture Checker
+
+A semantic module dependency guard that enforces architecture rules at the
+Rust module level using rust-analyzer's semantic analysis engine.
+
+## Overview
+
+The checker reads a policy file (`boundaries.toml`) that declares the
+project's top-level modules and the rules governing their dependencies. It
+then loads the crate through rust-analyzer, discovers the actual dependency
+edges between modules, and evaluates every rule against the real graph.
+Violations are reported with source locations, underlined code snippets, and
+actionable diagnostics.
+
+The design separates three concerns:
+
+1. **Edge collection** — semantic analysis via rust-analyzer produces a
+   `BoundaryGraph` with provenance-tagged edges
+2. **Rule evaluation** — typed rules are checked against the graph
+   independently from how edges were collected
+3. **Reporting** — violations are rendered as compiler-style diagnostics,
+   JSON for IDE integration, or human-readable explain output
+
+This separation is the central architectural lesson from tools like
+[ArchUnit](https://www.archunit.org/),
+[Import Linter](https://import-linter.readthedocs.io/),
+[dependency-cruiser](https://github.com/nicedoc/dependency-cruiser),
+Nx [`enforce-module-boundaries`](https://nx.dev/features/enforce-module-boundaries),
+and [JS Boundaries](https://github.com/nicolo-ribaudo/eslint-plugin-boundaries).
+Unlike those tools, this checker operates on Rust's semantic module tree
+rather than file paths, catching re-exports and qualified paths that
+path-based checkers miss.
+
+## Policy File
+
+The policy file is `boundaries.toml` at the repository root (override with
+the `SEMANTIC_BOUNDARIES_CONFIG` environment variable).
+
+### Structure
+
+```toml
+version = 1
+
+[modules]
+# Declare governed modules and optional tags
+errors = {}
+format = {}
+graph = {}
+engines = { tags = { role = "runtime-facade" } }
+render = { tags = { role = "runtime-facade" } }
+runtime = {}
+
+[[rules]]
+id = "allow-graph"
+type = "allow"
+[rules.config]
+source = "graph"
+allowed = ["errors", "format"]
+
+[[exceptions]]
+id = "legacy-coupling"
+rule_id = "allow-graph"
+source = "graph"
+target = "render"
+reason = "historical coupling being unwound"
+owner = "alice"
+```
+
+Three top-level sections:
+
+- **`[modules]`** — declares the set of governed module boundaries. Each key
+  is a top-level module name. Values are tables with optional `tags`.
+  Modules not listed here are not governed (but imports _into_ them from
+  governed modules are still checked).
+
+- **`[[rules]]`** — an array of typed architecture rules. Each rule has an
+  `id`, a `type`, and a `[rules.config]` table with type-specific fields.
+
+- **`[[exceptions]]`** — named suppressions for known violations. Each
+  exception targets a specific rule, source, and target boundary.
+
+### Tags
+
+Modules can carry freeform key-value tags:
+
+```toml
+[modules.engines]
+tags = { role = "runtime-facade", layer = "layout" }
+```
+
+Tags are used for **tag-based rule targeting** — rule fields that accept
+boundary lists can alternatively reference boundaries by tag:
+
+```toml
+# Explicit list:
+targets = ["engines", "render", "builtins", "frontends"]
+
+# Equivalent via tag:
+targets = { tag = "role", value = "runtime-facade" }
+```
+
+Tag references are resolved at parse time. The rule's internal model always
+contains resolved boundary names. If a tag matches zero boundaries, parsing
+fails with an error.
+
+Tag targeting is supported on list-typed fields where order doesn't matter:
+`allow.allowed`, `protected.targets`, `protected.allowed_importers`,
+`independence.members`, `acyclic.members`. It is not supported on
+`allow.source` (single boundary) or `layers.order` (order matters).
+
+## Rule Types
+
+### allow
+
+Controls which modules a given source boundary may depend on.
+
+```toml
+[[rules]]
+id = "allow-graph"
+type = "allow"
+[rules.config]
+source = "graph"
+allowed = ["errors", "format"]
+```
+
+Any edge from `graph` to a module not in `allowed` is a violation. This is
+the most common rule type — one per governed boundary.
+
+**Fields:**
+
+- `source` — the boundary being governed (single name, always explicit)
+- `allowed` — boundaries that `source` may depend on (list or tag reference)
+
+### layers
+
+Enforces a strict layer ordering. Lower layers must not depend on higher
+layers.
+
+```toml
+[[rules]]
+id = "pipeline-layers"
+type = "layers"
+[rules.config]
+order = ["errors", "format", "graph", "engines", "render", "runtime"]
+```
+
+A boundary at position _i_ may only depend on boundaries at positions _j_
+where _j < i_. An edge from a lower-position boundary to a same-or-higher-
+position boundary is a violation. Edges involving boundaries not in the
+`order` list are ignored.
+
+**Fields:**
+
+- `order` — boundaries from lowest to highest (always explicit, no tag
+  support — order matters)
+
+**Example violation:** If `graph` (position 2) depends on `runtime`
+(position 5), the violation detail says:
+`graph (layer 2) must not depend on runtime (layer 5)`
+
+### protected
+
+Restricts which modules may import a protected boundary. This is the
+complement of `allow` — where `allow` controls what a module _can reach_,
+`protected` controls what _can reach a module_.
+
+```toml
+[[rules]]
+id = "protect-runtime-facades"
+type = "protected"
+[rules.config]
+targets = { tag = "role", value = "runtime-facade" }
+allowed_importers = ["runtime"]
+```
+
+Any edge _to_ a protected target from a source not in `allowed_importers`
+is a violation. This catches violations from new modules that haven't been
+added to the allow list yet.
+
+**Fields:**
+
+- `targets` — boundaries whose access is restricted (list or tag reference)
+- `allowed_importers` — only these boundaries may import the targets (list
+  or tag reference)
+
+### independence
+
+Declares a group of peer modules that must not depend on each other.
+
+```toml
+[[rules]]
+id = "parser-independence"
+type = "independence"
+[rules.config]
+members = ["mermaid", "mmds"]
+```
+
+Any direct edge between group members (in either direction) is a violation.
+Edges to/from modules outside the group are ignored.
+
+**Fields:**
+
+- `members` — boundaries that must be independent peers (list or tag
+  reference)
+
+### acyclic
+
+Enforces that a set of boundaries forms a directed acyclic graph (DAG).
+
+```toml
+[[rules]]
+id = "no-boundary-cycles"
+type = "acyclic"
+[rules.config]
+members = [
+    "builtins", "diagrams", "engines", "errors", "format",
+    "frontends", "graph", "mermaid", "mmds", "payload",
+    "registry", "render", "runtime", "simplification", "timeline",
+]
+```
+
+Uses DFS-based cycle detection restricted to the member set. If a cycle is
+found, the violation detail includes the deterministic cycle path:
+`cycle: a -> b -> c -> a`
+
+Cycles are normalized (rotated so the lexicographically smallest element is
+first) and deduplicated for stable output.
+
+**Fields:**
+
+- `members` — boundaries that must form a DAG (list or tag reference)
+
+## Exceptions
+
+Exceptions suppress known violations with explicit justification:
+
+```toml
+[[exceptions]]
+id = "legacy-render-graph-cycle"
+rule_id = "pipeline-layers"
+source = "render"
+target = "graph"
+reason = "historical coupling being unwound in plan 0118"
+owner = "kevin"
+```
+
+Matching is exact: the exception must match the violation's `rule_id`,
+`source`, and `target`. No wildcards or fuzzy matching.
+
+**Suppression tracking:** The evaluator reports both suppressed violations
+and unused exceptions (suppression debt). Unused exceptions indicate stale
+suppressions that should be removed. In `--verbose` mode, both are logged.
+
+**Fields:**
+
+- `id` — unique identifier for this exception
+- `rule_id` — which rule this exception applies to
+- `source` — source boundary of the suppressed edge
+- `target` — target boundary of the suppressed edge
+- `reason` — human-readable justification
+- `owner` — who owns this exception
+
+## Semantic Edge Collection
+
+The checker uses rust-analyzer to discover actual module dependencies. This
+catches imports that path-based tools miss:
+
+- Re-exported symbols resolved through `pub use` chains
+- Qualified paths like `crate::graph::Node` used inline
+- Trait implementations that pull in cross-module dependencies
+
+Edge collection happens in two passes:
+
+1. **Module-scope pass** — walks the module tree via rust-analyzer's scope
+   API, collecting direct imports from each module's scope
+2. **Qualified-path pass** — parses source files for `crate::`, `self::`,
+   and `super::` path expressions, resolving them semantically
+
+Each edge is tagged with its **provenance**: `ModuleScope` (found by pass
+1), `QualifiedPath` (found by pass 2), or `Mixed` (found by both). This
+provenance is visible in `explain` output.
+
+The result is a `BoundaryGraph` — a set of boundary nodes and typed edges
+with representative source samples. Rules evaluate against this graph, not
+against the raw import data.
+
+## CLI
+
+```
+cargo xtask architecture [subcommand] [options]
+```
+
+### Subcommands
+
+**`check`** (default) — one-shot architecture check. Tries to reuse a warm
+host if one is running; falls back to local analysis.
+
+```bash
+cargo xtask architecture check
+cargo xtask architecture check --fresh    # bypass host, run locally
+cargo xtask architecture check --json     # cargo-compatible JSON diagnostics
+cargo xtask architecture check --timings  # phase timing breakdown
+cargo xtask architecture check --verbose  # detailed diagnostics
+```
+
+**`host`** — run the check, then watch for file changes and host results
+for one-shot reuse. This keeps a warmed rust-analyzer context in memory so
+subsequent `check` commands complete in milliseconds instead of seconds.
+
+```bash
+cargo xtask architecture host
+cargo xtask architecture host --timings --verbose
+```
+
+**`graph`** — print the boundary dependency graph as Mermaid.
+
+```bash
+cargo xtask architecture graph
+```
+
+Output:
+
+```
+graph LR
+    errors["errors"]
+    format["format"]
+    graph["graph"]
+    ...
+    graph --> errors
+    graph --> format
+    ...
+```
+
+**`explain`** — inspect specific edges or boundaries. Local-only (does not
+use host reuse).
+
+```bash
+# Why does this edge exist? Which rules govern it?
+cargo xtask architecture explain --edge render graph
+
+# What does this boundary depend on? What depends on it?
+cargo xtask architecture explain --boundary graph
+```
+
+### Check Options
+
+| Flag             | Description                                          |
+| ---------------- | ---------------------------------------------------- |
+| `--watch, -w`    | Rerun on file changes (interactive, requires TTY)    |
+| `--status`       | Print warm host status for this worktree             |
+| `--fresh`        | Bypass host reuse, run local analysis                |
+| `--fast-exit`    | Don't wait for a warming host; fall back immediately |
+| `--json`         | Output cargo-compatible JSON diagnostics             |
+| `--notify-dirty` | Tell the host to mark itself dirty (for hooks)       |
+| `--timings, -t`  | Print phase timing breakdown                         |
+| `--verbose, -v`  | Print verbose diagnostics and debug context          |
+
+## Host Reuse
+
+The architecture check is expensive (~5-30s) because it loads the crate
+through rust-analyzer for semantic analysis. The host reuse system
+eliminates this cost for repeated checks:
+
+1. `cargo xtask architecture host` starts a long-running process that keeps
+   a warmed rust-analyzer context in memory
+2. It watches for file changes and incrementally refreshes the context
+3. Subsequent `cargo xtask architecture check` commands connect to the host
+   via Unix socket (macOS/Linux) or named pipe (Windows) and get results in
+   milliseconds
+4. If no host is running or the protocol is incompatible, `check` falls
+   back to a local analysis
+
+The host uses a cluster model with leader election:
+
+- One leader owns the socket and serves requests
+- Zero or more standbys stay warm for failover
+- Dead processes are detected via PID validation
+- Protocol versioning ensures incompatible hosts trigger local fallback
+
+Host isolation is per-worktree (based on the repository path). The policy
+file is re-read from disk on every check, so branch switches that change
+`boundaries.toml` are picked up automatically without restarting the host.
+
+## JSON Diagnostics
+
+The `--json` flag outputs cargo-compatible diagnostics suitable for IDE
+integration. Each violation is a JSON object with `reason:
+"compiler-message"` containing spans, labels, and children notes. The
+format matches `cargo check --message-format=json`.
+
+Rule metadata (`rule_id`, `rule_type`, `detail`) appears as additional
+children notes when present.
+
+## Influences
+
+The design draws from several architecture enforcement tools:
+
+- **[ArchUnit](https://www.archunit.org/)** (Java) — the concept of typed
+  architecture rules evaluated against a dependency graph. ArchUnit's
+  `layeredArchitecture()` and `classes().should().onlyBeAccessed()` directly
+  inspired the `layers` and `protected` rule types.
+
+- **[Import Linter](https://import-linter.readthedocs.io/)** (Python) —
+  contract-based dependency checking with explicit exception management.
+  The separation of graph collection from rule evaluation follows Import
+  Linter's architecture.
+
+- **[dependency-cruiser](https://github.com/nicedoc/dependency-cruiser)**
+  (JavaScript) — rule-based dependency validation with rich reporting. The
+  diagnostic output style and the `explain` inspection command draw from
+  dependency-cruiser's `cruise --reaches` and `--output-type err`.
+
+- **[Nx `enforce-module-boundaries`](https://nx.dev/features/enforce-module-boundaries)**
+  (TypeScript) — tag-based boundary grouping. The tag system for grouping
+  modules and targeting rules by tag is directly inspired by Nx's tag
+  constraints.
+
+- **[JS Boundaries](https://github.com/nicolo-ribaudo/eslint-plugin-boundaries)**
+  (JavaScript) — ESLint-based boundary enforcement. The independence
+  contract idea draws from boundaries' element type isolation.
+
+The key difference from all these tools is that this checker operates on
+Rust's semantic module tree via rust-analyzer rather than on file paths or
+import strings. This catches re-exports, qualified paths, and trait-mediated
+dependencies that path-based tools would miss.

--- a/xtask/src/architecture/boundaries.rs
+++ b/xtask/src/architecture/boundaries.rs
@@ -1,7 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::io::{IsTerminal, Write};
-use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -24,7 +23,6 @@ use ra_ap_syntax::{AstNode, SyntaxNode, TextRange, TextSize, ast};
 use ra_ap_vfs::{Change, Vfs, VfsPath};
 use serde::{Deserialize, Serialize};
 
-const BOUNDARIES_CONFIG_ENV: &str = "SEMANTIC_BOUNDARIES_CONFIG";
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct SemanticBoundariesSuiteOptions {
     pub(crate) timings: bool,
@@ -32,13 +30,20 @@ pub(crate) struct SemanticBoundariesSuiteOptions {
     pub(crate) verbose: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct BoundariesRunReport {
     pub(crate) success: bool,
     pub(crate) rendered_output: String,
     pub(crate) summary: Option<String>,
     pub(crate) timings_output: Option<String>,
     pub(crate) violations: Vec<BoundaryViolation>,
+}
+
+/// Full result of a boundaries run, including the graph for inspection.
+#[derive(Debug, Clone)]
+pub(crate) struct BoundariesRunResult {
+    pub(crate) report: BoundariesRunReport,
+    pub(crate) graph: BoundaryGraph,
 }
 
 #[derive(Debug, Default)]
@@ -93,14 +98,6 @@ impl SemanticBoundariesContext {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct BoundariesConfig {
-    #[serde(default = "default_boundaries_config_version")]
-    version: u32,
-    #[serde(default)]
-    modules: BTreeMap<String, BTreeSet<String>>,
-}
-
 #[derive(Debug)]
 struct LoadedLibrary {
     krate: HirCrate,
@@ -152,6 +149,12 @@ pub(crate) struct BoundaryViolation {
     pub(crate) line_text: Option<String>,
     pub(crate) underline_offset: Option<usize>,
     pub(crate) underline_len: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) rule_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) rule_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) detail: Option<String>,
 }
 
 impl BoundaryViolation {
@@ -166,26 +169,138 @@ impl BoundaryViolation {
             line_text: sample.location.as_ref().map(|loc| loc.line_text.clone()),
             underline_offset: sample.location.as_ref().map(|loc| loc.underline_offset),
             underline_len: sample.location.as_ref().map(|loc| loc.underline_len),
+            rule_id: None,
+            rule_type: None,
+            detail: None,
         }
     }
 }
 
-#[derive(Debug, Clone)]
-struct DependencySample {
-    source: String,
-    symbol: String,
-    target: String,
-    location: Option<SourceLocation>,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DependencySample {
+    pub(crate) source: String,
+    pub(crate) symbol: String,
+    pub(crate) target: String,
+    pub(crate) location: Option<SourceLocation>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SourceLocation {
-    path: String,
-    line: usize,
-    column: usize,
-    line_text: String,
-    underline_offset: usize,
-    underline_len: usize,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SourceLocation {
+    pub(crate) path: String,
+    pub(crate) line: usize,
+    pub(crate) column: usize,
+    pub(crate) line_text: String,
+    pub(crate) underline_offset: usize,
+    pub(crate) underline_len: usize,
+}
+
+// ---------------------------------------------------------------------------
+// BoundaryGraph — reusable graph artifact for rule evaluation & inspection
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct BoundaryGraph {
+    pub(crate) boundaries: BTreeSet<String>,
+    #[serde(
+        serialize_with = "serialize_edges",
+        deserialize_with = "deserialize_edges"
+    )]
+    pub(crate) edges: BTreeMap<(String, String), BoundaryEdge>,
+}
+
+fn serialize_edges<S: serde::Serializer>(
+    edges: &BTreeMap<(String, String), BoundaryEdge>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    use serde::ser::SerializeSeq;
+    let mut seq = serializer.serialize_seq(Some(edges.len()))?;
+    for ((source, target), edge) in edges {
+        seq.serialize_element(&(source, target, edge))?;
+    }
+    seq.end()
+}
+
+fn deserialize_edges<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<BTreeMap<(String, String), BoundaryEdge>, D::Error> {
+    let entries: Vec<(String, String, BoundaryEdge)> =
+        serde::Deserialize::deserialize(deserializer)?;
+    Ok(entries
+        .into_iter()
+        .map(|(source, target, edge)| ((source, target), edge))
+        .collect())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct BoundaryEdge {
+    pub(crate) sample: DependencySample,
+    pub(crate) provenance: EdgeProvenance,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum EdgeProvenance {
+    ModuleScope,
+    QualifiedPath,
+    Mixed,
+}
+
+impl EdgeProvenance {
+    fn merge(self, other: EdgeProvenance) -> EdgeProvenance {
+        if self == other {
+            self
+        } else {
+            EdgeProvenance::Mixed
+        }
+    }
+}
+
+impl BoundaryGraph {
+    pub(crate) fn new(boundaries: BTreeSet<String>) -> Self {
+        Self {
+            boundaries,
+            edges: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn insert_edge(
+        &mut self,
+        source: String,
+        target: String,
+        sample: DependencySample,
+        provenance: EdgeProvenance,
+    ) {
+        let key = (source, target);
+        match self.edges.entry(key) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(BoundaryEdge { sample, provenance });
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                let existing = entry.get_mut();
+                existing.provenance = existing.provenance.merge(provenance);
+                if should_replace_dependency_sample(&existing.sample, &sample) {
+                    existing.sample = sample;
+                }
+            }
+        }
+    }
+
+    pub(crate) fn edge(&self, source: &str, target: &str) -> Option<&BoundaryEdge> {
+        self.edges.get(&(source.to_string(), target.to_string()))
+    }
+
+    /// Convert to the legacy edge map format for rendering code that
+    /// still expects the old shape.
+    pub(crate) fn to_legacy_edge_map(
+        &self,
+    ) -> BTreeMap<String, BTreeMap<String, DependencySample>> {
+        let mut map = BTreeMap::<String, BTreeMap<String, DependencySample>>::new();
+        for ((source, target), edge) in &self.edges {
+            map.entry(source.clone())
+                .or_default()
+                .insert(target.clone(), edge.sample.clone());
+        }
+        map
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -271,7 +386,7 @@ struct QualifiedPathScanBreakdown {
     slowest_module_locator_files: Vec<SlowModuleLocatorFile>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 enum PathResolutionKind {
     Ignored,
     SyntacticFastPath,
@@ -313,7 +428,8 @@ pub(crate) fn run_with_context(
     context: &mut SemanticBoundariesContext,
     options: SemanticBoundariesSuiteOptions,
 ) -> Result<()> {
-    let report = run_with_context_report(context, options)?;
+    let result = run_with_context_report(context, options)?;
+    let report = &result.report;
     if let Some(timings_output) = &report.timings_output {
         eprint!("{timings_output}");
     }
@@ -322,7 +438,7 @@ pub(crate) fn run_with_context(
     }
 
     if options.quiet {
-        anyhow::bail!(quiet_failure_message(&report));
+        anyhow::bail!(quiet_failure_message(report));
     }
 
     eprint!("{}", report.rendered_output);
@@ -337,12 +453,13 @@ pub(crate) fn run_with_context(
 pub(crate) fn run_with_context_report(
     context: &mut SemanticBoundariesContext,
     options: SemanticBoundariesSuiteOptions,
-) -> Result<BoundariesRunReport> {
+) -> Result<BoundariesRunResult> {
     let started = Instant::now();
     let mut timings = TimingBreakdown::default();
 
     let phase_started = Instant::now();
-    let (config_path, boundaries_config) = load_boundaries_config()?;
+    let config_path = super::policy::resolve_policy_path(&repo_root());
+    let arch_policy = super::policy::parse_policy_file(&config_path)?;
     timings.config_load = phase_started.elapsed();
     if !options.quiet && options.verbose {
         log_info(format!(
@@ -350,14 +467,9 @@ pub(crate) fn run_with_context_report(
             display_repo_relative(&config_path)
         ));
     }
-    if boundaries_config.version != 1 {
-        anyhow::bail!(
-            "unsupported semantic boundaries config version {} in {}",
-            boundaries_config.version,
-            config_path.display()
-        );
-    }
-    let policy = boundaries_config.modules;
+    // Extract legacy allow map for downstream rendering compatibility.
+    // This will be replaced by rule-aware rendering in a later task.
+    let policy = arch_policy.extract_allow_map();
 
     if !options.quiet && options.verbose {
         log_info(context.workspace_status());
@@ -369,7 +481,7 @@ pub(crate) fn run_with_context_report(
     let sema = Semantics::new(db);
     let root = loaded.krate.root_module();
 
-    let policy_boundaries: BTreeSet<_> = policy.keys().cloned().collect();
+    let policy_boundaries: BTreeSet<_> = arch_policy.modules.keys().cloned().collect();
     let phase_started = Instant::now();
     let discovered_boundaries = discover_top_level_boundaries(root, db);
     timings.boundary_discovery = phase_started.elapsed();
@@ -406,15 +518,47 @@ pub(crate) fn run_with_context_report(
         declared_boundaries: &policy_boundaries,
         verbose: !options.quiet && options.verbose,
     };
-    let actual = collect_actual_edges(&edge_collection, &mut timings);
+    let boundary_graph = collect_boundary_graph(&edge_collection, &mut timings);
     let phase_started = Instant::now();
-    let violations = find_policy_violations(&policy, &actual);
+    let eval_result = super::rules_eval::evaluate_rules(&boundary_graph, &arch_policy);
+    let mut boundary_violations: Vec<BoundaryViolation> = eval_result
+        .violations
+        .iter()
+        .map(|v| {
+            let mut bv =
+                BoundaryViolation::from_sample(&v.source_boundary, &v.target_boundary, &v.sample);
+            bv.rule_id = Some(v.rule_id.clone());
+            bv.rule_type = Some(v.rule_type.clone());
+            bv.detail = v.detail.clone();
+            bv
+        })
+        .collect();
+    boundary_violations.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then(a.line.cmp(&b.line))
+            .then(a.column.cmp(&b.column))
+            .then(a.source_boundary.cmp(&b.source_boundary))
+            .then(a.target_boundary.cmp(&b.target_boundary))
+    });
     timings.violation_analysis = phase_started.elapsed();
     let phase_started = Instant::now();
     if !options.quiet && options.verbose {
-        report_boundary_results(&policy, &actual);
+        let actual = boundary_graph.to_legacy_edge_map();
+        report_boundary_results(&policy, &arch_policy, &actual);
+        for suppressed in &eval_result.suppressed {
+            log_info(format!(
+                "suppressed: {} -> {} (exception: {})",
+                suppressed.violation.source_boundary,
+                suppressed.violation.target_boundary,
+                suppressed.exception_id,
+            ));
+        }
+        for unused in &eval_result.unused_exceptions {
+            log_info(format!("unused exception: {unused}"));
+        }
     }
-    let report = if violations.is_empty() {
+    let report = if boundary_violations.is_empty() {
         BoundariesRunReport {
             success: true,
             rendered_output: String::new(),
@@ -423,21 +567,18 @@ pub(crate) fn run_with_context_report(
             violations: Vec::new(),
         }
     } else {
-        let boundary_violations = violations
-            .iter()
-            .map(|(source, target, sample)| BoundaryViolation::from_sample(source, target, sample))
-            .collect();
+        let actual = boundary_graph.to_legacy_edge_map();
         BoundariesRunReport {
             success: false,
             rendered_output: render_violation_report(
                 &policy,
-                &violations,
+                &boundary_violations,
                 &actual,
                 options.verbose,
                 &diagnostic_renderer(),
                 false,
             ),
-            summary: Some(format_failure_summary(violations.len())),
+            summary: Some(format_failure_summary(boundary_violations.len())),
             timings_output: None,
             violations: boundary_violations,
         }
@@ -448,36 +589,54 @@ pub(crate) fn run_with_context_report(
         log_info(format!("finished in {:.2}s", timings.total.as_secs_f64()));
     }
 
-    Ok(BoundariesRunReport {
-        timings_output: options.timings.then(|| render_timing_breakdown(&timings)),
-        ..report
+    Ok(BoundariesRunResult {
+        report: BoundariesRunReport {
+            timings_output: options.timings.then(|| render_timing_breakdown(&timings)),
+            ..report
+        },
+        graph: boundary_graph,
     })
 }
 
-fn default_boundaries_config_version() -> u32 {
-    1
-}
+/// Load the library and collect the boundary graph for inspection commands.
+/// Reuses the same semantic analysis as `run_with_context_report` but skips
+/// violation analysis and reporting.
+pub(crate) fn collect_graph_for_inspection(
+    context: &mut SemanticBoundariesContext,
+) -> Result<BoundaryGraph> {
+    let config_path = super::policy::resolve_policy_path(&repo_root());
+    let arch_policy = super::policy::parse_policy_file(&config_path)?;
+    let policy_boundaries: BTreeSet<_> = arch_policy.modules.keys().cloned().collect();
 
-fn load_boundaries_config() -> Result<(PathBuf, BoundariesConfig)> {
-    let path = resolve_boundaries_config_path();
-    let content = std::fs::read_to_string(&path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let config =
-        toml::from_str(&content).with_context(|| format!("failed to parse {}", path.display()))?;
-    Ok((path, config))
-}
+    let loaded = context.load_library()?;
+    let db = loaded.host.raw_database();
+    let sema = Semantics::new(db);
+    let root = loaded.krate.root_module();
 
-fn resolve_boundaries_config_path() -> PathBuf {
-    std::env::var_os(BOUNDARIES_CONFIG_ENV)
-        .map(PathBuf::from)
-        .map(|path| {
-            if path.is_absolute() {
-                path
-            } else {
-                repo_root().join(path)
-            }
-        })
-        .unwrap_or_else(|| repo_root().join("boundaries.toml"))
+    let discovered_boundaries = discover_top_level_boundaries(root, db);
+    let missing: Vec<_> = policy_boundaries
+        .difference(&discovered_boundaries)
+        .cloned()
+        .collect();
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "{} declares missing top-level modules: {:?}",
+            display_repo_relative(&config_path),
+            missing
+        );
+    }
+
+    let edge_collection = EdgeCollectionContext {
+        sema: &sema,
+        vfs: &loaded.vfs,
+        krate: loaded.krate,
+        root,
+        db,
+        declared_boundaries: &policy_boundaries,
+        verbose: false,
+    };
+    let mut timings = TimingBreakdown::default();
+    Ok(collect_boundary_graph(&edge_collection, &mut timings))
 }
 
 fn load_library() -> Result<LoadedLibrary> {
@@ -686,11 +845,11 @@ fn discover_top_level_boundaries(root: Module, db: &RootDatabase) -> BTreeSet<St
         .collect()
 }
 
-fn collect_actual_edges(
+fn collect_boundary_graph(
     ctx: &EdgeCollectionContext<'_>,
     timings: &mut TimingBreakdown,
-) -> BTreeMap<String, BTreeMap<String, DependencySample>> {
-    let mut edges = BTreeMap::<String, BTreeMap<String, DependencySample>>::new();
+) -> BoundaryGraph {
+    let mut graph = BoundaryGraph::new(ctx.declared_boundaries.clone());
 
     if ctx.verbose {
         log_info("collect semantic module-scope edges");
@@ -711,7 +870,7 @@ fn collect_actual_edges(
             &source_boundary,
             ctx.root,
             ctx.db,
-            &mut edges,
+            &mut graph,
         );
     }
     timings.module_scope_scan = phase_started.elapsed();
@@ -720,7 +879,7 @@ fn collect_actual_edges(
         log_info("resolve qualified crate/self/super paths");
     }
     let phase_started = Instant::now();
-    let breakdown = collect_qualified_path_edges(ctx, &mut edges);
+    let breakdown = collect_qualified_path_edges(ctx, &mut graph);
     timings.qualified_path_scan = phase_started.elapsed();
     timings.qualified_path_candidate_file_filtering = breakdown.candidate_file_filtering;
     timings.qualified_path_file_reads = breakdown.file_reads;
@@ -745,7 +904,7 @@ fn collect_actual_edges(
     timings.qualified_path_slowest_files = breakdown.slowest_path_files;
     timings.qualified_path_slowest_module_locator_files = breakdown.slowest_module_locator_files;
 
-    edges
+    graph
 }
 
 fn collect_module_scope_edges(
@@ -753,7 +912,7 @@ fn collect_module_scope_edges(
     source_boundary: &str,
     root: Module,
     db: &RootDatabase,
-    edges: &mut BTreeMap<String, BTreeMap<String, DependencySample>>,
+    graph: &mut BoundaryGraph,
 ) {
     let source_module_path = module_path(module, db);
 
@@ -786,8 +945,7 @@ fn collect_module_scope_edges(
             })
             .unwrap_or_else(|| module_path(target_module, db));
 
-        insert_dependency_sample(
-            edges,
+        graph.insert_edge(
             source_boundary.to_string(),
             target_boundary.clone(),
             DependencySample {
@@ -796,17 +954,18 @@ fn collect_module_scope_edges(
                 target: module_path(target_module, db),
                 location: None,
             },
+            EdgeProvenance::ModuleScope,
         );
     }
 
     for child in module.children(db) {
-        collect_module_scope_edges(child, source_boundary, root, db, edges);
+        collect_module_scope_edges(child, source_boundary, root, db, graph);
     }
 }
 
 fn collect_qualified_path_edges(
     ctx: &EdgeCollectionContext<'_>,
-    edges: &mut BTreeMap<String, BTreeMap<String, DependencySample>>,
+    graph: &mut BoundaryGraph,
 ) -> QualifiedPathScanBreakdown {
     let src_root = AbsPathBuf::assert_utf8(repo_root().join("src"));
     let boundary_names = discover_top_level_boundaries(ctx.root, ctx.db);
@@ -920,7 +1079,7 @@ fn collect_qualified_path_edges(
                 &segments,
                 &file_text,
                 render_relative_path(&segments),
-                edges,
+                graph,
             );
             let elapsed = resolution_started.elapsed();
             match resolution {
@@ -1007,7 +1166,7 @@ fn collect_qualified_path_edges(
                 &segments,
                 &file_text,
                 path.syntax().text().to_string(),
-                edges,
+                graph,
             );
             let elapsed = resolution_started.elapsed();
             match resolution {
@@ -1085,7 +1244,7 @@ fn record_relative_path_edge(
     segments: &[RelativePathSegment],
     file_text: &str,
     symbol: String,
-    edges: &mut BTreeMap<String, BTreeMap<String, DependencySample>>,
+    graph: &mut BoundaryGraph,
 ) -> PathResolutionKind {
     let Some(source_module) = module_locator.locate(scope_node) else {
         return PathResolutionKind::Ignored;
@@ -1128,8 +1287,7 @@ fn record_relative_path_edge(
         return resolution_kind;
     }
 
-    insert_dependency_sample(
-        edges,
+    graph.insert_edge(
         source_boundary,
         target_boundary,
         DependencySample {
@@ -1142,28 +1300,10 @@ fn record_relative_path_edge(
                 path.syntax().text_range(),
             )),
         },
+        EdgeProvenance::QualifiedPath,
     );
 
     resolution_kind
-}
-
-fn insert_dependency_sample(
-    edges: &mut BTreeMap<String, BTreeMap<String, DependencySample>>,
-    source_boundary: String,
-    target_boundary: String,
-    sample: DependencySample,
-) {
-    let target_entry = edges.entry(source_boundary).or_default();
-    match target_entry.entry(target_boundary) {
-        std::collections::btree_map::Entry::Vacant(entry) => {
-            entry.insert(sample);
-        }
-        std::collections::btree_map::Entry::Occupied(mut entry) => {
-            if should_replace_dependency_sample(entry.get(), &sample) {
-                entry.insert(sample);
-            }
-        }
-    }
 }
 
 fn should_replace_dependency_sample(
@@ -1465,52 +1605,9 @@ fn top_level_path_for_offset(root: &SyntaxNode, offset: TextSize) -> Option<ast:
         .find_map(|token| token.parent()?.ancestors().find_map(ast::Path::cast))
 }
 
-fn find_policy_violations(
-    policy: &BTreeMap<String, BTreeSet<String>>,
-    actual: &BTreeMap<String, BTreeMap<String, DependencySample>>,
-) -> Vec<(String, String, DependencySample)> {
-    let mut violations = Vec::new();
-
-    for (source, targets) in actual {
-        let allowed = policy.get(source);
-        for (target, sample) in targets {
-            if !allowed.is_some_and(|deps| deps.contains(target)) {
-                violations.push((source.clone(), target.clone(), sample.clone()));
-            }
-        }
-    }
-
-    violations.sort_by(|left, right| {
-        compare_dependency_samples(&left.2, &right.2)
-            .then(left.0.cmp(&right.0))
-            .then(left.1.cmp(&right.1))
-    });
-    violations
-}
-
-fn compare_dependency_samples(
-    left: &DependencySample,
-    right: &DependencySample,
-) -> std::cmp::Ordering {
-    match (&left.location, &right.location) {
-        (Some(left), Some(right)) => left
-            .path
-            .cmp(&right.path)
-            .then(left.line.cmp(&right.line))
-            .then(left.column.cmp(&right.column)),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => left
-            .source
-            .cmp(&right.source)
-            .then(left.symbol.cmp(&right.symbol))
-            .then(left.target.cmp(&right.target)),
-    }
-}
-
 fn render_violation_report(
     policy: &BTreeMap<String, BTreeSet<String>>,
-    violations: &[(String, String, DependencySample)],
+    violations: &[BoundaryViolation],
     actual: &BTreeMap<String, BTreeMap<String, DependencySample>>,
     verbose: bool,
     renderer: &Renderer,
@@ -1539,38 +1636,61 @@ fn quiet_failure_message(report: &BoundariesRunReport) -> String {
 }
 
 fn render_violation(
-    source: &str,
-    target: &str,
-    sample: &DependencySample,
+    violation: &BoundaryViolation,
     allowed_targets: Option<&BTreeSet<String>>,
     renderer: &Renderer,
 ) -> String {
+    let source = &violation.source_boundary;
+    let target = &violation.target_boundary;
     let title = format!("forbidden dependency from `{source}` to `{target}`");
     let label = format!("forbidden dependency on `{target}`");
 
     let mut group = Group::with_title(Level::ERROR.primary_title(title).id("boundaries"));
-    if let Some(location) = &sample.location {
-        let span = line_span(location);
+    if let (Some(file), Some(line), Some(line_text)) =
+        (&violation.file, violation.line, &violation.line_text)
+    {
+        let char_start = violation.underline_offset.unwrap_or(0);
+        let char_end = char_start + violation.underline_len.unwrap_or(1);
+        let byte_start = char_offset_to_byte_index(line_text, char_start);
+        let byte_end = char_offset_to_byte_index(line_text, char_end);
+        let min_end = next_char_end_byte_index(line_text, byte_start);
+        let span = byte_start..byte_end.max(min_end);
         group = group.element(
-            Snippet::source(location.line_text.clone())
-                .line_start(location.line)
-                .path(location.path.clone())
+            Snippet::source(line_text.clone())
+                .line_start(line)
+                .path(file.clone())
                 .fold(false)
                 .annotation(AnnotationKind::Primary.span(span).label(label)),
         );
     } else {
         group = group.element(Level::NOTE.message(format!(
-            "observed via {} (`{}` -> {})",
-            sample.source, sample.symbol, sample.target
+            "observed via {} (`{}`)",
+            violation.source_boundary, violation.symbol
         )));
     }
 
-    group = group.element(Level::NOTE.message(format!("imported symbol: `{}`", sample.symbol)));
-    if let Some(allowed_targets) = allowed_targets {
-        let allowed = format_allowed_targets(allowed_targets);
-        group = group.element(Level::HELP.message(format!(
-            "allowed top-level dependencies for `{source}`: {allowed}"
-        )));
+    group = group.element(Level::NOTE.message(format!("imported symbol: `{}`", violation.symbol)));
+
+    // Dispatch help text based on rule type
+    match violation.rule_type.as_deref() {
+        Some("allow") | None => {
+            if let Some(allowed_targets) = allowed_targets {
+                let allowed = format_allowed_targets(allowed_targets);
+                group = group.element(Level::HELP.message(format!(
+                    "allowed top-level dependencies for `{source}`: {allowed}"
+                )));
+            }
+        }
+        Some(_) => {
+            if let Some(detail) = &violation.detail {
+                group = group.element(Level::HELP.message(detail.clone()));
+            }
+            if let Some(rule_id) = &violation.rule_id {
+                let rule_type = violation.rule_type.as_deref().unwrap_or("unknown");
+                group =
+                    group.element(Level::NOTE.message(format!("rule: {rule_id} ({rule_type})")));
+            }
+        }
     }
 
     renderer.render(&[group]).trim_end().to_string()
@@ -1579,18 +1699,19 @@ fn render_violation(
 fn write_violation_report<W: Write>(
     writer: &mut W,
     policy: &BTreeMap<String, BTreeSet<String>>,
-    violations: &[(String, String, DependencySample)],
+    violations: &[BoundaryViolation],
     actual: &BTreeMap<String, BTreeMap<String, DependencySample>>,
     verbose: bool,
     renderer: &Renderer,
     include_summary: bool,
 ) -> std::io::Result<()> {
-    for (index, (source, target, sample)) in violations.iter().enumerate() {
+    for (index, violation) in violations.iter().enumerate() {
         if index > 0 {
             writer.write_all(b"\n")?;
         }
         writer.write_all(
-            render_violation(source, target, sample, policy.get(source), renderer).as_bytes(),
+            render_violation(violation, policy.get(&violation.source_boundary), renderer)
+                .as_bytes(),
         )?;
     }
 
@@ -1665,21 +1786,10 @@ fn format_failure_summary(violation_count: usize) -> String {
     )
 }
 
-fn line_span(location: &SourceLocation) -> Range<usize> {
-    let start = char_offset_to_byte_index(&location.line_text, location.underline_offset);
-    let end = char_offset_to_byte_index(
-        &location.line_text,
-        location.underline_offset + location.underline_len,
-    );
-    let min_end = next_char_end_byte_index(&location.line_text, start);
-    start..end.max(min_end)
-}
-
 fn char_offset_to_byte_index(text: &str, char_offset: usize) -> usize {
     if char_offset == 0 {
         return 0;
     }
-
     text.char_indices()
         .map(|(idx, _)| idx)
         .nth(char_offset)
@@ -1694,10 +1804,12 @@ fn next_char_end_byte_index(text: &str, start: usize) -> usize {
 }
 
 fn report_boundary_results(
-    policy: &BTreeMap<String, BTreeSet<String>>,
+    allow_map: &BTreeMap<String, BTreeSet<String>>,
+    arch_policy: &super::policy::ArchitecturePolicy,
     actual: &BTreeMap<String, BTreeMap<String, DependencySample>>,
 ) {
-    for (boundary, allowed) in policy {
+    // Report allow rule results per boundary
+    for (boundary, allowed) in allow_map {
         let unexpected: Vec<_> = actual
             .get(boundary)
             .into_iter()
@@ -1710,6 +1822,34 @@ fn report_boundary_results(
             eprintln!("[PASS] {boundary}");
         } else {
             eprintln!("[FAIL] {boundary} unexpected: {}", unexpected.join(", "));
+        }
+    }
+
+    // Report non-allow rules
+    for rule in &arch_policy.rules {
+        match &rule.rule {
+            super::policy::RuleKind::Allow(_) => {} // already reported above
+            super::policy::RuleKind::Layers(l) => {
+                eprintln!("[INFO] layers rule {:?}: order = {:?}", rule.id, l.order);
+            }
+            super::policy::RuleKind::Independence(i) => {
+                eprintln!(
+                    "[INFO] independence rule {:?}: members = {:?}",
+                    rule.id, i.members
+                );
+            }
+            super::policy::RuleKind::Protected(p) => {
+                eprintln!(
+                    "[INFO] protected rule {:?}: targets = {:?}, allowed_importers = {:?}",
+                    rule.id, p.targets, p.allowed_importers
+                );
+            }
+            super::policy::RuleKind::Acyclic(a) => {
+                eprintln!(
+                    "[INFO] acyclic rule {:?}: members = {:?}",
+                    rule.id, a.members
+                );
+            }
         }
     }
 }
@@ -1933,10 +2073,14 @@ mod tests {
     use annotate_snippets::renderer::DecorStyle;
 
     use super::{
-        BoundariesRunReport, BoundaryViolation, DependencySample, PendingRefresh,
-        SemanticBoundariesContext, SourceLocation, insert_dependency_sample, quiet_failure_message,
+        BoundariesRunReport, BoundaryGraph, BoundaryViolation, DependencySample, EdgeProvenance,
+        PendingRefresh, SemanticBoundariesContext, SourceLocation, quiet_failure_message,
         render_violation_report, write_violation_report,
     };
+
+    fn test_violation(source: &str, target: &str, sample: DependencySample) -> BoundaryViolation {
+        BoundaryViolation::from_sample(source, target, &sample)
+    }
 
     #[test]
     fn boundary_violation_round_trips_through_json() {
@@ -1950,6 +2094,9 @@ mod tests {
             line_text: Some("use crate::EngineAlgorithmId;".to_string()),
             underline_offset: Some(4),
             underline_len: Some(24),
+            rule_id: None,
+            rule_type: None,
+            detail: None,
         };
 
         let json = serde_json::to_string(&violation).unwrap();
@@ -1969,6 +2116,9 @@ mod tests {
             line_text: None,
             underline_offset: None,
             underline_len: None,
+            rule_id: None,
+            rule_type: None,
+            detail: None,
         };
 
         let json = serde_json::to_string(&violation).unwrap();
@@ -2075,29 +2225,29 @@ mod tests {
 
     #[test]
     fn violation_report_defaults_to_compiler_style_output() {
+        let violations = vec![test_violation(
+            "graph",
+            "diagrams",
+            DependencySample {
+                source: "src/graph/direction_policy.rs".to_string(),
+                symbol: "crate::diagrams::flowchart::compile_to_graph".to_string(),
+                target: "crate::diagrams".to_string(),
+                location: Some(SourceLocation {
+                    path: "src/graph/direction_policy.rs".to_string(),
+                    line: 133,
+                    column: 9,
+                    line_text: "    use crate::diagrams::flowchart::compile_to_graph;".to_string(),
+                    underline_offset: 8,
+                    underline_len: 45,
+                }),
+            },
+        )];
         let report = render_violation_report(
             &BTreeMap::from([(
                 "graph".to_string(),
                 BTreeSet::from(["errors".to_string(), "format".to_string()]),
             )]),
-            &[(
-                "graph".to_string(),
-                "diagrams".to_string(),
-                DependencySample {
-                    source: "src/graph/direction_policy.rs".to_string(),
-                    symbol: "crate::diagrams::flowchart::compile_to_graph".to_string(),
-                    target: "crate::diagrams".to_string(),
-                    location: Some(SourceLocation {
-                        path: "src/graph/direction_policy.rs".to_string(),
-                        line: 133,
-                        column: 9,
-                        line_text: "    use crate::diagrams::flowchart::compile_to_graph;"
-                            .to_string(),
-                        underline_offset: 8,
-                        underline_len: 45,
-                    }),
-                },
-            )],
+            &violations,
             &BTreeMap::new(),
             false,
             &Renderer::plain()
@@ -2119,18 +2269,19 @@ mod tests {
 
     #[test]
     fn violation_report_verbose_includes_edge_dump() {
+        let violations = vec![test_violation(
+            "graph",
+            "diagrams",
+            DependencySample {
+                source: "src/graph/direction_policy.rs".to_string(),
+                symbol: "crate::diagrams::flowchart::compile_to_graph".to_string(),
+                target: "crate::diagrams".to_string(),
+                location: None,
+            },
+        )];
         let report = render_violation_report(
             &BTreeMap::from([("graph".to_string(), BTreeSet::from(["errors".to_string()]))]),
-            &[(
-                "graph".to_string(),
-                "diagrams".to_string(),
-                DependencySample {
-                    source: "src/graph/direction_policy.rs".to_string(),
-                    symbol: "crate::diagrams::flowchart::compile_to_graph".to_string(),
-                    target: "crate::diagrams".to_string(),
-                    location: None,
-                },
-            )],
+            &violations,
             &BTreeMap::from([(
                 "graph".to_string(),
                 BTreeMap::from([(
@@ -2160,9 +2311,9 @@ mod tests {
             "graph".to_string(),
             BTreeSet::from(["errors".to_string(), "format".to_string()]),
         )]);
-        let violations = vec![(
-            "graph".to_string(),
-            "diagrams".to_string(),
+        let violations = vec![test_violation(
+            "graph",
+            "diagrams",
             DependencySample {
                 source: "src/graph/direction_policy.rs".to_string(),
                 symbol: "crate::diagrams::flowchart::compile_to_graph".to_string(),
@@ -2222,9 +2373,9 @@ mod tests {
 
     #[test]
     fn location_backed_samples_replace_module_only_samples() {
-        let mut edges = BTreeMap::new();
-        insert_dependency_sample(
-            &mut edges,
+        let boundaries = BTreeSet::from(["graph".to_string(), "diagrams".to_string()]);
+        let mut graph = BoundaryGraph::new(boundaries);
+        graph.insert_edge(
             "graph".to_string(),
             "diagrams".to_string(),
             DependencySample {
@@ -2233,9 +2384,9 @@ mod tests {
                 target: "crate::diagrams".to_string(),
                 location: None,
             },
+            EdgeProvenance::ModuleScope,
         );
-        insert_dependency_sample(
-            &mut edges,
+        graph.insert_edge(
             "graph".to_string(),
             "diagrams".to_string(),
             DependencySample {
@@ -2251,17 +2402,94 @@ mod tests {
                     underline_len: 45,
                 }),
             },
+            EdgeProvenance::QualifiedPath,
         );
 
-        let sample = edges
-            .get("graph")
-            .and_then(|targets| targets.get("diagrams"))
-            .unwrap();
-        assert_eq!(sample.source, "src/graph/direction_policy.rs");
-        assert!(sample.location.is_some());
+        let edge = graph.edge("graph", "diagrams").unwrap();
+        assert_eq!(edge.sample.source, "src/graph/direction_policy.rs");
+        assert!(edge.sample.location.is_some());
+        assert_eq!(edge.provenance, EdgeProvenance::Mixed);
+    }
+
+    #[test]
+    fn boundary_graph_single_pass_retains_provenance() {
+        let boundaries = BTreeSet::from(["a".to_string(), "b".to_string()]);
+        let mut graph = BoundaryGraph::new(boundaries);
+        graph.insert_edge(
+            "a".to_string(),
+            "b".to_string(),
+            DependencySample {
+                source: "crate::a".to_string(),
+                symbol: "crate::b::Foo".to_string(),
+                target: "crate::b".to_string(),
+                location: None,
+            },
+            EdgeProvenance::ModuleScope,
+        );
+        let edge = graph.edge("a", "b").unwrap();
+        assert_eq!(edge.provenance, EdgeProvenance::ModuleScope);
+    }
+
+    #[test]
+    fn boundary_graph_to_legacy_edge_map_preserves_edge_pairs() {
+        let boundaries = BTreeSet::from(["a".to_string(), "b".to_string(), "c".to_string()]);
+        let mut graph = BoundaryGraph::new(boundaries);
+        graph.insert_edge(
+            "a".to_string(),
+            "b".to_string(),
+            DependencySample {
+                source: "crate::a".to_string(),
+                symbol: "crate::b::X".to_string(),
+                target: "crate::b".to_string(),
+                location: None,
+            },
+            EdgeProvenance::ModuleScope,
+        );
+        graph.insert_edge(
+            "a".to_string(),
+            "c".to_string(),
+            DependencySample {
+                source: "src/a.rs".to_string(),
+                symbol: "crate::c::Y".to_string(),
+                target: "crate::c".to_string(),
+                location: Some(SourceLocation {
+                    path: "src/a.rs".to_string(),
+                    line: 1,
+                    column: 1,
+                    line_text: "use crate::c::Y;".to_string(),
+                    underline_offset: 4,
+                    underline_len: 12,
+                }),
+            },
+            EdgeProvenance::QualifiedPath,
+        );
+
+        let legacy = graph.to_legacy_edge_map();
+        assert_eq!(legacy.len(), 1); // one source boundary: "a"
+        let a_targets = &legacy["a"];
+        assert_eq!(a_targets.len(), 2); // two targets: "b" and "c"
+        assert!(a_targets.contains_key("b"));
+        assert!(a_targets.contains_key("c"));
     }
 
     fn violation_report_fixture() -> BoundariesRunReport {
+        let violations = vec![test_violation(
+            "graph",
+            "diagrams",
+            DependencySample {
+                source: "src/graph/direction_policy.rs".to_string(),
+                symbol: "crate::diagrams::flowchart::compile_to_graph".to_string(),
+                target: "crate::diagrams".to_string(),
+                location: Some(SourceLocation {
+                    path: "src/graph/direction_policy.rs".to_string(),
+                    line: 133,
+                    column: 9,
+                    line_text: "    use crate::diagrams::flowchart::compile_to_graph;".to_string(),
+                    underline_offset: 8,
+                    underline_len: 45,
+                }),
+            },
+        )];
         BoundariesRunReport {
             success: false,
             rendered_output: render_violation_report(
@@ -2269,24 +2497,7 @@ mod tests {
                     "graph".to_string(),
                     BTreeSet::from(["errors".to_string(), "format".to_string()]),
                 )]),
-                &[(
-                    "graph".to_string(),
-                    "diagrams".to_string(),
-                    DependencySample {
-                        source: "src/graph/direction_policy.rs".to_string(),
-                        symbol: "crate::diagrams::flowchart::compile_to_graph".to_string(),
-                        target: "crate::diagrams".to_string(),
-                        location: Some(SourceLocation {
-                            path: "src/graph/direction_policy.rs".to_string(),
-                            line: 133,
-                            column: 9,
-                            line_text: "    use crate::diagrams::flowchart::compile_to_graph;"
-                                .to_string(),
-                            underline_offset: 8,
-                            underline_len: 45,
-                        }),
-                    },
-                )],
+                &violations,
                 &BTreeMap::new(),
                 false,
                 &Renderer::plain()

--- a/xtask/src/architecture/explain.rs
+++ b/xtask/src/architecture/explain.rs
@@ -1,0 +1,300 @@
+use std::fmt::Write;
+
+use crate::architecture::boundaries::BoundaryGraph;
+use crate::architecture::policy::ArchitecturePolicy;
+
+/// Explain a specific edge between two boundaries.
+pub(crate) fn explain_edge(
+    graph: &BoundaryGraph,
+    policy: &ArchitecturePolicy,
+    source: &str,
+    target: &str,
+) -> String {
+    let mut out = String::new();
+
+    writeln!(out, "Edge: {source} -> {target}").unwrap();
+    writeln!(out).unwrap();
+
+    match graph.edge(source, target) {
+        Some(edge) => {
+            writeln!(out, "  Exists: yes").unwrap();
+            writeln!(out, "  Provenance: {:?}", edge.provenance).unwrap();
+            writeln!(out, "  Sample:").unwrap();
+            writeln!(out, "    source: {}", edge.sample.source).unwrap();
+            writeln!(out, "    symbol: {}", edge.sample.symbol).unwrap();
+            writeln!(out, "    target: {}", edge.sample.target).unwrap();
+            if let Some(loc) = &edge.sample.location {
+                writeln!(
+                    out,
+                    "    location: {}:{}:{}",
+                    loc.path, loc.line, loc.column
+                )
+                .unwrap();
+            }
+        }
+        None => {
+            writeln!(out, "  Exists: no (no dependency detected)").unwrap();
+        }
+    }
+
+    // Show which rules govern this edge
+    writeln!(out).unwrap();
+    writeln!(out, "  Rules:").unwrap();
+    let mut found_rule = false;
+    for rule in &policy.rules {
+        if rule_governs_edge(&rule.rule, source, target) {
+            writeln!(out, "    - {} ({})", rule.id, rule_type_name(&rule.rule)).unwrap();
+            found_rule = true;
+        }
+    }
+    if !found_rule {
+        writeln!(out, "    (none)").unwrap();
+    }
+
+    // Show any exceptions for this edge
+    let matching_exceptions: Vec<_> = policy
+        .exceptions
+        .iter()
+        .filter(|exc| exc.source == source && exc.target == target)
+        .collect();
+    if !matching_exceptions.is_empty() {
+        writeln!(out).unwrap();
+        writeln!(out, "  Exceptions:").unwrap();
+        for exc in matching_exceptions {
+            writeln!(
+                out,
+                "    - {} ({}, owner: {})",
+                exc.id, exc.rule_id, exc.owner
+            )
+            .unwrap();
+            if !exc.reason.is_empty() {
+                writeln!(out, "      reason: {}", exc.reason).unwrap();
+            }
+        }
+    }
+
+    out
+}
+
+/// Explain a specific boundary: what it depends on and what depends on it.
+pub(crate) fn explain_boundary(
+    graph: &BoundaryGraph,
+    policy: &ArchitecturePolicy,
+    name: &str,
+) -> String {
+    let mut out = String::new();
+
+    writeln!(out, "Boundary: {name}").unwrap();
+    writeln!(out).unwrap();
+
+    if !graph.boundaries.contains(name) {
+        writeln!(out, "  Not found in the boundary graph.").unwrap();
+        return out;
+    }
+
+    // Show tags if present
+    if let Some(spec) = policy.modules.get(name)
+        && !spec.tags.is_empty()
+    {
+        writeln!(out, "  Tags:").unwrap();
+        for (key, value) in &spec.tags {
+            writeln!(out, "    {key}: {value}").unwrap();
+        }
+        writeln!(out).unwrap();
+    }
+
+    // Outgoing edges (what this boundary depends on)
+    let outgoing: Vec<_> = graph
+        .edges
+        .iter()
+        .filter(|((source, _), _)| source == name)
+        .collect();
+    writeln!(out, "  Depends on ({}):", outgoing.len()).unwrap();
+    for ((_, target), edge) in &outgoing {
+        writeln!(out, "    -> {target} ({:?})", edge.provenance).unwrap();
+    }
+
+    // Incoming edges (what depends on this boundary)
+    let incoming: Vec<_> = graph
+        .edges
+        .iter()
+        .filter(|((_, target), _)| target == name)
+        .collect();
+    writeln!(out).unwrap();
+    writeln!(out, "  Depended on by ({}):", incoming.len()).unwrap();
+    for ((source, _), edge) in &incoming {
+        writeln!(out, "    <- {source} ({:?})", edge.provenance).unwrap();
+    }
+
+    // Show which rules mention this boundary
+    let governing: Vec<_> = policy
+        .rules
+        .iter()
+        .filter(|c| rule_mentions_boundary(&c.rule, name))
+        .collect();
+    if !governing.is_empty() {
+        writeln!(out).unwrap();
+        writeln!(out, "  Rules:").unwrap();
+        for rule in governing {
+            writeln!(out, "    - {} ({})", rule.id, rule_type_name(&rule.rule)).unwrap();
+        }
+    }
+
+    out
+}
+
+fn rule_governs_edge(
+    rule: &crate::architecture::policy::RuleKind,
+    source: &str,
+    target: &str,
+) -> bool {
+    use crate::architecture::policy::RuleKind;
+    match rule {
+        RuleKind::Allow(a) => a.source == source,
+        RuleKind::Layers(l) => {
+            l.order.iter().any(|b| b == source) && l.order.iter().any(|b| b == target)
+        }
+        RuleKind::Protected(p) => p.targets.iter().any(|t| t == target),
+        RuleKind::Independence(i) => {
+            i.members.iter().any(|m| m == source) && i.members.iter().any(|m| m == target)
+        }
+        RuleKind::Acyclic(a) => {
+            a.members.iter().any(|m| m == source) && a.members.iter().any(|m| m == target)
+        }
+    }
+}
+
+fn rule_mentions_boundary(rule: &crate::architecture::policy::RuleKind, name: &str) -> bool {
+    use crate::architecture::policy::RuleKind;
+    match rule {
+        RuleKind::Allow(a) => a.source == name || a.allowed.iter().any(|d| d == name),
+        RuleKind::Layers(l) => l.order.iter().any(|b| b == name),
+        RuleKind::Protected(p) => {
+            p.targets.iter().any(|t| t == name) || p.allowed_importers.iter().any(|i| i == name)
+        }
+        RuleKind::Independence(i) => i.members.iter().any(|m| m == name),
+        RuleKind::Acyclic(a) => a.members.iter().any(|m| m == name),
+    }
+}
+
+fn rule_type_name(rule: &crate::architecture::policy::RuleKind) -> &'static str {
+    use crate::architecture::policy::RuleKind;
+    match rule {
+        RuleKind::Allow(_) => "allow",
+        RuleKind::Layers(_) => "layers",
+        RuleKind::Protected(_) => "protected",
+        RuleKind::Independence(_) => "independence",
+        RuleKind::Acyclic(_) => "acyclic",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use super::*;
+    use crate::architecture::boundaries::{DependencySample, EdgeProvenance};
+    use crate::architecture::policy::{AllowRule, ExceptionSpec, ModuleSpec, RuleKind, RuleSpec};
+
+    fn test_graph() -> BoundaryGraph {
+        let boundaries = BTreeSet::from([
+            "graph".to_string(),
+            "errors".to_string(),
+            "render".to_string(),
+        ]);
+        let mut graph = BoundaryGraph::new(boundaries);
+        graph.insert_edge(
+            "graph".to_string(),
+            "errors".to_string(),
+            DependencySample {
+                source: "crate::graph".to_string(),
+                symbol: "crate::errors::RenderError".to_string(),
+                target: "crate::errors".to_string(),
+                location: None,
+            },
+            EdgeProvenance::ModuleScope,
+        );
+        graph.insert_edge(
+            "render".to_string(),
+            "graph".to_string(),
+            DependencySample {
+                source: "crate::render".to_string(),
+                symbol: "crate::graph::Node".to_string(),
+                target: "crate::graph".to_string(),
+                location: None,
+            },
+            EdgeProvenance::QualifiedPath,
+        );
+        graph
+    }
+
+    fn test_policy() -> ArchitecturePolicy {
+        ArchitecturePolicy {
+            version: 1,
+            modules: BTreeMap::from([
+                ("graph".to_string(), ModuleSpec::default()),
+                ("errors".to_string(), ModuleSpec::default()),
+                ("render".to_string(), ModuleSpec::default()),
+            ]),
+            rules: vec![RuleSpec {
+                id: "allow-graph".to_string(),
+                rule: RuleKind::Allow(AllowRule {
+                    source: "graph".to_string(),
+                    allowed: vec!["errors".to_string()],
+                }),
+            }],
+            exceptions: vec![],
+        }
+    }
+
+    #[test]
+    fn explain_edge_existing() {
+        let output = explain_edge(&test_graph(), &test_policy(), "graph", "errors");
+        assert!(output.contains("Exists: yes"), "got:\n{output}");
+        assert!(output.contains("ModuleScope"), "got:\n{output}");
+        assert!(output.contains("allow-graph"), "got:\n{output}");
+    }
+
+    #[test]
+    fn explain_edge_nonexistent() {
+        let output = explain_edge(&test_graph(), &test_policy(), "errors", "render");
+        assert!(output.contains("Exists: no"), "got:\n{output}");
+    }
+
+    #[test]
+    fn explain_edge_shows_exceptions() {
+        let mut policy = test_policy();
+        policy.exceptions.push(ExceptionSpec {
+            id: "legacy-coupling".to_string(),
+            rule_id: "allow-graph".to_string(),
+            source: "graph".to_string(),
+            target: "errors".to_string(),
+            reason: "historical".to_string(),
+            owner: "kevin".to_string(),
+        });
+        let output = explain_edge(&test_graph(), &policy, "graph", "errors");
+        assert!(output.contains("legacy-coupling"), "got:\n{output}");
+        assert!(output.contains("historical"), "got:\n{output}");
+    }
+
+    #[test]
+    fn explain_boundary_shows_edges() {
+        let output = explain_boundary(&test_graph(), &test_policy(), "graph");
+        assert!(output.contains("Depends on (1):"), "got:\n{output}");
+        assert!(output.contains("-> errors"), "got:\n{output}");
+        assert!(output.contains("Depended on by (1):"), "got:\n{output}");
+        assert!(output.contains("<- render"), "got:\n{output}");
+    }
+
+    #[test]
+    fn explain_boundary_shows_rules() {
+        let output = explain_boundary(&test_graph(), &test_policy(), "graph");
+        assert!(output.contains("allow-graph"), "got:\n{output}");
+    }
+
+    #[test]
+    fn explain_boundary_not_found() {
+        let output = explain_boundary(&test_graph(), &test_policy(), "nonexistent");
+        assert!(output.contains("Not found"), "got:\n{output}");
+    }
+}

--- a/xtask/src/architecture/graph_output.rs
+++ b/xtask/src/architecture/graph_output.rs
@@ -1,0 +1,91 @@
+use std::fmt::Write;
+
+use crate::architecture::boundaries::BoundaryGraph;
+
+/// Render the boundary graph as a Mermaid flowchart.
+pub(crate) fn render_mermaid(graph: &BoundaryGraph) -> String {
+    let mut out = String::new();
+    writeln!(out, "graph LR").unwrap();
+
+    // Emit nodes (boundaries)
+    for boundary in &graph.boundaries {
+        writeln!(out, "    {boundary}[\"{boundary}\"]").unwrap();
+    }
+
+    // Emit edges
+    for (source, target) in graph.edges.keys() {
+        writeln!(out, "    {source} --> {target}").unwrap();
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+    use crate::architecture::boundaries::{DependencySample, EdgeProvenance};
+
+    fn sample_graph() -> BoundaryGraph {
+        let boundaries = BTreeSet::from([
+            "errors".to_string(),
+            "format".to_string(),
+            "graph".to_string(),
+        ]);
+        let mut graph = BoundaryGraph::new(boundaries);
+        graph.insert_edge(
+            "graph".to_string(),
+            "errors".to_string(),
+            DependencySample {
+                source: "crate::graph".to_string(),
+                symbol: "crate::errors::E".to_string(),
+                target: "crate::errors".to_string(),
+                location: None,
+            },
+            EdgeProvenance::ModuleScope,
+        );
+        graph.insert_edge(
+            "graph".to_string(),
+            "format".to_string(),
+            DependencySample {
+                source: "crate::graph".to_string(),
+                symbol: "crate::format::F".to_string(),
+                target: "crate::format".to_string(),
+                location: None,
+            },
+            EdgeProvenance::QualifiedPath,
+        );
+        graph
+    }
+
+    #[test]
+    fn mermaid_output_contains_graph_header() {
+        let output = render_mermaid(&sample_graph());
+        assert!(output.starts_with("graph LR"), "got:\n{output}");
+    }
+
+    #[test]
+    fn mermaid_output_contains_all_boundaries_as_nodes() {
+        let output = render_mermaid(&sample_graph());
+        assert!(output.contains("errors[\"errors\"]"), "got:\n{output}");
+        assert!(output.contains("format[\"format\"]"), "got:\n{output}");
+        assert!(output.contains("graph[\"graph\"]"), "got:\n{output}");
+    }
+
+    #[test]
+    fn mermaid_output_contains_edges() {
+        let output = render_mermaid(&sample_graph());
+        assert!(output.contains("graph --> errors"), "got:\n{output}");
+        assert!(output.contains("graph --> format"), "got:\n{output}");
+    }
+
+    #[test]
+    fn mermaid_output_for_empty_graph() {
+        let graph = BoundaryGraph::new(BTreeSet::from(["a".to_string()]));
+        let output = render_mermaid(&graph);
+        assert!(output.contains("graph LR"));
+        assert!(output.contains("a[\"a\"]"));
+        assert!(!output.contains("-->"));
+    }
+}

--- a/xtask/src/architecture/host.rs
+++ b/xtask/src/architecture/host.rs
@@ -19,7 +19,7 @@ const HOST_DISCOVERY_ROOT_ENV: &str = "XTASK_BOUNDARIES_HOST_DISCOVERY_ROOT";
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
 
-pub(crate) const HOST_PROTOCOL_VERSION: u32 = 4;
+pub(crate) const HOST_PROTOCOL_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum HostTransport {
@@ -52,6 +52,7 @@ pub(crate) enum HostRequest {
     NotifyDirty,
     Status,
     Shutdown,
+    Graph,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -60,6 +61,7 @@ pub(crate) enum HostResponse {
     NotifyDirtyAck,
     Status(StatusResponse),
     ShuttingDown,
+    Graph(super::boundaries::BoundaryGraph),
     Error {
         retry_locally: bool,
         message: String,
@@ -360,6 +362,7 @@ struct SharedHostSnapshot {
     last_started_at: Option<String>,
     last_finished_at: Option<String>,
     last_report: Option<BoundariesRunReport>,
+    last_graph: Option<super::boundaries::BoundaryGraph>,
 }
 
 impl SharedHostState {
@@ -398,6 +401,7 @@ impl Default for SharedHostSnapshot {
             last_started_at: None,
             last_finished_at: None,
             last_report: None,
+            last_graph: None,
         }
     }
 }
@@ -439,7 +443,10 @@ impl SharedHostState {
         self.inner.updates.notify_all();
     }
 
-    pub(crate) fn complete_run(&self, report: BoundariesRunReport) {
+    pub(crate) fn complete_run(
+        &self,
+        result: crate::architecture::boundaries::BoundariesRunResult,
+    ) {
         let mut snapshot = self
             .inner
             .snapshot
@@ -447,12 +454,13 @@ impl SharedHostState {
             .expect("host state mutex poisoned");
         snapshot.generation += 1;
         snapshot.last_finished_at = Some(unix_timestamp_string());
-        snapshot.freshness = if report.success {
+        snapshot.freshness = if result.report.success {
             HostFreshness::IdleClean
         } else {
             HostFreshness::IdleFailed
         };
-        snapshot.last_report = Some(report);
+        snapshot.last_graph = Some(result.graph);
+        snapshot.last_report = Some(result.report);
         self.inner.updates.notify_all();
     }
 
@@ -548,6 +556,20 @@ impl SharedHostState {
                     None => HostResponse::Error {
                         retry_locally: true,
                         message: "host has no completed boundaries result yet".to_string(),
+                    },
+                }
+            }
+            HostRequest::Graph => {
+                let snapshot = self
+                    .inner
+                    .snapshot
+                    .lock()
+                    .expect("host state mutex poisoned");
+                match snapshot.last_graph.as_ref() {
+                    Some(graph) => HostResponse::Graph(graph.clone()),
+                    None => HostResponse::Error {
+                        retry_locally: true,
+                        message: "host has no boundary graph yet".to_string(),
                     },
                 }
             }
@@ -648,8 +670,11 @@ impl<E: HostEndpoint> ArchitectureHost<E> {
         self.state.begin_run();
     }
 
-    pub(crate) fn complete_run(&self, report: BoundariesRunReport) {
-        self.state.complete_run(report);
+    pub(crate) fn complete_run(
+        &self,
+        result: crate::architecture::boundaries::BoundariesRunResult,
+    ) {
+        self.state.complete_run(result);
     }
 
     pub(crate) fn handle_request(&self, request: HostRequest) -> HostResponse {
@@ -846,6 +871,27 @@ pub(crate) fn try_request_check(
 
     HostCheckResult::RetryLocally {
         reason: "host connection failed after retry".to_string(),
+    }
+}
+
+/// Try to get the boundary graph from a running host. Returns `None` if no
+/// host is available or it hasn't completed a run yet — caller should fall
+/// back to local graph collection.
+pub(crate) fn try_request_graph(repo_root: &Path) -> Option<super::boundaries::BoundaryGraph> {
+    let loaded = match load_metadata_for_repo(repo_root) {
+        Ok(Some(loaded)) => loaded,
+        _ => return None,
+    };
+
+    if let Some(leader) = &loaded.cluster.leader
+        && leader.state == HostState::Warming
+    {
+        return None;
+    }
+
+    match send_request(&loaded.cluster, &HostRequest::Graph) {
+        Ok(HostResponse::Graph(graph)) => Some(graph),
+        _ => None,
     }
 }
 
@@ -1294,7 +1340,7 @@ mod tests {
         HostFreshness, HostMetadata, HostRenderOptions, HostRequest, HostResponse, HostTransport,
         SharedHostState,
     };
-    use crate::architecture::boundaries::BoundariesRunReport;
+    use crate::architecture::boundaries::{BoundariesRunReport, BoundaryGraph};
 
     fn render_options() -> HostRenderOptions {
         HostRenderOptions {
@@ -1396,7 +1442,7 @@ mod tests {
         });
 
         std::thread::sleep(Duration::from_millis(20));
-        host.complete_run(failing_report());
+        host.complete_run(failing_result());
 
         let response = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
         waiting_thread.join().unwrap();
@@ -1418,7 +1464,7 @@ mod tests {
     fn status_request_reports_generation_and_last_outcome() {
         let host = SharedHostState::default();
         host.begin_run();
-        host.complete_run(passing_report());
+        host.complete_run(passing_result());
 
         let status = host.handle_status(render_options());
 
@@ -1434,7 +1480,7 @@ mod tests {
     fn notify_dirty_transitions_idle_to_dirty() {
         let host = SharedHostState::default();
         host.begin_run();
-        host.complete_run(passing_report());
+        host.complete_run(passing_result());
         assert_eq!(
             host.handle_status(render_options()).freshness,
             HostFreshness::IdleClean
@@ -1471,23 +1517,29 @@ mod tests {
         assert!(host.is_shutdown_requested());
     }
 
-    fn passing_report() -> BoundariesRunReport {
-        BoundariesRunReport {
-            success: true,
-            rendered_output: String::new(),
-            summary: None,
-            timings_output: None,
-            violations: Vec::new(),
+    fn passing_result() -> crate::architecture::boundaries::BoundariesRunResult {
+        crate::architecture::boundaries::BoundariesRunResult {
+            report: BoundariesRunReport {
+                success: true,
+                rendered_output: String::new(),
+                summary: None,
+                timings_output: None,
+                violations: Vec::new(),
+            },
+            graph: BoundaryGraph::new(std::collections::BTreeSet::new()),
         }
     }
 
-    fn failing_report() -> BoundariesRunReport {
-        BoundariesRunReport {
-            success: false,
-            rendered_output: "error[boundaries]: forbidden dependency ...".to_string(),
-            summary: Some("error: architecture boundaries failed with 1 violation".to_string()),
-            timings_output: None,
-            violations: Vec::new(),
+    fn failing_result() -> crate::architecture::boundaries::BoundariesRunResult {
+        crate::architecture::boundaries::BoundariesRunResult {
+            report: BoundariesRunReport {
+                success: false,
+                rendered_output: "error[boundaries]: forbidden dependency ...".to_string(),
+                summary: Some("error: architecture boundaries failed with 1 violation".to_string()),
+                timings_output: None,
+                violations: Vec::new(),
+            },
+            graph: BoundaryGraph::new(std::collections::BTreeSet::new()),
         }
     }
 }

--- a/xtask/src/architecture/json_output.rs
+++ b/xtask/src/architecture/json_output.rs
@@ -79,20 +79,49 @@ pub(crate) fn violation_to_cargo_diagnostic_json(
                 "explanation": null,
             },
             "spans": spans,
-            "children": [{
-                "level": "note",
-                "message": format!("imported symbol: `{}`", violation.symbol),
-                "code": null,
-                "spans": [],
-                "children": [],
-                "rendered": null,
-            }],
+            "children": build_children(violation),
             "rendered": format!(
                 "error[boundaries]: {message}\n  --> imported symbol: `{}`",
                 violation.symbol
             ),
         },
     })
+}
+
+fn build_children(violation: &BoundaryViolation) -> Value {
+    let mut children = vec![json!({
+        "level": "note",
+        "message": format!("imported symbol: `{}`", violation.symbol),
+        "code": null,
+        "spans": [],
+        "children": [],
+        "rendered": null,
+    })];
+
+    if let Some(rule_id) = &violation.rule_id {
+        let rule_type = violation.rule_type.as_deref().unwrap_or("unknown");
+        children.push(json!({
+            "level": "note",
+            "message": format!("rule: {rule_id} ({rule_type})"),
+            "code": null,
+            "spans": [],
+            "children": [],
+            "rendered": null,
+        }));
+    }
+
+    if let Some(detail) = &violation.detail {
+        children.push(json!({
+            "level": "note",
+            "message": detail,
+            "code": null,
+            "spans": [],
+            "children": [],
+            "rendered": null,
+        }));
+    }
+
+    Value::Array(children)
 }
 
 pub(crate) fn emit_violations_json(
@@ -142,6 +171,9 @@ mod tests {
             line_text: Some("use crate::EngineAlgorithmId;".to_string()),
             underline_offset: Some(4),
             underline_len: Some(24),
+            rule_id: None,
+            rule_type: None,
+            detail: None,
         };
 
         let json = violation_to_cargo_diagnostic_json(&violation, &repo_root());
@@ -174,6 +206,9 @@ mod tests {
             line_text: None,
             underline_offset: None,
             underline_len: None,
+            rule_id: None,
+            rule_type: None,
+            detail: None,
         };
 
         let json = violation_to_cargo_diagnostic_json(&violation, &repo_root());
@@ -195,6 +230,9 @@ mod tests {
             line_text: None,
             underline_offset: None,
             underline_len: None,
+            rule_id: None,
+            rule_type: None,
+            detail: None,
         };
 
         let json = violation_to_cargo_diagnostic_json(&violation, &repo_root());
@@ -217,5 +255,71 @@ mod tests {
 
         let json = build_finished_json(false);
         assert_eq!(json["success"], false);
+    }
+
+    #[test]
+    fn violation_with_rule_metadata_includes_rule_note() {
+        let violation = BoundaryViolation {
+            source_boundary: "graph".to_string(),
+            target_boundary: "diagrams".to_string(),
+            symbol: "crate::diagrams::Foo".to_string(),
+            file: Some("src/graph/mod.rs".to_string()),
+            line: Some(10),
+            column: Some(5),
+            line_text: None,
+            underline_offset: None,
+            underline_len: None,
+            rule_id: Some("allow-graph".to_string()),
+            rule_type: Some("allow".to_string()),
+            detail: Some("graph may only depend on errors, format".to_string()),
+        };
+
+        let json = violation_to_cargo_diagnostic_json(&violation, &repo_root());
+        let children = &json["message"]["children"];
+
+        // First child: symbol note (always present)
+        assert!(
+            children[0]["message"]
+                .as_str()
+                .unwrap()
+                .contains("crate::diagrams::Foo")
+        );
+        // Second child: rule note
+        assert!(
+            children[1]["message"]
+                .as_str()
+                .unwrap()
+                .contains("allow-graph")
+        );
+        assert!(children[1]["message"].as_str().unwrap().contains("allow"));
+        // Third child: detail note
+        assert!(
+            children[2]["message"]
+                .as_str()
+                .unwrap()
+                .contains("graph may only depend on")
+        );
+    }
+
+    #[test]
+    fn violation_without_rule_metadata_has_single_child() {
+        let violation = BoundaryViolation {
+            source_boundary: "graph".to_string(),
+            target_boundary: "diagrams".to_string(),
+            symbol: "crate::diagrams::Foo".to_string(),
+            file: None,
+            line: None,
+            column: None,
+            line_text: None,
+            underline_offset: None,
+            underline_len: None,
+            rule_id: None,
+            rule_type: None,
+            detail: None,
+        };
+
+        let json = violation_to_cargo_diagnostic_json(&violation, &repo_root());
+        let children = json["message"]["children"].as_array().unwrap();
+        assert_eq!(children.len(), 1); // only the symbol note
     }
 }

--- a/xtask/src/architecture/mod.rs
+++ b/xtask/src/architecture/mod.rs
@@ -1,6 +1,10 @@
 pub(crate) mod boundaries;
+pub(crate) mod explain;
+pub(crate) mod graph_output;
 pub(crate) mod host;
 pub(crate) mod json_output;
+pub(crate) mod policy;
+pub(crate) mod rules_eval;
 pub(crate) mod watch;
 
 use std::path::{Path, PathBuf};
@@ -16,7 +20,7 @@ pub(crate) struct RenderFlags {
     pub(crate) verbose: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ArchitectureCommand {
     Check {
         render: RenderFlags,
@@ -36,6 +40,14 @@ pub(crate) enum ArchitectureCommand {
     },
     Host {
         render: RenderFlags,
+    },
+    Graph,
+    ExplainEdge {
+        source: String,
+        target: String,
+    },
+    ExplainBoundary {
+        name: String,
     },
 }
 
@@ -105,7 +117,46 @@ pub(crate) fn run(command: ArchitectureCommand) -> Result<()> {
             fast_exit,
         } => run_boundaries_json(render, notify_dirty, fresh, fast_exit),
         ArchitectureCommand::Host { render } => watch::run_host(render, ArchitectureContext::new()),
+        ArchitectureCommand::Graph => run_graph(),
+        ArchitectureCommand::ExplainEdge { source, target } => run_explain_edge(&source, &target),
+        ArchitectureCommand::ExplainBoundary { name } => run_explain_boundary(&name),
     }
+}
+
+/// Try to get the boundary graph from a running host, falling back to local
+/// collection if no host is available.
+fn get_graph_for_inspection() -> Result<boundaries::BoundaryGraph> {
+    let context = ArchitectureContext::new();
+    if let Some(graph) = host::try_request_graph(context.repo_root()) {
+        return Ok(graph);
+    }
+    let mut context = ArchitectureContext::new();
+    boundaries::collect_graph_for_inspection(&mut context.boundaries)
+}
+
+fn run_graph() -> Result<()> {
+    let graph = get_graph_for_inspection()?;
+    let mermaid = graph_output::render_mermaid(&graph);
+    print!("{mermaid}");
+    Ok(())
+}
+
+fn run_explain_edge(source: &str, target: &str) -> Result<()> {
+    let context = ArchitectureContext::new();
+    let graph = get_graph_for_inspection()?;
+    let pol = policy::parse_policy_file(&policy::resolve_policy_path(context.repo_root()))?;
+    let output = explain::explain_edge(&graph, &pol, source, target);
+    print!("{output}");
+    Ok(())
+}
+
+fn run_explain_boundary(name: &str) -> Result<()> {
+    let context = ArchitectureContext::new();
+    let graph = get_graph_for_inspection()?;
+    let pol = policy::parse_policy_file(&policy::resolve_policy_path(context.repo_root()))?;
+    let output = explain::explain_boundary(&graph, &pol, name);
+    print!("{output}");
+    Ok(())
 }
 
 pub(crate) fn run_boundaries_report(
@@ -122,7 +173,7 @@ pub(crate) fn run_boundaries_report(
         Some(report) => Ok(report),
         None => {
             let mut context = ArchitectureContext::new();
-            run_boundaries_watch_report(&mut context, render)
+            run_boundaries_watch_report(&mut context, render).map(|r| r.report)
         }
     }
 }
@@ -153,6 +204,8 @@ Run the semantic module dependency guard.
 Subcommands:
     check            One-shot boundaries check (default if no subcommand)
     host             Run check, then watch and host results for one-shot reuse
+    graph            Print the boundary dependency graph as Mermaid
+    explain          Inspect edges and boundaries (local-only)
 
 Check options:
     --watch, -w      Rerun boundaries when files change (interactive, requires TTY)
@@ -166,13 +219,17 @@ Check options:
 
 Host options:
     --timings, -t    Print phase timing breakdown
-    --verbose, -v    Print verbose diagnostics and debug context"
+    --verbose, -v    Print verbose diagnostics and debug context
+
+Explain usage:
+    explain --edge <source> <target>    Show why an edge exists and which rules govern it
+    explain --boundary <name>           Show what a boundary depends on and what depends on it"
 }
 
 pub(crate) fn run_boundaries_watch_report(
     context: &mut ArchitectureContext,
     render: RenderFlags,
-) -> Result<boundaries::BoundariesRunReport> {
+) -> Result<boundaries::BoundariesRunResult> {
     boundaries::run_with_context_report(
         &mut context.boundaries,
         SemanticBoundariesSuiteOptions {
@@ -341,6 +398,24 @@ where
 
     let args_collected: Vec<String> = args.map(|s| s.as_ref().to_string()).collect();
 
+    // Handle explain early — its positional args would collide with subcommand names.
+    if args_collected.first().map(|s| s.as_str()) == Some("explain") {
+        let explain_args: Vec<&str> = args_collected[1..].iter().map(|s| s.as_str()).collect();
+        return match explain_args.as_slice() {
+            ["--edge", source, target] => Ok(ArchitectureCommand::ExplainEdge {
+                source: source.to_string(),
+                target: target.to_string(),
+            }),
+            ["--boundary", name] => Ok(ArchitectureCommand::ExplainBoundary {
+                name: name.to_string(),
+            }),
+            _ => bail!(
+                "usage: cargo xtask architecture explain --edge <source> <target>\n       \
+                 cargo xtask architecture explain --boundary <name>"
+            ),
+        };
+    }
+
     for arg in &args_collected {
         let arg = arg.as_str();
         match arg {
@@ -355,6 +430,12 @@ where
                     bail!("multiple subcommands provided; unexpected `{arg}`");
                 }
                 subcommand = Some("host");
+            }
+            "graph" => {
+                if subcommand.is_some() {
+                    bail!("multiple subcommands provided; unexpected `{arg}`");
+                }
+                subcommand = Some("graph");
             }
             "--watch" | "-w" => watch = true,
             "--notify-dirty" => notify_dirty = true,
@@ -420,6 +501,12 @@ where
                 fresh,
                 fast_exit,
             })
+        }
+        Some("graph") => {
+            if watch || json || fresh || notify_dirty || status || fast_exit {
+                bail!("`graph` subcommand does not accept check flags");
+            }
+            Ok(ArchitectureCommand::Graph)
         }
         Some(other) => bail!("unknown subcommand `{other}`"),
     }
@@ -540,6 +627,49 @@ mod tests {
     }
 
     #[test]
+    fn graph_subcommand() {
+        let cmd = parse_architecture_args(["architecture", "graph"]).unwrap();
+        assert_eq!(cmd, ArchitectureCommand::Graph);
+    }
+
+    #[test]
+    fn explain_edge_subcommand() {
+        let cmd = parse_architecture_args(["architecture", "explain", "--edge", "graph", "render"])
+            .unwrap();
+        assert_eq!(
+            cmd,
+            ArchitectureCommand::ExplainEdge {
+                source: "graph".to_string(),
+                target: "render".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn explain_boundary_subcommand() {
+        let cmd =
+            parse_architecture_args(["architecture", "explain", "--boundary", "graph"]).unwrap();
+        assert_eq!(
+            cmd,
+            ArchitectureCommand::ExplainBoundary {
+                name: "graph".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn explain_without_args_fails() {
+        assert!(parse_architecture_args(["architecture", "explain"]).is_err());
+    }
+
+    #[test]
+    fn graph_rejects_check_flags() {
+        assert!(parse_architecture_args(["architecture", "graph", "--json"]).is_err());
+        assert!(parse_architecture_args(["architecture", "graph", "--fresh"]).is_err());
+        assert!(parse_architecture_args(["architecture", "graph", "--watch"]).is_err());
+    }
+
+    #[test]
     fn host_subcommand() {
         let cmd = parse_architecture_args(["architecture", "host"]).unwrap();
         assert_eq!(
@@ -606,6 +736,10 @@ mod tests {
         let help = super::help_text();
         assert!(help.contains("check"));
         assert!(help.contains("host"));
+        assert!(help.contains("graph"));
+        assert!(help.contains("explain"));
+        assert!(help.contains("--edge"));
+        assert!(help.contains("--boundary"));
         assert!(!help.contains("--background"));
         assert!(!help.contains("daemon"));
         // "boundaries" is fine in descriptions — just not as a subcommand/alias

--- a/xtask/src/architecture/policy.rs
+++ b/xtask/src/architecture/policy.rs
@@ -1,0 +1,655 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+// ---------------------------------------------------------------------------
+// Public model — the internal representation after parsing and validation
+// ---------------------------------------------------------------------------
+
+/// Parsed and validated architecture policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ArchitecturePolicy {
+    /// Format version.
+    pub(crate) version: u32,
+    /// Declared modules keyed by name.
+    pub(crate) modules: BTreeMap<String, ModuleSpec>,
+    /// Typed architecture rules.
+    pub(crate) rules: Vec<RuleSpec>,
+    /// Named exceptions that suppress known violations.
+    pub(crate) exceptions: Vec<ExceptionSpec>,
+}
+
+impl ArchitecturePolicy {
+    /// Extract the allow map (source → allowed targets) from allow rules.
+    /// Used for rendering compatibility with the existing text reporter.
+    pub(crate) fn extract_allow_map(&self) -> BTreeMap<String, BTreeSet<String>> {
+        let mut map = BTreeMap::new();
+        for rule in &self.rules {
+            if let RuleKind::Allow(allow) = &rule.rule {
+                map.insert(
+                    allow.source.clone(),
+                    allow.allowed.iter().cloned().collect(),
+                );
+            }
+        }
+        map
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct ModuleSpec {
+    /// Freeform key-value tags for grouping and filtering.
+    pub(crate) tags: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuleSpec {
+    /// Unique identifier for this rule (used in exceptions and reports).
+    pub(crate) id: String,
+    /// The typed rule body.
+    pub(crate) rule: RuleKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RuleKind {
+    Allow(AllowRule),
+    Layers(LayersRule),
+    Protected(ProtectedRule),
+    Independence(IndependenceRule),
+    Acyclic(AcyclicRule),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AllowRule {
+    /// The source boundary this rule governs.
+    pub(crate) source: String,
+    /// Boundaries that `source` is allowed to depend on.
+    pub(crate) allowed: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LayersRule {
+    /// Ordered list of boundaries from lowest to highest.
+    /// A boundary may only depend on boundaries earlier in the list.
+    pub(crate) order: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProtectedRule {
+    /// Boundaries whose access is restricted.
+    pub(crate) targets: Vec<String>,
+    /// Only these boundaries may import the protected targets.
+    pub(crate) allowed_importers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IndependenceRule {
+    /// Boundaries that must not depend on each other.
+    pub(crate) members: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AcyclicRule {
+    /// Boundaries that must form a DAG (no dependency cycles among them).
+    pub(crate) members: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExceptionSpec {
+    /// Unique identifier for this exception.
+    pub(crate) id: String,
+    /// Which rule this exception applies to.
+    pub(crate) rule_id: String,
+    /// Source boundary of the suppressed edge.
+    pub(crate) source: String,
+    /// Target boundary of the suppressed edge.
+    pub(crate) target: String,
+    /// Human-readable justification.
+    pub(crate) reason: String,
+    /// Who owns this exception.
+    pub(crate) owner: String,
+}
+
+// ---------------------------------------------------------------------------
+// Serde shapes — raw TOML deserialization before validation
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct RawPolicy {
+    version: u32,
+    #[serde(default)]
+    modules: BTreeMap<String, RawModuleSpec>,
+    #[serde(default)]
+    rules: Vec<RawRuleSpec>,
+    #[serde(default)]
+    exceptions: Vec<RawExceptionSpec>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RawModuleSpec {
+    #[serde(default)]
+    tags: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawRuleSpec {
+    id: String,
+    #[serde(rename = "type")]
+    rule_type: Option<String>,
+    #[serde(default)]
+    config: toml::Table,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawExceptionSpec {
+    id: String,
+    rule_id: Option<String>,
+    source: Option<String>,
+    target: Option<String>,
+    reason: Option<String>,
+    owner: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Parsing entrypoint
+// ---------------------------------------------------------------------------
+
+pub(crate) fn parse_policy_str(input: &str) -> Result<ArchitecturePolicy> {
+    let raw: RawPolicy =
+        toml::from_str(input).context("failed to parse architecture policy TOML")?;
+
+    match raw.version {
+        1 => validate_policy(raw),
+        v => bail!("unsupported policy version: {v}"),
+    }
+}
+
+pub(crate) fn parse_policy_file(path: &Path) -> Result<ArchitecturePolicy> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    parse_policy_str(&content).with_context(|| format!("in policy file {}", path.display()))
+}
+
+const BOUNDARIES_CONFIG_ENV: &str = "SEMANTIC_BOUNDARIES_CONFIG";
+
+/// Resolve the policy file path using the same logic as the existing checker:
+/// `SEMANTIC_BOUNDARIES_CONFIG` env var, or `boundaries.toml` at the repo root.
+pub(crate) fn resolve_policy_path(repo_root: &Path) -> std::path::PathBuf {
+    std::env::var_os(BOUNDARIES_CONFIG_ENV)
+        .map(std::path::PathBuf::from)
+        .map(|path| {
+            if path.is_absolute() {
+                path
+            } else {
+                repo_root.join(path)
+            }
+        })
+        .unwrap_or_else(|| repo_root.join("boundaries.toml"))
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+fn validate_policy(raw: RawPolicy) -> Result<ArchitecturePolicy> {
+    let modules: BTreeMap<String, ModuleSpec> = raw
+        .modules
+        .into_iter()
+        .map(|(name, spec)| (name, ModuleSpec { tags: spec.tags }))
+        .collect();
+
+    let mut rules = Vec::with_capacity(raw.rules.len());
+    for raw_rule in raw.rules {
+        let rule = parse_rule(&raw_rule, &modules)?;
+        rules.push(RuleSpec {
+            id: raw_rule.id,
+            rule,
+        });
+    }
+
+    let mut exceptions = Vec::with_capacity(raw.exceptions.len());
+    for raw_exc in raw.exceptions {
+        let exc = validate_exception(raw_exc, &modules)?;
+        exceptions.push(exc);
+    }
+
+    Ok(ArchitecturePolicy {
+        version: 1,
+        modules,
+        rules,
+        exceptions,
+    })
+}
+
+fn parse_rule(raw: &RawRuleSpec, boundaries: &BTreeMap<String, ModuleSpec>) -> Result<RuleKind> {
+    let rule_type = raw
+        .rule_type
+        .as_deref()
+        .with_context(|| format!("rule {:?} is missing required field \"type\"", raw.id))?;
+
+    match rule_type {
+        "allow" => {
+            let source: String = get_config_string(&raw.config, "source", &raw.id)?;
+            let allowed =
+                get_config_string_array_or_tag(&raw.config, "allowed", &raw.id, boundaries)?;
+            ensure_boundary_exists(&source, boundaries, &raw.id)?;
+            for dep in &allowed {
+                ensure_boundary_exists(dep, boundaries, &raw.id)?;
+            }
+            Ok(RuleKind::Allow(AllowRule { source, allowed }))
+        }
+        "layers" => {
+            // layers.order stays explicit — order matters, tags have no natural ordering
+            let order: Vec<String> = get_config_string_array(&raw.config, "order", &raw.id)?;
+            check_no_duplicates(&order, "order", &raw.id)?;
+            for boundary in &order {
+                ensure_boundary_exists(boundary, boundaries, &raw.id)?;
+            }
+            Ok(RuleKind::Layers(LayersRule { order }))
+        }
+        "protected" => {
+            let targets =
+                get_config_string_array_or_tag(&raw.config, "targets", &raw.id, boundaries)?;
+            let allowed_importers = get_config_string_array_or_tag(
+                &raw.config,
+                "allowed_importers",
+                &raw.id,
+                boundaries,
+            )?;
+            for t in &targets {
+                ensure_boundary_exists(t, boundaries, &raw.id)?;
+            }
+            for i in &allowed_importers {
+                ensure_boundary_exists(i, boundaries, &raw.id)?;
+            }
+            Ok(RuleKind::Protected(ProtectedRule {
+                targets,
+                allowed_importers,
+            }))
+        }
+        "independence" => {
+            let members =
+                get_config_string_array_or_tag(&raw.config, "members", &raw.id, boundaries)?;
+            for m in &members {
+                ensure_boundary_exists(m, boundaries, &raw.id)?;
+            }
+            Ok(RuleKind::Independence(IndependenceRule { members }))
+        }
+        "acyclic" => {
+            let members =
+                get_config_string_array_or_tag(&raw.config, "members", &raw.id, boundaries)?;
+            for m in &members {
+                ensure_boundary_exists(m, boundaries, &raw.id)?;
+            }
+            Ok(RuleKind::Acyclic(AcyclicRule { members }))
+        }
+        other => bail!("rule {:?} has unknown type {:?}", raw.id, other),
+    }
+}
+
+fn validate_exception(
+    raw: RawExceptionSpec,
+    boundaries: &BTreeMap<String, ModuleSpec>,
+) -> Result<ExceptionSpec> {
+    let rule_id = raw.rule_id.with_context(|| {
+        format!(
+            "exception {:?} is missing required field \"rule_id\"",
+            raw.id
+        )
+    })?;
+    let source = raw.source.with_context(|| {
+        format!(
+            "exception {:?} is missing required field \"source\"",
+            raw.id
+        )
+    })?;
+    let target = raw.target.with_context(|| {
+        format!(
+            "exception {:?} is missing required field \"target\"",
+            raw.id
+        )
+    })?;
+    let reason = raw.reason.unwrap_or_default();
+    let owner = raw.owner.unwrap_or_default();
+
+    ensure_boundary_exists(&source, boundaries, &format!("exception {:?}", raw.id))?;
+    ensure_boundary_exists(&target, boundaries, &format!("exception {:?}", raw.id))?;
+
+    Ok(ExceptionSpec {
+        id: raw.id,
+        rule_id,
+        source,
+        target,
+        reason,
+        owner,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn ensure_boundary_exists(
+    name: &str,
+    boundaries: &BTreeMap<String, ModuleSpec>,
+    context: &str,
+) -> Result<()> {
+    if !boundaries.contains_key(name) {
+        bail!("{context}: unknown boundary {name:?}");
+    }
+    Ok(())
+}
+
+fn check_no_duplicates(items: &[String], field: &str, rule_id: &str) -> Result<()> {
+    let mut seen = std::collections::BTreeSet::new();
+    for item in items {
+        if !seen.insert(item) {
+            bail!("rule {rule_id:?}: duplicate boundary {item:?} in {field}");
+        }
+    }
+    Ok(())
+}
+
+fn get_config_string(table: &toml::Table, key: &str, rule_id: &str) -> Result<String> {
+    table
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .with_context(|| format!("rule {rule_id:?}: missing or invalid field {key:?}"))
+}
+
+fn get_config_string_array(table: &toml::Table, key: &str, rule_id: &str) -> Result<Vec<String>> {
+    let arr = table
+        .get(key)
+        .and_then(|v| v.as_array())
+        .with_context(|| format!("rule {rule_id:?}: missing or invalid field {key:?}"))?;
+
+    arr.iter()
+        .map(|v| {
+            v.as_str()
+                .map(|s| s.to_string())
+                .with_context(|| format!("rule {rule_id:?}: {key} must contain only strings"))
+        })
+        .collect()
+}
+
+fn resolve_tag(
+    tag_key: &str,
+    tag_value: &str,
+    boundaries: &BTreeMap<String, ModuleSpec>,
+    rule_id: &str,
+    field_name: &str,
+) -> Result<Vec<String>> {
+    let matched: Vec<String> = boundaries
+        .iter()
+        .filter(|(_, spec)| spec.tags.get(tag_key).is_some_and(|v| v == tag_value))
+        .map(|(name, _)| name.clone())
+        .collect();
+    if matched.is_empty() {
+        bail!(
+            "rule {rule_id:?}: tag {tag_key}={tag_value:?} in {field_name} matches no boundaries"
+        );
+    }
+    Ok(matched)
+}
+
+fn get_config_string_array_or_tag(
+    table: &toml::Table,
+    key: &str,
+    rule_id: &str,
+    boundaries: &BTreeMap<String, ModuleSpec>,
+) -> Result<Vec<String>> {
+    let value = table
+        .get(key)
+        .with_context(|| format!("rule {rule_id:?}: missing field {key:?}"))?;
+
+    if let Some(arr) = value.as_array() {
+        arr.iter()
+            .map(|v| {
+                v.as_str()
+                    .map(|s| s.to_string())
+                    .with_context(|| format!("rule {rule_id:?}: {key} must contain only strings"))
+            })
+            .collect()
+    } else if let Some(tbl) = value.as_table() {
+        let tag_key = tbl.get("tag").and_then(|v| v.as_str()).with_context(|| {
+            format!("rule {rule_id:?}: {key} table must have a \"tag\" string key")
+        })?;
+        let tag_value = tbl.get("value").and_then(|v| v.as_str()).with_context(|| {
+            format!("rule {rule_id:?}: {key} table must have a \"value\" string key")
+        })?;
+        resolve_tag(tag_key, tag_value, boundaries, rule_id, key)
+    } else {
+        bail!("rule {rule_id:?}: {key} must be an array or a {{ tag, value }} table")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_path(name: &str) -> std::path::PathBuf {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        manifest_dir
+            .join("tests")
+            .join("fixtures")
+            .join("architecture-policy")
+            .join(name)
+    }
+
+    fn parse_fixture(name: &str) -> Result<ArchitecturePolicy> {
+        parse_policy_file(&fixture_path(name))
+    }
+
+    // -- v2 shape tests --
+
+    #[test]
+    fn parse_v2_minimal() {
+        let policy = parse_fixture("v2-minimal.toml").unwrap();
+        assert_eq!(policy.version, 1);
+        assert!(policy.modules.contains_key("graph"));
+        assert!(policy.modules.contains_key("errors"));
+        assert!(policy.modules.contains_key("format"));
+        assert!(policy.modules.contains_key("render"));
+        assert_eq!(policy.rules.len(), 1);
+        assert_eq!(policy.rules[0].id, "core-deps");
+        assert!(matches!(policy.rules[0].rule, RuleKind::Allow(_)));
+        assert!(policy.exceptions.is_empty());
+    }
+
+    #[test]
+    fn parse_v2_with_tags_and_exceptions() {
+        let policy = parse_fixture("v2-tags-and-exceptions.toml").unwrap();
+        assert_eq!(policy.version, 1);
+        assert_eq!(policy.modules["runtime"].tags["layer"], "runtime");
+        assert_eq!(policy.modules["errors"].tags["layer"], "foundation");
+        assert_eq!(policy.rules.len(), 2);
+        assert_eq!(policy.rules[1].id, "pipeline-layers");
+        assert!(matches!(policy.rules[1].rule, RuleKind::Layers(_)));
+        assert_eq!(policy.exceptions.len(), 1);
+        assert_eq!(policy.exceptions[0].rule_id, "pipeline-layers");
+        assert_eq!(policy.exceptions[0].source, "render");
+        assert_eq!(policy.exceptions[0].target, "graph");
+        assert_eq!(policy.exceptions[0].owner, "kevin");
+    }
+
+    // -- v1 shape tests --
+
+    // -- repo compatibility tests --
+
+    fn repo_root() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask should live at the workspace root")
+            .to_path_buf()
+    }
+
+    #[test]
+    fn current_repo_boundaries_file_loads() {
+        let path = resolve_policy_path(&repo_root());
+        let policy = parse_policy_file(&path).unwrap();
+        assert_eq!(policy.version, 1);
+        assert!(!policy.modules.is_empty());
+        assert!(policy.modules.contains_key("graph"));
+        assert!(policy.modules.contains_key("runtime"));
+        // Must have at least the allow rules
+        assert!(
+            policy
+                .rules
+                .iter()
+                .any(|c| matches!(c.rule, RuleKind::Allow(_)))
+        );
+    }
+
+    // -- extract_allow_map tests --
+
+    #[test]
+    fn extract_allow_map_from_policy() {
+        let policy = parse_fixture("v2-minimal.toml").unwrap();
+        let allow_map = policy.extract_allow_map();
+        assert_eq!(
+            allow_map["graph"],
+            BTreeSet::from(["errors".to_string(), "format".to_string()])
+        );
+    }
+
+    // -- tag resolution tests --
+
+    #[test]
+    fn parse_v2_tag_targeting() {
+        let policy = parse_fixture("v2-tag-targeting.toml").unwrap();
+        // protect-facades should resolve tag to builtins, engines, render (sorted)
+        let prot = policy
+            .rules
+            .iter()
+            .find(|c| c.id == "protect-facades")
+            .expect("should have protect-facades");
+        match &prot.rule {
+            RuleKind::Protected(p) => {
+                assert_eq!(p.targets, vec!["builtins", "engines", "render"]);
+                assert_eq!(p.allowed_importers, vec!["runtime"]);
+            }
+            _ => panic!("expected protected"),
+        }
+        // facade-independence should resolve to the same set
+        let ind = policy
+            .rules
+            .iter()
+            .find(|c| c.id == "facade-independence")
+            .expect("should have facade-independence");
+        match &ind.rule {
+            RuleKind::Independence(i) => {
+                assert_eq!(i.members, vec!["builtins", "engines", "render"]);
+            }
+            _ => panic!("expected independence"),
+        }
+    }
+
+    #[test]
+    fn rejects_tag_matching_zero_boundaries() {
+        let err = parse_fixture("invalid-tag-no-match.toml").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("matches no boundaries"), "got: {msg}");
+    }
+
+    #[test]
+    fn tag_and_explicit_array_both_work_for_same_rule_type() {
+        let toml = "\
+            version = 1\n\
+            [modules.a]\n\
+            tags = { group = \"x\" }\n\
+            [modules.b]\n\
+            tags = { group = \"x\" }\n\
+            [modules.c]\n\
+            \n\
+            [[rules]]\n\
+            id = \"ind-by-tag\"\n\
+            type = \"independence\"\n\
+            [rules.config]\n\
+            members = { tag = \"group\", value = \"x\" }\n\
+            \n\
+            [[rules]]\n\
+            id = \"ind-explicit\"\n\
+            type = \"independence\"\n\
+            [rules.config]\n\
+            members = [\"a\", \"b\"]\n\
+        ";
+        let policy = parse_policy_str(toml).unwrap();
+        let by_tag = policy.rules.iter().find(|c| c.id == "ind-by-tag").unwrap();
+        let explicit = policy
+            .rules
+            .iter()
+            .find(|c| c.id == "ind-explicit")
+            .unwrap();
+        match (&by_tag.rule, &explicit.rule) {
+            (RuleKind::Independence(t), RuleKind::Independence(e)) => {
+                assert_eq!(t.members, e.members);
+            }
+            _ => panic!("expected independence"),
+        }
+    }
+
+    // -- invalid config tests --
+
+    #[test]
+    fn rejects_unknown_boundary_in_rule() {
+        let err = parse_fixture("invalid-unknown-boundary.toml").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("unknown boundary"), "got: {msg}");
+        assert!(msg.contains("nonexistent"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_rule_missing_type() {
+        let err = parse_fixture("invalid-rule-shape.toml").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("type") || msg.contains("missing"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn rejects_layers_with_duplicate_boundary() {
+        let err = parse_fixture("invalid-layers-duplicate.toml").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("duplicate"), "got: {msg}");
+        assert!(msg.contains("errors"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_exception_missing_rule_id() {
+        let err = parse_fixture("invalid-exception-missing-rule-id.toml").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("rule_id"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_exception_with_unknown_boundary() {
+        let err = parse_fixture("invalid-exception-unknown-boundary.toml").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("unknown boundary"), "got: {msg}");
+        assert!(msg.contains("nonexistent"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_unknown_rule_type() {
+        let err = parse_fixture("invalid-unknown-type.toml").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("unknown type"), "got: {msg}");
+        assert!(msg.contains("transitive"), "got: {msg}");
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let err = parse_fixture("invalid-version.toml").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("unsupported policy version"), "got: {msg}");
+    }
+}

--- a/xtask/src/architecture/rules_eval.rs
+++ b/xtask/src/architecture/rules_eval.rs
@@ -1,0 +1,854 @@
+use std::collections::BTreeSet;
+
+use crate::architecture::boundaries::{BoundaryGraph, DependencySample};
+use crate::architecture::policy::{ArchitecturePolicy, RuleKind, RuleSpec};
+
+// ---------------------------------------------------------------------------
+// Violation — the output of rule evaluation
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Violation {
+    pub(crate) rule_id: String,
+    pub(crate) rule_type: String,
+    pub(crate) source_boundary: String,
+    pub(crate) target_boundary: String,
+    pub(crate) sample: DependencySample,
+    pub(crate) detail: Option<String>,
+}
+
+/// Result of evaluating all rules, including exception handling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EvaluationResult {
+    /// Violations not suppressed by any exception.
+    pub(crate) violations: Vec<Violation>,
+    /// Violations that were suppressed by a matching exception.
+    pub(crate) suppressed: Vec<SuppressedViolation>,
+    /// Exceptions that did not match any violation (suppression debt).
+    pub(crate) unused_exceptions: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SuppressedViolation {
+    pub(crate) violation: Violation,
+    pub(crate) exception_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Evaluate all rules against a boundary graph
+// ---------------------------------------------------------------------------
+
+pub(crate) fn evaluate_rules(
+    graph: &BoundaryGraph,
+    policy: &ArchitecturePolicy,
+) -> EvaluationResult {
+    let mut all_violations = Vec::new();
+    for rule in &policy.rules {
+        match &rule.rule {
+            RuleKind::Allow(allow) => {
+                evaluate_allow(
+                    graph,
+                    rule,
+                    &allow.source,
+                    &allow.allowed,
+                    &mut all_violations,
+                );
+            }
+            RuleKind::Layers(layers) => {
+                evaluate_layers(graph, rule, &layers.order, &mut all_violations);
+            }
+            RuleKind::Protected(prot) => {
+                evaluate_protected(
+                    graph,
+                    rule,
+                    &prot.targets,
+                    &prot.allowed_importers,
+                    &mut all_violations,
+                );
+            }
+            RuleKind::Independence(ind) => {
+                evaluate_independence(graph, rule, &ind.members, &mut all_violations);
+            }
+            RuleKind::Acyclic(acyc) => {
+                evaluate_acyclic(graph, rule, &acyc.members, &mut all_violations);
+            }
+        }
+    }
+
+    apply_exceptions(all_violations, &policy.exceptions)
+}
+
+fn apply_exceptions(
+    violations: Vec<Violation>,
+    exceptions: &[crate::architecture::policy::ExceptionSpec],
+) -> EvaluationResult {
+    let mut used_exception_ids: BTreeSet<String> = BTreeSet::new();
+    let mut active_violations = Vec::new();
+    let mut suppressed = Vec::new();
+
+    for violation in violations {
+        let matching_exception = exceptions.iter().find(|exc| {
+            exc.rule_id == violation.rule_id
+                && exc.source == violation.source_boundary
+                && exc.target == violation.target_boundary
+        });
+
+        if let Some(exc) = matching_exception {
+            used_exception_ids.insert(exc.id.clone());
+            suppressed.push(SuppressedViolation {
+                violation,
+                exception_id: exc.id.clone(),
+            });
+        } else {
+            active_violations.push(violation);
+        }
+    }
+
+    let unused_exceptions: Vec<String> = exceptions
+        .iter()
+        .filter(|exc| !used_exception_ids.contains(&exc.id))
+        .map(|exc| exc.id.clone())
+        .collect();
+
+    EvaluationResult {
+        violations: active_violations,
+        suppressed,
+        unused_exceptions,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// allow — same semantics as the current v1 allowlist
+// ---------------------------------------------------------------------------
+
+fn evaluate_allow(
+    graph: &BoundaryGraph,
+    rule: &RuleSpec,
+    source: &str,
+    allowed: &[String],
+    violations: &mut Vec<Violation>,
+) {
+    let allowed_set: BTreeSet<&str> = allowed.iter().map(|s| s.as_str()).collect();
+    for ((edge_source, edge_target), edge) in &graph.edges {
+        if edge_source != source {
+            continue;
+        }
+        if !allowed_set.contains(edge_target.as_str()) {
+            violations.push(Violation {
+                rule_id: rule.id.clone(),
+                rule_type: "allow".to_string(),
+                source_boundary: edge_source.clone(),
+                target_boundary: edge_target.clone(),
+                sample: edge.sample.clone(),
+                detail: None,
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// layers — boundaries may only depend on earlier (lower) entries in order
+// ---------------------------------------------------------------------------
+
+fn evaluate_layers(
+    graph: &BoundaryGraph,
+    rule: &RuleSpec,
+    order: &[String],
+    violations: &mut Vec<Violation>,
+) {
+    // Build a position map: boundary name -> index in the layer order.
+    // Lower index = lower layer. A boundary at index i may only depend on
+    // boundaries at index j where j < i.
+    let positions: std::collections::BTreeMap<&str, usize> = order
+        .iter()
+        .enumerate()
+        .map(|(i, name)| (name.as_str(), i))
+        .collect();
+
+    for ((edge_source, edge_target), edge) in &graph.edges {
+        let Some(&source_pos) = positions.get(edge_source.as_str()) else {
+            continue; // edge source not in this layer set — not governed
+        };
+        let Some(&target_pos) = positions.get(edge_target.as_str()) else {
+            continue; // edge target not in this layer set — not governed
+        };
+        if target_pos >= source_pos {
+            // Depending on same layer or higher layer is a violation
+            violations.push(Violation {
+                rule_id: rule.id.clone(),
+                rule_type: "layers".to_string(),
+                source_boundary: edge_source.clone(),
+                target_boundary: edge_target.clone(),
+                sample: edge.sample.clone(),
+                detail: Some(format!(
+                    "{} (layer {}) must not depend on {} (layer {})",
+                    edge_source, source_pos, edge_target, target_pos
+                )),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// protected — only listed importers may access the protected targets
+// ---------------------------------------------------------------------------
+
+fn evaluate_protected(
+    graph: &BoundaryGraph,
+    rule: &RuleSpec,
+    targets: &[String],
+    allowed_importers: &[String],
+    violations: &mut Vec<Violation>,
+) {
+    let target_set: BTreeSet<&str> = targets.iter().map(|s| s.as_str()).collect();
+    let allowed_set: BTreeSet<&str> = allowed_importers.iter().map(|s| s.as_str()).collect();
+
+    for ((edge_source, edge_target), edge) in &graph.edges {
+        if !target_set.contains(edge_target.as_str()) {
+            continue; // edge target is not protected by this rule
+        }
+        if allowed_set.contains(edge_source.as_str()) {
+            continue; // source is an authorized importer
+        }
+        violations.push(Violation {
+            rule_id: rule.id.clone(),
+            rule_type: "protected".to_string(),
+            source_boundary: edge_source.clone(),
+            target_boundary: edge_target.clone(),
+            sample: edge.sample.clone(),
+            detail: Some(format!(
+                "{} is not an allowed importer of protected boundary {}",
+                edge_source, edge_target
+            )),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// independence — any direct edge among group members is a violation
+// ---------------------------------------------------------------------------
+
+fn evaluate_independence(
+    graph: &BoundaryGraph,
+    rule: &RuleSpec,
+    members: &[String],
+    violations: &mut Vec<Violation>,
+) {
+    let member_set: BTreeSet<&str> = members.iter().map(|s| s.as_str()).collect();
+
+    for ((edge_source, edge_target), edge) in &graph.edges {
+        if member_set.contains(edge_source.as_str()) && member_set.contains(edge_target.as_str()) {
+            violations.push(Violation {
+                rule_id: rule.id.clone(),
+                rule_type: "independence".to_string(),
+                source_boundary: edge_source.clone(),
+                target_boundary: edge_target.clone(),
+                sample: edge.sample.clone(),
+                detail: Some(format!(
+                    "{} and {} must be independent (no direct dependencies)",
+                    edge_source, edge_target
+                )),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// acyclic — boundaries must form a DAG (no dependency cycles)
+// ---------------------------------------------------------------------------
+
+fn evaluate_acyclic(
+    graph: &BoundaryGraph,
+    rule: &RuleSpec,
+    members: &[String],
+    violations: &mut Vec<Violation>,
+) {
+    let member_set: BTreeSet<&str> = members.iter().map(|s| s.as_str()).collect();
+
+    // Build adjacency list restricted to members
+    let mut adj: std::collections::BTreeMap<&str, Vec<&str>> = std::collections::BTreeMap::new();
+    for member in &member_set {
+        adj.entry(member).or_default();
+    }
+    for (source, target) in graph.edges.keys() {
+        if member_set.contains(source.as_str()) && member_set.contains(target.as_str()) {
+            adj.entry(source.as_str())
+                .or_default()
+                .push(target.as_str());
+        }
+    }
+
+    // DFS-based cycle detection
+    #[derive(Clone, Copy, PartialEq)]
+    enum Color {
+        White,
+        Gray,
+        Black,
+    }
+
+    let mut color: std::collections::BTreeMap<&str, Color> =
+        member_set.iter().map(|&m| (m, Color::White)).collect();
+    let mut path: Vec<&str> = Vec::new();
+
+    fn dfs<'a>(
+        node: &'a str,
+        adj: &std::collections::BTreeMap<&'a str, Vec<&'a str>>,
+        color: &mut std::collections::BTreeMap<&'a str, Color>,
+        path: &mut Vec<&'a str>,
+        cycles: &mut Vec<Vec<String>>,
+    ) {
+        color.insert(node, Color::Gray);
+        path.push(node);
+
+        if let Some(neighbors) = adj.get(node) {
+            for &next in neighbors {
+                match color.get(next) {
+                    Some(Color::Gray) => {
+                        // Found a cycle. Extract the cycle path starting from `next`.
+                        let cycle_start = path.iter().position(|&n| n == next).unwrap();
+                        let mut cycle: Vec<String> =
+                            path[cycle_start..].iter().map(|s| s.to_string()).collect();
+                        cycle.push(next.to_string()); // close the cycle
+                        cycles.push(cycle);
+                    }
+                    Some(Color::White) | None => {
+                        dfs(next, adj, color, path, cycles);
+                    }
+                    Some(Color::Black) => {}
+                }
+            }
+        }
+
+        path.pop();
+        color.insert(node, Color::Black);
+    }
+
+    let mut cycles: Vec<Vec<String>> = Vec::new();
+    for &node in &member_set {
+        if color.get(node) == Some(&Color::White) {
+            dfs(node, &adj, &mut color, &mut path, &mut cycles);
+        }
+    }
+
+    // Normalize cycles for deterministic output: rotate so the
+    // lexicographically smallest element is first.
+    for cycle in &mut cycles {
+        if cycle.len() > 1 {
+            // Last element duplicates the first (closing the cycle); exclude it for rotation
+            let body = &cycle[..cycle.len() - 1];
+            if let Some(min_pos) = body
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, v)| *v)
+                .map(|(i, _)| i)
+            {
+                let mut rotated: Vec<String> = body[min_pos..].to_vec();
+                rotated.extend_from_slice(&body[..min_pos]);
+                rotated.push(rotated[0].clone());
+                *cycle = rotated;
+            }
+        }
+    }
+
+    // Deduplicate identical cycles
+    cycles.sort();
+    cycles.dedup();
+
+    for cycle in &cycles {
+        let cycle_path = cycle.join(" -> ");
+        // Use the first edge in the cycle as the representative sample
+        let source = &cycle[0];
+        let target = &cycle[1];
+        let sample = graph
+            .edge(source, target)
+            .map(|e| e.sample.clone())
+            .unwrap_or_else(|| DependencySample {
+                source: format!("crate::{source}"),
+                symbol: format!("crate::{target}"),
+                target: format!("crate::{target}"),
+                location: None,
+            });
+
+        violations.push(Violation {
+            rule_id: rule.id.clone(),
+            rule_type: "acyclic".to_string(),
+            source_boundary: source.clone(),
+            target_boundary: target.clone(),
+            sample,
+            detail: Some(format!("cycle: {cycle_path}")),
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::architecture::boundaries::EdgeProvenance;
+
+    fn graph_with_edge(source: &str, target: &str) -> BoundaryGraph {
+        let boundaries = BTreeSet::from([source.to_string(), target.to_string()]);
+        let mut graph = BoundaryGraph::new(boundaries);
+        graph.insert_edge(
+            source.to_string(),
+            target.to_string(),
+            DependencySample {
+                source: format!("crate::{source}"),
+                symbol: format!("crate::{target}::Item"),
+                target: format!("crate::{target}"),
+                location: None,
+            },
+            EdgeProvenance::ModuleScope,
+        );
+        graph
+    }
+
+    fn graph_with_edges(edges: &[(&str, &str)]) -> BoundaryGraph {
+        let mut all_names = BTreeSet::new();
+        for (s, t) in edges {
+            all_names.insert(s.to_string());
+            all_names.insert(t.to_string());
+        }
+        let mut graph = BoundaryGraph::new(all_names);
+        for (source, target) in edges {
+            graph.insert_edge(
+                source.to_string(),
+                target.to_string(),
+                DependencySample {
+                    source: format!("crate::{source}"),
+                    symbol: format!("crate::{target}::Item"),
+                    target: format!("crate::{target}"),
+                    location: None,
+                },
+                EdgeProvenance::ModuleScope,
+            );
+        }
+        graph
+    }
+
+    fn allow_policy(source: &str, allowed: &[&str]) -> ArchitecturePolicy {
+        let mut boundaries = BTreeMap::new();
+        boundaries.insert(source.to_string(), Default::default());
+        for dep in allowed {
+            boundaries.insert(dep.to_string(), Default::default());
+        }
+        ArchitecturePolicy {
+            version: 1,
+            modules: boundaries,
+            rules: vec![RuleSpec {
+                id: format!("allow-{source}"),
+                rule: RuleKind::Allow(crate::architecture::policy::AllowRule {
+                    source: source.to_string(),
+                    allowed: allowed.iter().map(|s| s.to_string()).collect(),
+                }),
+            }],
+            exceptions: Vec::new(),
+        }
+    }
+
+    fn layers_policy(order: &[&str]) -> ArchitecturePolicy {
+        let boundaries = order
+            .iter()
+            .map(|name| (name.to_string(), Default::default()))
+            .collect();
+        ArchitecturePolicy {
+            version: 1,
+            modules: boundaries,
+            rules: vec![RuleSpec {
+                id: "pipeline-layers".to_string(),
+                rule: RuleKind::Layers(crate::architecture::policy::LayersRule {
+                    order: order.iter().map(|s| s.to_string()).collect(),
+                }),
+            }],
+            exceptions: Vec::new(),
+        }
+    }
+
+    // -- allow rule tests --
+
+    #[test]
+    fn allow_rule_reports_disallowed_edge() {
+        let graph = graph_with_edge("runtime", "render");
+        let policy = allow_policy("runtime", &["graph"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_id, "allow-runtime");
+        assert_eq!(violations[0].rule_type, "allow");
+        assert_eq!(violations[0].source_boundary, "runtime");
+        assert_eq!(violations[0].target_boundary, "render");
+    }
+
+    #[test]
+    fn allow_rule_passes_when_edge_is_allowed() {
+        let graph = graph_with_edge("runtime", "graph");
+        let policy = allow_policy("runtime", &["graph"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn allow_rule_ignores_edges_from_ungoverned_sources() {
+        let graph = graph_with_edge("mermaid", "graph");
+        let policy = allow_policy("runtime", &["graph"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert!(violations.is_empty());
+    }
+
+    // -- layers rule tests --
+
+    #[test]
+    fn layers_rule_reports_upward_dependency() {
+        // order: errors (0) < graph (1) < runtime (2)
+        // graph -> runtime is upward = violation
+        let graph = graph_with_edge("graph", "runtime");
+        let policy = layers_policy(&["errors", "graph", "runtime"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_type, "layers");
+        assert_eq!(violations[0].source_boundary, "graph");
+        assert_eq!(violations[0].target_boundary, "runtime");
+        assert!(violations[0].detail.is_some());
+    }
+
+    #[test]
+    fn layers_rule_allows_downward_dependency() {
+        // runtime (2) -> graph (1) is downward = ok
+        let graph = graph_with_edge("runtime", "graph");
+        let policy = layers_policy(&["errors", "graph", "runtime"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn layers_rule_reports_same_layer_dependency() {
+        // graph -> graph would be same layer, but the collector already filters
+        // self-edges. Test with two boundaries at... actually this can't happen
+        // since each name is unique. Test peer dependency instead.
+        // graph (1) -> render (1) would require duplicate positions, which
+        // layers prevents. This test verifies that an edge between non-governed
+        // boundaries is ignored.
+        let graph = graph_with_edge("mermaid", "mmds");
+        let policy = layers_policy(&["errors", "graph", "runtime"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn layers_rule_with_multiple_violations() {
+        let graph = graph_with_edges(&[
+            ("errors", "graph"),   // upward: 0 -> 1
+            ("errors", "runtime"), // upward: 0 -> 2
+            ("runtime", "errors"), // downward: 2 -> 0 (ok)
+        ]);
+        let policy = layers_policy(&["errors", "graph", "runtime"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert_eq!(violations.len(), 2);
+        assert!(violations.iter().all(|v| v.source_boundary == "errors"));
+    }
+
+    // -- protected rule tests --
+
+    fn protected_policy(targets: &[&str], allowed_importers: &[&str]) -> ArchitecturePolicy {
+        let mut boundaries = BTreeMap::new();
+        for name in targets.iter().chain(allowed_importers.iter()) {
+            boundaries.insert(name.to_string(), Default::default());
+        }
+        ArchitecturePolicy {
+            version: 1,
+            modules: boundaries,
+            rules: vec![RuleSpec {
+                id: "protect-internal".to_string(),
+                rule: RuleKind::Protected(crate::architecture::policy::ProtectedRule {
+                    targets: targets.iter().map(|s| s.to_string()).collect(),
+                    allowed_importers: allowed_importers.iter().map(|s| s.to_string()).collect(),
+                }),
+            }],
+            exceptions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn protected_rule_allows_declared_importers() {
+        let graph = graph_with_edge("runtime", "payload");
+        let policy = protected_policy(&["payload"], &["runtime", "registry"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn protected_rule_rejects_unauthorized_importer() {
+        let graph = graph_with_edge("render", "payload");
+        let mut policy = protected_policy(&["payload"], &["runtime", "registry"]);
+        // Add "render" as a boundary so the graph is valid
+        policy
+            .modules
+            .insert("render".to_string(), Default::default());
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_type, "protected");
+        assert_eq!(violations[0].source_boundary, "render");
+        assert_eq!(violations[0].target_boundary, "payload");
+    }
+
+    #[test]
+    fn protected_rule_ignores_edges_to_non_protected_targets() {
+        let graph = graph_with_edge("render", "graph");
+        let mut policy = protected_policy(&["payload"], &["runtime"]);
+        policy
+            .modules
+            .insert("render".to_string(), Default::default());
+        policy
+            .modules
+            .insert("graph".to_string(), Default::default());
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert!(violations.is_empty());
+    }
+
+    // -- independence rule tests --
+
+    fn independence_policy(members: &[&str]) -> ArchitecturePolicy {
+        let boundaries = members
+            .iter()
+            .map(|name| (name.to_string(), Default::default()))
+            .collect();
+        ArchitecturePolicy {
+            version: 1,
+            modules: boundaries,
+            rules: vec![RuleSpec {
+                id: "peer-isolation".to_string(),
+                rule: RuleKind::Independence(crate::architecture::policy::IndependenceRule {
+                    members: members.iter().map(|s| s.to_string()).collect(),
+                }),
+            }],
+            exceptions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn independence_rule_rejects_peer_dependency() {
+        let graph = graph_with_edge("mermaid", "mmds");
+        let policy = independence_policy(&["mermaid", "mmds"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_type, "independence");
+        assert_eq!(violations[0].source_boundary, "mermaid");
+        assert_eq!(violations[0].target_boundary, "mmds");
+    }
+
+    #[test]
+    fn independence_rule_rejects_in_either_direction() {
+        let graph = graph_with_edges(&[("mermaid", "mmds"), ("mmds", "mermaid")]);
+        let policy = independence_policy(&["mermaid", "mmds"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert_eq!(violations.len(), 2);
+    }
+
+    #[test]
+    fn independence_rule_ignores_edges_outside_group() {
+        let graph = graph_with_edge("mermaid", "graph");
+        let mut policy = independence_policy(&["mermaid", "mmds"]);
+        policy
+            .modules
+            .insert("graph".to_string(), Default::default());
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert!(violations.is_empty());
+    }
+
+    // -- acyclic rule tests --
+
+    fn acyclic_policy(members: &[&str]) -> ArchitecturePolicy {
+        let boundaries = members
+            .iter()
+            .map(|name| (name.to_string(), Default::default()))
+            .collect();
+        ArchitecturePolicy {
+            version: 1,
+            modules: boundaries,
+            rules: vec![RuleSpec {
+                id: "no-cycles".to_string(),
+                rule: RuleKind::Acyclic(crate::architecture::policy::AcyclicRule {
+                    members: members.iter().map(|s| s.to_string()).collect(),
+                }),
+            }],
+            exceptions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn acyclic_rule_detects_simple_cycle() {
+        let graph = graph_with_edges(&[("a", "b"), ("b", "a")]);
+        let policy = acyclic_policy(&["a", "b"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0].rule_type, "acyclic");
+        let detail = violations[0].detail.as_ref().unwrap();
+        assert!(detail.contains("cycle:"), "got: {detail}");
+        assert!(
+            detail.contains("a") && detail.contains("b"),
+            "got: {detail}"
+        );
+    }
+
+    #[test]
+    fn acyclic_rule_detects_three_node_cycle() {
+        let graph = graph_with_edges(&[("a", "b"), ("b", "c"), ("c", "a")]);
+        let policy = acyclic_policy(&["a", "b", "c"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert_eq!(violations.len(), 1);
+        let detail = violations[0].detail.as_ref().unwrap();
+        // Normalized: starts with "a" (lexicographically smallest)
+        assert!(detail.starts_with("cycle: a"), "got: {detail}");
+    }
+
+    #[test]
+    fn acyclic_rule_passes_for_dag() {
+        let graph = graph_with_edges(&[("a", "b"), ("b", "c"), ("a", "c")]);
+        let policy = acyclic_policy(&["a", "b", "c"]);
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn acyclic_rule_ignores_edges_outside_member_set() {
+        let graph = graph_with_edges(&[("a", "x"), ("x", "a")]);
+        let mut policy = acyclic_policy(&["a", "b"]);
+        policy.modules.insert("x".to_string(), Default::default());
+        let violations = evaluate_rules(&graph, &policy).violations;
+        assert!(violations.is_empty());
+    }
+
+    // -- exception tests --
+
+    #[test]
+    fn exception_suppresses_matching_violation() {
+        let graph = graph_with_edge("graph", "diagrams");
+        let mut policy = allow_policy("graph", &["errors"]);
+        policy
+            .modules
+            .insert("diagrams".to_string(), Default::default());
+        policy
+            .exceptions
+            .push(crate::architecture::policy::ExceptionSpec {
+                id: "legacy-graph-diagrams".to_string(),
+                rule_id: "allow-graph".to_string(),
+                source: "graph".to_string(),
+                target: "diagrams".to_string(),
+                reason: "historical coupling".to_string(),
+                owner: "kevin".to_string(),
+            });
+
+        let result = evaluate_rules(&graph, &policy);
+        assert!(result.violations.is_empty());
+        assert_eq!(result.suppressed.len(), 1);
+        assert_eq!(result.suppressed[0].exception_id, "legacy-graph-diagrams");
+    }
+
+    #[test]
+    fn exception_must_match_exact_rule_id() {
+        let graph = graph_with_edge("graph", "diagrams");
+        let mut policy = allow_policy("graph", &["errors"]);
+        policy
+            .modules
+            .insert("diagrams".to_string(), Default::default());
+        policy
+            .exceptions
+            .push(crate::architecture::policy::ExceptionSpec {
+                id: "wrong-contract".to_string(),
+                rule_id: "some-other-contract".to_string(),
+                source: "graph".to_string(),
+                target: "diagrams".to_string(),
+                reason: "mismatched rule_id".to_string(),
+                owner: "kevin".to_string(),
+            });
+
+        let result = evaluate_rules(&graph, &policy);
+        assert_eq!(result.violations.len(), 1); // not suppressed
+        assert!(result.suppressed.is_empty());
+        assert_eq!(result.unused_exceptions, vec!["wrong-contract"]);
+    }
+
+    #[test]
+    fn unused_exceptions_are_reported() {
+        let graph = graph_with_edge("graph", "errors"); // allowed edge, no violation
+        let mut policy = allow_policy("graph", &["errors"]);
+        policy
+            .exceptions
+            .push(crate::architecture::policy::ExceptionSpec {
+                id: "stale-exception".to_string(),
+                rule_id: "allow-graph".to_string(),
+                source: "graph".to_string(),
+                target: "diagrams".to_string(),
+                reason: "no longer needed".to_string(),
+                owner: "kevin".to_string(),
+            });
+
+        let result = evaluate_rules(&graph, &policy);
+        assert!(result.violations.is_empty());
+        assert!(result.suppressed.is_empty());
+        assert_eq!(result.unused_exceptions, vec!["stale-exception"]);
+    }
+
+    #[test]
+    fn no_exceptions_means_empty_suppression_and_unused() {
+        let graph = graph_with_edge("graph", "diagrams");
+        let mut policy = allow_policy("graph", &["errors"]);
+        policy
+            .modules
+            .insert("diagrams".to_string(), Default::default());
+
+        let result = evaluate_rules(&graph, &policy);
+        assert_eq!(result.violations.len(), 1);
+        assert!(result.suppressed.is_empty());
+        assert!(result.unused_exceptions.is_empty());
+    }
+
+    // -- parity and smoke tests --
+
+    #[test]
+    fn parsed_allow_rules_detect_forbidden_edges() {
+        let graph = graph_with_edges(&[
+            ("graph", "errors"),   // allowed
+            ("graph", "format"),   // allowed
+            ("graph", "diagrams"), // forbidden
+        ]);
+        let toml = "\
+            version = 1\n\
+            [modules]\n\
+            graph = {}\n\
+            errors = {}\n\
+            format = {}\n\
+            render = {}\n\
+            diagrams = {}\n\
+            \n\
+            [[rules]]\n\
+            id = \"allow-graph\"\n\
+            type = \"allow\"\n\
+            [rules.config]\n\
+            source = \"graph\"\n\
+            allowed = [\"errors\", \"format\"]\n\
+        ";
+        let policy = crate::architecture::policy::parse_policy_str(toml).unwrap();
+        let result = evaluate_rules(&graph, &policy);
+
+        assert_eq!(result.violations.len(), 1);
+        assert_eq!(result.violations[0].source_boundary, "graph");
+        assert_eq!(result.violations[0].target_boundary, "diagrams");
+        assert_eq!(result.violations[0].rule_type, "allow");
+    }
+
+    #[test]
+    fn current_repo_boundaries_file_parses_to_valid_rules() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask should live at the workspace root");
+        let path = crate::architecture::policy::resolve_policy_path(repo_root);
+        let policy = crate::architecture::policy::parse_policy_file(&path).unwrap();
+        assert!(!policy.modules.is_empty());
+        assert!(!policy.rules.is_empty());
+    }
+}

--- a/xtask/src/architecture/watch.rs
+++ b/xtask/src/architecture/watch.rs
@@ -473,7 +473,7 @@ where
             runner.run_once(run_number, &[])
         }
     };
-    boundaries_host.complete_run(initial.report);
+    boundaries_host.complete_run(initial.result);
     let mut last_status = initial.status;
     let mut reruns = 0usize;
 
@@ -497,7 +497,7 @@ where
         run_number += 1;
         boundaries_host.begin_run();
         let outcome = runner.run_once(run_number, &changes);
-        boundaries_host.complete_run(outcome.report);
+        boundaries_host.complete_run(outcome.result);
         last_status = outcome.status;
     }
 
@@ -700,7 +700,7 @@ struct ArchitectureWatchRunner {
 
 struct ArchitectureRunOutcome {
     status: WatchRunStatus,
-    report: super::boundaries::BoundariesRunReport,
+    result: super::boundaries::BoundariesRunResult,
 }
 
 impl ArchitectureWatchRunner {
@@ -718,17 +718,21 @@ impl ArchitectureWatchRunner {
         }
 
         let started = Instant::now();
-        let report = match run_boundaries_watch_report(&mut self.context, self.render) {
-            Ok(report) => report,
-            Err(error) => super::boundaries::BoundariesRunReport {
-                success: false,
-                rendered_output: String::new(),
-                summary: Some(format!("{error:#}")),
-                timings_output: None,
-                violations: Vec::new(),
+        let run_result = match run_boundaries_watch_report(&mut self.context, self.render) {
+            Ok(result) => result,
+            Err(error) => super::boundaries::BoundariesRunResult {
+                report: super::boundaries::BoundariesRunReport {
+                    success: false,
+                    rendered_output: String::new(),
+                    summary: Some(format!("{error:#}")),
+                    timings_output: None,
+                    violations: Vec::new(),
+                },
+                graph: super::boundaries::BoundaryGraph::new(std::collections::BTreeSet::new()),
             },
         };
         let duration = started.elapsed();
+        let report = &run_result.report;
         let status = if report.success {
             WatchRunStatus::Passed
         } else {
@@ -747,11 +751,14 @@ impl ArchitectureWatchRunner {
         if !report.success {
             eprintln!(
                 "[run {run_number}] failure detail for boundaries:\n{}",
-                render_failure_detail(&report)
+                render_failure_detail(report)
             );
         }
 
-        ArchitectureRunOutcome { status, report }
+        ArchitectureRunOutcome {
+            status,
+            result: run_result,
+        }
     }
 }
 

--- a/xtask/tests/architecture_boundaries_cli.rs
+++ b/xtask/tests/architecture_boundaries_cli.rs
@@ -55,11 +55,7 @@ fn boundaries_falls_back_locally_when_no_host_is_present() {
     let outcome = harness.run(&["architecture", "check"]);
 
     assert_ne!(outcome.status_code, 0);
-    assert!(
-        outcome
-            .output
-            .contains("unsupported semantic boundaries config version 2")
-    );
+    assert!(outcome.output.contains("unsupported policy version: 99"));
 }
 
 #[cfg(unix)]
@@ -71,11 +67,7 @@ fn boundaries_uses_host_when_metadata_and_protocol_match() {
 
     assert_eq!(outcome.status_code, 0);
     assert_eq!(harness.host_requests(), 1);
-    assert!(
-        !outcome
-            .output
-            .contains("unsupported semantic boundaries config version 2")
-    );
+    assert!(!outcome.output.contains("unsupported policy version: 99"));
 }
 
 #[test]
@@ -85,11 +77,7 @@ fn boundaries_falls_back_locally_on_protocol_mismatch() {
     let outcome = harness.run(&["architecture", "check"]);
 
     assert_ne!(outcome.status_code, 0);
-    assert!(
-        outcome
-            .output
-            .contains("unsupported semantic boundaries config version 2")
-    );
+    assert!(outcome.output.contains("unsupported policy version: 99"));
     assert_eq!(harness.host_requests(), 0);
 }
 
@@ -100,11 +88,7 @@ fn boundaries_ignores_host_metadata_from_a_different_worktree() {
     let outcome = harness.run(&["architecture", "check"]);
 
     assert_ne!(outcome.status_code, 0);
-    assert!(
-        outcome
-            .output
-            .contains("unsupported semantic boundaries config version 2")
-    );
+    assert!(outcome.output.contains("unsupported policy version: 99"));
     assert_eq!(harness.host_requests(), 0);
 }
 
@@ -132,11 +116,7 @@ fn boundaries_fresh_bypasses_host_reuse() {
             .output
             .contains("running local boundaries check (--fresh)")
     );
-    assert!(
-        outcome
-            .output
-            .contains("unsupported semantic boundaries config version 2")
-    );
+    assert!(outcome.output.contains("unsupported policy version: 99"));
 }
 
 #[cfg(unix)]
@@ -209,7 +189,7 @@ impl BoundariesCliHarness {
         let discovery_root = unique_temp_dir("xbd-root");
         let config_path = discovery_root.join("invalid-boundaries.toml");
         fs::create_dir_all(&discovery_root).unwrap();
-        fs::write(&config_path, "version = 2\n").unwrap();
+        fs::write(&config_path, "version = 99\n").unwrap();
 
         let metadata_path = host_metadata_path(&discovery_root);
         if let Some(parent) = metadata_path.parent() {
@@ -352,10 +332,10 @@ impl HostFixture {
         self.socket_path = Some(socket_path.clone());
         self.metadata_json = Some(
             serde_json::json!({
-                "protocol_version": 4,
+                "protocol_version": 1,
                 "repo_root": discovery_root,
                 "worktree_id": worktree_id_for_repo(discovery_root),
-                "binary_version": "xtask-boundaries-host-v4",
+                "binary_version": "xtask-boundaries-host-v1",
                 "transport": {
                     "UnixSocket": {
                         "path": socket_path
@@ -421,7 +401,7 @@ fn incompatible_metadata_json(discovery_root: &Path) -> String {
         "protocol_version": 99,
         "repo_root": discovery_root,
         "worktree_id": worktree_id_for_repo(discovery_root),
-        "binary_version": "xtask-boundaries-host-v4",
+        "binary_version": "xtask-boundaries-host-v1",
         "transport": {
             transport_key(): transport_value(discovery_root)
         },
@@ -437,10 +417,10 @@ fn incompatible_metadata_json(discovery_root: &Path) -> String {
 fn foreign_worktree_metadata_json(discovery_root: &Path) -> String {
     let foreign_root = discovery_root.join("foreign-worktree");
     serde_json::json!({
-        "protocol_version": 4,
+        "protocol_version": 1,
         "repo_root": foreign_root,
         "worktree_id": worktree_id_for_repo(&foreign_root),
-        "binary_version": "xtask-boundaries-host-v4",
+        "binary_version": "xtask-boundaries-host-v1",
         "transport": {
             transport_key(): transport_value(&foreign_root)
         },
@@ -455,10 +435,10 @@ fn foreign_worktree_metadata_json(discovery_root: &Path) -> String {
 
 fn stale_transport_metadata_json(discovery_root: &Path) -> String {
     serde_json::json!({
-        "protocol_version": 4,
+        "protocol_version": 1,
         "repo_root": discovery_root,
         "worktree_id": worktree_id_for_repo(discovery_root),
-        "binary_version": "xtask-boundaries-host-v4",
+        "binary_version": "xtask-boundaries-host-v1",
         "transport": {
             "UnixSocket": {
                 "path": host_socket_path(discovery_root)

--- a/xtask/tests/architecture_watch_cli.rs
+++ b/xtask/tests/architecture_watch_cli.rs
@@ -42,7 +42,7 @@ fn architecture_watch_noninteractive_preserves_failure_status() {
             .unwrap()
             .as_nanos()
     ));
-    fs::write(&temp_path, "version = 2\n").unwrap();
+    fs::write(&temp_path, "version = 99\n").unwrap();
 
     let run = run_xtask(
         &["architecture", "check", "--watch"],
@@ -52,10 +52,7 @@ fn architecture_watch_noninteractive_preserves_failure_status() {
     let _ = fs::remove_file(&temp_path);
 
     assert_ne!(run.status_code, 0);
-    assert!(
-        run.output
-            .contains("unsupported semantic boundaries config version 2")
-    );
+    assert!(run.output.contains("unsupported policy version: 99"));
     assert!(run.output.contains("last run failed"));
 }
 

--- a/xtask/tests/fixtures/architecture-policy/invalid-exception-missing-rule-id.toml
+++ b/xtask/tests/fixtures/architecture-policy/invalid-exception-missing-rule-id.toml
@@ -1,0 +1,12 @@
+version = 1
+
+[modules]
+graph = {}
+render = {}
+
+[[exceptions]]
+id = "orphan-exception"
+source = "render"
+target = "graph"
+reason = "no rule_id"
+owner = "kevin"

--- a/xtask/tests/fixtures/architecture-policy/invalid-exception-unknown-boundary.toml
+++ b/xtask/tests/fixtures/architecture-policy/invalid-exception-unknown-boundary.toml
@@ -1,0 +1,20 @@
+version = 1
+
+[modules]
+graph = {}
+
+[[rules]]
+id = "some-contract"
+type = "allow"
+
+[rules.config]
+source = "graph"
+allowed = []
+
+[[exceptions]]
+id = "bad-exc"
+rule_id = "some-contract"
+source = "nonexistent"
+target = "graph"
+reason = "source does not exist"
+owner = "kevin"

--- a/xtask/tests/fixtures/architecture-policy/invalid-layers-duplicate.toml
+++ b/xtask/tests/fixtures/architecture-policy/invalid-layers-duplicate.toml
@@ -1,0 +1,13 @@
+version = 1
+
+[modules]
+errors = {}
+format = {}
+graph = {}
+
+[[rules]]
+id = "bad-layers"
+type = "layers"
+
+[rules.config]
+order = ["errors", "format", "errors"]

--- a/xtask/tests/fixtures/architecture-policy/invalid-rule-shape.toml
+++ b/xtask/tests/fixtures/architecture-policy/invalid-rule-shape.toml
@@ -1,0 +1,12 @@
+version = 1
+
+[modules]
+graph = {}
+render = {}
+
+[[rules]]
+id = "missing-type"
+
+[rules.config]
+source = "graph"
+allowed = ["render"]

--- a/xtask/tests/fixtures/architecture-policy/invalid-tag-no-match.toml
+++ b/xtask/tests/fixtures/architecture-policy/invalid-tag-no-match.toml
@@ -1,0 +1,12 @@
+version = 1
+
+[modules]
+graph = {}
+
+[[rules]]
+id = "bad-tag"
+type = "protected"
+
+[rules.config]
+targets = { tag = "role", value = "nonexistent" }
+allowed_importers = ["graph"]

--- a/xtask/tests/fixtures/architecture-policy/invalid-unknown-boundary.toml
+++ b/xtask/tests/fixtures/architecture-policy/invalid-unknown-boundary.toml
@@ -1,0 +1,12 @@
+version = 1
+
+[modules]
+graph = {}
+
+[[rules]]
+id = "bad-ref"
+type = "allow"
+
+[rules.config]
+source = "nonexistent"
+allowed = ["graph"]

--- a/xtask/tests/fixtures/architecture-policy/invalid-unknown-type.toml
+++ b/xtask/tests/fixtures/architecture-policy/invalid-unknown-type.toml
@@ -1,0 +1,12 @@
+version = 1
+
+[modules]
+graph = {}
+
+[[rules]]
+id = "bad-type"
+type = "transitive"
+
+[rules.config]
+source = "graph"
+allowed = []

--- a/xtask/tests/fixtures/architecture-policy/invalid-version.toml
+++ b/xtask/tests/fixtures/architecture-policy/invalid-version.toml
@@ -1,0 +1,4 @@
+version = 99
+
+[modules]
+graph = {}

--- a/xtask/tests/fixtures/architecture-policy/v2-minimal.toml
+++ b/xtask/tests/fixtures/architecture-policy/v2-minimal.toml
@@ -1,0 +1,15 @@
+version = 1
+
+[modules]
+errors = {}
+format = {}
+graph = {}
+render = {}
+
+[[rules]]
+id = "core-deps"
+type = "allow"
+
+[rules.config]
+source = "graph"
+allowed = ["errors", "format"]

--- a/xtask/tests/fixtures/architecture-policy/v2-tag-targeting.toml
+++ b/xtask/tests/fixtures/architecture-policy/v2-tag-targeting.toml
@@ -1,0 +1,26 @@
+version = 1
+
+[modules.engines]
+tags = { role = "runtime-facade" }
+
+[modules.render]
+tags = { role = "runtime-facade" }
+
+[modules.builtins]
+tags = { role = "runtime-facade" }
+
+[modules.runtime]
+[modules.errors]
+
+[[rules]]
+id = "protect-facades"
+type = "protected"
+[rules.config]
+targets = { tag = "role", value = "runtime-facade" }
+allowed_importers = ["runtime"]
+
+[[rules]]
+id = "facade-independence"
+type = "independence"
+[rules.config]
+members = { tag = "role", value = "runtime-facade" }

--- a/xtask/tests/fixtures/architecture-policy/v2-tags-and-exceptions.toml
+++ b/xtask/tests/fixtures/architecture-policy/v2-tags-and-exceptions.toml
@@ -1,0 +1,39 @@
+version = 1
+
+[modules.errors]
+tags = { layer = "foundation" }
+
+[modules.format]
+tags = { layer = "foundation" }
+
+[modules.graph]
+tags = { layer = "core" }
+
+[modules.render]
+tags = { layer = "output" }
+
+[modules.runtime]
+tags = { layer = "runtime" }
+
+[[rules]]
+id = "core-deps"
+type = "allow"
+
+[rules.config]
+source = "graph"
+allowed = ["errors", "format"]
+
+[[rules]]
+id = "pipeline-layers"
+type = "layers"
+
+[rules.config]
+order = ["errors", "format", "graph", "render", "runtime"]
+
+[[exceptions]]
+id = "legacy-render-graph-cycle"
+rule_id = "pipeline-layers"
+source = "render"
+target = "graph"
+reason = "historical coupling being unwound in plan 0118"
+owner = "kevin"


### PR DESCRIPTION
## Summary

- Add v2 policy model to the architecture checker with 5 contract types: `allow`, `layers`, `protected`, `independence`, and `acyclic`
- Add contract evaluation engine with tag-based targeting and exception support
- Add `graph` and `explain` subcommands for inspecting dependency edges and boundaries
- Add host reuse for graph/explain commands, trim CLAUDE.md, and add verify/test skills
- Includes comprehensive test fixtures for policy parsing and validation

## Test plan

- [x] Existing architecture CLI tests updated and passing
- [x] New policy parsing fixtures cover valid and invalid configs
- [x] Contract evaluation covers all 5 contract types
- [x] `just check` passes (lint + test + architecture)