### PR TITLE
fix: exclude nesting edges from LayoutResult edge output

### DIFF
--- a/src/engines/graph/algorithms/layered/kernel/pipeline.rs
+++ b/src/engines/graph/algorithms/layered/kernel/pipeline.rs
@@ -274,7 +274,11 @@ where
     // Build edge layouts, using waypoints for normalized edges
     let mut edges_by_orig_idx: HashMap<usize, EdgeLayout> = HashMap::new();
 
-    for &(from, to, orig_idx) in &lg.edges {
+    for (edge_pos, &(from, to, orig_idx)) in lg.edges.iter().enumerate() {
+        // Skip excluded edges (nesting edges removed during compound cleanup)
+        if lg.excluded_edges.contains(&edge_pos) {
+            continue;
+        }
         // Skip if this edge is already processed (part of a chain)
         if edges_by_orig_idx.contains_key(&orig_idx) {
             continue;


### PR DESCRIPTION
## Summary

The edge-building loop in the kernel pipeline iterated all edges without checking `excluded_edges`. Nesting edges (exit constraints from `border_bottom`, nesting root connections) leaked into the `LayoutResult` as phantom edges, causing the routing layer to generate spurious paths that interfered with real cross-boundary edge rendering.

Added an `excluded_edges` check at the top of the edge-building loop, matching the pattern already used in `normalize::run()` and `count_forward_edges_per_gap()`.

Partial fix for #113, #124 — removes phantom edges. The text mode edge rendering gap (grid conversion not rendering the segment below the subgraph) is a separate grid-layer issue still tracked in #124.

## Test plan

- [x] All 2152 tests pass
- [x] Lint clean
- [x] No snapshot changes needed (phantom edges didn't affect existing flowchart tests)