### PR TITLE
ci: use cocogitto bump profiles for CI release automation

### DIFF
--- a/.github/workflows/release-plan.yml
+++ b/.github/workflows/release-plan.yml
@@ -45,7 +45,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install cocogitto
-        run: cargo binstall --no-confirm cocogitto
+        run: cargo binstall --no-confirm cocogitto@6.5.0
 
       - name: Generate release plan
         env:
@@ -202,7 +202,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install tools
-        run: cargo binstall --no-confirm cocogitto cargo-edit
+        run: cargo binstall --no-confirm cocogitto@6.5.0 cargo-edit
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -224,107 +224,19 @@ jobs:
           PLAN_FILE="${RUNNER_TEMP}/release-plan.md"
           out() { tee -a "$PLAN_FILE" >> "$GITHUB_STEP_SUMMARY"; }
 
-          # Package definitions: name -> tag_prefix and release workflows
-          declare -A TAG_PREFIXES=(
-            [mmdflux]="mmdflux-v"
-            [mmds-core]="mmds-core-v"
-            [mmds-excalidraw]="mmds-excalidraw-v"
-            [mmds-tldraw]="mmds-tldraw-v"
-          )
-          declare -A RELEASE_WORKFLOWS=(
-            [mmdflux]="release.yml crate-release.yml wasm-release.yml playground-deploy.yml"
-            [mmds-core]="packages-release.yml"
-            [mmds-excalidraw]="packages-release.yml"
-            [mmds-tldraw]="packages-release.yml"
-          )
-
-          # Determine which packages to process
+          # The CI bump profile (defined in cog.toml) skips lint/test and
+          # handles git push + workflow dispatch via per-package post_bump_hooks.
           if [ -n "${INPUT_PACKAGE}" ]; then
-            PACKAGES="${INPUT_PACKAGE}"
+            cog bump --package "${INPUT_PACKAGE}" --auto --hook-profile ci
           else
-            PACKAGES="mmdflux mmds-core mmds-excalidraw mmds-tldraw"
+            cog bump --auto --hook-profile ci
           fi
 
-          # Patch cog.toml: strip lint/test hooks (CI already validated)
-          # and push hooks (we push and dispatch workflows ourselves).
-          sed -i '/"just lint",/d' cog.toml
-          sed -i '/"just test",/d' cog.toml
-          sed -i '/"git push",/d' cog.toml
-          sed -i '/"git push origin {{package}}-v{{version}}",/d' cog.toml
-
-          # Hide the patched file from git so cog bump won't commit it
-          git update-index --assume-unchanged cog.toml
-
-          released_tags=()
-
-          for pkg in $PACKAGES; do
-            tag_prefix="${TAG_PREFIXES[$pkg]}"
-
-            dry_output=$(cog bump --package "$pkg" --auto --dry-run 2>&1 || true)
-
-            if echo "$dry_output" | grep -q "No conventional commits"; then
-              echo "::notice::Skipping ${pkg}: no unreleased changes"
-              continue
-            fi
-
-            echo "Bumping ${pkg}..."
-            cog bump --package "$pkg" --auto --skip-untracked
-
-            new_tag=$(git describe --tags --match "${tag_prefix}*" --abbrev=0)
-            released_tags+=("${pkg}|${new_tag}")
-            echo "::notice::Created tag ${new_tag}"
-          done
-
-          if [ ${#released_tags[@]} -eq 0 ]; then
-            echo "::warning::No packages had unreleased changes."
-            echo "No packages to release." | out
-            exit 0
-          fi
-
-          # Push commits and tags
-          git push
-          for entry in "${released_tags[@]}"; do
-            tag="${entry##*|}"
-            git push origin "$tag"
-          done
-
-          # Dispatch release workflows
-          # (GITHUB_TOKEN tag pushes don't trigger workflows, so we dispatch explicitly)
-          for entry in "${released_tags[@]}"; do
-            pkg="${entry%%|*}"
-            tag="${entry##*|}"
-
-            for wf in ${RELEASE_WORKFLOWS[$pkg]}; do
-              echo "Dispatching ${wf} for ${tag}..."
-              if [ "$wf" = "playground-deploy.yml" ]; then
-                gh workflow run "$wf" || echo "::warning::Failed to dispatch ${wf}"
-              else
-                gh workflow run "$wf" -f "tag=${tag}" || echo "::warning::Failed to dispatch ${wf}"
-              fi
-            done
-          done
-
-          # --- Summary ---
           {
             echo "# Release Complete"
             echo ""
-            echo "## Released"
-            echo ""
-            for entry in "${released_tags[@]}"; do
-              pkg="${entry%%|*}"
-              tag="${entry##*|}"
-              echo "- **${pkg}**: \`${tag}\`"
-            done
-            echo ""
-            echo "## Dispatched Workflows"
-            echo ""
-            for entry in "${released_tags[@]}"; do
-              pkg="${entry%%|*}"
-              tag="${entry##*|}"
-              for wf in ${RELEASE_WORKFLOWS[$pkg]}; do
-                echo "- \`${wf}\` (\`${tag}\`)"
-              done
-            done
+            echo "Release executed via \`cog bump --auto --hook-profile ci\`."
+            echo "See workflow logs for details on which packages were bumped and which workflows were dispatched."
           } | out
 
       - name: Upload release report

--- a/cog.toml
+++ b/cog.toml
@@ -6,7 +6,6 @@ disable_bump_commit = false
 generate_mono_repository_global_tag = false
 generate_mono_repository_package_tags = true
 branch_whitelist = []
-pre = "alpha.*"
 skip_ci = "[skip ci]"
 skip_untracked = false
 tag_prefix = "v"
@@ -17,10 +16,14 @@ scopes = ["version", "wasm", "xtask", "web", "mmds-core", "mmds-excalidraw", "mm
 pre_bump_hooks = []
 post_bump_hooks = []
 pre_package_bump_hooks = []
-post_package_bump_hooks = [
-    "git push",
-    "git push origin {{package}}-v{{version}}",
-]
+post_package_bump_hooks = []
+
+# CI profile: used by release-plan.yml to skip lint/test and dispatch
+# release workflows instead of relying on tag-push triggers.
+# Usage: cog bump --auto --hook-profile ci
+[bump_profiles.ci]
+pre_bump_hooks = []
+post_bump_hooks = []
 
 [git_hooks.commit-msg]
 script = '''#!/bin/sh
@@ -89,7 +92,12 @@ repository = "mmdflux"
 owner = "kevinswiber"
 authors = []
 
-[monorepo.packages.mmdflux]
+# --- Monorepo packages ---
+# Only public packages are listed. Internal crates (mmdflux-wasm, xtask) are
+# version-locked to mmdflux via its pre_bump_hooks and excluded here to avoid
+# unwanted independent tags.
+
+[packages.mmdflux]
 path = "."
 include = ["**"]
 ignore = ["crates/mmdflux-wasm/**", "xtask/**", "packages/mmds-core/**", "packages/mmds-excalidraw/**", "packages/mmds-tldraw/**"]
@@ -101,35 +109,72 @@ pre_bump_hooks = [
     "cargo set-version --manifest-path crates/mmdflux-wasm/Cargo.toml {{version}}",
     "cargo set-version --manifest-path xtask/Cargo.toml {{version}}",
 ]
+bump_profiles.ci.pre_bump_hooks = [
+    "cargo set-version {{version}}",
+    "cargo set-version --manifest-path crates/mmdflux-wasm/Cargo.toml {{version}}",
+    "cargo set-version --manifest-path xtask/Cargo.toml {{version}}",
+]
+bump_profiles.ci.post_bump_hooks = [
+    "git push",
+    "git push origin {{package}}-v{{version}}",
+    "gh workflow run release.yml -f tag={{package}}-v{{version}}",
+    "gh workflow run crate-release.yml -f tag={{package}}-v{{version}}",
+    "gh workflow run wasm-release.yml -f tag={{package}}-v{{version}}",
+    "gh workflow run playground-deploy.yml",
+]
 
-[monorepo.packages.mmdflux-wasm]
-path = "crates/mmdflux-wasm"
-public_api = false
-
-[monorepo.packages.xtask]
-path = "xtask"
-public_api = false
-
-[monorepo.packages.mmds-core]
+[packages.mmds-core]
 path = "packages/mmds-core"
 public_api = true
 pre_bump_hooks = [
     "npm version {{version}} --no-git-tag-version",
 ]
+bump_profiles.ci.pre_bump_hooks = [
+    "npm version {{version}} --no-git-tag-version",
+]
+bump_profiles.ci.post_bump_hooks = [
+    "git push",
+    "git push origin {{package}}-v{{version}}",
+    "gh workflow run packages-release.yml -f tag={{package}}-v{{version}}",
+]
 bump_order = 1
 
-[monorepo.packages.mmds-excalidraw]
+[packages.mmds-excalidraw]
 path = "packages/mmds-excalidraw"
 public_api = true
 pre_bump_hooks = [
+    "npm pkg set \"dependencies.@mmds/core=^$(node -p \"require('../mmds-core/package.json').version\")\"",
+    "npm install --package-lock-only",
     "npm version {{version}} --no-git-tag-version",
+]
+bump_profiles.ci.pre_bump_hooks = [
+    "npm pkg set \"dependencies.@mmds/core=^$(node -p \"require('../mmds-core/package.json').version\")\"",
+    "npm install --package-lock-only",
+    "npm version {{version}} --no-git-tag-version",
+]
+bump_profiles.ci.post_bump_hooks = [
+    "git push",
+    "git push origin {{package}}-v{{version}}",
+    "gh workflow run packages-release.yml -f tag={{package}}-v{{version}}",
 ]
 bump_order = 2
 
-[monorepo.packages.mmds-tldraw]
+[packages.mmds-tldraw]
 path = "packages/mmds-tldraw"
 public_api = true
 pre_bump_hooks = [
+    "npm pkg set \"dependencies.@mmds/core=^$(node -p \"require('../mmds-core/package.json').version\")\"",
+    "npm install --package-lock-only",
     "npm version {{version}} --no-git-tag-version",
+]
+bump_profiles.ci.pre_bump_hooks = [
+    "npm pkg set \"dependencies.@mmds/core=^$(node -p \"require('../mmds-core/package.json').version\")\"",
+    "npm install --package-lock-only",
+    "npm version {{version}} --no-git-tag-version",
+]
+bump_profiles.ci.post_bump_hooks = [
+    "git push",
+    "git push origin {{package}}-v{{version}}",
+    "gh workflow run packages-release.yml -f tag={{package}}-v{{version}}",
 ]
 bump_order = 2

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -6,7 +6,7 @@ All releases are managed through [cocogitto](https://docs.cocogitto.io/) (`cog b
 
 The following tools must be installed locally:
 
-- [cocogitto](https://docs.cocogitto.io/) (`cog`) — version management, changelogs, and tagging
+- [cocogitto](https://docs.cocogitto.io/) 6.5.0 (`cog`) — version management, changelogs, and tagging. Pin to 6.5.0; version 7.0 has a [bump_order bug](https://github.com/kevinswiber/mmdflux/pull/86) that ignores package ordering.
 - [cargo-edit](https://github.com/killercup/cargo-edit) — provides `cargo set-version`, used by pre-bump hooks
 - [just](https://just.systems/) — task runner for lint/test hooks
 - [gh](https://cli.github.com/) — GitHub CLI for checking CI status and downloading release assets
@@ -103,9 +103,14 @@ This will:
 - Update version in `Cargo.toml`, `crates/mmdflux-wasm/Cargo.toml`, and `xtask/Cargo.toml` via `cargo set-version`
 - Generate the changelog in `CHANGELOG.md`
 - Commit and tag (`mmdflux-v{version}`)
-- **Automatically push** the commit and tag to origin (post-bump hooks) — no manual push needed
 
-5. Confirm the four release workflows complete:
+5. Push the commit and tag:
+
+```bash
+git push && git push origin mmdflux-v{version}
+```
+
+6. Confirm the four release workflows complete:
 
 ```bash
 gh run list --limit 8
@@ -118,7 +123,7 @@ gh run watch
 - **WASM Release** — publishes `@mmds/wasm` to npm
 - **Playground Deploy** — deploys web playground to Cloudflare Pages
 
-6. The Homebrew formula is updated automatically by the Release workflow (see below).
+7. The Homebrew formula is updated automatically by the Release workflow (see below).
 
 ## npm Adapter Packages
 
@@ -138,10 +143,16 @@ cog bump --package mmds-tldraw --patch
 
 This will:
 
-1. Run `npm version` to update `package.json` (pre-bump hook)
-2. Generate a package-specific changelog in the package directory
-3. Commit and tag (e.g., `mmds-core-v0.2.0`)
-4. **Automatically push** the commit and tag to origin (post-bump hooks)
+1. Sync `@mmds/core` dependency version and lockfiles (adapter packages only, pre-bump hook)
+2. Run `npm version` to update `package.json` (pre-bump hook)
+3. Generate a package-specific changelog in the package directory
+4. Commit and tag (e.g., `mmds-core-v0.2.0`)
+
+Then push manually:
+
+```bash
+git push && git push origin {tag}
+```
 
 The tag push triggers the **Packages Release** workflow, which builds and publishes the package to npm.
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -9,7 +9,7 @@ Install the following tools before working on mmdflux:
 | [Rust](https://rustup.rs/) (stable + nightly) | Build, test, format | `rustup install stable nightly` |
 | [just](https://github.com/casey/just) | Task runner | `cargo install just` or `brew install just` |
 | [cargo-nextest](https://nexte.st/) | Parallel test runner | `cargo install cargo-nextest` |
-| [cocogitto](https://docs.cocogitto.io/) | Conventional Commits enforcement | `cargo install cocogitto` or `brew install cocogitto` |
+| [cocogitto](https://docs.cocogitto.io/) 6.5.0 | Conventional Commits enforcement | `cargo install cocogitto@6.5.0` |
 
 Optional (for specific workflows):
 


### PR DESCRIPTION
## Summary

- Replace sed-patching and per-package bash loops in the release-plan workflow with cocogitto's native bump profiles (`--hook-profile ci`)
- Remove `mmdflux-wasm` and `xtask` from `[monorepo.packages]` — they're version-locked to mmdflux and don't need independent tags
- Add per-package CI profiles that skip lint/test, push tags, and dispatch release workflows
- Adapter CI pre-bump hooks auto-sync `@mmds/core` dependency version and lockfiles via `npm pkg set` + `npm install --package-lock-only`
- Release mode in `release-plan.yml` simplifies to `cog bump --auto --hook-profile ci`

## Test plan

- [x] `cog check` passes on the branch
- [x] `cog bump --auto --dry-run --skip-untracked` (default profile) — no unexpected packages
- [x] `cog bump --auto --dry-run --skip-untracked --hook-profile ci` — same result, no parse errors
- [x] `cog bump --package mmdflux --auto --dry-run --skip-untracked` — still works for single-package
- [x] Run the Release Plan workflow in plan mode — verify report generates correctly
- [x] Verify `(wasm)` and `(xtask)` scoped commits are still valid (in `scopes` list) and don't trigger phantom package bumps
- [ ] End-to-end: after merging, make a test `fix:` commit, run release plan in plan mode, verify it detects the bump, then execute release mode and confirm hooks push + dispatch correctly