### PR TITLE
feat: add state diagram test fixtures and compliance harness

### DIFF
--- a/tests/compliance_state.rs
+++ b/tests/compliance_state.rs
@@ -1,0 +1,171 @@
+//! State diagram compliance tests and snapshot assertions.
+//!
+//! Validates state diagram rendering against text and SVG snapshots.
+//! All tests are ignored until the state diagram type is wired up.
+//!
+//! Generate snapshots: `GENERATE_STATE_TEXT_SNAPSHOTS=1 cargo test --test compliance_state`
+//! Generate SVG:       `GENERATE_STATE_SVG_SNAPSHOTS=1 cargo test --test compliance_state`
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use mmdflux::{OutputFormat, RenderConfig};
+
+fn state_fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("state")
+}
+
+fn state_text_snapshot_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("snapshots")
+        .join("state")
+}
+
+fn state_svg_snapshot_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("svg-snapshots")
+        .join("state")
+}
+
+fn list_state_fixtures() -> Vec<String> {
+    let dir = state_fixture_dir();
+    let mut fixtures: Vec<String> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("Failed to read state fixtures dir: {e}"))
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if path.extension().is_some_and(|e| e == "mmd") {
+                Some(path.file_name()?.to_str()?.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    fixtures.sort();
+    fixtures
+}
+
+fn render_state_text(fixture: &str) -> String {
+    let path = state_fixture_dir().join(fixture);
+    let input = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to read fixture {fixture}: {e}"));
+    mmdflux::render_diagram(&input, OutputFormat::Text, &RenderConfig::default())
+        .expect("Failed to render state fixture")
+}
+
+fn render_state_svg(fixture: &str) -> String {
+    let path = state_fixture_dir().join(fixture);
+    let input = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("Failed to read fixture {fixture}: {e}"));
+    mmdflux::render_diagram(&input, OutputFormat::Svg, &RenderConfig::default())
+        .expect("Failed to render state fixture as SVG")
+}
+
+// --- Text snapshots ---
+
+#[test]
+#[ignore]
+fn state_text_snapshots() {
+    let snapshot_dir = state_text_snapshot_dir();
+    let regenerate = std::env::var("GENERATE_STATE_TEXT_SNAPSHOTS").is_ok();
+
+    if regenerate {
+        fs::create_dir_all(&snapshot_dir).unwrap();
+    }
+
+    for fixture in list_state_fixtures() {
+        let stem = fixture.trim_end_matches(".mmd");
+        let output = render_state_text(&fixture);
+        let snapshot_path = snapshot_dir.join(format!("{stem}.txt"));
+
+        if regenerate {
+            fs::write(&snapshot_path, &output).unwrap();
+        } else {
+            let expected = fs::read_to_string(&snapshot_path).unwrap_or_else(|_| {
+                panic!(
+                    "Missing state text snapshot: {}. Set GENERATE_STATE_TEXT_SNAPSHOTS=1 to generate.",
+                    snapshot_path.display()
+                )
+            });
+            assert_eq!(
+                output, expected,
+                "State text snapshot mismatch for {fixture}. Set GENERATE_STATE_TEXT_SNAPSHOTS=1 to regenerate."
+            );
+        }
+    }
+}
+
+// --- SVG snapshots ---
+
+#[test]
+#[ignore]
+fn state_svg_snapshots() {
+    let snapshot_dir = state_svg_snapshot_dir();
+    let regenerate = std::env::var("GENERATE_STATE_SVG_SNAPSHOTS").is_ok();
+
+    if regenerate {
+        fs::create_dir_all(&snapshot_dir).unwrap();
+    }
+
+    for fixture in list_state_fixtures() {
+        let stem = fixture.trim_end_matches(".mmd");
+        let output = render_state_svg(&fixture);
+        let snapshot_path = snapshot_dir.join(format!("{stem}.svg"));
+
+        if regenerate {
+            fs::write(&snapshot_path, &output).unwrap();
+        } else {
+            let expected = fs::read_to_string(&snapshot_path).unwrap_or_else(|_| {
+                panic!(
+                    "Missing state SVG snapshot: {}. Set GENERATE_STATE_SVG_SNAPSHOTS=1 to generate.",
+                    snapshot_path.display()
+                )
+            });
+            assert_eq!(
+                output, expected,
+                "State SVG snapshot mismatch for {fixture}. Set GENERATE_STATE_SVG_SNAPSHOTS=1 to regenerate."
+            );
+        }
+    }
+}
+
+// --- Compliance assertions ---
+
+#[test]
+#[ignore]
+fn state_all_fixtures_parse() {
+    for fixture in list_state_fixtures() {
+        let path = state_fixture_dir().join(&fixture);
+        let input = fs::read_to_string(&path).unwrap();
+        mmdflux::render_diagram(&input, OutputFormat::Text, &RenderConfig::default())
+            .unwrap_or_else(|e| panic!("Failed to parse and render state fixture {fixture}: {e}"));
+    }
+}
+
+#[test]
+#[ignore]
+fn state_all_fixtures_render_text() {
+    for fixture in list_state_fixtures() {
+        let output = render_state_text(&fixture);
+        assert!(
+            !output.is_empty(),
+            "Empty text output for state fixture: {fixture}"
+        );
+    }
+}
+
+#[test]
+#[ignore]
+fn state_all_fixtures_render_svg() {
+    for fixture in list_state_fixtures() {
+        let output = render_state_svg(&fixture);
+        assert!(
+            output.starts_with("<svg"),
+            "Invalid SVG output for state fixture: {fixture}"
+        );
+    }
+}

--- a/tests/fixtures/state/composite.mmd
+++ b/tests/fixtures/state/composite.mmd
@@ -1,0 +1,9 @@
+stateDiagram-v2
+    [*] --> Active
+    state Active {
+        [*] --> Running
+        Running --> Paused : pause
+        Paused --> Running : resume
+        Running --> [*]
+    }
+    Active --> [*]

--- a/tests/fixtures/state/descriptions.mmd
+++ b/tests/fixtures/state/descriptions.mmd
@@ -1,0 +1,6 @@
+stateDiagram-v2
+    [*] --> Active
+    Active : The system is active
+    Active --> Idle : timeout
+    Idle : Waiting for input
+    Idle --> [*]

--- a/tests/fixtures/state/direction_lr.mmd
+++ b/tests/fixtures/state/direction_lr.mmd
@@ -1,0 +1,6 @@
+stateDiagram-v2
+    direction LR
+    [*] --> A
+    A --> B
+    B --> C
+    C --> [*]

--- a/tests/fixtures/state/kitchen_sink.mmd
+++ b/tests/fixtures/state/kitchen_sink.mmd
@@ -1,0 +1,28 @@
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Processing : submit
+    state Processing {
+        direction LR
+        [*] --> Validating
+        Validating --> Executing : valid
+        Validating --> Failed : invalid
+        Executing --> [*]
+        Failed --> [*]
+    }
+    Processing --> Done : complete
+    Processing --> Error : fail
+    state fork_state <<fork>>
+    Error --> fork_state
+    fork_state --> Retry
+    fork_state --> Log
+    state join_state <<join>>
+    Retry --> join_state
+    Log --> join_state
+    join_state --> Idle
+    state check <<choice>>
+    Done --> check
+    check --> Archived : old
+    check --> Active : recent
+    Active : Currently active item
+    Archived --> [*]
+    Active --> Idle : reset

--- a/tests/fixtures/state/pseudo_states.mmd
+++ b/tests/fixtures/state/pseudo_states.mmd
@@ -1,0 +1,14 @@
+stateDiagram-v2
+    state fork_state <<fork>>
+    state join_state <<join>>
+    state if_state <<choice>>
+    [*] --> fork_state
+    fork_state --> State2
+    fork_state --> State3
+    State2 --> join_state
+    State3 --> join_state
+    join_state --> if_state
+    if_state --> State4 : yes
+    if_state --> State5 : no
+    State4 --> [*]
+    State5 --> [*]

--- a/tests/fixtures/state/self_transition.mmd
+++ b/tests/fixtures/state/self_transition.mmd
@@ -1,0 +1,5 @@
+stateDiagram-v2
+    [*] --> Processing
+    Processing --> Processing : retry
+    Processing --> Done
+    Done --> [*]

--- a/tests/fixtures/state/simple.mmd
+++ b/tests/fixtures/state/simple.mmd
@@ -1,0 +1,4 @@
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Active
+    Active --> [*]

--- a/tests/fixtures/state/transitions.mmd
+++ b/tests/fixtures/state/transitions.mmd
@@ -1,0 +1,7 @@
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Processing : submit
+    Processing --> Done : complete
+    Processing --> Error : fail
+    Error --> Idle : retry
+    Done --> [*]


### PR DESCRIPTION
## Summary
- Add 8 `stateDiagram-v2` fixture files in `tests/fixtures/state/` covering simple states, labeled transitions, pseudo-states (fork/join/choice), composite states, direction overrides, state descriptions, self-transitions, and a kitchen-sink combining all features
- Add `tests/compliance_state.rs` test harness modeled after `compliance_class.rs` with text snapshot, SVG snapshot, parse, and render assertions
- All tests are `#[ignore]` since the state diagram type is not yet wired up — this is pure additive scaffolding with zero conflict risk

## Test plan
- [x] `cargo test --test compliance_state --no-run` compiles successfully
- [x] `just test` passes all 2072 tests with no regressions
- [x] All 5 state compliance tests are `#[ignore]` and skipped
- [ ] Verify fixtures match valid Mermaid `stateDiagram-v2` syntax