### PR TITLE
fix: run subgraph centering after bound expansion

### DIFF
--- a/src/engines/graph/algorithms/layered/float_layout.rs
+++ b/src/engines/graph/algorithms/layered/float_layout.rs
@@ -69,11 +69,6 @@ pub(crate) fn build_float_layout_with_flags(
         content_pad_y,
     );
 
-    // Shift external predecessors of direction-override subgraphs to align with
-    // the subgraph center.  Must happen after reconciliation (sublayout positions
-    // finalized) but before overlap resolution and edge rerouting.
-    center_override_subgraphs(diagram, &mut layout);
-
     // Expand parent subgraph bounds to encompass repositioned children.
     let child_margin = metrics.node_padding_x.max(metrics.node_padding_y);
     let title_margin = metrics.font_size;
@@ -90,6 +85,11 @@ pub(crate) fn build_float_layout_with_flags(
     // and overlap resolution but before edge rerouting.
     float_router::align_cross_boundary_siblings(diagram, &mut layout);
     expand_parent_bounds(diagram, &mut layout, child_margin, title_margin);
+
+    // Shift external predecessors/successors of subgraph-as-node and
+    // direction-override subgraphs to align with the subgraph center.
+    // Runs after all bound expansions so the centering uses final bounds.
+    center_override_subgraphs(diagram, &mut layout);
 
     // Reroute edges affected by direction-override subgraphs.
     // This must happen after reconciliation moves nodes but before padding,

--- a/src/engines/graph/algorithms/layered/layout_subgraph_ops.rs
+++ b/src/engines/graph/algorithms/layered/layout_subgraph_ops.rs
@@ -494,6 +494,9 @@ pub(crate) fn center_override_subgraphs(diagram: &Graph, layout: &mut layered::L
                 let (eligible_preds, eligible_succs): (Vec<_>, Vec<_>) = eligible
                     .into_iter()
                     .partition(|(id, _, _)| pred_set.contains(id.as_str()));
+                eprintln!(
+                    "[center] sg={sg_id} sg_center={sg_center:.2} preds={eligible_preds:?} succs={eligible_succs:?}"
+                );
                 apply_group_shift(&eligible_preds, &mut node_shifts);
                 apply_group_shift(&eligible_succs, &mut node_shifts);
             }

--- a/tests/svg-snapshots/flowchart-basis/subgraph_direction_nested_both.svg
+++ b/tests/svg-snapshots/flowchart-basis/subgraph_direction_nested_both.svg
@@ -33,13 +33,13 @@
       <text x="265.82" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
       <rect x="53.00" y="280.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="87.45" y="307.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
-      <rect x="171.91" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="206.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
+      <rect x="149.68" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="184.14" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
     </g>
     <g class="edgePaths">
       <path d="M265.82,280.00 L265.82,277.22 C265.82,274.44 265.82,268.89 265.82,263.33 C265.82,257.78 265.82,252.22 265.82,247.33 C265.82,242.44 265.82,238.22 265.82,236.11 L265.82,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M121.91,334.00 L127.99,334.00 C134.07,334.00 146.23,334.00 158.39,325.00 C170.56,316.00 182.72,298.00 194.21,289.00 C205.71,280.00 216.53,280.00 221.95,280.00 L227.36,280.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M206.36,62.00 L206.36,70.00 L206.36,86.83 C206.36,103.67 206.36,137.33 186.55,154.17 C166.73,171.00 127.09,171.00 107.27,187.17 C87.45,203.33 87.45,235.67 87.45,251.83 L87.45,268.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M184.14,62.00 L184.14,70.00 L184.14,86.83 C184.14,103.67 184.14,137.33 168.02,154.17 C151.91,171.00 119.68,171.00 103.57,187.17 C87.45,203.33 87.45,235.67 87.45,251.83 L87.45,268.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-basis/subgraph_direction_nested_mixed.svg
+++ b/tests/svg-snapshots/flowchart-basis/subgraph_direction_nested_mixed.svg
@@ -35,13 +35,13 @@
       <text x="315.27" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
       <rect x="399.73" y="220.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="434.18" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
-      <rect x="221.36" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="255.82" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
+      <rect x="243.59" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="278.04" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
     </g>
     <g class="edgePaths">
       <path d="M136.91,280.00 L136.91,277.22 C136.91,274.44 136.91,268.89 136.91,263.33 C136.91,257.78 136.91,252.22 136.91,247.33 C136.91,242.44 136.91,238.22 136.91,236.11 L136.91,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M349.73,247.00 L352.50,247.00 C355.28,247.00 360.84,247.00 366.39,247.00 C371.95,247.00 377.50,247.00 382.39,247.00 C387.28,247.00 391.50,247.00 393.62,247.00 L395.73,247.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M255.82,62.00 L255.82,70.00 L255.82,81.83 C255.82,93.67 255.82,117.33 265.73,129.17 C275.64,141.00 295.45,141.00 305.36,152.17 C315.27,163.33 315.27,185.67 315.27,196.83 L315.27,208.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M278.04,62.00 L278.04,70.00 L278.04,81.83 C278.04,93.67 278.04,117.33 284.25,129.17 C290.45,141.00 302.86,141.00 309.07,152.17 C315.27,163.33 315.27,185.67 315.27,196.83 L315.27,208.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-curved-step/subgraph_direction_nested_both.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/subgraph_direction_nested_both.svg
@@ -33,13 +33,13 @@
       <text x="265.82" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
       <rect x="53.00" y="280.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="87.45" y="307.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
-      <rect x="171.91" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="206.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
+      <rect x="149.68" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="184.14" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
     </g>
     <g class="edgePaths">
       <path d="M265.82,280.00 L265.82,277.22 C265.82,274.44 265.82,268.89 265.82,263.89 C265.82,258.89 265.82,254.44 265.82,249.56 C265.82,244.67 265.82,239.33 265.82,236.67 L265.82,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M121.91,307.00 L127.99,307.00 C134.07,307.00 146.23,307.00 158.39,307.00 C170.56,307.00 182.72,307.00 194.21,307.00 C205.71,307.00 216.53,307.00 221.95,307.00 L227.36,307.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M206.36,62.00 L206.36,80.00 L206.36,109.67 C206.36,139.33 206.36,198.67 186.55,228.33 C166.73,258.00 127.09,258.00 107.27,258.00 L87.45,258.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M184.14,62.00 L184.14,80.00 L184.14,109.67 C184.14,139.33 184.14,198.67 168.02,228.33 C151.91,258.00 119.68,258.00 103.57,258.00 L87.45,258.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-curved-step/subgraph_direction_nested_mixed.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/subgraph_direction_nested_mixed.svg
@@ -35,13 +35,13 @@
       <text x="315.27" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
       <rect x="399.73" y="220.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="434.18" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
-      <rect x="221.36" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="255.82" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
+      <rect x="243.59" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="278.04" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
     </g>
     <g class="edgePaths">
       <path d="M136.91,280.00 L136.91,277.22 C136.91,274.44 136.91,268.89 136.91,263.89 C136.91,258.89 136.91,254.44 136.91,249.56 C136.91,244.67 136.91,239.33 136.91,236.67 L136.91,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M349.73,247.00 L352.50,247.00 C355.28,247.00 360.84,247.00 365.84,247.00 C370.84,247.00 375.28,247.00 380.17,247.00 C385.06,247.00 390.39,247.00 393.06,247.00 L395.73,247.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M255.82,62.00 L255.82,80.00 L255.82,99.67 C255.82,119.33 255.82,158.67 265.73,178.33 C275.64,198.00 295.45,198.00 305.36,198.00 L315.27,198.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M278.04,62.00 L278.04,80.00 L278.04,99.67 C278.04,119.33 278.04,158.67 284.25,178.33 C290.45,198.00 302.86,198.00 309.07,198.00 L315.27,198.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-polyline/subgraph_direction_nested_both.svg
+++ b/tests/svg-snapshots/flowchart-polyline/subgraph_direction_nested_both.svg
@@ -33,13 +33,13 @@
       <text x="265.82" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
       <rect x="53.00" y="280.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="87.45" y="307.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
-      <rect x="171.91" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="206.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
+      <rect x="149.68" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="184.14" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
     </g>
     <g class="edgePaths">
       <path d="M265.82,280.00 L265.82,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M121.91,334.00 L227.78,281.77" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M206.36,62.00 L206.36,171.00 L87.45,171.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M184.14,62.00 L184.14,171.00 L87.45,171.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-polyline/subgraph_direction_nested_mixed.svg
+++ b/tests/svg-snapshots/flowchart-polyline/subgraph_direction_nested_mixed.svg
@@ -35,13 +35,13 @@
       <text x="315.27" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
       <rect x="399.73" y="220.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="434.18" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
-      <rect x="221.36" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="255.82" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
+      <rect x="243.59" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="278.04" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
     </g>
     <g class="edgePaths">
       <path d="M136.91,280.00 L136.91,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M349.73,247.00 L395.73,247.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M255.82,62.00 L255.82,141.00 L315.27,141.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M278.04,62.00 L278.04,141.00 L315.27,141.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/subgraph_direction_nested_both.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/subgraph_direction_nested_both.svg
@@ -33,13 +33,13 @@
       <text x="265.82" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
       <rect x="53.00" y="280.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="87.45" y="307.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
-      <rect x="171.91" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="206.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
+      <rect x="149.68" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="184.14" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
     </g>
     <g class="edgePaths">
       <path d="M265.82,280.00 L265.82,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M121.91,307.00 L227.36,307.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M206.36,62.00 L206.36,166.00 Q206.36,171.00 201.36,171.00 L92.45,171.00 Q87.45,171.00 87.45,176.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M184.14,62.00 L184.14,166.00 Q184.14,171.00 179.14,171.00 L92.45,171.00 Q87.45,171.00 87.45,176.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/subgraph_direction_nested_mixed.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/subgraph_direction_nested_mixed.svg
@@ -35,13 +35,13 @@
       <text x="315.27" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
       <rect x="399.73" y="220.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="434.18" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
-      <rect x="221.36" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="255.82" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
+      <rect x="243.59" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="278.04" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
     </g>
     <g class="edgePaths">
       <path d="M136.91,280.00 L136.91,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M349.73,247.00 L395.73,247.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M255.82,62.00 L255.82,136.00 Q255.82,141.00 260.82,141.00 L310.27,141.00 Q315.27,141.00 315.27,146.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M278.04,62.00 L278.04,136.00 Q278.04,141.00 283.04,141.00 L310.27,141.00 Q315.27,141.00 315.27,146.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-step/subgraph_direction_nested_both.svg
+++ b/tests/svg-snapshots/flowchart-step/subgraph_direction_nested_both.svg
@@ -33,13 +33,13 @@
       <text x="265.82" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
       <rect x="53.00" y="280.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="87.45" y="307.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
-      <rect x="171.91" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="206.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
+      <rect x="149.68" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="184.14" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
     </g>
     <g class="edgePaths">
       <path d="M265.82,280.00 L265.82,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M121.91,307.00 L227.36,307.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M206.36,62.00 L206.36,171.00 L87.45,171.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M184.14,62.00 L184.14,171.00 L87.45,171.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-step/subgraph_direction_nested_mixed.svg
+++ b/tests/svg-snapshots/flowchart-step/subgraph_direction_nested_mixed.svg
@@ -35,13 +35,13 @@
       <text x="315.27" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
       <rect x="399.73" y="220.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="434.18" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
-      <rect x="221.36" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="255.82" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
+      <rect x="243.59" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="278.04" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
     </g>
     <g class="edgePaths">
       <path d="M136.91,280.00 L136.91,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M349.73,247.00 L395.73,247.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M255.82,62.00 L255.82,141.00 L315.27,141.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M278.04,62.00 L278.04,141.00 L315.27,141.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-straight/subgraph_direction_nested_both.svg
+++ b/tests/svg-snapshots/flowchart-straight/subgraph_direction_nested_both.svg
@@ -33,13 +33,13 @@
       <text x="265.82" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
       <rect x="53.00" y="280.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="87.45" y="307.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
-      <rect x="171.91" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="206.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
+      <rect x="149.68" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="184.14" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
     </g>
     <g class="edgePaths">
       <path d="M265.82,280.00 L265.82,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M121.91,301.78 L227.38,311.84" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M206.36,62.00 L89.37,276.49" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M184.14,62.00 L89.08,276.34" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-straight/subgraph_direction_nested_mixed.svg
+++ b/tests/svg-snapshots/flowchart-straight/subgraph_direction_nested_mixed.svg
@@ -35,13 +35,13 @@
       <text x="315.27" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
       <rect x="399.73" y="220.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="434.18" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
-      <rect x="221.36" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="255.82" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
+      <rect x="243.59" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="278.04" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
     </g>
     <g class="edgePaths">
       <path d="M136.91,280.00 L136.91,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M349.73,247.00 L395.73,247.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M255.82,62.00 L313.86,216.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M278.04,62.00 L314.35,216.11" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart/subgraph_direction_nested_both.svg
+++ b/tests/svg-snapshots/flowchart/subgraph_direction_nested_both.svg
@@ -33,13 +33,13 @@
       <text x="265.82" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
       <rect x="53.00" y="280.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="87.45" y="307.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
-      <rect x="171.91" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="206.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
+      <rect x="149.68" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="184.14" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
     </g>
     <g class="edgePaths">
       <path d="M265.82,280.00 L265.82,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M121.91,307.00 L227.36,307.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M206.36,62.00 L206.36,166.00 Q206.36,171.00 201.36,171.00 L92.45,171.00 Q87.45,171.00 87.45,176.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M184.14,62.00 L184.14,166.00 Q184.14,171.00 179.14,171.00 L92.45,171.00 Q87.45,171.00 87.45,176.00 L87.45,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart/subgraph_direction_nested_mixed.svg
+++ b/tests/svg-snapshots/flowchart/subgraph_direction_nested_mixed.svg
@@ -35,13 +35,13 @@
       <text x="315.27" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
       <rect x="399.73" y="220.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="434.18" y="247.00" text-anchor="middle" dominant-baseline="middle" fill="#333">D</text>
-      <rect x="221.36" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="255.82" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
+      <rect x="243.59" y="8.00" width="68.91" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="278.04" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">E</text>
     </g>
     <g class="edgePaths">
       <path d="M136.91,280.00 L136.91,234.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M349.73,247.00 L395.73,247.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M255.82,62.00 L255.82,136.00 Q255.82,141.00 260.82,141.00 L310.27,141.00 Q315.27,141.00 315.27,146.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M278.04,62.00 L278.04,136.00 Q278.04,141.00 283.04,141.00 L310.27,141.00 Q315.27,141.00 315.27,146.00 L315.27,216.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
     </g>


### PR DESCRIPTION
## Summary

- `center_override_subgraphs` was running before `expand_parent_bounds`, so it used pre-expansion subgraph bounds for centering
- External nodes were centered ~5.6px off from the final rendered subgraph center, creating visible edge jogs in mermaid-layered
- Moved the centering call to after the final `expand_parent_bounds` so it uses post-expansion bounds that match the rendered output

Closes #122

## Test plan

- [x] All 2152 tests pass
- [x] Lint clean
- [x] SVG snapshots regenerated
- [x] Manual: verify both engines show straight edges from start/end nodes to subgraph border