### PR TITLE
Unify playground wasm loading in worker

### DIFF
--- a/web/src/app/bootstrap.ts
+++ b/web/src/app/bootstrap.ts
@@ -553,9 +553,17 @@ export function renderApp(
     output: previewOutput,
     error: previewError,
   });
+  const workerClient = options.renderClientFactory
+    ? options.renderClientFactory()
+    : typeof Worker === "undefined"
+      ? null
+      : createRenderWorkerClient();
   const editor = createEditorController({
     root: editorRoot,
     initialValue: stateStore.getState().input,
+    validateWithWorker: workerClient
+      ? (input) => workerClient.validate(input)
+      : undefined,
   });
   const previewControls = createPreviewControls({
     viewportRoot: previewOutput,
@@ -599,12 +607,6 @@ export function renderApp(
   });
   themeController.apply();
   updateThemeToggleButton(themeToggleButton, themeController.getPreference());
-
-  const workerClient = options.renderClientFactory
-    ? options.renderClientFactory()
-    : typeof Worker === "undefined"
-      ? null
-      : createRenderWorkerClient();
 
   const renderControlBindings: RenderControlBinding[] = [
     {

--- a/web/src/editor.ts
+++ b/web/src/editor.ts
@@ -4,7 +4,10 @@ import { EditorState } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 import { minimalSetup } from "codemirror";
 import { mermaidSyntaxHighlighting } from "./mermaid-language";
-import { wasmLintExtension } from "./wasm-diagnostics";
+import {
+  createWasmLintExtension,
+  type ValidateWithWorker,
+} from "./wasm-diagnostics";
 
 export interface EditorController {
   getValue: () => string;
@@ -15,6 +18,7 @@ export interface EditorController {
 interface CreateEditorControllerOptions {
   root: HTMLElement;
   initialValue: string;
+  validateWithWorker?: ValidateWithWorker;
 }
 
 function supportsCodeMirrorView(): boolean {
@@ -83,28 +87,34 @@ export function createEditorController(
   }
 
   try {
+    const extensions = [
+      minimalSetup,
+      keymap.of([indentWithTab]),
+      EditorView.lineWrapping,
+      indentUnit.of("  "),
+      ...mermaidSyntaxHighlighting,
+    ];
+    if (options.validateWithWorker) {
+      extensions.push(createWasmLintExtension(options.validateWithWorker));
+    }
+    extensions.push(
+      EditorView.updateListener.of((update) => {
+        if (!update.docChanged) {
+          return;
+        }
+
+        currentValue = update.state.doc.toString();
+        syncTextarea.value = currentValue;
+
+        if (!suppressEditorEvents) {
+          emit(currentValue);
+        }
+      }),
+    );
+
     const editorState = EditorState.create({
       doc: currentValue,
-      extensions: [
-        minimalSetup,
-        keymap.of([indentWithTab]),
-        EditorView.lineWrapping,
-        indentUnit.of("  "),
-        ...mermaidSyntaxHighlighting,
-        wasmLintExtension,
-        EditorView.updateListener.of((update) => {
-          if (!update.docChanged) {
-            return;
-          }
-
-          currentValue = update.state.doc.toString();
-          syncTextarea.value = currentValue;
-
-          if (!suppressEditorEvents) {
-            emit(currentValue);
-          }
-        }),
-      ],
+      extensions,
     });
 
     const view = new EditorView({

--- a/web/src/main.test.ts
+++ b/web/src/main.test.ts
@@ -27,6 +27,7 @@ describe("renderApp", () => {
             format: request.format,
             output: `${request.format}:${request.input}`,
           }),
+          validate: async () => '{"valid":true}',
           terminate: () => {},
         }),
         stateStorage: {

--- a/web/src/render-client.test.ts
+++ b/web/src/render-client.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { createRenderWorkerClient } from "./services/render-client";
+import type {
+  WorkerRequestMessage,
+  WorkerResponseMessage,
+} from "./worker-protocol";
+
+class MockWorker {
+  onmessage: ((event: MessageEvent<WorkerResponseMessage>) => void) | null = null;
+
+  postMessage(message: WorkerRequestMessage): void {
+    if (!this.onmessage) {
+      throw new Error("worker message handler was not installed");
+    }
+
+    queueMicrotask(() => {
+      if (message.type === "render") {
+        this.onmessage?.({
+          data: {
+            type: "result",
+            seq: message.seq,
+            format: message.format,
+            output: `${message.format}:${message.input}:${message.configJson}`,
+          },
+        } as MessageEvent<WorkerResponseMessage>);
+        return;
+      }
+
+      this.onmessage?.({
+        data: {
+          type: "validation",
+          seq: message.seq,
+          resultJson: '{"valid":true}',
+        },
+      } as MessageEvent<WorkerResponseMessage>);
+    });
+  }
+
+  terminate(): void {}
+}
+
+describe("createRenderWorkerClient", () => {
+  it("routes render and validation requests over the same worker", async () => {
+    const worker = new MockWorker();
+    const client = createRenderWorkerClient(worker as unknown as Worker);
+
+    const renderPromise = client.render({
+      seq: 7,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: '{"padding":2}',
+    });
+    const validatePromise = client.validate("graph TD\nA-->B");
+
+    await expect(renderPromise).resolves.toEqual({
+      seq: 7,
+      format: "svg",
+      output: 'svg:graph TD\nA-->B:{"padding":2}',
+    });
+    await expect(validatePromise).resolves.toBe('{"valid":true}');
+  });
+});

--- a/web/src/services/render-client.ts
+++ b/web/src/services/render-client.ts
@@ -17,13 +17,23 @@ export interface RenderResponse {
   output: string;
 }
 
-interface PendingRequest {
+interface PendingRenderRequest {
+  kind: "render";
   resolve: (response: RenderResponse) => void;
   reject: (error: Error) => void;
 }
 
+interface PendingValidateRequest {
+  kind: "validate";
+  resolve: (resultJson: string) => void;
+  reject: (error: Error) => void;
+}
+
+type PendingRequest = PendingRenderRequest | PendingValidateRequest;
+
 export interface RenderWorkerClient {
   render: (request: RenderRequest) => Promise<RenderResponse>;
+  validate: (input: string) => Promise<string>;
   terminate: () => void;
 }
 
@@ -41,6 +51,7 @@ export function createRenderWorkerClient(
   worker: Worker = createDefaultWorker(),
 ): RenderWorkerClient {
   const pending = new Map<number, PendingRequest>();
+  let nextValidationSeq = -1;
 
   worker.onmessage = (event: MessageEvent<WorkerResponseMessage>) => {
     const response = event.data;
@@ -52,11 +63,30 @@ export function createRenderWorkerClient(
     pending.delete(response.seq);
 
     if (response.type === "result") {
+      if (pendingRequest.kind !== "render") {
+        pendingRequest.reject(
+          new Error("worker returned render output for a validation request"),
+        );
+        return;
+      }
+
       pendingRequest.resolve({
         seq: response.seq,
         format: response.format,
         output: response.output,
       });
+      return;
+    }
+
+    if (response.type === "validation") {
+      if (pendingRequest.kind !== "validate") {
+        pendingRequest.reject(
+          new Error("worker returned validation output for a render request"),
+        );
+        return;
+      }
+
+      pendingRequest.resolve(response.resultJson);
       return;
     }
 
@@ -76,7 +106,7 @@ export function createRenderWorkerClient(
           configJson: request.configJson ?? "{}",
         };
 
-        pending.set(currentSeq, { resolve, reject });
+        pending.set(currentSeq, { kind: "render", resolve, reject });
 
         try {
           worker.postMessage(message);
@@ -84,6 +114,29 @@ export function createRenderWorkerClient(
           pending.delete(currentSeq);
           reject(
             new Error(`failed to post render request: ${toMessage(error)}`),
+          );
+        }
+      });
+    },
+    validate: (input) => {
+      const seq = nextValidationSeq;
+      nextValidationSeq -= 1;
+
+      return new Promise<string>((resolve, reject) => {
+        const message: WorkerRequestMessage = {
+          type: "validate",
+          seq,
+          input,
+        };
+
+        pending.set(seq, { kind: "validate", resolve, reject });
+
+        try {
+          worker.postMessage(message);
+        } catch (error) {
+          pending.delete(seq);
+          reject(
+            new Error(`failed to post validation request: ${toMessage(error)}`),
           );
         }
       });

--- a/web/src/wasm-diagnostics.ts
+++ b/web/src/wasm-diagnostics.ts
@@ -122,42 +122,25 @@ export function normalizeValidateResultToDiagnostics(
   );
 }
 
-interface WasmModule {
-  default: () => Promise<void>;
-  validate: (input: string) => string;
-}
+export type ValidateWithWorker = (input: string) => Promise<string>;
 
-let wasmPromise: Promise<WasmModule> | null = null;
-
-async function loadWasm(): Promise<WasmModule> {
-  if (!wasmPromise) {
-    wasmPromise = import("./wasm-pkg/mmdflux_wasm.js")
-      .then(async (module) => {
-        const wasm = module as unknown as WasmModule;
-        await wasm.default();
-        return wasm;
-      })
-      .catch((error: unknown) => {
-        wasmPromise = null;
-        throw error;
-      });
-  }
-  return wasmPromise;
-}
-
-export async function lintWithWasm(
+export async function lintWithWorker(
   input: string,
+  validateWithWorker: ValidateWithWorker,
 ): Promise<readonly Diagnostic[]> {
   if (input.trim().length === 0) {
     return [];
   }
 
-  const wasm = await loadWasm();
-  const resultJson = wasm.validate(input);
+  const resultJson = await validateWithWorker(input);
   return normalizeValidateResultToDiagnostics(input, resultJson);
 }
 
-export const wasmLintExtension: Extension = linter(
-  async (view) => lintWithWasm(view.state.doc.toString()),
-  { delay: 350 },
-);
+export function createWasmLintExtension(
+  validateWithWorker: ValidateWithWorker,
+): Extension {
+  return linter(
+    async (view) => lintWithWorker(view.state.doc.toString(), validateWithWorker),
+    { delay: 350 },
+  );
+}

--- a/web/src/worker-protocol.ts
+++ b/web/src/worker-protocol.ts
@@ -1,12 +1,22 @@
 export type WorkerOutputFormat = "text" | "ascii" | "svg" | "mmds" | "mermaid";
 
-export interface WorkerRequestMessage {
+export interface WorkerRenderRequestMessage {
   type: "render";
   seq: number;
   input: string;
   format: WorkerOutputFormat;
   configJson: string;
 }
+
+export interface WorkerValidateRequestMessage {
+  type: "validate";
+  seq: number;
+  input: string;
+}
+
+export type WorkerRequestMessage =
+  | WorkerRenderRequestMessage
+  | WorkerValidateRequestMessage;
 
 export interface WorkerResultMessage {
   type: "result";
@@ -15,10 +25,19 @@ export interface WorkerResultMessage {
   output: string;
 }
 
+export interface WorkerValidationMessage {
+  type: "validation";
+  seq: number;
+  resultJson: string;
+}
+
 export interface WorkerErrorMessage {
   type: "error";
   seq: number;
   error: string;
 }
 
-export type WorkerResponseMessage = WorkerResultMessage | WorkerErrorMessage;
+export type WorkerResponseMessage =
+  | WorkerResultMessage
+  | WorkerValidationMessage
+  | WorkerErrorMessage;

--- a/web/src/worker.test.ts
+++ b/web/src/worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createRenderRequestHandler } from "./worker";
+import { createWorkerRequestHandler } from "./worker";
 import type {
   WorkerRequestMessage,
   WorkerResponseMessage,
@@ -8,9 +8,10 @@ import type {
 interface MockWasmModule {
   default: () => Promise<void>;
   render: (input: string, format: string, configJson: string) => string;
+  validate: (input: string) => string;
 }
 
-describe("createRenderRequestHandler", () => {
+describe("createWorkerRequestHandler", () => {
   it("initializes worker once and returns render results", async () => {
     const initialize = vi.fn(async () => {});
     const render = vi.fn(
@@ -18,15 +19,17 @@ describe("createRenderRequestHandler", () => {
         return `${format}:${input}:${configJson}`;
       },
     );
+    const validate = vi.fn((input: string) => `{"valid":true,"input":"${input}"}`);
     const loadWasmModule = vi.fn(
       async (): Promise<MockWasmModule> => ({
         default: initialize,
         render,
+        validate,
       }),
     );
 
     const responses: WorkerResponseMessage[] = [];
-    const handler = createRenderRequestHandler({
+    const handler = createWorkerRequestHandler({
       loadWasmModule,
       postMessage: (message) => responses.push(message),
     });
@@ -52,6 +55,7 @@ describe("createRenderRequestHandler", () => {
     expect(loadWasmModule).toHaveBeenCalledTimes(1);
     expect(initialize).toHaveBeenCalledTimes(1);
     expect(render).toHaveBeenCalledTimes(2);
+    expect(validate).not.toHaveBeenCalled();
     expect(responses).toEqual([
       {
         type: "result",
@@ -75,11 +79,12 @@ describe("createRenderRequestHandler", () => {
         render: () => {
           throw new Error("unknown output format: bad");
         },
+        validate: () => '{"valid":true}',
       }),
     );
 
     const responses: WorkerResponseMessage[] = [];
-    const handler = createRenderRequestHandler({
+    const handler = createWorkerRequestHandler({
       loadWasmModule,
       postMessage: (message) => responses.push(message),
     });
@@ -100,5 +105,46 @@ describe("createRenderRequestHandler", () => {
       seq: 42,
       error: "unknown output format: bad",
     });
+  });
+
+  it("returns validation results without reinitializing wasm", async () => {
+    const initialize = vi.fn(async () => {});
+    const loadWasmModule = vi.fn(
+      async (): Promise<MockWasmModule> => ({
+        default: initialize,
+        render: () => "unused",
+        validate: (input) =>
+          JSON.stringify({
+            valid: input.includes("A-->B"),
+            diagnostics: input.includes("A-->B")
+              ? []
+              : [{ message: "expected edge" }],
+          }),
+      }),
+    );
+
+    const responses: WorkerResponseMessage[] = [];
+    const handler = createWorkerRequestHandler({
+      loadWasmModule,
+      postMessage: (message) => responses.push(message),
+    });
+
+    const request: WorkerRequestMessage = {
+      type: "validate",
+      seq: -1,
+      input: "graph TD\nA-->B",
+    };
+
+    await handler(request);
+
+    expect(loadWasmModule).toHaveBeenCalledTimes(1);
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(responses).toEqual([
+      {
+        type: "validation",
+        seq: -1,
+        resultJson: '{"valid":true,"diagnostics":[]}',
+      },
+    ]);
   });
 });

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -11,6 +11,7 @@ export type {
 interface WasmModule {
   default: () => Promise<void>;
   render: (input: string, format: string, configJson: string) => string;
+  validate: (input: string) => string;
 }
 
 interface RenderRequestHandlerOptions {
@@ -22,7 +23,7 @@ export async function loadWasmModule(): Promise<WasmModule> {
   return (await import("./wasm-pkg/mmdflux_wasm.js")) as unknown as WasmModule;
 }
 
-export function createRenderRequestHandler(
+export function createWorkerRequestHandler(
   options: RenderRequestHandlerOptions,
 ): (message: WorkerRequestMessage) => Promise<void> {
   const loadModule = options.loadWasmModule ?? loadWasmModule;
@@ -41,23 +42,29 @@ export function createRenderRequestHandler(
   };
 
   return async (message: WorkerRequestMessage): Promise<void> => {
-    if (message.type !== "render") {
-      return;
-    }
-
     try {
       const wasmModule = await getWasmModule();
-      const output = wasmModule.render(
-        message.input,
-        message.format,
-        message.configJson,
-      );
+      if (message.type === "render") {
+        const output = wasmModule.render(
+          message.input,
+          message.format,
+          message.configJson,
+        );
 
+        postMessage({
+          type: "result",
+          seq: message.seq,
+          format: message.format,
+          output,
+        });
+        return;
+      }
+
+      const resultJson = wasmModule.validate(message.input);
       postMessage({
-        type: "result",
+        type: "validation",
         seq: message.seq,
-        format: message.format,
-        output,
+        resultJson,
       });
     } catch (error) {
       postMessage({
@@ -105,7 +112,7 @@ function getWorkerScope(scope: unknown): WorkerScope | null {
 
 const workerScope = getWorkerScope(globalThis);
 if (workerScope) {
-  const handler = createRenderRequestHandler({
+  const handler = createWorkerRequestHandler({
     postMessage: (message) => {
       workerScope.postMessage(message);
     },

--- a/web/tests/examples.test.ts
+++ b/web/tests/examples.test.ts
@@ -10,6 +10,7 @@ function createFakeRenderClient() {
   }));
   return {
     render,
+    validate: vi.fn(async () => '{"valid":true}'),
     terminate: vi.fn(),
   } satisfies RenderWorkerClient;
 }

--- a/web/tests/state-persistence.test.ts
+++ b/web/tests/state-persistence.test.ts
@@ -27,6 +27,7 @@ function createFakeRenderClient() {
       format: request.format,
       output: `${request.format}:${request.input}`,
     })),
+    validate: vi.fn(async () => '{"valid":true}'),
     terminate: vi.fn(),
   } satisfies RenderWorkerClient;
 }
@@ -245,6 +246,7 @@ describe("playground state persistence", () => {
             ? "\u001b[38;2;255;0;0mAlpha\u001b[0m"
             : `${request.format}:${request.input}`,
       })),
+      validate: vi.fn(async () => '{"valid":true}'),
       terminate: vi.fn(),
     } satisfies RenderWorkerClient;
 

--- a/web/tests/ui-controls.test.ts
+++ b/web/tests/ui-controls.test.ts
@@ -16,6 +16,7 @@ function createFakeRenderClient() {
 
   return {
     render,
+    validate: vi.fn(async () => '{"valid":true}'),
     terminate: vi.fn(),
   } satisfies RenderWorkerClient;
 }
@@ -135,6 +136,7 @@ describe("format-aware controls", () => {
             ? "\u001b[38;2;255;0;0mAlpha\u001b[0m"
             : `${request.format}:${request.input}`,
       })),
+      validate: vi.fn(async () => '{"valid":true}'),
       terminate: vi.fn(),
     } satisfies RenderWorkerClient;
 


### PR DESCRIPTION
## Summary
- route playground validation through the existing render worker so the worker owns the single wasm runtime
- extend the worker protocol/client to support validation requests alongside render requests
- remove direct main-thread wasm loading from the editor diagnostics path and update tests for the shared worker flow

## Verification
- `npm run test` in `web/`
- `npm run build:release` in `web/`