### PR TITLE
fix: constrain backward edge routing to parent subgraph bounds

### DIFF
--- a/src/graph/routing/orthogonal/backward.rs
+++ b/src/graph/routing/orthogonal/backward.rs
@@ -264,6 +264,35 @@ pub(super) fn avoid_backward_td_bt_vertical_lane_node_intrusion(
     }
 }
 
+/// If both edge endpoints share the same parent subgraph, return that
+/// subgraph's rect.  Used to constrain backward edge routing channels
+/// to the interior of the containing subgraph.
+pub(in crate::graph::routing) fn shared_parent_subgraph_rect(
+    edge: &LayoutEdge,
+    geometry: &GraphGeometry,
+) -> Option<FRect> {
+    let from_parent = geometry.nodes.get(&edge.from)?.parent.as_deref()?;
+    let to_parent = geometry.nodes.get(&edge.to)?.parent.as_deref()?;
+    if from_parent != to_parent {
+        return None;
+    }
+    geometry.subgraphs.get(from_parent).map(|sg| sg.rect)
+}
+
+/// Check if a node belongs to the given parent subgraph (or has no
+/// parent when `parent_id` is None).
+pub(in crate::graph::routing) fn node_in_scope(
+    node_id: &str,
+    parent_id: Option<&str>,
+    geometry: &GraphGeometry,
+) -> bool {
+    let node_parent = geometry
+        .nodes
+        .get(node_id)
+        .and_then(|n| n.parent.as_deref());
+    node_parent == parent_id
+}
+
 pub(super) fn has_backward_corridor_obstructions(
     edge: &LayoutEdge,
     geometry: &GraphGeometry,
@@ -276,6 +305,11 @@ pub(super) fn has_backward_corridor_obstructions(
         return false;
     };
 
+    let scope_parent = geometry
+        .nodes
+        .get(&edge.from)
+        .and_then(|n| n.parent.as_deref());
+
     match direction {
         Direction::TopDown | Direction::BottomTop => {
             let corridor_left = sr.x.min(tr.x);
@@ -284,6 +318,9 @@ pub(super) fn has_backward_corridor_obstructions(
             let max_y = (sr.y + sr.height).max(tr.y + tr.height);
             geometry.nodes.values().any(|node| {
                 if node.id == edge.from || node.id == edge.to {
+                    return false;
+                }
+                if !node_in_scope(&node.id, scope_parent, geometry) {
                     return false;
                 }
                 let cy = node.rect.center_y();
@@ -301,6 +338,9 @@ pub(super) fn has_backward_corridor_obstructions(
             let max_x = (sr.x + sr.width).max(tr.x + tr.width);
             geometry.nodes.values().any(|node| {
                 if node.id == edge.from || node.id == edge.to {
+                    return false;
+                }
+                if !node_in_scope(&node.id, scope_parent, geometry) {
                     return false;
                 }
                 let cx = node.rect.center_x();
@@ -321,8 +361,11 @@ pub(crate) fn build_backward_orthogonal_channel_path(
 ) -> Option<Vec<FPoint>> {
     const CHANNEL_CLEARANCE: f64 = 12.0;
 
-    let sr = geometry.nodes.get(&edge.from)?.rect;
+    let from_node = geometry.nodes.get(&edge.from)?;
+    let sr = from_node.rect;
     let tr = geometry.nodes.get(&edge.to)?.rect;
+    let scope_parent = from_node.parent.as_deref();
+    let sg_rect = shared_parent_subgraph_rect(edge, geometry);
 
     match direction {
         Direction::TopDown | Direction::BottomTop => {
@@ -339,11 +382,18 @@ pub(crate) fn build_backward_orthogonal_channel_path(
                 if node.id == edge.from || node.id == edge.to {
                     continue;
                 }
+                if !node_in_scope(&node.id, scope_parent, geometry) {
+                    continue;
+                }
                 let cy = node.rect.center_y();
                 let node_right = node.rect.x + node.rect.width;
                 if cy >= min_y && cy <= max_y {
                     lane_x = lane_x.max(node_right + CHANNEL_CLEARANCE);
                 }
+            }
+            // Cap at subgraph right boundary when both endpoints share a parent.
+            if let Some(sg) = sg_rect {
+                lane_x = lane_x.min(sg.x + sg.width - CHANNEL_CLEARANCE);
             }
 
             Some(vec![
@@ -368,12 +418,19 @@ pub(crate) fn build_backward_orthogonal_channel_path(
                 if node.id == edge.from || node.id == edge.to {
                     continue;
                 }
+                if !node_in_scope(&node.id, scope_parent, geometry) {
+                    continue;
+                }
                 let cx = node.rect.center_x();
                 let node_bottom = node.rect.y + node.rect.height;
                 if cx >= min_x && cx <= max_x && node.rect.y < lane_y && node_bottom > corridor_top
                 {
                     lane_y = lane_y.max(node_bottom + CHANNEL_CLEARANCE);
                 }
+            }
+            // Cap at subgraph bottom boundary when both endpoints share a parent.
+            if let Some(sg) = sg_rect {
+                lane_y = lane_y.min(sg.y + sg.height - CHANNEL_CLEARANCE);
             }
 
             Some(vec![

--- a/src/graph/routing/stage.rs
+++ b/src/graph/routing/stage.rs
@@ -354,12 +354,17 @@ pub(crate) fn build_backward_channel_path(
     const CHANNEL_CLEARANCE: f64 = 8.0;
     const LANE_SPACING: f64 = 8.0;
 
-    let from_rect = geometry.nodes.get(&edge.from).map(|n| n.rect);
-    let to_rect = geometry.nodes.get(&edge.to).map(|n| n.rect);
+    let from_node = geometry.nodes.get(&edge.from);
+    let to_node = geometry.nodes.get(&edge.to);
+    let from_rect = from_node.map(|n| n.rect);
+    let to_rect = to_node.map(|n| n.rect);
 
     let (Some(sr), Some(tr)) = (from_rect, to_rect) else {
         return path;
     };
+
+    let scope_parent = from_node.and_then(|n| n.parent.as_deref());
+    let sg_rect = super::orthogonal::backward::shared_parent_subgraph_rect(edge, geometry);
 
     let lane_offset = CHANNEL_CLEARANCE + (backward_lane_index as f64) * LANE_SPACING;
 
@@ -377,11 +382,17 @@ pub(crate) fn build_backward_channel_path(
                 if node.id == edge.from || node.id == edge.to {
                     continue;
                 }
+                if !super::orthogonal::backward::node_in_scope(&node.id, scope_parent, geometry) {
+                    continue;
+                }
                 let cy = node.rect.center_y();
                 let node_right = node.rect.x + node.rect.width;
                 if cy >= min_y && cy <= max_y {
                     lane_x = lane_x.max(node_right + lane_offset);
                 }
+            }
+            if let Some(sg) = sg_rect {
+                lane_x = lane_x.min(sg.x + sg.width - CHANNEL_CLEARANCE);
             }
 
             vec![
@@ -405,12 +416,18 @@ pub(crate) fn build_backward_channel_path(
                 if node.id == edge.from || node.id == edge.to {
                     continue;
                 }
+                if !super::orthogonal::backward::node_in_scope(&node.id, scope_parent, geometry) {
+                    continue;
+                }
                 let cx = node.rect.center_x();
                 let node_bottom = node.rect.y + node.rect.height;
                 if cx >= min_x && cx <= max_x && node.rect.y < lane_y && node_bottom > corridor_top
                 {
                     lane_y = lane_y.max(node_bottom + lane_offset);
                 }
+            }
+            if let Some(sg) = sg_rect {
+                lane_y = lane_y.min(sg.y + sg.height - CHANNEL_CLEARANCE);
             }
 
             vec![

--- a/tests/svg-snapshots/state/composite.svg
+++ b/tests/svg-snapshots/state/composite.svg
@@ -44,13 +44,13 @@
       <path d="M116.16,22.00 L116.16,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M86.12,136.00 L86.12,182.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M121.24,240.00 L121.24,251.70 Q121.24,256.70 126.24,256.70 L142.39,256.70 Q147.39,256.70 147.39,261.70 L147.39,339.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M189.32,370.00 L196.32,370.00 Q201.32,370.00 201.32,365.00 L201.32,218.00 Q201.32,213.00 196.32,213.00 L133.24,213.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M189.32,370.00 L190.82,370.00 Q192.32,370.00 192.32,368.50 L192.32,218.00 Q192.32,213.00 187.32,213.00 L133.24,213.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M51.00,240.00 L51.00,243.00 Q51.00,246.00 54.00,246.00 L69.65,246.00 Q74.65,246.00 74.65,251.00 L74.65,261.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M116.16,412.00 L116.16,493.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
       <text x="147.39" y="276.42" text-anchor="middle" dominant-baseline="middle" fill="#333">pause</text>
-      <text x="201.32" y="263.46" text-anchor="middle" dominant-baseline="middle" fill="#333">resume</text>
+      <text x="192.32" y="263.46" text-anchor="middle" dominant-baseline="middle" fill="#333">resume</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

The backward edge channel computation iterated all nodes in the graph to determine the routing lane, causing edges inside a direction-override subgraph to route far outside the subgraph boundary (e.g. `Paused → Running : resume` extended 210px beyond the Active subgraph box).

- Filter node iteration to only consider nodes sharing the same parent subgraph as the edge endpoints
- Cap the channel at the subgraph boundary when both endpoints share a parent
- Applied to both the orthogonal router (`backward.rs`) and the polyline router (`stage.rs`)

**Before:** resume edge max_x=557.9, subgraph right=347.5 (210px overflow)
**After:** resume edge max_x=335.5, subgraph right=347.5 (inside)

Closes #131

## Test plan

- [x] All 2152 tests pass
- [x] Lint clean
- [x] SVG snapshots regenerated
- [x] Manual: verify backward edges stay inside subgraph in playground