### PR TITLE
fix: center SVG edge labels using arc-length midpoint of rendered path

### DIFF
--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -10,54 +10,10 @@ use crate::graph::measure::ProportionalTextMetrics;
 use crate::graph::routing::compute_end_label_positions;
 use crate::graph::{Graph, Stroke};
 
-const LABEL_ANCHOR_REVALIDATION_MAX_DISTANCE: f64 = 2.0;
 const LABEL_POINT_EPS: f64 = 0.000_001;
-
-fn revalidate_svg_label_anchor(candidate: Point, rendered_path: Option<&[Point]>) -> Point {
-    let Some(path) = rendered_path else {
-        return candidate;
-    };
-    if path.is_empty() {
-        return candidate;
-    }
-
-    let drift = distance_point_to_svg_path(candidate, path);
-    if drift <= LABEL_ANCHOR_REVALIDATION_MAX_DISTANCE {
-        return candidate;
-    }
-    svg_path_midpoint(path).unwrap_or(candidate)
-}
 
 fn point_distance_svg(a: Point, b: Point) -> f64 {
     ((a.x - b.x).powi(2) + (a.y - b.y).powi(2)).sqrt()
-}
-
-fn distance_point_to_svg_segment(point: Point, a: Point, b: Point) -> f64 {
-    let dx = b.x - a.x;
-    let dy = b.y - a.y;
-    let seg_len_sq = dx * dx + dy * dy;
-    if seg_len_sq <= LABEL_POINT_EPS {
-        return point_distance_svg(point, a);
-    }
-    let projection = ((point.x - a.x) * dx + (point.y - a.y) * dy) / seg_len_sq;
-    let t = projection.clamp(0.0, 1.0);
-    let closest = Point {
-        x: a.x + t * dx,
-        y: a.y + t * dy,
-    };
-    point_distance_svg(point, closest)
-}
-
-fn distance_point_to_svg_path(point: Point, path: &[Point]) -> f64 {
-    if path.is_empty() {
-        return f64::INFINITY;
-    }
-    if path.len() == 1 {
-        return point_distance_svg(point, path[0]);
-    }
-    path.windows(2)
-        .map(|segment| distance_point_to_svg_segment(point, segment[0], segment[1]))
-        .fold(f64::INFINITY, f64::min)
 }
 
 fn svg_path_midpoint(path: &[Point]) -> Option<Point> {
@@ -132,22 +88,24 @@ pub(super) fn render_edge_labels(
         } else {
             false
         };
-        let use_precomputed =
-            edge.from_subgraph.is_none() && edge.to_subgraph.is_none() && !cross_boundary;
-        let position = if use_precomputed {
-            label_positions.get(&edge_idx).copied()
-        } else {
-            None
-        }
-        .or_else(|| fallback_label_position(geom, edge_idx, self_edge_paths, rendered_edge_paths))
-        .map(|candidate| {
-            revalidate_svg_label_anchor(
-                candidate,
-                rendered_edge_paths
-                    .get(&edge_idx)
-                    .map(|path| path.as_slice()),
-            )
-        });
+        // Prefer the arc-length midpoint of the rendered path when available,
+        // since the layout engine's precomputed label position may not correspond
+        // to the visual midpoint of the final edge path.
+        let position = rendered_edge_paths
+            .get(&edge_idx)
+            .and_then(|path| svg_path_midpoint(path))
+            .or_else(|| {
+                let use_precomputed =
+                    edge.from_subgraph.is_none() && edge.to_subgraph.is_none() && !cross_boundary;
+                if use_precomputed {
+                    label_positions.get(&edge_idx).copied()
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                fallback_label_position(geom, edge_idx, self_edge_paths, rendered_edge_paths)
+            });
         let Some(point) = position else {
             continue;
         };
@@ -243,29 +201,7 @@ pub(super) fn precomputed_label_positions(geom: &GraphGeometry) -> HashMap<usize
 
 #[cfg(test)]
 mod tests {
-    use super::{Point, revalidate_svg_label_anchor, svg_path_midpoint};
-
-    #[test]
-    fn revalidate_svg_label_anchor_keeps_nearby_anchor() {
-        let candidate = Point { x: 5.0, y: 1.0 };
-        let path = [Point { x: 0.0, y: 0.0 }, Point { x: 10.0, y: 0.0 }];
-
-        assert_eq!(
-            revalidate_svg_label_anchor(candidate, Some(&path)),
-            candidate
-        );
-    }
-
-    #[test]
-    fn revalidate_svg_label_anchor_falls_back_to_path_midpoint_when_drifted() {
-        let candidate = Point { x: 50.0, y: 25.0 };
-        let path = [Point { x: 0.0, y: 0.0 }, Point { x: 10.0, y: 0.0 }];
-
-        assert_eq!(
-            revalidate_svg_label_anchor(candidate, Some(&path)),
-            Point { x: 5.0, y: 0.0 }
-        );
-    }
+    use super::{Point, svg_path_midpoint};
 
     #[test]
     fn svg_path_midpoint_handles_multi_segment_paths_by_distance() {

--- a/tests/svg-snapshots/class/all_relations.svg
+++ b/tests/svg-snapshots/class/all_relations.svg
@@ -60,13 +60,13 @@
       <path d="M757.95,62.00 L757.95,212.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="42.45" y="124.50" text-anchor="middle" dominant-baseline="middle" fill="#333">association</text>
-      <text x="161.36" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">directed</text>
-      <text x="280.27" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">inheritance</text>
-      <text x="399.18" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">composition</text>
-      <text x="518.09" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">aggregation</text>
+      <text x="42.45" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">association</text>
+      <text x="161.36" y="137.00" text-anchor="middle" dominant-baseline="middle" fill="#333">directed</text>
+      <text x="280.27" y="141.00" text-anchor="middle" dominant-baseline="middle" fill="#333">inheritance</text>
+      <text x="399.18" y="141.50" text-anchor="middle" dominant-baseline="middle" fill="#333">composition</text>
+      <text x="518.09" y="141.50" text-anchor="middle" dominant-baseline="middle" fill="#333">aggregation</text>
       <text x="637.00" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">dependency</text>
-      <text x="757.95" y="153.50" text-anchor="middle" dominant-baseline="middle" fill="#333">directed dep</text>
+      <text x="757.95" y="137.00" text-anchor="middle" dominant-baseline="middle" fill="#333">directed dep</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/class/cardinality_labels.svg
+++ b/tests/svg-snapshots/class/cardinality_labels.svg
@@ -35,8 +35,8 @@
       <path d="M222.43,62.00 L222.43,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="66.12" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">owns</text>
-      <text x="222.43" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">contains</text>
+      <text x="66.12" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">owns</text>
+      <text x="222.43" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">contains</text>
       <text x="84.12" y="149.12" text-anchor="middle" dominant-baseline="middle" fill="#333">*</text>
       <text x="84.12" y="73.88" text-anchor="middle" dominant-baseline="middle" fill="#333">1</text>
       <text x="240.43" y="149.12" text-anchor="middle" dominant-baseline="middle" fill="#333">*</text>

--- a/tests/svg-snapshots/class/class_labels.svg
+++ b/tests/svg-snapshots/class/class_labels.svg
@@ -30,7 +30,7 @@
       <path d="M98.23,62.00 L98.23,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="98.23" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reads</text>
+      <text x="98.23" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">reads</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/class/members.svg
+++ b/tests/svg-snapshots/class/members.svg
@@ -40,7 +40,7 @@
       <path d="M87.83,206.00 L87.83,301.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="87.83" y="243.00" text-anchor="middle" dominant-baseline="middle" fill="#333">creates</text>
+      <text x="87.83" y="253.50" text-anchor="middle" dominant-baseline="middle" fill="#333">creates</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/class/relationships.svg
+++ b/tests/svg-snapshots/class/relationships.svg
@@ -36,9 +36,9 @@
       <path d="M65.47,62.00 L65.47,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="65.47" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">places</text>
-      <text x="65.47" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">contains</text>
-      <text x="65.47" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">authenticates</text>
+      <text x="65.47" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">places</text>
+      <text x="65.47" y="420.00" text-anchor="middle" dominant-baseline="middle" fill="#333">contains</text>
+      <text x="65.47" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">authenticates</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-basis/backward_loop_lr.svg
@@ -51,7 +51,7 @@
     </g>
     <g class="edgeLabels">
       <text x="1127.13" y="157.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <text x="1398.63" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-basis/br_line_breaks.svg
@@ -37,8 +37,8 @@
       <path d="M61.85,214.00 L61.85,222.00 L61.85,228.83 C61.85,235.67 61.85,249.33 61.85,266.50 C61.85,283.67 61.85,304.33 61.85,314.67 L61.85,325.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="61.85" y="261.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="61.85" y="285.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-basis/compat_class_annotation.svg
@@ -37,7 +37,7 @@
     </g>
     <g class="edgeLabels">
       <text x="45.64" y="258.82" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="158.18" y="258.82" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-basis/compat_directive.svg
@@ -37,7 +37,7 @@
     </g>
     <g class="edgeLabels">
       <text x="73.75" y="255.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="211.55" y="255.19" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-basis/compat_hyphenated_ids.svg
@@ -36,7 +36,7 @@
       <path d="M75.49,313.06 L75.49,321.06 L75.49,325.89 C75.49,330.73 75.49,340.39 75.49,353.56 C75.49,366.73 75.49,383.39 75.49,391.73 L75.49,400.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
+      <text x="75.49" y="360.56" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-basis/compat_kitchen_sink.svg
@@ -41,7 +41,7 @@
     </g>
     <g class="edgeLabels">
       <text x="83.50" y="284.12" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="232.04" y="284.12" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/complex.svg
+++ b/tests/svg-snapshots/flowchart-basis/complex.svg
@@ -54,10 +54,10 @@
       <path d="M182.38,620.28 L182.38,623.06 C182.38,625.84 182.38,631.39 190.27,636.95 C198.15,642.51 213.93,648.06 221.81,652.95 C229.70,657.84 229.70,662.06 229.70,664.17 L229.70,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="386.37" y="230.92" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <text x="179.63" y="239.70" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="461.94" y="578.28" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="541.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="399.81" y="614.05" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-basis/crossing_minimize.svg
@@ -54,10 +54,10 @@
       <path d="M461.94,541.28 L461.94,549.28 L461.94,554.12 C461.94,558.95 461.94,568.62 437.04,587.79 C412.14,606.95 362.34,635.63 337.44,649.96 L312.54,664.30 L305.61,668.29" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="386.37" y="230.92" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <text x="179.63" y="239.70" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="461.94" y="578.28" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="541.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="399.81" y="614.05" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-basis/flowchart_code_flow.svg
@@ -451,13 +451,13 @@
       <path d="M10995.46,1460.19 L10995.46,1469.02 C10995.46,1477.85 10995.46,1495.52 11014.50,1513.19 C11033.55,1530.85 11071.64,1548.52 11090.68,1565.52 C11109.73,1582.52 11109.73,1598.85 11109.73,1607.02 L11109.73,1615.19" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
-      <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
-      <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
-      <text x="9480.10" y="730.45" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="9480.10" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <text x="9746.00" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <text x="10011.91" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <text x="9553.28" y="769.45" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="9746.00" y="744.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="9961.70" y="761.76" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
+      <text x="439.32" y="1657.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-basis/git_workflow.svg
@@ -37,9 +37,9 @@
       <path d="M924.69,62.00 L924.69,70.00 L924.69,71.00 C924.69,72.00 924.69,74.00 784.05,75.00 C643.42,76.00 362.15,76.00 221.51,75.67 C80.87,75.33 80.87,74.67 80.87,74.33 L80.87,74.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="203.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="487.26" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="776.03" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
       <text x="504.78" y="76.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-basis/git_workflow_td.svg
@@ -37,10 +37,10 @@
       <path d="M164.51,469.00 L172.51,469.00 L172.85,469.00 C173.18,469.00 173.85,469.00 174.18,396.67 C174.51,324.33 174.51,179.67 173.95,107.33 C173.38,35.00 172.26,35.00 171.69,35.00 L171.13,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <text x="172.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <text x="86.26" y="97.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="86.26" y="237.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="86.26" y="390.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="174.51" y="251.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/http_request.svg
+++ b/tests/svg-snapshots/flowchart-basis/http_request.svg
@@ -44,10 +44,10 @@
       <path d="M352.16,632.20 L360.16,632.20 L373.04,632.20 C385.93,632.20 411.71,632.20 424.60,532.67 C437.49,433.14 437.49,234.07 419.39,134.53 C401.29,35.00 365.09,35.00 346.99,35.00 L328.89,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <text x="266.29" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
       <text x="145.87" y="431.53" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <text x="437.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <text x="324.26" y="444.95" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="437.49" y="317.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-basis/inline_edge_labels.svg
@@ -39,10 +39,10 @@
       <path d="M57.58,521.00 L57.58,529.00 L57.58,533.83 C57.58,538.67 57.58,548.33 57.58,561.50 C57.58,574.67 57.58,591.33 57.58,599.67 L57.58,608.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
-      <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="57.58" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="57.58" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="57.58" y="415.50" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <text x="57.58" y="568.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-basis/inline_label_flowchart.svg
@@ -92,14 +92,14 @@
     </g>
     <g class="edgeLabels">
       <text x="344.18" y="608.88" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="599.47" y="621.27" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="484.81" y="881.16" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
-      <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <text x="713.66" y="892.17" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <text x="643.00" y="1563.74" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <text x="563.45" y="1560.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="89.60" y="417.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <text x="89.60" y="437.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <text x="295.33" y="465.89" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
-      <text x="748.85" y="1346.59" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
+      <text x="748.85" y="1388.56" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-basis/label_spacing.svg
@@ -34,7 +34,7 @@
     </g>
     <g class="edgeLabels">
       <text x="42.45" y="102.75" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="161.36" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="161.36" y="102.75" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-basis/labeled_edges.svg
@@ -40,11 +40,11 @@
       <path d="M327.04,512.80 L335.04,512.80 L335.37,512.80 C335.70,512.80 336.37,512.80 336.70,458.67 C337.04,404.53 337.04,296.27 309.29,242.13 C281.55,188.00 226.07,188.00 198.33,188.00 L170.58,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
-      <text x="87.44" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <text x="108.35" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <text x="88.36" y="249.18" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
       <text x="66.77" y="428.90" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="177.44" y="416.07" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="335.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="337.04" y="268.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-basis/self_loop_labeled.svg
@@ -34,8 +34,8 @@
       <path d="M58.20,212.40 L58.20,220.40 L58.20,225.23 C58.20,230.07 58.20,239.73 58.20,252.90 C58.20,266.07 58.20,282.73 58.20,291.07 L58.20,299.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
+      <text x="143.90" y="160.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="58.20" y="259.90" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/backward_loop_lr.svg
@@ -51,7 +51,7 @@
     </g>
     <g class="edgeLabels">
       <text x="1127.13" y="190.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <text x="1398.63" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/br_line_breaks.svg
@@ -37,8 +37,8 @@
       <path d="M61.85,214.00 L61.85,255.00 L61.85,258.42 C61.85,261.83 61.85,268.67 61.85,275.50 C61.85,282.33 61.85,289.17 61.85,292.58 L61.85,296.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="61.85" y="261.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="61.85" y="285.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compat_class_annotation.svg
@@ -36,8 +36,8 @@
       <path d="M133.16,195.63 L137.86,195.63 C142.56,195.63 151.96,195.63 156.66,216.67 C161.36,237.71 161.36,279.79 161.36,300.84 L161.36,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="42.45" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="42.45" y="244.65" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="161.36" y="244.65" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compat_directive.svg
@@ -36,8 +36,8 @@
       <path d="M177.32,192.21 L184.19,192.21 C191.06,192.21 204.79,192.21 211.66,213.82 C218.53,235.43 218.53,278.65 218.53,300.26 L218.53,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="66.77" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="66.77" y="236.44" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="218.53" y="236.44" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compat_hyphenated_ids.svg
@@ -36,7 +36,7 @@
       <path d="M75.49,313.06 L75.49,346.06 L75.49,348.81 C75.49,351.56 75.49,357.06 75.49,362.56 C75.49,368.06 75.49,373.56 75.49,376.31 L75.49,379.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
+      <text x="75.49" y="360.56" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compat_kitchen_sink.svg
@@ -40,8 +40,8 @@
       <path d="M218.83,411.06 L218.83,413.84 C218.83,416.61 218.83,422.17 215.20,427.17 C211.57,432.17 204.30,436.61 200.67,441.50 C197.04,446.39 197.04,451.72 197.04,454.39 L197.04,457.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.31" y="280.56" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="75.31" y="264.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="240.24" y="264.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/complex.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/complex.svg
@@ -54,10 +54,10 @@
       <path d="M182.38,620.28 L182.38,623.06 C182.38,625.84 182.38,631.39 186.99,636.39 C191.60,641.39 200.83,645.84 205.44,650.73 C210.05,655.62 210.05,660.95 210.05,663.62 L210.05,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="432.80" y="178.99" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="156.83" y="210.07" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="543.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="300.45" y="523.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/crossing_minimize.svg
@@ -54,10 +54,10 @@
       <path d="M417.10,496.44 L397.66,496.44 C378.22,496.44 339.33,496.44 319.89,524.75 C300.45,553.05 300.45,609.67 300.45,637.98 L300.45,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="432.80" y="178.99" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="156.83" y="210.07" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="543.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="300.45" y="523.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/decision.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/decision.svg
@@ -37,7 +37,7 @@
       <path d="M277.44,403.36 L289.44,403.36 L289.44,372.66 C289.44,341.97 289.44,280.57 289.44,219.18 C289.44,157.79 289.44,96.39 289.44,65.70 L289.44,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="73.13" y="299.86" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="73.13" y="315.77" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="204.71" y="267.85" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/flowchart_code_flow.svg
@@ -451,13 +451,13 @@
       <path d="M11070.44,1460.19 L11070.44,1469.02 C11070.44,1477.85 11070.44,1495.52 11076.99,1513.19 C11083.54,1530.85 11096.63,1548.52 11103.18,1565.52 C11109.73,1582.52 11109.73,1598.85 11109.73,1607.02 L11109.73,1615.19" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
-      <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
-      <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <text x="9480.10" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <text x="9746.00" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <text x="10011.91" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
       <text x="9659.23" y="665.89" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="9746.00" y="744.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="9832.78" y="641.67" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
+      <text x="439.32" y="1657.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/git_workflow.svg
@@ -37,9 +37,9 @@
       <path d="M924.69,62.00 L924.69,86.00 L854.37,86.00 C784.05,86.00 643.42,86.00 502.78,86.00 C362.15,86.00 221.51,86.00 151.19,86.00 L80.87,86.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="203.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="487.26" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="776.03" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
       <text x="504.78" y="86.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/git_workflow_td.svg
@@ -37,9 +37,9 @@
       <path d="M164.51,469.00 L183.13,469.00 L183.13,432.83 C183.13,396.67 183.13,324.33 183.13,252.00 C183.13,179.67 183.13,107.33 183.13,71.17 L183.13,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="86.26" y="97.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="86.26" y="237.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="86.26" y="390.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
       <text x="183.13" y="251.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/http_request.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/http_request.svg
@@ -44,10 +44,10 @@
       <path d="M352.16,632.20 L441.49,632.20 L441.49,582.44 C441.49,532.67 441.49,433.14 441.49,333.60 C441.49,234.07 441.49,134.53 441.49,84.77 L441.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
-      <text x="99.80" y="449.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <text x="441.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <text x="266.29" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <text x="99.80" y="378.96" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="335.55" y="427.58" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="441.49" y="317.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/inline_edge_labels.svg
@@ -39,10 +39,10 @@
       <path d="M57.58,521.00 L57.58,554.00 L57.58,556.75 C57.58,559.50 57.58,565.00 57.58,570.50 C57.58,576.00 57.58,581.50 57.58,584.25 L57.58,587.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
-      <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="57.58" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="57.58" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="57.58" y="415.50" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <text x="57.58" y="568.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/inline_label_flowchart.svg
@@ -91,10 +91,10 @@
       <path d="M412.63,1819.26 L412.63,1822.04 C412.63,1824.81 412.63,1830.37 412.63,1835.37 C412.63,1840.37 412.63,1844.81 412.63,1849.70 C412.63,1854.59 412.63,1859.92 412.63,1862.59 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="268.80" y="624.57" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="455.10" y="891.09" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
-      <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <text x="295.06" y="551.07" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="620.23" y="588.61" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="455.10" y="833.52" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <text x="723.91" y="864.25" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <text x="677.73" y="1542.99" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <text x="545.84" y="1526.71" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="52.80" y="437.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>

--- a/tests/svg-snapshots/flowchart-curved-step/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/labeled_edges.svg
@@ -40,11 +40,11 @@
       <path d="M327.04,512.80 L339.04,512.80 L339.04,485.73 C339.04,458.67 339.04,404.53 339.04,350.40 C339.04,296.27 339.04,242.13 339.04,215.07 L339.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <text x="108.35" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
       <text x="93.49" y="250.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
-      <text x="66.77" y="409.30" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="65.97" y="423.17" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="231.58" y="362.23" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="339.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="339.04" y="268.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/self_loop_labeled.svg
@@ -34,8 +34,8 @@
       <path d="M58.20,212.40 L58.20,245.40 L58.20,248.15 C58.20,250.90 58.20,256.40 58.20,261.90 C58.20,267.40 58.20,272.90 58.20,275.65 L58.20,278.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
+      <text x="143.90" y="160.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="58.20" y="259.90" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-polyline/backward_loop_lr.svg
@@ -51,7 +51,7 @@
     </g>
     <g class="edgeLabels">
       <text x="1127.13" y="157.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <text x="1398.63" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-polyline/br_line_breaks.svg
@@ -37,8 +37,8 @@
       <path d="M61.85,214.00 L61.85,263.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="61.85" y="261.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="61.85" y="285.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compat_class_annotation.svg
@@ -37,7 +37,7 @@
     </g>
     <g class="edgeLabels">
       <text x="45.64" y="258.82" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="158.18" y="258.82" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compat_directive.svg
@@ -37,7 +37,7 @@
     </g>
     <g class="edgeLabels">
       <text x="73.75" y="255.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="211.55" y="255.19" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compat_hyphenated_ids.svg
@@ -36,7 +36,7 @@
       <path d="M75.49,313.06 L75.49,350.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
+      <text x="75.49" y="360.56" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compat_kitchen_sink.svg
@@ -41,7 +41,7 @@
     </g>
     <g class="edgeLabels">
       <text x="83.50" y="284.12" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="232.04" y="284.12" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/complex.svg
+++ b/tests/svg-snapshots/flowchart-polyline/complex.svg
@@ -54,10 +54,10 @@
       <path d="M182.38,620.28 L226.95,667.38" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="386.37" y="230.92" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <text x="179.63" y="239.70" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="461.94" y="578.28" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="541.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="399.81" y="614.05" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-polyline/crossing_minimize.svg
@@ -54,10 +54,10 @@
       <path d="M461.94,541.28 L461.94,578.28 L305.61,668.29" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="386.37" y="230.92" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <text x="179.63" y="239.70" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="461.94" y="578.28" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="541.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="399.81" y="614.05" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-polyline/flowchart_code_flow.svg
@@ -451,13 +451,13 @@
       <path d="M10995.46,1460.19 L11107.39,1615.94" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
-      <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
-      <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
-      <text x="9480.10" y="730.45" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="9480.10" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <text x="9746.00" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <text x="10011.91" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <text x="9553.28" y="769.45" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="9746.00" y="744.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="9961.70" y="761.76" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
+      <text x="439.32" y="1657.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-polyline/git_workflow.svg
@@ -37,9 +37,9 @@
       <path d="M924.69,62.00 L924.69,76.00 L80.87,76.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="203.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="487.26" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="776.03" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
       <text x="504.78" y="76.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-polyline/git_workflow_td.svg
@@ -37,10 +37,10 @@
       <path d="M164.51,469.00 L174.51,469.00 L174.51,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <text x="172.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <text x="86.26" y="97.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="86.26" y="237.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="86.26" y="390.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="174.51" y="251.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/http_request.svg
+++ b/tests/svg-snapshots/flowchart-polyline/http_request.svg
@@ -44,10 +44,10 @@
       <path d="M352.16,632.20 L437.49,632.20 L437.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <text x="266.29" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
       <text x="145.87" y="431.53" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <text x="437.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <text x="324.26" y="444.95" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="437.49" y="317.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-polyline/inline_edge_labels.svg
@@ -39,10 +39,10 @@
       <path d="M57.58,521.00 L57.58,558.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
-      <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="57.58" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="57.58" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="57.58" y="415.50" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <text x="57.58" y="568.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-polyline/inline_label_flowchart.svg
@@ -92,14 +92,14 @@
     </g>
     <g class="edgeLabels">
       <text x="344.18" y="608.88" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="599.47" y="621.27" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="484.81" y="881.16" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
-      <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <text x="713.66" y="892.17" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <text x="643.00" y="1563.74" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <text x="563.45" y="1560.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="89.60" y="417.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <text x="89.60" y="437.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <text x="295.33" y="465.89" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
-      <text x="748.85" y="1346.59" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
+      <text x="748.85" y="1388.56" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-polyline/label_spacing.svg
@@ -34,7 +34,7 @@
     </g>
     <g class="edgeLabels">
       <text x="42.45" y="102.75" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="161.36" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="161.36" y="102.75" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-polyline/labeled_edges.svg
@@ -40,11 +40,11 @@
       <path d="M327.04,512.80 L337.04,512.80 L337.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
-      <text x="87.44" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <text x="108.35" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <text x="88.36" y="249.18" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
       <text x="66.77" y="428.90" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="177.44" y="416.07" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="335.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="337.04" y="268.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-polyline/self_loop_labeled.svg
@@ -34,8 +34,8 @@
       <path d="M58.20,212.40 L58.20,249.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
+      <text x="143.90" y="160.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="58.20" y="259.90" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/backward_loop_lr.svg
@@ -51,7 +51,7 @@
     </g>
     <g class="edgeLabels">
       <text x="1127.13" y="182.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <text x="1398.63" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/br_line_breaks.svg
@@ -37,8 +37,8 @@
       <path d="M61.85,214.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="61.85" y="261.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="61.85" y="285.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compat_class_annotation.svg
@@ -36,8 +36,8 @@
       <path d="M133.16,195.63 L156.36,195.63 Q161.36,195.63 161.36,200.63 L161.36,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="42.45" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="42.45" y="244.65" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="161.36" y="244.65" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compat_directive.svg
@@ -36,8 +36,8 @@
       <path d="M177.32,192.21 L213.53,192.21 Q218.53,192.21 218.53,197.21 L218.53,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="66.77" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="66.77" y="236.44" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="218.53" y="236.44" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compat_hyphenated_ids.svg
@@ -36,7 +36,7 @@
       <path d="M75.49,313.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
+      <text x="75.49" y="360.56" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compat_kitchen_sink.svg
@@ -40,8 +40,8 @@
       <path d="M218.83,411.06 L218.83,417.46 Q218.83,422.46 213.83,422.46 L202.04,422.46 Q197.04,422.46 197.04,427.46 L197.04,457.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.31" y="280.56" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="75.31" y="264.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="240.24" y="264.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/complex.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/complex.svg
@@ -54,10 +54,10 @@
       <path d="M182.38,620.28 L182.38,626.68 Q182.38,631.68 187.38,631.68 L205.05,631.68 Q210.05,631.68 210.05,636.68 L210.05,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="432.80" y="178.99" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="156.83" y="210.07" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="543.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="300.45" y="523.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/crossing_minimize.svg
@@ -54,10 +54,10 @@
       <path d="M417.10,496.44 L305.45,496.44 Q300.45,496.44 300.45,501.44 L300.45,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="432.80" y="178.99" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="156.83" y="210.07" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="543.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="300.45" y="523.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/decision.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/decision.svg
@@ -37,7 +37,7 @@
       <path d="M277.44,403.36 L284.44,403.36 Q289.44,403.36 289.44,398.36 L289.44,40.00 Q289.44,35.00 284.44,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="73.13" y="299.86" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="73.13" y="315.77" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="204.71" y="267.85" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/flowchart_code_flow.svg
@@ -451,13 +451,13 @@
       <path d="M11070.44,1460.19 L11070.44,1477.49 Q11070.44,1482.49 11075.44,1482.49 L11104.73,1482.49 Q11109.73,1482.49 11109.73,1487.49 L11109.73,1615.19" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
-      <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
-      <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <text x="9480.10" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <text x="9746.00" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <text x="10011.91" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
       <text x="9659.23" y="665.89" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="9746.00" y="744.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="9832.78" y="641.67" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
+      <text x="439.32" y="1657.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/git_workflow.svg
@@ -37,9 +37,9 @@
       <path d="M924.69,62.00 L924.69,73.00 Q924.69,78.00 919.69,78.00 L85.87,78.00 Q80.87,78.00 80.87,73.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="203.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="487.26" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="776.03" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
       <text x="504.78" y="78.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/git_workflow_td.svg
@@ -37,10 +37,10 @@
       <path d="M164.51,469.00 L171.51,469.00 Q176.51,469.00 176.51,464.00 L176.51,40.00 Q176.51,35.00 171.51,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <text x="176.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <text x="86.26" y="97.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="86.26" y="237.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="86.26" y="390.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="176.51" y="251.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/http_request.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/http_request.svg
@@ -44,10 +44,10 @@
       <path d="M352.16,632.20 L436.49,632.20 Q441.49,632.20 441.49,627.20 L441.49,40.00 Q441.49,35.00 436.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
-      <text x="99.80" y="449.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <text x="441.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <text x="266.29" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <text x="99.80" y="378.96" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="335.55" y="427.58" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="441.49" y="317.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/inline_edge_labels.svg
@@ -39,10 +39,10 @@
       <path d="M57.58,521.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
-      <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="57.58" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="57.58" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="57.58" y="415.50" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <text x="57.58" y="568.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/inline_label_flowchart.svg
@@ -91,15 +91,15 @@
       <path d="M412.63,1819.26 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="268.80" y="624.57" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="455.10" y="891.09" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
-      <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <text x="295.06" y="551.07" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="620.23" y="588.61" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="455.10" y="833.52" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <text x="723.91" y="864.25" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <text x="635.47" y="1585.25" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <text x="545.84" y="1526.71" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="50.80" y="439.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <text x="287.26" y="486.26" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
-      <text x="748.85" y="1346.59" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
+      <text x="748.85" y="1392.29" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/label_spacing.svg
@@ -33,8 +33,8 @@
       <path d="M128.36,62.00 L128.36,73.30 Q128.36,78.30 133.36,78.30 L156.36,78.30 Q161.36,78.30 161.36,83.30 L161.36,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="42.45" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="161.36" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="42.45" y="93.00" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="161.36" y="93.00" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/labeled_edges.svg
@@ -40,11 +40,11 @@
       <path d="M327.04,512.80 L334.04,512.80 Q339.04,512.80 339.04,507.80 L339.04,193.00 Q339.04,188.00 334.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
-      <text x="87.44" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
-      <text x="66.77" y="409.30" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="108.35" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <text x="95.49" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <text x="65.97" y="423.17" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="231.58" y="362.23" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="339.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="339.04" y="268.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/self_loop_labeled.svg
@@ -34,8 +34,8 @@
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
+      <text x="143.90" y="159.46" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="58.20" y="259.90" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-step/backward_loop_lr.svg
@@ -51,7 +51,7 @@
     </g>
     <g class="edgeLabels">
       <text x="1127.13" y="182.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <text x="1398.63" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-step/br_line_breaks.svg
@@ -37,8 +37,8 @@
       <path d="M61.85,214.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="61.85" y="261.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="61.85" y="285.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-step/compat_class_annotation.svg
@@ -36,8 +36,8 @@
       <path d="M133.16,195.63 L161.36,195.63 L161.36,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="42.45" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="42.45" y="244.65" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="161.36" y="244.65" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-step/compat_directive.svg
@@ -36,8 +36,8 @@
       <path d="M177.32,192.21 L218.53,192.21 L218.53,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="66.77" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="66.77" y="236.44" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="218.53" y="236.44" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-step/compat_hyphenated_ids.svg
@@ -36,7 +36,7 @@
       <path d="M75.49,313.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
+      <text x="75.49" y="360.56" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-step/compat_kitchen_sink.svg
@@ -40,8 +40,8 @@
       <path d="M218.83,411.06 L218.83,422.46 L197.04,422.46 L197.04,457.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.31" y="280.56" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="75.31" y="264.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="240.24" y="264.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/complex.svg
+++ b/tests/svg-snapshots/flowchart-step/complex.svg
@@ -54,10 +54,10 @@
       <path d="M182.38,620.28 L182.38,631.68 L210.05,631.68 L210.05,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="432.80" y="178.99" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="156.83" y="210.07" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="543.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="300.45" y="523.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-step/crossing_minimize.svg
@@ -54,10 +54,10 @@
       <path d="M417.10,496.44 L300.45,496.44 L300.45,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="432.80" y="178.99" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="156.83" y="210.07" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="543.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="300.45" y="523.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/decision.svg
+++ b/tests/svg-snapshots/flowchart-step/decision.svg
@@ -37,7 +37,7 @@
       <path d="M277.44,403.36 L289.44,403.36 L289.44,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="73.13" y="299.86" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="73.13" y="315.77" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="204.71" y="267.85" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-step/flowchart_code_flow.svg
@@ -451,13 +451,13 @@
       <path d="M11070.44,1460.19 L11070.44,1482.49 L11109.73,1482.49 L11109.73,1615.19" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
-      <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
-      <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <text x="9480.10" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <text x="9746.00" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <text x="10011.91" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
       <text x="9659.23" y="665.89" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="9746.00" y="744.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="9832.78" y="641.67" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
+      <text x="439.32" y="1657.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-step/git_workflow.svg
@@ -37,9 +37,9 @@
       <path d="M924.69,62.00 L924.69,78.00 L80.87,78.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="203.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="487.26" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="776.03" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
       <text x="504.78" y="78.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-step/git_workflow_td.svg
@@ -37,10 +37,10 @@
       <path d="M164.51,469.00 L176.51,469.00 L176.51,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <text x="176.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <text x="86.26" y="97.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="86.26" y="237.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="86.26" y="390.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="176.51" y="251.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/http_request.svg
+++ b/tests/svg-snapshots/flowchart-step/http_request.svg
@@ -44,10 +44,10 @@
       <path d="M352.16,632.20 L441.49,632.20 L441.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
-      <text x="99.80" y="449.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <text x="441.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <text x="266.29" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <text x="99.80" y="378.96" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="335.55" y="427.58" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="441.49" y="317.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-step/inline_edge_labels.svg
@@ -39,10 +39,10 @@
       <path d="M57.58,521.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
-      <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="57.58" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="57.58" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="57.58" y="415.50" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <text x="57.58" y="568.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-step/inline_label_flowchart.svg
@@ -91,15 +91,15 @@
       <path d="M412.63,1819.26 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="268.80" y="624.57" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="455.10" y="891.09" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
-      <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <text x="295.06" y="551.07" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="620.23" y="588.61" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="455.10" y="833.52" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <text x="723.91" y="864.25" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <text x="635.47" y="1585.25" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <text x="545.84" y="1526.71" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="50.80" y="439.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <text x="287.26" y="486.26" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
-      <text x="748.85" y="1346.59" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
+      <text x="748.85" y="1392.29" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-step/label_spacing.svg
@@ -33,8 +33,8 @@
       <path d="M128.36,62.00 L128.36,78.30 L161.36,78.30 L161.36,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="42.45" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="161.36" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="42.45" y="93.00" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="161.36" y="93.00" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-step/labeled_edges.svg
@@ -40,11 +40,11 @@
       <path d="M327.04,512.80 L339.04,512.80 L339.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
-      <text x="87.44" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
-      <text x="66.77" y="409.30" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="108.35" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <text x="95.49" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <text x="65.97" y="423.17" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="231.58" y="362.23" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="339.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="339.04" y="268.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-step/self_loop_labeled.svg
@@ -34,8 +34,8 @@
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
+      <text x="143.90" y="157.29" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="58.20" y="259.90" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-straight/backward_loop_lr.svg
@@ -51,7 +51,7 @@
     </g>
     <g class="edgeLabels">
       <text x="1127.13" y="157.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <text x="1398.63" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-straight/br_line_breaks.svg
@@ -37,8 +37,8 @@
       <path d="M61.85,214.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="61.85" y="261.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="61.85" y="285.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-straight/compat_hyphenated_ids.svg
@@ -36,7 +36,7 @@
       <path d="M75.49,313.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
+      <text x="75.49" y="360.56" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/complex.svg
+++ b/tests/svg-snapshots/flowchart-straight/complex.svg
@@ -56,7 +56,7 @@
     <g class="edgeLabels">
       <text x="367.67" y="243.35" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <text x="195.16" y="247.60" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="541.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="342.31" y="586.67" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-straight/crossing_minimize.svg
@@ -56,7 +56,7 @@
     <g class="edgeLabels">
       <text x="367.67" y="243.35" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <text x="195.16" y="247.60" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="541.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="342.31" y="586.67" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-straight/flowchart_code_flow.svg
@@ -451,13 +451,13 @@
       <path d="M10976.06,1460.19 L11126.36,1616.31" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
-      <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
-      <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <text x="9480.10" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <text x="9746.00" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <text x="10011.91" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
       <text x="9639.50" y="728.20" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="9746.00" y="744.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="9860.44" y="711.91" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
+      <text x="439.32" y="1657.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-straight/git_workflow.svg
@@ -37,9 +37,9 @@
       <path d="M924.69,62.00 L924.69,76.00 L80.87,76.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="203.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="487.26" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="776.03" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
       <text x="504.78" y="76.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-straight/git_workflow_td.svg
@@ -37,10 +37,10 @@
       <path d="M164.51,469.00 L174.51,469.00 L174.51,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <text x="172.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <text x="86.26" y="97.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="86.26" y="237.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="86.26" y="390.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="174.51" y="251.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/http_request.svg
+++ b/tests/svg-snapshots/flowchart-straight/http_request.svg
@@ -44,10 +44,10 @@
       <path d="M352.16,632.20 L437.49,632.20 L437.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <text x="266.29" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
       <text x="163.52" y="441.85" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="312.62" y="449.86" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <text x="437.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <text x="437.49" y="317.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-straight/inline_edge_labels.svg
@@ -39,10 +39,10 @@
       <path d="M57.58,521.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
-      <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="57.58" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="57.58" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="57.58" y="415.50" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <text x="57.58" y="568.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-straight/inline_label_flowchart.svg
@@ -97,7 +97,7 @@
       <text x="682.00" y="905.51" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <text x="643.00" y="1563.74" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <text x="529.77" y="1547.11" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="89.60" y="417.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <text x="89.60" y="437.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <text x="279.33" y="456.81" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
       <text x="707.61" y="1399.01" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>

--- a/tests/svg-snapshots/flowchart-straight/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-straight/labeled_edges.svg
@@ -40,11 +40,11 @@
       <path d="M327.04,512.80 L337.04,512.80 L337.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <text x="108.35" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
       <text x="101.79" y="253.58" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
       <text x="74.38" y="431.32" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="180.73" y="422.11" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="335.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="337.04" y="268.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-straight/self_loop_labeled.svg
@@ -34,8 +34,8 @@
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
+      <text x="143.90" y="158.07" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="58.20" y="259.90" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart/backward_loop_lr.svg
@@ -51,7 +51,7 @@
     </g>
     <g class="edgeLabels">
       <text x="1127.13" y="190.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <text x="1398.63" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart/br_line_breaks.svg
@@ -37,8 +37,8 @@
       <path d="M61.85,214.00 L61.85,255.00 L61.85,258.42 C61.85,261.83 61.85,268.67 61.85,275.50 C61.85,282.33 61.85,289.17 61.85,292.58 L61.85,296.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="61.85" y="261.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="61.85" y="285.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart/compat_class_annotation.svg
@@ -36,8 +36,8 @@
       <path d="M133.16,195.63 L137.86,195.63 C142.56,195.63 151.96,195.63 156.66,216.67 C161.36,237.71 161.36,279.79 161.36,300.84 L161.36,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="42.45" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="42.45" y="244.65" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="161.36" y="244.65" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart/compat_directive.svg
@@ -36,8 +36,8 @@
       <path d="M177.32,192.21 L184.19,192.21 C191.06,192.21 204.79,192.21 211.66,213.82 C218.53,235.43 218.53,278.65 218.53,300.26 L218.53,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="66.77" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="66.77" y="236.44" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="218.53" y="236.44" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart/compat_hyphenated_ids.svg
@@ -36,7 +36,7 @@
       <path d="M75.49,313.06 L75.49,346.06 L75.49,348.81 C75.49,351.56 75.49,357.06 75.49,362.56 C75.49,368.06 75.49,373.56 75.49,376.31 L75.49,379.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
+      <text x="75.49" y="360.56" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart/compat_kitchen_sink.svg
@@ -40,8 +40,8 @@
       <path d="M218.83,411.06 L218.83,413.84 C218.83,416.61 218.83,422.17 215.20,427.17 C211.57,432.17 204.30,436.61 200.67,441.50 C197.04,446.39 197.04,451.72 197.04,454.39 L197.04,457.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="75.31" y="280.56" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="75.31" y="264.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="240.24" y="264.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/complex.svg
+++ b/tests/svg-snapshots/flowchart/complex.svg
@@ -54,10 +54,10 @@
       <path d="M182.38,620.28 L182.38,623.06 C182.38,625.84 182.38,631.39 186.99,636.39 C191.60,641.39 200.83,645.84 205.44,650.73 C210.05,655.62 210.05,660.95 210.05,663.62 L210.05,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="432.80" y="178.99" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="156.83" y="210.07" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="543.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="300.45" y="523.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart/crossing_minimize.svg
@@ -54,10 +54,10 @@
       <path d="M417.10,496.44 L397.66,496.44 C378.22,496.44 339.33,496.44 319.89,524.75 C300.45,553.05 300.45,609.67 300.45,637.98 L300.45,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="432.80" y="178.99" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <text x="156.83" y="210.07" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <text x="543.45" y="142.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="300.45" y="523.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/decision.svg
+++ b/tests/svg-snapshots/flowchart/decision.svg
@@ -37,7 +37,7 @@
       <path d="M277.44,403.36 L289.44,403.36 L289.44,372.66 C289.44,341.97 289.44,280.57 289.44,219.18 C289.44,157.79 289.44,96.39 289.44,65.70 L289.44,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="73.13" y="299.86" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="73.13" y="315.77" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="204.71" y="267.85" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart/flowchart_code_flow.svg
@@ -451,13 +451,13 @@
       <path d="M11070.44,1460.19 L11070.44,1469.02 C11070.44,1477.85 11070.44,1495.52 11076.99,1513.19 C11083.54,1530.85 11096.63,1548.52 11103.18,1565.52 C11109.73,1582.52 11109.73,1598.85 11109.73,1607.02 L11109.73,1615.19" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
-      <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
-      <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <text x="9480.10" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <text x="9746.00" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <text x="10011.91" y="461.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
       <text x="9659.23" y="665.89" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="9746.00" y="744.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <text x="9832.78" y="641.67" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
+      <text x="439.32" y="1657.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart/git_workflow.svg
@@ -37,9 +37,9 @@
       <path d="M924.69,62.00 L924.69,86.00 L854.37,86.00 C784.05,86.00 643.42,86.00 502.78,86.00 C362.15,86.00 221.51,86.00 151.19,86.00 L80.87,86.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="203.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="487.26" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="776.03" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
       <text x="504.78" y="86.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart/git_workflow_td.svg
@@ -37,9 +37,9 @@
       <path d="M164.51,469.00 L183.13,469.00 L183.13,432.83 C183.13,396.67 183.13,324.33 183.13,252.00 C183.13,179.67 183.13,107.33 183.13,71.17 L183.13,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
-      <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
-      <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <text x="86.26" y="97.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <text x="86.26" y="237.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <text x="86.26" y="390.50" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
       <text x="183.13" y="251.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/http_request.svg
+++ b/tests/svg-snapshots/flowchart/http_request.svg
@@ -44,10 +44,10 @@
       <path d="M352.16,632.20 L441.49,632.20 L441.49,582.44 C441.49,532.67 441.49,433.14 441.49,333.60 C441.49,234.07 441.49,134.53 441.49,84.77 L441.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
-      <text x="99.80" y="449.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <text x="441.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <text x="266.29" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <text x="99.80" y="378.96" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <text x="335.55" y="427.58" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <text x="441.49" y="317.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart/inline_edge_labels.svg
@@ -39,10 +39,10 @@
       <path d="M57.58,521.00 L57.58,554.00 L57.58,556.75 C57.58,559.50 57.58,565.00 57.58,570.50 C57.58,576.00 57.58,581.50 57.58,584.25 L57.58,587.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
-      <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="57.58" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="57.58" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="57.58" y="415.50" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <text x="57.58" y="568.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart/inline_label_flowchart.svg
@@ -91,10 +91,10 @@
       <path d="M412.63,1819.26 L412.63,1822.04 C412.63,1824.81 412.63,1830.37 412.63,1835.37 C412.63,1840.37 412.63,1844.81 412.63,1849.70 C412.63,1854.59 412.63,1859.92 412.63,1862.59 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="268.80" y="624.57" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="455.10" y="891.09" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
-      <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <text x="295.06" y="551.07" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <text x="620.23" y="588.61" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="455.10" y="833.52" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <text x="723.91" y="864.25" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <text x="677.73" y="1542.99" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <text x="545.84" y="1526.71" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="52.80" y="437.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>

--- a/tests/svg-snapshots/flowchart/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart/labeled_edges.svg
@@ -40,11 +40,11 @@
       <path d="M327.04,512.80 L339.04,512.80 L339.04,485.73 C339.04,458.67 339.04,404.53 339.04,350.40 C339.04,296.27 339.04,242.13 339.04,215.07 L339.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <text x="108.35" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
       <text x="93.49" y="250.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
-      <text x="66.77" y="409.30" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="65.97" y="423.17" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="231.58" y="362.23" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <text x="339.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="339.04" y="268.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart/self_loop_labeled.svg
@@ -34,8 +34,8 @@
       <path d="M58.20,212.40 L58.20,245.40 L58.20,248.15 C58.20,250.90 58.20,256.40 58.20,261.90 C58.20,267.40 58.20,272.90 58.20,275.65 L58.20,278.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
-      <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
+      <text x="143.90" y="160.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <text x="58.20" y="259.90" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/mmds/routed-basic.svg
+++ b/tests/svg-snapshots/mmds/routed-basic.svg
@@ -34,7 +34,7 @@
       <path d="M60.00,60.00 L63.33,66.67 C66.67,73.33 73.33,86.67 73.80,96.20 C74.28,105.72 68.55,111.45 65.69,114.31 L62.83,117.17" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
-      <text x="80.00" y="100.00" text-anchor="middle" dominant-baseline="middle" fill="#333">go</text>
+      <text x="75.43" y="90.86" text-anchor="middle" dominant-baseline="middle" fill="#333">go</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

- SVG edge labels now use the arc-length midpoint of the rendered edge path instead of the layout engine's precomputed label position
- Removes the perpendicular-distance revalidation logic, which couldn't detect labels at the wrong position along a straight edge (distance = 0 for a point on a vertical line regardless of y)
- Falls back to precomputed position only when the rendered path is unavailable

## Root cause

The revalidation in `revalidate_svg_label_anchor` measured perpendicular distance from the label to the edge path. For a vertical edge, a label at `(x, 84.5)` has distance 0 from the path even though the midpoint is `(x, 109.5)`. So the off-center position was never corrected.

## Impact

123 SVG snapshots changed — edge labels shift to the true visual midpoint. Most shifts are small; a few (like "owns" in `cardinality_labels.svg`) are significant.

Refs #84

## Test plan

- [x] Full test suite passing (2064/2064)
- [x] Architecture check passing
- [x] Visual review via `scripts/svg-gallery-diff`