### PR TITLE
fix: add background rectangles behind SVG edge labels

### DIFF
--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use super::text::{TextRenderStyle, render_text_centered};
+use super::text::{BackgroundStyle, TextRenderStyle, render_text_centered};
 use super::{GraphSvgPalette, Point, dynamic_css_attrs};
 use crate::graph::geometry::GraphGeometry;
 use crate::graph::measure::ProportionalTextMetrics;
@@ -114,6 +114,15 @@ pub(super) fn render_edge_labels(
         "graph-edge-text",
         &["fill:var(--_text);"],
     );
+    let bg_dynamic_attrs = dynamic_css_attrs(
+        palette.dynamic_css,
+        "graph-edge-label-bg",
+        &["fill:var(--bg);"],
+    );
+    let bg_style = BackgroundStyle {
+        fill: &palette.edge_label_background,
+        extra_attrs: bg_dynamic_attrs.as_str(),
+    };
 
     writer.start_group("edgeLabels");
 
@@ -169,6 +178,10 @@ pub(super) fn render_edge_labels(
             TextRenderStyle {
                 color: &palette.edge_label_text,
                 extra_attrs: dynamic_attrs.as_str(),
+                background: Some(BackgroundStyle {
+                    fill: bg_style.fill,
+                    extra_attrs: bg_style.extra_attrs,
+                }),
             },
         );
     }
@@ -202,6 +215,10 @@ pub(super) fn render_edge_labels(
                 TextRenderStyle {
                     color: &palette.edge_label_text,
                     extra_attrs: dynamic_attrs.as_str(),
+                    background: Some(BackgroundStyle {
+                        fill: bg_style.fill,
+                        extra_attrs: bg_style.extra_attrs,
+                    }),
                 },
             );
         }
@@ -218,6 +235,10 @@ pub(super) fn render_edge_labels(
                 TextRenderStyle {
                     color: &palette.edge_label_text,
                     extra_attrs: dynamic_attrs.as_str(),
+                    background: Some(BackgroundStyle {
+                        fill: bg_style.fill,
+                        extra_attrs: bg_style.extra_attrs,
+                    }),
                 },
             );
         }

--- a/src/render/graph/svg/mod.rs
+++ b/src/render/graph/svg/mod.rs
@@ -48,6 +48,7 @@ pub(super) struct GraphSvgPalette {
     pub(super) edge_label_text: String,
     pub(super) subgraph_stroke: String,
     pub(super) subgraph_title_text: String,
+    pub(super) edge_label_background: String,
     pub(super) marker_color: String,
     pub(super) dynamic_css: bool,
 }
@@ -69,6 +70,7 @@ impl GraphSvgPalette {
                 node_text: theme.roles.text.clone(),
                 edge_stroke: theme.roles.line.clone(),
                 edge_label_text: theme.roles.text.clone(),
+                edge_label_background: theme.roles.background.clone(),
                 subgraph_stroke: theme.roles.inner_stroke.clone(),
                 subgraph_title_text: theme.roles.group_header.clone(),
                 marker_color: theme.roles.arrow.clone(),
@@ -81,6 +83,7 @@ impl GraphSvgPalette {
                 node_text: UNTHEMED_TEXT_COLOR.to_string(),
                 edge_stroke: UNTHEMED_STROKE_COLOR.to_string(),
                 edge_label_text: UNTHEMED_TEXT_COLOR.to_string(),
+                edge_label_background: UNTHEMED_NODE_FILL.to_string(),
                 subgraph_stroke: UNTHEMED_SUBGRAPH_STROKE.to_string(),
                 subgraph_title_text: UNTHEMED_TEXT_COLOR.to_string(),
                 marker_color: UNTHEMED_STROKE_COLOR.to_string(),

--- a/src/render/graph/svg/nodes.rs
+++ b/src/render/graph/svg/nodes.rs
@@ -237,6 +237,7 @@ fn render_node_label(
             TextRenderStyle {
                 color: text_color,
                 extra_attrs: text_dynamic_attrs.as_str(),
+                background: None,
             },
         );
         return;

--- a/src/render/graph/svg/text.rs
+++ b/src/render/graph/svg/text.rs
@@ -7,7 +7,16 @@ use crate::render::svg::{SvgWriter, escape_text, fmt_f64};
 pub(super) struct TextRenderStyle<'a> {
     pub(super) color: &'a str,
     pub(super) extra_attrs: &'a str,
+    pub(super) background: Option<BackgroundStyle<'a>>,
 }
+
+pub(super) struct BackgroundStyle<'a> {
+    pub(super) fill: &'a str,
+    pub(super) extra_attrs: &'a str,
+}
+
+const LABEL_BG_PAD_X: f64 = 4.0;
+const LABEL_BG_PAD_Y: f64 = 2.0;
 
 pub(super) fn render_text_centered(
     writer: &mut SvgWriter,
@@ -17,6 +26,22 @@ pub(super) fn render_text_centered(
     scale: f64,
     style: TextRenderStyle<'_>,
 ) {
+    if let Some(bg) = &style.background {
+        let (w, h) = metrics.measure_text_with_padding(text, LABEL_BG_PAD_X, LABEL_BG_PAD_Y);
+        let rect_w = w * scale;
+        let rect_h = h * scale;
+        let rect = format!(
+            "<rect x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\" fill=\"{fill}\"{extra} />",
+            x = fmt_f64(center.x - rect_w / 2.0),
+            y = fmt_f64(center.y - rect_h / 2.0),
+            w = fmt_f64(rect_w),
+            h = fmt_f64(rect_h),
+            fill = bg.fill,
+            extra = bg.extra_attrs,
+        );
+        writer.push_line(&rect);
+    }
+
     let lines: Vec<&str> = text.split('\n').collect();
     if lines.len() == 1 {
         let line = format!(

--- a/tests/svg-snapshots/class/all_relations.svg
+++ b/tests/svg-snapshots/class/all_relations.svg
@@ -54,12 +54,19 @@
       <path d="M757.95,62.00 L757.95,212.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="-3.31" y="110.50" width="91.52" height="28.00" fill="white" />
       <text x="42.45" y="124.50" text-anchor="middle" dominant-baseline="middle" fill="#333">association</text>
+      <rect x="127.76" y="125.00" width="67.21" height="28.00" fill="white" />
       <text x="161.36" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">directed</text>
+      <rect x="235.81" y="125.00" width="88.92" height="28.00" fill="white" />
       <text x="280.27" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">inheritance</text>
+      <rect x="351.19" y="125.00" width="95.97" height="28.00" fill="white" />
       <text x="399.18" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">composition</text>
+      <rect x="471.68" y="125.00" width="92.82" height="28.00" fill="white" />
       <text x="518.09" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">aggregation</text>
+      <rect x="590.31" y="125.00" width="93.38" height="28.00" fill="white" />
       <text x="637.00" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">dependency</text>
+      <rect x="707.27" y="139.50" width="101.36" height="28.00" fill="white" />
       <text x="757.95" y="153.50" text-anchor="middle" dominant-baseline="middle" fill="#333">directed dep</text>
     </g>
   </g>

--- a/tests/svg-snapshots/class/cardinality_labels.svg
+++ b/tests/svg-snapshots/class/cardinality_labels.svg
@@ -20,11 +20,17 @@
       <path d="M222.43,62.00 L222.43,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="42.82" y="70.50" width="46.60" height="28.00" fill="white" />
       <text x="66.12" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">owns</text>
+      <rect x="187.52" y="99.50" width="69.80" height="28.00" fill="white" />
       <text x="222.43" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">contains</text>
+      <rect x="75.85" y="135.12" width="16.54" height="28.00" fill="white" />
       <text x="84.12" y="149.12" text-anchor="middle" dominant-baseline="middle" fill="#333">*</text>
+      <rect x="75.85" y="59.88" width="16.54" height="28.00" fill="white" />
       <text x="84.12" y="73.88" text-anchor="middle" dominant-baseline="middle" fill="#333">1</text>
+      <rect x="232.16" y="135.12" width="16.54" height="28.00" fill="white" />
       <text x="240.43" y="149.12" text-anchor="middle" dominant-baseline="middle" fill="#333">*</text>
+      <rect x="223.25" y="59.88" width="34.36" height="28.00" fill="white" />
       <text x="240.43" y="73.88" text-anchor="middle" dominant-baseline="middle" fill="#333">0..1</text>
     </g>
   </g>

--- a/tests/svg-snapshots/class/class_labels.svg
+++ b/tests/svg-snapshots/class/class_labels.svg
@@ -15,6 +15,7 @@
       <path d="M98.23,62.00 L98.23,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="74.18" y="85.00" width="48.09" height="28.00" fill="white" />
       <text x="98.23" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reads</text>
     </g>
   </g>

--- a/tests/svg-snapshots/class/members.svg
+++ b/tests/svg-snapshots/class/members.svg
@@ -25,6 +25,7 @@
       <path d="M87.83,206.00 L87.83,301.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="56.55" y="229.00" width="62.57" height="28.00" fill="white" />
       <text x="87.83" y="243.00" text-anchor="middle" dominant-baseline="middle" fill="#333">creates</text>
     </g>
   </g>

--- a/tests/svg-snapshots/class/relationships.svg
+++ b/tests/svg-snapshots/class/relationships.svg
@@ -24,8 +24,11 @@
       <path d="M65.47,62.00 L65.47,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="37.80" y="238.00" width="55.33" height="28.00" fill="white" />
       <text x="65.47" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">places</text>
+      <rect x="30.57" y="391.00" width="69.80" height="28.00" fill="white" />
       <text x="65.47" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">contains</text>
+      <rect x="11.82" y="85.00" width="107.30" height="28.00" fill="white" />
       <text x="65.47" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">authenticates</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-basis/backward_loop_lr.svg
@@ -35,7 +35,9 @@
       <path d="M1345.87,139.00 L1353.87,139.00 L1359.58,139.00 C1365.29,139.00 1376.71,139.00 1391.63,139.00 C1406.55,139.00 1424.97,139.00 1434.18,139.00 L1443.39,139.00 L1451.39,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="1107.77" y="143.00" width="34.73" height="28.00" fill="white" />
       <text x="1125.13" y="157.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1366.87" y="125.00" width="42.52" height="28.00" fill="white" />
       <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-basis/br_line_breaks.svg
@@ -22,6 +22,7 @@
       <path d="M61.85,214.00 L61.85,222.00 L61.85,228.83 C61.85,235.67 61.85,249.33 61.85,266.50 C61.85,283.67 61.85,304.33 61.85,314.67 L61.85,325.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="45.04" y="237.00" width="33.61" height="52.00" fill="white" />
       <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>

--- a/tests/svg-snapshots/flowchart-basis/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-basis/ci_pipeline.svg
@@ -30,7 +30,9 @@
       <path d="M793.82,103.83 L801.14,107.05 L813.25,112.38 C825.36,117.70 849.58,128.35 874.38,133.68 C899.17,139.00 924.55,139.00 937.24,139.00 L949.93,139.00 L957.93,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="840.72" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="871.35" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="830.18" y="124.35" width="84.28" height="28.00" fill="white" />
       <text x="872.32" y="138.35" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-basis/compat_class_annotation.svg
@@ -21,7 +21,9 @@
       <path d="M124.10,204.69 L128.36,211.46 L133.86,220.19 C139.36,228.93 150.36,246.40 155.86,263.47 C161.36,280.54 161.36,297.21 161.36,305.54 L161.36,313.88 L161.36,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="28.64" y="244.82" width="33.98" height="28.00" fill="white" />
       <text x="45.64" y="258.82" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="148.64" y="264.38" width="25.45" height="28.00" fill="white" />
       <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-basis/compat_directive.svg
@@ -21,7 +21,9 @@
       <path d="M168.24,201.29 L173.25,207.52 L180.80,216.92 C188.34,226.31 203.43,245.09 210.98,262.82 C218.53,280.54 218.53,297.21 218.53,305.54 L218.53,313.88 L218.53,321.88" stroke="#d3d3d3" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="56.76" y="241.19" width="33.98" height="28.00" fill="#333333" />
       <text x="73.75" y="255.19" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">Yes</text>
+      <rect x="205.80" y="264.38" width="25.45" height="28.00" fill="#333333" />
       <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-basis/compat_hyphenated_ids.svg
@@ -21,6 +21,7 @@
       <path d="M75.49,313.06 L75.49,321.06 L75.49,325.89 C75.49,330.73 75.49,340.39 75.49,353.56 C75.49,366.73 75.49,383.39 75.49,391.73 L75.49,400.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="62.95" y="336.06" width="25.08" height="28.00" fill="white" />
       <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-basis/compat_kitchen_sink.svg
@@ -25,7 +25,9 @@
       <path d="M218.83,411.06 L218.83,413.84 C218.83,416.61 218.83,422.17 212.22,427.72 C205.62,433.28 192.40,438.84 185.79,443.72 C179.18,448.61 179.18,452.84 179.18,454.95 L179.18,457.06" stroke="#333333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="62.06" y="270.12" width="42.89" height="28.00" fill="#ffffff" />
       <text x="83.50" y="284.12" text-anchor="middle" dominant-baseline="middle" fill="#333333">valid</text>
+      <rect x="212.21" y="295.56" width="56.07" height="28.00" fill="#ffffff" />
       <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/complex.svg
+++ b/tests/svg-snapshots/flowchart-basis/complex.svg
@@ -39,9 +39,13 @@
       <path d="M182.38,620.28 L182.38,623.06 C182.38,625.84 182.38,631.39 190.27,636.95 C198.15,642.51 213.93,648.06 221.81,652.95 C229.70,657.84 229.70,662.06 229.70,664.17 L229.70,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="151.60" y="225.70" width="56.07" height="28.00" fill="white" />
       <text x="179.63" y="239.70" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="522.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="449.41" y="564.28" width="25.08" height="28.00" fill="white" />
       <text x="461.94" y="578.28" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-basis/compound_backward_cross_boundary.svg
@@ -47,14 +47,23 @@
       <path d="M260.91,1022.06 L268.91,1022.06 L282.45,1022.06 C295.99,1022.06 323.07,1022.06 336.60,912.14 C350.14,802.21 350.14,582.35 349.81,472.43 C349.48,362.50 348.81,362.50 348.48,362.50 L348.14,362.50 L340.14,362.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="97.75" y="170.50" width="62.57" height="28.00" fill="white" />
       <text x="129.03" y="184.50" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
+      <rect x="317.90" y="199.50" width="52.73" height="28.00" fill="white" />
       <text x="344.27" y="213.50" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
+      <rect x="214.15" y="471.50" width="39.55" height="28.00" fill="white" />
       <text x="233.93" y="485.50" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="314.65" y="451.50" width="77.04" height="28.00" fill="white" />
       <text x="353.17" y="465.50" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
+      <rect x="144.18" y="409.08" width="46.05" height="28.00" fill="white" />
       <text x="167.21" y="423.08" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
+      <rect x="208.86" y="654.86" width="50.13" height="28.00" fill="white" />
       <text x="233.93" y="668.86" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
+      <rect x="339.62" y="565.00" width="27.12" height="28.00" fill="white" />
       <text x="353.17" y="579.00" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="197.07" y="907.86" width="73.70" height="28.00" fill="white" />
       <text x="233.93" y="921.86" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="328.70" y="717.90" width="42.89" height="28.00" fill="white" />
       <text x="350.14" y="731.90" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-basis/crossing_minimize.svg
@@ -39,9 +39,13 @@
       <path d="M461.94,541.28 L461.94,549.28 L461.94,554.12 C461.94,558.95 461.94,568.62 437.04,587.79 C412.14,606.95 362.34,635.63 337.44,649.96 L312.54,664.30 L305.61,668.29" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="151.60" y="225.70" width="56.07" height="28.00" fill="white" />
       <text x="179.63" y="239.70" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="522.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="449.41" y="564.28" width="25.08" height="28.00" fill="white" />
       <text x="461.94" y="578.28" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/decision.svg
+++ b/tests/svg-snapshots/flowchart-basis/decision.svg
@@ -22,7 +22,9 @@
       <path d="M277.44,403.36 L285.44,403.36 L285.77,403.36 C286.11,403.36 286.77,403.36 287.11,341.97 C287.44,280.57 287.44,157.79 265.14,96.39 C242.83,35.00 198.23,35.00 175.92,35.00 L153.62,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="56.14" y="305.32" width="33.98" height="28.00" fill="white" />
       <text x="73.13" y="319.32" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="143.15" y="300.10" width="25.45" height="28.00" fill="white" />
       <text x="155.88" y="314.10" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-basis/flowchart_code_flow.svg
@@ -436,12 +436,19 @@
       <path d="M10995.46,1460.19 L10995.46,1469.02 C10995.46,1477.85 10995.46,1495.52 11014.50,1513.19 C11033.55,1530.85 11071.64,1548.52 11090.68,1565.52 C11109.73,1582.52 11109.73,1598.85 11109.73,1607.02 L11109.73,1615.19" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="9400.37" y="422.21" width="159.45" height="28.00" fill="white" />
       <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <rect x="9651.52" y="436.71" width="188.96" height="28.00" fill="white" />
       <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <rect x="9902.30" y="451.21" width="219.21" height="28.00" fill="white" />
       <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <rect x="9463.11" y="716.45" width="33.98" height="28.00" fill="white" />
       <text x="9480.10" y="730.45" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9729.01" y="730.95" width="33.98" height="28.00" fill="white" />
       <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9944.71" y="747.76" width="33.98" height="28.00" fill="white" />
       <text x="9961.70" y="761.76" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="370.73" y="1617.19" width="137.18" height="28.00" fill="white" />
       <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-basis/git_workflow.svg
@@ -22,9 +22,13 @@
       <path d="M924.69,62.00 L924.69,70.00 L924.69,71.00 C924.69,72.00 924.69,74.00 784.05,75.00 C643.42,76.00 362.15,76.00 221.51,75.67 C80.87,75.33 80.87,74.67 80.87,74.33 L80.87,74.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="174.75" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="432.11" y="21.00" width="89.29" height="28.00" fill="white" />
       <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="730.63" y="21.00" width="69.80" height="28.00" fill="white" />
       <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="473.78" y="62.00" width="62.01" height="28.00" fill="white" />
       <text x="504.78" y="76.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-basis/git_workflow_td.svg
@@ -22,9 +22,13 @@
       <path d="M164.51,469.00 L172.51,469.00 L172.85,469.00 C173.18,469.00 173.85,469.00 174.18,396.67 C174.51,324.33 174.51,179.67 173.95,107.33 C173.38,35.00 172.26,35.00 171.69,35.00 L171.13,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="55.62" y="85.00" width="61.27" height="28.00" fill="white" />
       <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="41.61" y="213.00" width="89.29" height="28.00" fill="white" />
       <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="51.35" y="366.00" width="69.80" height="28.00" fill="white" />
       <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="141.51" y="235.31" width="62.01" height="28.00" fill="white" />
       <text x="172.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/http_request.svg
+++ b/tests/svg-snapshots/flowchart-basis/http_request.svg
@@ -29,9 +29,13 @@
       <path d="M352.16,632.20 L360.16,632.20 L373.04,632.20 C385.93,632.20 411.71,632.20 424.60,532.67 C437.49,433.14 437.49,234.07 419.39,134.53 C401.29,35.00 365.09,35.00 346.99,35.00 L328.89,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="211.44" y="85.00" width="109.71" height="28.00" fill="white" />
       <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <rect x="128.87" y="417.53" width="33.98" height="28.00" fill="white" />
       <text x="145.87" y="431.53" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="322.83" y="464.70" width="25.45" height="28.00" fill="white" />
       <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="377.07" y="301.97" width="120.84" height="28.00" fill="white" />
       <text x="437.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-basis/inline_edge_labels.svg
@@ -24,9 +24,13 @@
       <path d="M57.58,521.00 L57.58,529.00 L57.58,533.83 C57.58,538.67 57.58,548.33 57.58,561.50 C57.58,574.67 57.58,591.33 57.58,599.67 L57.58,608.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="40.77" y="85.00" width="33.61" height="28.00" fill="white" />
       <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="36.13" y="238.00" width="42.89" height="28.00" fill="white" />
       <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="17.39" y="391.00" width="80.38" height="28.00" fill="white" />
       <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <rect x="45.04" y="544.00" width="25.08" height="28.00" fill="white" />
       <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-basis/inline_label_flowchart.svg
@@ -76,14 +76,23 @@
       <path d="M412.63,1819.26 L412.63,1822.04 C412.63,1824.81 412.63,1830.37 412.63,1835.92 C412.63,1841.48 412.63,1847.04 412.63,1851.92 C412.63,1856.81 412.63,1861.04 412.63,1863.15 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="331.64" y="594.88" width="25.08" height="28.00" fill="white" />
       <text x="344.18" y="608.88" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="603.43" y="639.57" width="33.61" height="28.00" fill="white" />
       <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="463.73" y="867.16" width="42.15" height="28.00" fill="white" />
       <text x="484.81" y="881.16" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <rect x="698.56" y="906.09" width="50.69" height="28.00" fill="white" />
       <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <rect x="630.46" y="1549.74" width="25.08" height="28.00" fill="white" />
       <text x="643.00" y="1563.74" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="546.64" y="1546.54" width="33.61" height="28.00" fill="white" />
       <text x="563.45" y="1560.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="76.04" y="403.76" width="27.12" height="28.00" fill="white" />
       <text x="89.60" y="417.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="273.98" y="451.89" width="42.71" height="28.00" fill="white" />
       <text x="295.33" y="465.89" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="726.84" y="1332.59" width="44.01" height="28.00" fill="white" />
       <text x="748.85" y="1346.59" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-basis/label_spacing.svg
@@ -18,7 +18,9 @@
       <path d="M126.99,62.00 L132.44,67.86 L137.26,73.05 C142.08,78.24 151.72,88.62 156.54,102.14 C161.36,115.67 161.36,132.33 161.36,140.67 L161.36,149.00 L161.36,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="21.01" y="88.75" width="42.89" height="28.00" fill="white" />
       <text x="42.45" y="102.75" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="133.33" y="99.50" width="56.07" height="28.00" fill="white" />
       <text x="161.36" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-basis/labeled_edges.svg
@@ -25,10 +25,15 @@
       <path d="M327.04,512.80 L335.04,512.80 L335.37,512.80 C335.70,512.80 336.37,512.80 336.70,458.67 C337.04,404.53 337.04,296.27 309.29,242.13 C281.55,188.00 226.07,188.00 198.33,188.00 L170.58,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="72.71" y="85.00" width="71.29" height="28.00" fill="white" />
       <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <rect x="49.57" y="238.00" width="75.74" height="28.00" fill="white" />
       <text x="87.44" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <rect x="49.96" y="414.90" width="33.61" height="28.00" fill="white" />
       <text x="66.77" y="428.90" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="164.90" y="402.07" width="25.08" height="28.00" fill="white" />
       <text x="177.44" y="416.07" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="313.59" y="252.17" width="42.89" height="28.00" fill="white" />
       <text x="335.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-basis/multi_edge_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M42.45,215.00 L42.45,217.78 C42.45,220.56 42.45,226.11 42.45,231.67 C42.45,237.22 42.45,242.78 42.45,247.67 C42.45,252.56 42.45,256.78 42.45,258.89 L42.45,261.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="-16.49" y="94.55" width="56.63" height="28.00" fill="white" />
       <text x="11.82" y="108.55" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="44.77" y="94.55" width="56.63" height="28.00" fill="white" />
       <text x="73.09" y="108.55" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-basis/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-basis/self_loop_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M58.20,212.40 L58.20,220.40 L58.20,225.23 C58.20,230.07 58.20,239.73 58.20,252.90 C58.20,266.07 58.20,282.73 58.20,291.07 L58.20,299.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="122.45" y="148.20" width="42.89" height="28.00" fill="white" />
       <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="37.12" y="235.40" width="42.15" height="28.00" fill="white" />
       <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/backward_loop_lr.svg
@@ -35,7 +35,9 @@
       <path d="M1345.87,139.00 L1382.37,139.00 L1385.42,139.00 C1388.46,139.00 1394.54,139.00 1400.63,139.00 C1406.71,139.00 1412.80,139.00 1415.84,139.00 L1418.88,139.00 L1451.39,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="1109.77" y="176.00" width="34.73" height="28.00" fill="white" />
       <text x="1127.13" y="190.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1366.87" y="125.00" width="42.52" height="28.00" fill="white" />
       <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/br_line_breaks.svg
@@ -22,6 +22,7 @@
       <path d="M61.85,214.00 L61.85,255.00 L61.85,258.42 C61.85,261.83 61.85,268.67 61.85,275.50 C61.85,282.33 61.85,289.17 61.85,292.58 L61.85,296.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="45.04" y="237.00" width="33.61" height="52.00" fill="white" />
       <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>

--- a/tests/svg-snapshots/flowchart-curved-step/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/ci_pipeline.svg
@@ -30,7 +30,9 @@
       <path d="M786.81,110.84 L786.81,115.54 C786.81,120.23 786.81,129.61 815.33,134.31 C843.85,139.00 900.89,139.00 929.41,139.00 L957.93,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="827.66" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="858.29" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="816.15" y="125.00" width="84.28" height="28.00" fill="white" />
       <text x="858.29" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compat_class_annotation.svg
@@ -21,7 +21,9 @@
       <path d="M133.16,195.63 L137.86,195.63 C142.56,195.63 151.96,195.63 156.66,216.67 C161.36,237.71 161.36,279.79 161.36,300.84 L161.36,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="25.46" y="235.38" width="33.98" height="28.00" fill="white" />
       <text x="42.45" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="148.64" y="264.38" width="25.45" height="28.00" fill="white" />
       <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compat_directive.svg
@@ -21,7 +21,9 @@
       <path d="M177.32,192.21 L184.19,192.21 C191.06,192.21 204.79,192.21 211.66,213.82 C218.53,235.43 218.53,278.65 218.53,300.26 L218.53,321.88" stroke="#d3d3d3" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="49.78" y="235.38" width="33.98" height="28.00" fill="#333333" />
       <text x="66.77" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">Yes</text>
+      <rect x="205.80" y="264.38" width="25.45" height="28.00" fill="#333333" />
       <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compat_hyphenated_ids.svg
@@ -21,6 +21,7 @@
       <path d="M75.49,313.06 L75.49,346.06 L75.49,348.81 C75.49,351.56 75.49,357.06 75.49,362.56 C75.49,368.06 75.49,373.56 75.49,376.31 L75.49,379.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="62.95" y="336.06" width="25.08" height="28.00" fill="white" />
       <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compat_kitchen_sink.svg
@@ -25,7 +25,9 @@
       <path d="M218.83,411.06 L218.83,413.84 C218.83,416.61 218.83,422.17 215.20,427.17 C211.57,432.17 204.30,436.61 200.67,441.50 C197.04,446.39 197.04,451.72 197.04,454.39 L197.04,457.06" stroke="#333333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="53.86" y="266.56" width="42.89" height="28.00" fill="#ffffff" />
       <text x="75.31" y="280.56" text-anchor="middle" dominant-baseline="middle" fill="#333333">valid</text>
+      <rect x="212.21" y="295.56" width="56.07" height="28.00" fill="#ffffff" />
       <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/complex.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/complex.svg
@@ -39,9 +39,13 @@
       <path d="M182.38,620.28 L182.38,623.06 C182.38,625.84 182.38,631.39 186.99,636.39 C191.60,641.39 200.83,645.84 205.44,650.73 C210.05,655.62 210.05,660.95 210.05,663.62 L210.05,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="128.80" y="232.78" width="56.07" height="28.00" fill="white" />
       <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="526.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="287.91" y="511.03" width="25.08" height="28.00" fill="white" />
       <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compound_backward_cross_boundary.svg
@@ -47,14 +47,23 @@
       <path d="M260.91,1022.06 L360.14,1022.06 L360.14,967.10 C360.14,912.14 360.14,802.21 360.14,692.28 C360.14,582.35 360.14,472.43 360.14,417.46 L360.14,362.50 L340.14,362.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="97.75" y="170.50" width="62.57" height="28.00" fill="white" />
       <text x="129.03" y="184.50" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
+      <rect x="317.90" y="199.50" width="52.73" height="28.00" fill="white" />
       <text x="344.27" y="213.50" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
+      <rect x="254.19" y="469.16" width="39.55" height="28.00" fill="white" />
       <text x="273.96" y="483.16" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="314.65" y="451.50" width="77.04" height="28.00" fill="white" />
       <text x="353.17" y="465.50" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
+      <rect x="90.05" y="422.50" width="46.05" height="28.00" fill="white" />
       <text x="113.07" y="436.50" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
+      <rect x="208.86" y="654.86" width="50.13" height="28.00" fill="white" />
       <text x="233.93" y="668.86" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
+      <rect x="306.31" y="670.43" width="27.12" height="28.00" fill="white" />
       <text x="319.87" y="684.43" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="193.60" y="920.36" width="73.70" height="28.00" fill="white" />
       <text x="230.45" y="934.36" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="338.70" y="717.90" width="42.89" height="28.00" fill="white" />
       <text x="360.14" y="731.90" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/crossing_minimize.svg
@@ -39,9 +39,13 @@
       <path d="M417.10,496.44 L397.66,496.44 C378.22,496.44 339.33,496.44 319.89,524.75 C300.45,553.05 300.45,609.67 300.45,637.98 L300.45,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="128.80" y="232.78" width="56.07" height="28.00" fill="white" />
       <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="526.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="287.91" y="511.03" width="25.08" height="28.00" fill="white" />
       <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/decision.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/decision.svg
@@ -22,7 +22,9 @@
       <path d="M277.44,403.36 L289.44,403.36 L289.44,372.66 C289.44,341.97 289.44,280.57 289.44,219.18 C289.44,157.79 289.44,96.39 289.44,65.70 L289.44,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="56.14" y="285.86" width="33.98" height="28.00" fill="white" />
       <text x="73.13" y="299.86" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="191.98" y="253.85" width="25.45" height="28.00" fill="white" />
       <text x="204.71" y="267.85" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/flowchart_code_flow.svg
@@ -436,12 +436,19 @@
       <path d="M11070.44,1460.19 L11070.44,1469.02 C11070.44,1477.85 11070.44,1495.52 11076.99,1513.19 C11083.54,1530.85 11096.63,1548.52 11103.18,1565.52 C11109.73,1582.52 11109.73,1598.85 11109.73,1607.02 L11109.73,1615.19" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="9400.37" y="422.21" width="159.45" height="28.00" fill="white" />
       <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <rect x="9651.52" y="436.71" width="188.96" height="28.00" fill="white" />
       <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <rect x="9902.30" y="451.21" width="219.21" height="28.00" fill="white" />
       <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <rect x="9642.24" y="651.89" width="33.98" height="28.00" fill="white" />
       <text x="9659.23" y="665.89" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9729.01" y="730.95" width="33.98" height="28.00" fill="white" />
       <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9815.79" y="627.67" width="33.98" height="28.00" fill="white" />
       <text x="9832.78" y="641.67" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="370.73" y="1617.19" width="137.18" height="28.00" fill="white" />
       <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/git_workflow.svg
@@ -22,9 +22,13 @@
       <path d="M924.69,62.00 L924.69,86.00 L854.37,86.00 C784.05,86.00 643.42,86.00 502.78,86.00 C362.15,86.00 221.51,86.00 151.19,86.00 L80.87,86.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="174.75" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="432.11" y="21.00" width="89.29" height="28.00" fill="white" />
       <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="730.63" y="21.00" width="69.80" height="28.00" fill="white" />
       <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="473.78" y="72.00" width="62.01" height="28.00" fill="white" />
       <text x="504.78" y="86.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/git_workflow_td.svg
@@ -22,9 +22,13 @@
       <path d="M164.51,469.00 L183.13,469.00 L183.13,432.83 C183.13,396.67 183.13,324.33 183.13,252.00 C183.13,179.67 183.13,107.33 183.13,71.17 L183.13,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="55.62" y="85.00" width="61.27" height="28.00" fill="white" />
       <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="41.61" y="213.00" width="89.29" height="28.00" fill="white" />
       <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="51.35" y="366.00" width="69.80" height="28.00" fill="white" />
       <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="152.12" y="237.31" width="62.01" height="28.00" fill="white" />
       <text x="183.13" y="251.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/http_request.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/http_request.svg
@@ -29,9 +29,13 @@
       <path d="M352.16,632.20 L441.49,632.20 L441.49,582.44 C441.49,532.67 441.49,433.14 441.49,333.60 C441.49,234.07 441.49,134.53 441.49,84.77 L441.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="211.44" y="85.00" width="109.71" height="28.00" fill="white" />
       <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <rect x="82.81" y="435.70" width="33.98" height="28.00" fill="white" />
       <text x="99.80" y="449.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="322.83" y="464.70" width="25.45" height="28.00" fill="white" />
       <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="381.07" y="301.97" width="120.84" height="28.00" fill="white" />
       <text x="441.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/inline_edge_labels.svg
@@ -24,9 +24,13 @@
       <path d="M57.58,521.00 L57.58,554.00 L57.58,556.75 C57.58,559.50 57.58,565.00 57.58,570.50 C57.58,576.00 57.58,581.50 57.58,584.25 L57.58,587.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="40.77" y="85.00" width="33.61" height="28.00" fill="white" />
       <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="36.13" y="238.00" width="42.89" height="28.00" fill="white" />
       <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="17.39" y="391.00" width="80.38" height="28.00" fill="white" />
       <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <rect x="45.04" y="544.00" width="25.08" height="28.00" fill="white" />
       <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/inline_label_flowchart.svg
@@ -76,14 +76,23 @@
       <path d="M412.63,1819.26 L412.63,1822.04 C412.63,1824.81 412.63,1830.37 412.63,1835.37 C412.63,1840.37 412.63,1844.81 412.63,1849.70 C412.63,1854.59 412.63,1859.92 412.63,1862.59 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="256.26" y="610.57" width="25.08" height="28.00" fill="white" />
       <text x="268.80" y="624.57" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="603.43" y="639.57" width="33.61" height="28.00" fill="white" />
       <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="434.02" y="877.09" width="42.15" height="28.00" fill="white" />
       <text x="455.10" y="891.09" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <rect x="698.56" y="906.09" width="50.69" height="28.00" fill="white" />
       <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <rect x="665.19" y="1528.99" width="25.08" height="28.00" fill="white" />
       <text x="677.73" y="1542.99" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="529.03" y="1512.71" width="33.61" height="28.00" fill="white" />
       <text x="545.84" y="1526.71" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="39.24" y="423.76" width="27.12" height="28.00" fill="white" />
       <text x="52.80" y="437.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="265.90" y="472.26" width="42.71" height="28.00" fill="white" />
       <text x="287.26" y="486.26" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="720.21" y="1384.92" width="44.01" height="28.00" fill="white" />
       <text x="742.22" y="1398.92" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/label_spacing.svg
@@ -18,7 +18,9 @@
       <path d="M128.36,62.00 L128.36,80.00 L128.36,89.83 C128.36,99.67 128.36,119.33 133.86,129.17 C139.36,139.00 150.36,139.00 155.86,139.00 L161.36,139.00 L161.36,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="37.51" y="95.50" width="42.89" height="28.00" fill="white" />
       <text x="58.95" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="116.83" y="95.50" width="56.07" height="28.00" fill="white" />
       <text x="144.86" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/labeled_edges.svg
@@ -25,10 +25,15 @@
       <path d="M327.04,512.80 L339.04,512.80 L339.04,485.73 C339.04,458.67 339.04,404.53 339.04,350.40 C339.04,296.27 339.04,242.13 339.04,215.07 L339.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="72.71" y="85.00" width="71.29" height="28.00" fill="white" />
       <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <rect x="55.61" y="236.00" width="75.74" height="28.00" fill="white" />
       <text x="93.49" y="250.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <rect x="49.96" y="395.30" width="33.61" height="28.00" fill="white" />
       <text x="66.77" y="409.30" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="219.05" y="348.23" width="25.08" height="28.00" fill="white" />
       <text x="231.58" y="362.23" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="317.59" y="252.17" width="42.89" height="28.00" fill="white" />
       <text x="339.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/multi_edge_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M42.45,215.00 L42.45,217.78 C42.45,220.56 42.45,226.11 42.45,231.11 C42.45,236.11 42.45,240.56 42.45,245.44 C42.45,250.33 42.45,255.67 42.45,258.33 L42.45,261.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="0.91" y="95.50" width="56.63" height="28.00" fill="white" />
       <text x="29.23" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="40.60" y="95.50" width="56.63" height="28.00" fill="white" />
       <text x="68.91" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-curved-step/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/self_loop_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M58.20,212.40 L58.20,245.40 L58.20,248.15 C58.20,250.90 58.20,256.40 58.20,261.90 C58.20,267.40 58.20,272.90 58.20,275.65 L58.20,278.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="122.45" y="148.20" width="42.89" height="28.00" fill="white" />
       <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="37.12" y="235.40" width="42.15" height="28.00" fill="white" />
       <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-polyline/backward_loop_lr.svg
@@ -35,7 +35,9 @@
       <path d="M1345.87,139.00 L1388.13,139.00 L1451.39,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="1107.77" y="143.00" width="34.73" height="28.00" fill="white" />
       <text x="1125.13" y="157.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1366.87" y="125.00" width="42.52" height="28.00" fill="white" />
       <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-polyline/br_line_breaks.svg
@@ -22,6 +22,7 @@
       <path d="M61.85,214.00 L61.85,263.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="45.04" y="237.00" width="33.61" height="52.00" fill="white" />
       <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>

--- a/tests/svg-snapshots/flowchart-polyline/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-polyline/ci_pipeline.svg
@@ -30,7 +30,9 @@
       <path d="M793.82,103.83 L873.79,139.00 L957.93,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="840.72" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="871.35" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="830.18" y="124.35" width="84.28" height="28.00" fill="white" />
       <text x="872.32" y="138.35" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compat_class_annotation.svg
@@ -21,7 +21,9 @@
       <path d="M124.10,204.69 L161.36,263.88 L161.36,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="28.64" y="244.82" width="33.98" height="28.00" fill="white" />
       <text x="45.64" y="258.82" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="148.64" y="264.38" width="25.45" height="28.00" fill="white" />
       <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compat_directive.svg
@@ -21,7 +21,9 @@
       <path d="M168.24,201.29 L218.53,263.88 L218.53,321.88" stroke="#d3d3d3" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="56.76" y="241.19" width="33.98" height="28.00" fill="#333333" />
       <text x="73.75" y="255.19" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">Yes</text>
+      <rect x="205.80" y="264.38" width="25.45" height="28.00" fill="#333333" />
       <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compat_hyphenated_ids.svg
@@ -21,6 +21,7 @@
       <path d="M75.49,313.06 L75.49,350.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="62.95" y="336.06" width="25.08" height="28.00" fill="white" />
       <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compat_kitchen_sink.svg
@@ -25,7 +25,9 @@
       <path d="M218.83,411.06 L181.67,457.92" stroke="#333333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="62.06" y="270.12" width="42.89" height="28.00" fill="#ffffff" />
       <text x="83.50" y="284.12" text-anchor="middle" dominant-baseline="middle" fill="#333333">valid</text>
+      <rect x="212.21" y="295.56" width="56.07" height="28.00" fill="#ffffff" />
       <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/complex.svg
+++ b/tests/svg-snapshots/flowchart-polyline/complex.svg
@@ -39,9 +39,13 @@
       <path d="M182.38,620.28 L226.95,667.38" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="151.60" y="225.70" width="56.07" height="28.00" fill="white" />
       <text x="179.63" y="239.70" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="522.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="449.41" y="564.28" width="25.08" height="28.00" fill="white" />
       <text x="461.94" y="578.28" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compound_backward_cross_boundary.svg
@@ -47,14 +47,23 @@
       <path d="M260.91,1022.06 L350.14,1022.06 L350.14,362.50 L340.14,362.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="97.75" y="170.50" width="62.57" height="28.00" fill="white" />
       <text x="129.03" y="184.50" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
+      <rect x="317.90" y="199.50" width="52.73" height="28.00" fill="white" />
       <text x="344.27" y="213.50" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
+      <rect x="214.15" y="471.50" width="39.55" height="28.00" fill="white" />
       <text x="233.93" y="485.50" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="314.65" y="451.50" width="77.04" height="28.00" fill="white" />
       <text x="353.17" y="465.50" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
+      <rect x="144.18" y="409.08" width="46.05" height="28.00" fill="white" />
       <text x="167.21" y="423.08" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
+      <rect x="208.86" y="654.86" width="50.13" height="28.00" fill="white" />
       <text x="233.93" y="668.86" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
+      <rect x="339.62" y="565.00" width="27.12" height="28.00" fill="white" />
       <text x="353.17" y="579.00" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="197.07" y="907.86" width="73.70" height="28.00" fill="white" />
       <text x="233.93" y="921.86" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="328.70" y="717.90" width="42.89" height="28.00" fill="white" />
       <text x="350.14" y="731.90" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-polyline/crossing_minimize.svg
@@ -39,9 +39,13 @@
       <path d="M461.94,541.28 L461.94,578.28 L305.61,668.29" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="151.60" y="225.70" width="56.07" height="28.00" fill="white" />
       <text x="179.63" y="239.70" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="522.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="449.41" y="564.28" width="25.08" height="28.00" fill="white" />
       <text x="461.94" y="578.28" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/decision.svg
+++ b/tests/svg-snapshots/flowchart-polyline/decision.svg
@@ -22,7 +22,9 @@
       <path d="M277.44,403.36 L287.44,403.36 L287.44,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="56.14" y="305.32" width="33.98" height="28.00" fill="white" />
       <text x="73.13" y="319.32" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="143.15" y="300.10" width="25.45" height="28.00" fill="white" />
       <text x="155.88" y="314.10" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-polyline/flowchart_code_flow.svg
@@ -436,12 +436,19 @@
       <path d="M10995.46,1460.19 L11107.39,1615.94" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="9400.37" y="422.21" width="159.45" height="28.00" fill="white" />
       <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <rect x="9651.52" y="436.71" width="188.96" height="28.00" fill="white" />
       <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <rect x="9902.30" y="451.21" width="219.21" height="28.00" fill="white" />
       <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <rect x="9463.11" y="716.45" width="33.98" height="28.00" fill="white" />
       <text x="9480.10" y="730.45" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9729.01" y="730.95" width="33.98" height="28.00" fill="white" />
       <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9944.71" y="747.76" width="33.98" height="28.00" fill="white" />
       <text x="9961.70" y="761.76" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="370.73" y="1617.19" width="137.18" height="28.00" fill="white" />
       <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-polyline/git_workflow.svg
@@ -22,9 +22,13 @@
       <path d="M924.69,62.00 L924.69,76.00 L80.87,76.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="174.75" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="432.11" y="21.00" width="89.29" height="28.00" fill="white" />
       <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="730.63" y="21.00" width="69.80" height="28.00" fill="white" />
       <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="473.78" y="62.00" width="62.01" height="28.00" fill="white" />
       <text x="504.78" y="76.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-polyline/git_workflow_td.svg
@@ -22,9 +22,13 @@
       <path d="M164.51,469.00 L174.51,469.00 L174.51,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="55.62" y="85.00" width="61.27" height="28.00" fill="white" />
       <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="41.61" y="213.00" width="89.29" height="28.00" fill="white" />
       <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="51.35" y="366.00" width="69.80" height="28.00" fill="white" />
       <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="141.51" y="235.31" width="62.01" height="28.00" fill="white" />
       <text x="172.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/http_request.svg
+++ b/tests/svg-snapshots/flowchart-polyline/http_request.svg
@@ -29,9 +29,13 @@
       <path d="M352.16,632.20 L437.49,632.20 L437.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="211.44" y="85.00" width="109.71" height="28.00" fill="white" />
       <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <rect x="128.87" y="417.53" width="33.98" height="28.00" fill="white" />
       <text x="145.87" y="431.53" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="322.83" y="464.70" width="25.45" height="28.00" fill="white" />
       <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="377.07" y="301.97" width="120.84" height="28.00" fill="white" />
       <text x="437.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-polyline/inline_edge_labels.svg
@@ -24,9 +24,13 @@
       <path d="M57.58,521.00 L57.58,558.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="40.77" y="85.00" width="33.61" height="28.00" fill="white" />
       <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="36.13" y="238.00" width="42.89" height="28.00" fill="white" />
       <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="17.39" y="391.00" width="80.38" height="28.00" fill="white" />
       <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <rect x="45.04" y="544.00" width="25.08" height="28.00" fill="white" />
       <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-polyline/inline_label_flowchart.svg
@@ -76,14 +76,23 @@
       <path d="M412.63,1819.26 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="331.64" y="594.88" width="25.08" height="28.00" fill="white" />
       <text x="344.18" y="608.88" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="603.43" y="639.57" width="33.61" height="28.00" fill="white" />
       <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="463.73" y="867.16" width="42.15" height="28.00" fill="white" />
       <text x="484.81" y="881.16" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <rect x="698.56" y="906.09" width="50.69" height="28.00" fill="white" />
       <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <rect x="630.46" y="1549.74" width="25.08" height="28.00" fill="white" />
       <text x="643.00" y="1563.74" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="546.64" y="1546.54" width="33.61" height="28.00" fill="white" />
       <text x="563.45" y="1560.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="76.04" y="403.76" width="27.12" height="28.00" fill="white" />
       <text x="89.60" y="417.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="273.98" y="451.89" width="42.71" height="28.00" fill="white" />
       <text x="295.33" y="465.89" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="726.84" y="1332.59" width="44.01" height="28.00" fill="white" />
       <text x="748.85" y="1346.59" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-polyline/label_spacing.svg
@@ -18,7 +18,9 @@
       <path d="M126.99,62.00 L161.36,99.00 L161.36,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="21.01" y="88.75" width="42.89" height="28.00" fill="white" />
       <text x="42.45" y="102.75" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="133.33" y="99.50" width="56.07" height="28.00" fill="white" />
       <text x="161.36" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-polyline/labeled_edges.svg
@@ -25,10 +25,15 @@
       <path d="M327.04,512.80 L337.04,512.80 L337.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="72.71" y="85.00" width="71.29" height="28.00" fill="white" />
       <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <rect x="49.57" y="238.00" width="75.74" height="28.00" fill="white" />
       <text x="87.44" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <rect x="49.96" y="414.90" width="33.61" height="28.00" fill="white" />
       <text x="66.77" y="428.90" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="164.90" y="402.07" width="25.08" height="28.00" fill="white" />
       <text x="177.44" y="416.07" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="313.59" y="252.17" width="42.89" height="28.00" fill="white" />
       <text x="335.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-polyline/multi_edge_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M42.45,215.00 L42.45,261.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="-16.49" y="94.55" width="56.63" height="28.00" fill="white" />
       <text x="11.82" y="108.55" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="44.77" y="94.55" width="56.63" height="28.00" fill="white" />
       <text x="73.09" y="108.55" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-polyline/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-polyline/self_loop_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M58.20,212.40 L58.20,249.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="122.45" y="148.20" width="42.89" height="28.00" fill="white" />
       <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="37.12" y="235.40" width="42.15" height="28.00" fill="white" />
       <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/backward_loop_lr.svg
@@ -35,7 +35,9 @@
       <path d="M1345.87,139.00 L1451.39,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="1109.77" y="168.00" width="34.73" height="28.00" fill="white" />
       <text x="1127.13" y="182.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1366.87" y="125.00" width="42.52" height="28.00" fill="white" />
       <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/br_line_breaks.svg
@@ -22,6 +22,7 @@
       <path d="M61.85,214.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="45.04" y="237.00" width="33.61" height="52.00" fill="white" />
       <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/ci_pipeline.svg
@@ -30,7 +30,9 @@
       <path d="M786.81,110.84 L786.81,134.00 Q786.81,139.00 791.81,139.00 L957.93,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="827.66" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="858.29" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="816.15" y="125.00" width="84.28" height="28.00" fill="white" />
       <text x="858.29" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compat_class_annotation.svg
@@ -21,7 +21,9 @@
       <path d="M133.16,195.63 L156.36,195.63 Q161.36,195.63 161.36,200.63 L161.36,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="25.46" y="235.38" width="33.98" height="28.00" fill="white" />
       <text x="42.45" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="148.64" y="264.38" width="25.45" height="28.00" fill="white" />
       <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compat_directive.svg
@@ -21,7 +21,9 @@
       <path d="M177.32,192.21 L213.53,192.21 Q218.53,192.21 218.53,197.21 L218.53,321.88" stroke="#d3d3d3" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="49.78" y="235.38" width="33.98" height="28.00" fill="#333333" />
       <text x="66.77" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">Yes</text>
+      <rect x="205.80" y="264.38" width="25.45" height="28.00" fill="#333333" />
       <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compat_hyphenated_ids.svg
@@ -21,6 +21,7 @@
       <path d="M75.49,313.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="62.95" y="336.06" width="25.08" height="28.00" fill="white" />
       <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compat_kitchen_sink.svg
@@ -25,7 +25,9 @@
       <path d="M218.83,411.06 L218.83,417.46 Q218.83,422.46 213.83,422.46 L202.04,422.46 Q197.04,422.46 197.04,427.46 L197.04,457.06" stroke="#333333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="53.86" y="266.56" width="42.89" height="28.00" fill="#ffffff" />
       <text x="75.31" y="280.56" text-anchor="middle" dominant-baseline="middle" fill="#333333">valid</text>
+      <rect x="212.21" y="295.56" width="56.07" height="28.00" fill="#ffffff" />
       <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/complex.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/complex.svg
@@ -39,9 +39,13 @@
       <path d="M182.38,620.28 L182.38,626.68 Q182.38,631.68 187.38,631.68 L205.05,631.68 Q210.05,631.68 210.05,636.68 L210.05,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="128.80" y="232.78" width="56.07" height="28.00" fill="white" />
       <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="526.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="287.91" y="511.03" width="25.08" height="28.00" fill="white" />
       <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compound_backward_cross_boundary.svg
@@ -47,14 +47,23 @@
       <path d="M260.91,1022.06 L347.14,1022.06 Q352.14,1022.06 352.14,1017.06 L352.14,367.50 Q352.14,362.50 347.14,362.50 L340.14,362.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="97.75" y="170.50" width="62.57" height="28.00" fill="white" />
       <text x="129.03" y="184.50" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
+      <rect x="317.90" y="199.50" width="52.73" height="28.00" fill="white" />
       <text x="344.27" y="213.50" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
+      <rect x="254.19" y="469.16" width="39.55" height="28.00" fill="white" />
       <text x="273.96" y="483.16" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="314.65" y="451.50" width="77.04" height="28.00" fill="white" />
       <text x="353.17" y="465.50" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
+      <rect x="90.05" y="422.50" width="46.05" height="28.00" fill="white" />
       <text x="113.07" y="436.50" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
+      <rect x="208.86" y="654.86" width="50.13" height="28.00" fill="white" />
       <text x="233.93" y="668.86" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
+      <rect x="339.62" y="565.00" width="27.12" height="28.00" fill="white" />
       <text x="353.17" y="579.00" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="193.60" y="920.36" width="73.70" height="28.00" fill="white" />
       <text x="230.45" y="934.36" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="330.70" y="717.90" width="42.89" height="28.00" fill="white" />
       <text x="352.14" y="731.90" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/crossing_minimize.svg
@@ -39,9 +39,13 @@
       <path d="M417.10,496.44 L305.45,496.44 Q300.45,496.44 300.45,501.44 L300.45,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="128.80" y="232.78" width="56.07" height="28.00" fill="white" />
       <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="526.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="287.91" y="511.03" width="25.08" height="28.00" fill="white" />
       <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/decision.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/decision.svg
@@ -22,7 +22,9 @@
       <path d="M277.44,403.36 L284.44,403.36 Q289.44,403.36 289.44,398.36 L289.44,40.00 Q289.44,35.00 284.44,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="56.14" y="285.86" width="33.98" height="28.00" fill="white" />
       <text x="73.13" y="299.86" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="191.98" y="253.85" width="25.45" height="28.00" fill="white" />
       <text x="204.71" y="267.85" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/flowchart_code_flow.svg
@@ -436,12 +436,19 @@
       <path d="M11070.44,1460.19 L11070.44,1477.49 Q11070.44,1482.49 11075.44,1482.49 L11104.73,1482.49 Q11109.73,1482.49 11109.73,1487.49 L11109.73,1615.19" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="9400.37" y="422.21" width="159.45" height="28.00" fill="white" />
       <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <rect x="9651.52" y="436.71" width="188.96" height="28.00" fill="white" />
       <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <rect x="9902.30" y="451.21" width="219.21" height="28.00" fill="white" />
       <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <rect x="9642.24" y="651.89" width="33.98" height="28.00" fill="white" />
       <text x="9659.23" y="665.89" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9729.01" y="730.95" width="33.98" height="28.00" fill="white" />
       <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9815.79" y="627.67" width="33.98" height="28.00" fill="white" />
       <text x="9832.78" y="641.67" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="370.73" y="1617.19" width="137.18" height="28.00" fill="white" />
       <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/git_workflow.svg
@@ -22,9 +22,13 @@
       <path d="M924.69,62.00 L924.69,73.00 Q924.69,78.00 919.69,78.00 L85.87,78.00 Q80.87,78.00 80.87,73.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="174.75" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="432.11" y="21.00" width="89.29" height="28.00" fill="white" />
       <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="730.63" y="21.00" width="69.80" height="28.00" fill="white" />
       <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="473.78" y="64.00" width="62.01" height="28.00" fill="white" />
       <text x="504.78" y="78.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/git_workflow_td.svg
@@ -22,9 +22,13 @@
       <path d="M164.51,469.00 L171.51,469.00 Q176.51,469.00 176.51,464.00 L176.51,40.00 Q176.51,35.00 171.51,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="55.62" y="85.00" width="61.27" height="28.00" fill="white" />
       <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="41.61" y="213.00" width="89.29" height="28.00" fill="white" />
       <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="51.35" y="366.00" width="69.80" height="28.00" fill="white" />
       <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="145.51" y="235.31" width="62.01" height="28.00" fill="white" />
       <text x="176.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/http_request.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/http_request.svg
@@ -29,9 +29,13 @@
       <path d="M352.16,632.20 L436.49,632.20 Q441.49,632.20 441.49,627.20 L441.49,40.00 Q441.49,35.00 436.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="211.44" y="85.00" width="109.71" height="28.00" fill="white" />
       <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <rect x="82.81" y="435.70" width="33.98" height="28.00" fill="white" />
       <text x="99.80" y="449.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="322.83" y="464.70" width="25.45" height="28.00" fill="white" />
       <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="381.07" y="301.97" width="120.84" height="28.00" fill="white" />
       <text x="441.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/inline_edge_labels.svg
@@ -24,9 +24,13 @@
       <path d="M57.58,521.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="40.77" y="85.00" width="33.61" height="28.00" fill="white" />
       <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="36.13" y="238.00" width="42.89" height="28.00" fill="white" />
       <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="17.39" y="391.00" width="80.38" height="28.00" fill="white" />
       <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <rect x="45.04" y="544.00" width="25.08" height="28.00" fill="white" />
       <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/inline_label_flowchart.svg
@@ -76,14 +76,23 @@
       <path d="M412.63,1819.26 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="256.26" y="610.57" width="25.08" height="28.00" fill="white" />
       <text x="268.80" y="624.57" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="603.43" y="639.57" width="33.61" height="28.00" fill="white" />
       <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="434.02" y="877.09" width="42.15" height="28.00" fill="white" />
       <text x="455.10" y="891.09" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <rect x="698.56" y="906.09" width="50.69" height="28.00" fill="white" />
       <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <rect x="622.93" y="1571.25" width="25.08" height="28.00" fill="white" />
       <text x="635.47" y="1585.25" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="529.03" y="1512.71" width="33.61" height="28.00" fill="white" />
       <text x="545.84" y="1526.71" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="37.24" y="425.76" width="27.12" height="28.00" fill="white" />
       <text x="50.80" y="439.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="265.90" y="472.26" width="42.71" height="28.00" fill="white" />
       <text x="287.26" y="486.26" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="726.84" y="1332.59" width="44.01" height="28.00" fill="white" />
       <text x="748.85" y="1346.59" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/label_spacing.svg
@@ -18,7 +18,9 @@
       <path d="M128.36,62.00 L128.36,73.30 Q128.36,78.30 133.36,78.30 L156.36,78.30 Q161.36,78.30 161.36,83.30 L161.36,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="21.01" y="70.50" width="42.89" height="28.00" fill="white" />
       <text x="42.45" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="133.33" y="99.50" width="56.07" height="28.00" fill="white" />
       <text x="161.36" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/labeled_edges.svg
@@ -25,10 +25,15 @@
       <path d="M327.04,512.80 L334.04,512.80 Q339.04,512.80 339.04,507.80 L339.04,193.00 Q339.04,188.00 334.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="72.71" y="85.00" width="71.29" height="28.00" fill="white" />
       <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <rect x="49.57" y="238.00" width="75.74" height="28.00" fill="white" />
       <text x="87.44" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <rect x="49.96" y="395.30" width="33.61" height="28.00" fill="white" />
       <text x="66.77" y="409.30" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="219.05" y="348.23" width="25.08" height="28.00" fill="white" />
       <text x="231.58" y="362.23" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="317.59" y="252.17" width="42.89" height="28.00" fill="white" />
       <text x="339.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/multi_edge_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M42.45,215.00 L42.45,261.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="12.75" y="83.67" width="56.63" height="28.00" fill="white" />
       <text x="41.06" y="97.67" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="40.60" y="95.50" width="56.63" height="28.00" fill="white" />
       <text x="68.91" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/self_loop_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="122.45" y="148.20" width="42.89" height="28.00" fill="white" />
       <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="37.12" y="235.40" width="42.15" height="28.00" fill="white" />
       <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-step/backward_loop_lr.svg
@@ -35,7 +35,9 @@
       <path d="M1345.87,139.00 L1451.39,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="1109.77" y="168.00" width="34.73" height="28.00" fill="white" />
       <text x="1127.13" y="182.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1366.87" y="125.00" width="42.52" height="28.00" fill="white" />
       <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-step/br_line_breaks.svg
@@ -22,6 +22,7 @@
       <path d="M61.85,214.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="45.04" y="237.00" width="33.61" height="52.00" fill="white" />
       <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>

--- a/tests/svg-snapshots/flowchart-step/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-step/ci_pipeline.svg
@@ -30,7 +30,9 @@
       <path d="M786.81,110.84 L786.81,139.00 L957.93,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="827.66" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="858.29" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="816.15" y="125.00" width="84.28" height="28.00" fill="white" />
       <text x="858.29" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-step/compat_class_annotation.svg
@@ -21,7 +21,9 @@
       <path d="M133.16,195.63 L161.36,195.63 L161.36,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="25.46" y="235.38" width="33.98" height="28.00" fill="white" />
       <text x="42.45" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="148.64" y="264.38" width="25.45" height="28.00" fill="white" />
       <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-step/compat_directive.svg
@@ -21,7 +21,9 @@
       <path d="M177.32,192.21 L218.53,192.21 L218.53,321.88" stroke="#d3d3d3" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="49.78" y="235.38" width="33.98" height="28.00" fill="#333333" />
       <text x="66.77" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">Yes</text>
+      <rect x="205.80" y="264.38" width="25.45" height="28.00" fill="#333333" />
       <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-step/compat_hyphenated_ids.svg
@@ -21,6 +21,7 @@
       <path d="M75.49,313.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="62.95" y="336.06" width="25.08" height="28.00" fill="white" />
       <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-step/compat_kitchen_sink.svg
@@ -25,7 +25,9 @@
       <path d="M218.83,411.06 L218.83,422.46 L197.04,422.46 L197.04,457.06" stroke="#333333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="53.86" y="266.56" width="42.89" height="28.00" fill="#ffffff" />
       <text x="75.31" y="280.56" text-anchor="middle" dominant-baseline="middle" fill="#333333">valid</text>
+      <rect x="212.21" y="295.56" width="56.07" height="28.00" fill="#ffffff" />
       <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/complex.svg
+++ b/tests/svg-snapshots/flowchart-step/complex.svg
@@ -39,9 +39,13 @@
       <path d="M182.38,620.28 L182.38,631.68 L210.05,631.68 L210.05,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="128.80" y="232.78" width="56.07" height="28.00" fill="white" />
       <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="526.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="287.91" y="511.03" width="25.08" height="28.00" fill="white" />
       <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-step/compound_backward_cross_boundary.svg
@@ -47,14 +47,23 @@
       <path d="M260.91,1022.06 L352.14,1022.06 L352.14,362.50 L340.14,362.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="97.75" y="170.50" width="62.57" height="28.00" fill="white" />
       <text x="129.03" y="184.50" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
+      <rect x="317.90" y="199.50" width="52.73" height="28.00" fill="white" />
       <text x="344.27" y="213.50" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
+      <rect x="254.19" y="469.16" width="39.55" height="28.00" fill="white" />
       <text x="273.96" y="483.16" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="314.65" y="451.50" width="77.04" height="28.00" fill="white" />
       <text x="353.17" y="465.50" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
+      <rect x="90.05" y="422.50" width="46.05" height="28.00" fill="white" />
       <text x="113.07" y="436.50" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
+      <rect x="208.86" y="654.86" width="50.13" height="28.00" fill="white" />
       <text x="233.93" y="668.86" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
+      <rect x="339.62" y="565.00" width="27.12" height="28.00" fill="white" />
       <text x="353.17" y="579.00" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="193.60" y="920.36" width="73.70" height="28.00" fill="white" />
       <text x="230.45" y="934.36" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="330.70" y="717.90" width="42.89" height="28.00" fill="white" />
       <text x="352.14" y="731.90" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-step/crossing_minimize.svg
@@ -39,9 +39,13 @@
       <path d="M417.10,496.44 L300.45,496.44 L300.45,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="128.80" y="232.78" width="56.07" height="28.00" fill="white" />
       <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="526.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="287.91" y="511.03" width="25.08" height="28.00" fill="white" />
       <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/decision.svg
+++ b/tests/svg-snapshots/flowchart-step/decision.svg
@@ -22,7 +22,9 @@
       <path d="M277.44,403.36 L289.44,403.36 L289.44,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="56.14" y="285.86" width="33.98" height="28.00" fill="white" />
       <text x="73.13" y="299.86" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="191.98" y="253.85" width="25.45" height="28.00" fill="white" />
       <text x="204.71" y="267.85" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-step/flowchart_code_flow.svg
@@ -436,12 +436,19 @@
       <path d="M11070.44,1460.19 L11070.44,1482.49 L11109.73,1482.49 L11109.73,1615.19" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="9400.37" y="422.21" width="159.45" height="28.00" fill="white" />
       <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <rect x="9651.52" y="436.71" width="188.96" height="28.00" fill="white" />
       <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <rect x="9902.30" y="451.21" width="219.21" height="28.00" fill="white" />
       <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <rect x="9642.24" y="651.89" width="33.98" height="28.00" fill="white" />
       <text x="9659.23" y="665.89" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9729.01" y="730.95" width="33.98" height="28.00" fill="white" />
       <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9815.79" y="627.67" width="33.98" height="28.00" fill="white" />
       <text x="9832.78" y="641.67" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="370.73" y="1617.19" width="137.18" height="28.00" fill="white" />
       <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-step/git_workflow.svg
@@ -22,9 +22,13 @@
       <path d="M924.69,62.00 L924.69,78.00 L80.87,78.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="174.75" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="432.11" y="21.00" width="89.29" height="28.00" fill="white" />
       <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="730.63" y="21.00" width="69.80" height="28.00" fill="white" />
       <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="473.78" y="64.00" width="62.01" height="28.00" fill="white" />
       <text x="504.78" y="78.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-step/git_workflow_td.svg
@@ -22,9 +22,13 @@
       <path d="M164.51,469.00 L176.51,469.00 L176.51,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="55.62" y="85.00" width="61.27" height="28.00" fill="white" />
       <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="41.61" y="213.00" width="89.29" height="28.00" fill="white" />
       <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="51.35" y="366.00" width="69.80" height="28.00" fill="white" />
       <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="145.51" y="235.31" width="62.01" height="28.00" fill="white" />
       <text x="176.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/http_request.svg
+++ b/tests/svg-snapshots/flowchart-step/http_request.svg
@@ -29,9 +29,13 @@
       <path d="M352.16,632.20 L441.49,632.20 L441.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="211.44" y="85.00" width="109.71" height="28.00" fill="white" />
       <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <rect x="82.81" y="435.70" width="33.98" height="28.00" fill="white" />
       <text x="99.80" y="449.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="322.83" y="464.70" width="25.45" height="28.00" fill="white" />
       <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="381.07" y="301.97" width="120.84" height="28.00" fill="white" />
       <text x="441.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-step/inline_edge_labels.svg
@@ -24,9 +24,13 @@
       <path d="M57.58,521.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="40.77" y="85.00" width="33.61" height="28.00" fill="white" />
       <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="36.13" y="238.00" width="42.89" height="28.00" fill="white" />
       <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="17.39" y="391.00" width="80.38" height="28.00" fill="white" />
       <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <rect x="45.04" y="544.00" width="25.08" height="28.00" fill="white" />
       <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-step/inline_label_flowchart.svg
@@ -76,14 +76,23 @@
       <path d="M412.63,1819.26 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="256.26" y="610.57" width="25.08" height="28.00" fill="white" />
       <text x="268.80" y="624.57" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="603.43" y="639.57" width="33.61" height="28.00" fill="white" />
       <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="434.02" y="877.09" width="42.15" height="28.00" fill="white" />
       <text x="455.10" y="891.09" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <rect x="698.56" y="906.09" width="50.69" height="28.00" fill="white" />
       <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <rect x="622.93" y="1571.25" width="25.08" height="28.00" fill="white" />
       <text x="635.47" y="1585.25" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="529.03" y="1512.71" width="33.61" height="28.00" fill="white" />
       <text x="545.84" y="1526.71" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="37.24" y="425.76" width="27.12" height="28.00" fill="white" />
       <text x="50.80" y="439.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="265.90" y="472.26" width="42.71" height="28.00" fill="white" />
       <text x="287.26" y="486.26" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="726.84" y="1332.59" width="44.01" height="28.00" fill="white" />
       <text x="748.85" y="1346.59" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-step/label_spacing.svg
@@ -18,7 +18,9 @@
       <path d="M128.36,62.00 L128.36,78.30 L161.36,78.30 L161.36,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="21.01" y="70.50" width="42.89" height="28.00" fill="white" />
       <text x="42.45" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="133.33" y="99.50" width="56.07" height="28.00" fill="white" />
       <text x="161.36" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-step/labeled_edges.svg
@@ -25,10 +25,15 @@
       <path d="M327.04,512.80 L339.04,512.80 L339.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="72.71" y="85.00" width="71.29" height="28.00" fill="white" />
       <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <rect x="49.57" y="238.00" width="75.74" height="28.00" fill="white" />
       <text x="87.44" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <rect x="49.96" y="395.30" width="33.61" height="28.00" fill="white" />
       <text x="66.77" y="409.30" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="219.05" y="348.23" width="25.08" height="28.00" fill="white" />
       <text x="231.58" y="362.23" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="317.59" y="252.17" width="42.89" height="28.00" fill="white" />
       <text x="339.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-step/multi_edge_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M42.45,215.00 L42.45,261.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="12.75" y="83.67" width="56.63" height="28.00" fill="white" />
       <text x="41.06" y="97.67" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="40.60" y="95.50" width="56.63" height="28.00" fill="white" />
       <text x="68.91" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-step/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-step/self_loop_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="122.45" y="148.20" width="42.89" height="28.00" fill="white" />
       <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="37.12" y="235.40" width="42.15" height="28.00" fill="white" />
       <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-straight/backward_loop_lr.svg
@@ -35,7 +35,9 @@
       <path d="M1345.87,139.00 L1451.39,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="1107.77" y="143.00" width="34.73" height="28.00" fill="white" />
       <text x="1125.13" y="157.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1366.87" y="125.00" width="42.52" height="28.00" fill="white" />
       <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart-straight/br_line_breaks.svg
@@ -22,6 +22,7 @@
       <path d="M61.85,214.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="45.04" y="237.00" width="33.61" height="52.00" fill="white" />
       <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>

--- a/tests/svg-snapshots/flowchart-straight/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-straight/ci_pipeline.svg
@@ -30,7 +30,9 @@
       <path d="M799.56,98.09 L958.06,138.02" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="848.17" y="41.94" width="61.27" height="28.00" fill="white" />
       <text x="878.81" y="55.94" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="836.67" y="104.06" width="84.28" height="28.00" fill="white" />
       <text x="878.81" y="118.06" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-straight/compat_class_annotation.svg
@@ -21,7 +21,9 @@
       <path d="M117.73,211.06 L159.94,322.14" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="47.99" y="252.60" width="33.98" height="28.00" fill="white" />
       <text x="64.98" y="266.60" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="126.11" y="252.60" width="25.45" height="28.00" fill="white" />
       <text x="138.83" y="266.60" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-straight/compat_directive.svg
@@ -21,7 +21,9 @@
       <path d="M161.41,208.12 L216.78,322.28" stroke="#d3d3d3" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="79.21" y="251.20" width="33.98" height="28.00" fill="#333333" />
       <text x="96.20" y="265.20" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">Yes</text>
+      <rect x="176.37" y="251.20" width="25.45" height="28.00" fill="#333333" />
       <text x="189.10" y="265.20" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart-straight/compat_hyphenated_ids.svg
@@ -21,6 +21,7 @@
       <path d="M75.49,313.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="62.95" y="336.06" width="25.08" height="28.00" fill="white" />
       <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-straight/compat_kitchen_sink.svg
@@ -25,7 +25,9 @@
       <path d="M240.24,411.06 L161.19,458.98" stroke="#333333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="84.13" y="279.92" width="42.89" height="28.00" fill="#ffffff" />
       <text x="105.57" y="293.92" text-anchor="middle" dominant-baseline="middle" fill="#333333">valid</text>
+      <rect x="181.94" y="279.92" width="56.07" height="28.00" fill="#ffffff" />
       <text x="209.98" y="293.92" text-anchor="middle" dominant-baseline="middle" fill="#333333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/complex.svg
+++ b/tests/svg-snapshots/flowchart-straight/complex.svg
@@ -39,9 +39,13 @@
       <path d="M156.83,620.28 L251.68,668.47" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="346.22" y="229.35" width="42.89" height="28.00" fill="white" />
       <text x="367.67" y="243.35" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="167.12" y="233.60" width="56.07" height="28.00" fill="white" />
       <text x="195.16" y="247.60" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="522.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="329.77" y="572.67" width="25.08" height="28.00" fill="white" />
       <text x="342.31" y="586.67" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-straight/compound_backward_cross_boundary.svg
@@ -47,14 +47,23 @@
       <path d="M260.91,1022.06 L350.14,1022.06 L350.14,362.50 L340.14,362.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="164.63" y="205.67" width="62.57" height="28.00" fill="white" />
       <text x="195.92" y="219.67" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
+      <rect x="293.51" y="200.51" width="52.73" height="28.00" fill="white" />
       <text x="319.87" y="214.51" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
+      <rect x="234.87" y="469.44" width="39.55" height="28.00" fill="white" />
       <text x="254.65" y="483.44" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="288.52" y="426.15" width="77.04" height="28.00" fill="white" />
       <text x="327.05" y="440.15" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
+      <rect x="162.58" y="420.95" width="46.05" height="28.00" fill="white" />
       <text x="185.60" y="434.95" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
+      <rect x="208.86" y="654.86" width="50.13" height="28.00" fill="white" />
       <text x="233.93" y="668.86" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
+      <rect x="280.75" y="670.58" width="27.12" height="28.00" fill="white" />
       <text x="294.31" y="684.58" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="191.69" y="918.38" width="73.70" height="28.00" fill="white" />
       <text x="228.54" y="932.38" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="328.70" y="717.90" width="42.89" height="28.00" fill="white" />
       <text x="350.14" y="731.90" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-straight/crossing_minimize.svg
@@ -39,9 +39,13 @@
       <path d="M426.49,505.83 L258.13,667.51" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="346.22" y="229.35" width="42.89" height="28.00" fill="white" />
       <text x="367.67" y="243.35" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="167.12" y="233.60" width="56.07" height="28.00" fill="white" />
       <text x="195.16" y="247.60" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="522.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="539.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="329.77" y="572.67" width="25.08" height="28.00" fill="white" />
       <text x="342.31" y="586.67" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/decision.svg
+++ b/tests/svg-snapshots/flowchart-straight/decision.svg
@@ -22,7 +22,9 @@
       <path d="M277.44,403.36 L287.44,403.36 L287.44,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="61.46" y="307.23" width="33.98" height="28.00" fill="white" />
       <text x="78.46" y="321.23" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="162.02" y="293.62" width="25.45" height="28.00" fill="white" />
       <text x="174.74" y="307.62" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-straight/flowchart_code_flow.svg
@@ -436,12 +436,19 @@
       <path d="M10976.06,1460.19 L11126.36,1616.31" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="9400.37" y="422.21" width="159.45" height="28.00" fill="white" />
       <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <rect x="9651.52" y="436.71" width="188.96" height="28.00" fill="white" />
       <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <rect x="9902.30" y="451.21" width="219.21" height="28.00" fill="white" />
       <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <rect x="9622.51" y="714.20" width="33.98" height="28.00" fill="white" />
       <text x="9639.50" y="728.20" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9729.01" y="730.95" width="33.98" height="28.00" fill="white" />
       <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9843.45" y="697.91" width="33.98" height="28.00" fill="white" />
       <text x="9860.44" y="711.91" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="370.73" y="1617.19" width="137.18" height="28.00" fill="white" />
       <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-straight/git_workflow.svg
@@ -22,9 +22,13 @@
       <path d="M924.69,62.00 L924.69,76.00 L80.87,76.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="174.75" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="432.11" y="21.00" width="89.29" height="28.00" fill="white" />
       <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="730.63" y="21.00" width="69.80" height="28.00" fill="white" />
       <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="473.78" y="62.00" width="62.01" height="28.00" fill="white" />
       <text x="504.78" y="76.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-straight/git_workflow_td.svg
@@ -22,9 +22,13 @@
       <path d="M164.51,469.00 L174.51,469.00 L174.51,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="55.62" y="85.00" width="61.27" height="28.00" fill="white" />
       <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="41.61" y="213.00" width="89.29" height="28.00" fill="white" />
       <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="51.35" y="366.00" width="69.80" height="28.00" fill="white" />
       <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="141.51" y="235.31" width="62.01" height="28.00" fill="white" />
       <text x="172.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/http_request.svg
+++ b/tests/svg-snapshots/flowchart-straight/http_request.svg
@@ -29,9 +29,13 @@
       <path d="M352.16,632.20 L437.49,632.20 L437.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="211.44" y="85.00" width="109.71" height="28.00" fill="white" />
       <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <rect x="146.53" y="427.85" width="33.98" height="28.00" fill="white" />
       <text x="163.52" y="441.85" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="299.90" y="435.86" width="25.45" height="28.00" fill="white" />
       <text x="312.62" y="449.86" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="377.07" y="301.97" width="120.84" height="28.00" fill="white" />
       <text x="437.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart-straight/inline_edge_labels.svg
@@ -24,9 +24,13 @@
       <path d="M57.58,521.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="40.77" y="85.00" width="33.61" height="28.00" fill="white" />
       <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="36.13" y="238.00" width="42.89" height="28.00" fill="white" />
       <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="17.39" y="391.00" width="80.38" height="28.00" fill="white" />
       <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <rect x="45.04" y="544.00" width="25.08" height="28.00" fill="white" />
       <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-straight/inline_label_flowchart.svg
@@ -76,14 +76,23 @@
       <path d="M412.63,1819.26 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="362.96" y="616.73" width="25.08" height="28.00" fill="white" />
       <text x="375.49" y="630.73" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="543.56" y="633.86" width="33.61" height="28.00" fill="white" />
       <text x="560.37" y="647.86" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="503.31" y="888.02" width="42.15" height="28.00" fill="white" />
       <text x="524.39" y="902.02" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <rect x="656.65" y="891.51" width="50.69" height="28.00" fill="white" />
       <text x="682.00" y="905.51" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <rect x="630.46" y="1549.74" width="25.08" height="28.00" fill="white" />
       <text x="643.00" y="1563.74" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="512.96" y="1533.11" width="33.61" height="28.00" fill="white" />
       <text x="529.77" y="1547.11" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="76.04" y="403.76" width="27.12" height="28.00" fill="white" />
       <text x="89.60" y="417.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="257.98" y="442.81" width="42.71" height="28.00" fill="white" />
       <text x="279.33" y="456.81" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="685.61" y="1385.01" width="44.01" height="28.00" fill="white" />
       <text x="707.61" y="1399.01" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-straight/label_spacing.svg
@@ -18,7 +18,9 @@
       <path d="M101.91,62.00 L159.30,157.57" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="51.76" y="95.79" width="42.89" height="28.00" fill="white" />
       <text x="73.21" y="109.79" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="102.57" y="95.79" width="56.07" height="28.00" fill="white" />
       <text x="130.61" y="109.79" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-straight/labeled_edges.svg
@@ -25,10 +25,15 @@
       <path d="M327.04,512.80 L337.04,512.80 L337.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="72.71" y="85.00" width="71.29" height="28.00" fill="white" />
       <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <rect x="63.92" y="239.58" width="75.74" height="28.00" fill="white" />
       <text x="101.79" y="253.58" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <rect x="57.58" y="417.32" width="33.61" height="28.00" fill="white" />
       <text x="74.38" y="431.32" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="168.19" y="408.11" width="25.08" height="28.00" fill="white" />
       <text x="180.73" y="422.11" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="313.59" y="252.17" width="42.89" height="28.00" fill="white" />
       <text x="335.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-straight/multi_edge_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M42.45,215.00 L42.45,261.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="14.14" y="95.50" width="56.63" height="28.00" fill="white" />
       <text x="42.45" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="14.14" y="95.50" width="56.63" height="28.00" fill="white" />
       <text x="42.45" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart-straight/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-straight/self_loop_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="122.45" y="148.20" width="42.89" height="28.00" fill="white" />
       <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="37.12" y="235.40" width="42.15" height="28.00" fill="white" />
       <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart/backward_loop_lr.svg
@@ -35,7 +35,9 @@
       <path d="M1345.87,139.00 L1451.39,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="1109.77" y="168.00" width="34.73" height="28.00" fill="white" />
       <text x="1127.13" y="182.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1366.87" y="125.00" width="42.52" height="28.00" fill="white" />
       <text x="1388.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/br_line_breaks.svg
+++ b/tests/svg-snapshots/flowchart/br_line_breaks.svg
@@ -22,6 +22,7 @@
       <path d="M61.85,214.00 L61.85,333.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="45.04" y="237.00" width="33.61" height="52.00" fill="white" />
       <text x="61.85" y="251.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <text x="61.85" y="275.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>

--- a/tests/svg-snapshots/flowchart/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart/ci_pipeline.svg
@@ -30,7 +30,9 @@
       <path d="M786.81,110.84 L786.81,134.00 Q786.81,139.00 791.81,139.00 L957.93,139.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="827.66" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="858.29" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="816.15" y="125.00" width="84.28" height="28.00" fill="white" />
       <text x="858.29" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart/compat_class_annotation.svg
@@ -21,7 +21,9 @@
       <path d="M133.16,195.63 L156.36,195.63 Q161.36,195.63 161.36,200.63 L161.36,321.88" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="25.46" y="235.38" width="33.98" height="28.00" fill="white" />
       <text x="42.45" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="148.64" y="264.38" width="25.45" height="28.00" fill="white" />
       <text x="161.36" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart/compat_directive.svg
@@ -21,7 +21,9 @@
       <path d="M177.32,192.21 L213.53,192.21 Q218.53,192.21 218.53,197.21 L218.53,321.88" stroke="#d3d3d3" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="49.78" y="235.38" width="33.98" height="28.00" fill="#333333" />
       <text x="66.77" y="249.38" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">Yes</text>
+      <rect x="205.80" y="264.38" width="25.45" height="28.00" fill="#333333" />
       <text x="218.53" y="278.38" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/compat_hyphenated_ids.svg
+++ b/tests/svg-snapshots/flowchart/compat_hyphenated_ids.svg
@@ -21,6 +21,7 @@
       <path d="M75.49,313.06 L75.49,408.06" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="62.95" y="336.06" width="25.08" height="28.00" fill="white" />
       <text x="75.49" y="350.06" text-anchor="middle" dominant-baseline="middle" fill="#333">ok</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart/compat_kitchen_sink.svg
@@ -25,7 +25,9 @@
       <path d="M218.83,411.06 L218.83,417.46 Q218.83,422.46 213.83,422.46 L202.04,422.46 Q197.04,422.46 197.04,427.46 L197.04,457.06" stroke="#333333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="53.86" y="266.56" width="42.89" height="28.00" fill="#ffffff" />
       <text x="75.31" y="280.56" text-anchor="middle" dominant-baseline="middle" fill="#333333">valid</text>
+      <rect x="212.21" y="295.56" width="56.07" height="28.00" fill="#ffffff" />
       <text x="240.24" y="309.56" text-anchor="middle" dominant-baseline="middle" fill="#333333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/complex.svg
+++ b/tests/svg-snapshots/flowchart/complex.svg
@@ -39,9 +39,13 @@
       <path d="M182.38,620.28 L182.38,626.68 Q182.38,631.68 187.38,631.68 L205.05,631.68 Q210.05,631.68 210.05,636.68 L210.05,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="128.80" y="232.78" width="56.07" height="28.00" fill="white" />
       <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="526.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="287.91" y="511.03" width="25.08" height="28.00" fill="white" />
       <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart/compound_backward_cross_boundary.svg
@@ -47,14 +47,23 @@
       <path d="M260.91,1022.06 L347.14,1022.06 Q352.14,1022.06 352.14,1017.06 L352.14,367.50 Q352.14,362.50 347.14,362.50 L340.14,362.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="97.75" y="170.50" width="62.57" height="28.00" fill="white" />
       <text x="129.03" y="184.50" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
+      <rect x="317.90" y="199.50" width="52.73" height="28.00" fill="white" />
       <text x="344.27" y="213.50" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
+      <rect x="254.19" y="469.16" width="39.55" height="28.00" fill="white" />
       <text x="273.96" y="483.16" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="314.65" y="451.50" width="77.04" height="28.00" fill="white" />
       <text x="353.17" y="465.50" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
+      <rect x="90.05" y="422.50" width="46.05" height="28.00" fill="white" />
       <text x="113.07" y="436.50" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
+      <rect x="208.86" y="654.86" width="50.13" height="28.00" fill="white" />
       <text x="233.93" y="668.86" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
+      <rect x="339.62" y="565.00" width="27.12" height="28.00" fill="white" />
       <text x="353.17" y="579.00" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="193.60" y="920.36" width="73.70" height="28.00" fill="white" />
       <text x="230.45" y="934.36" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="330.70" y="717.90" width="42.89" height="28.00" fill="white" />
       <text x="352.14" y="731.90" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart/crossing_minimize.svg
@@ -39,9 +39,13 @@
       <path d="M417.10,496.44 L305.45,496.44 Q300.45,496.44 300.45,501.44 L300.45,666.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="428.33" y="261.78" width="42.89" height="28.00" fill="white" />
       <text x="449.77" y="275.78" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="128.80" y="232.78" width="56.07" height="28.00" fill="white" />
       <text x="156.83" y="246.78" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="526.64" y="126.41" width="33.61" height="28.00" fill="white" />
       <text x="543.45" y="140.41" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="287.91" y="511.03" width="25.08" height="28.00" fill="white" />
       <text x="300.45" y="525.03" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/decision.svg
+++ b/tests/svg-snapshots/flowchart/decision.svg
@@ -22,7 +22,9 @@
       <path d="M277.44,403.36 L284.44,403.36 Q289.44,403.36 289.44,398.36 L289.44,40.00 Q289.44,35.00 284.44,35.00 L145.62,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="56.14" y="285.86" width="33.98" height="28.00" fill="white" />
       <text x="73.13" y="299.86" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="191.98" y="253.85" width="25.45" height="28.00" fill="white" />
       <text x="204.71" y="267.85" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart/flowchart_code_flow.svg
@@ -436,12 +436,19 @@
       <path d="M11070.44,1460.19 L11070.44,1477.49 Q11070.44,1482.49 11075.44,1482.49 L11104.73,1482.49 Q11109.73,1482.49 11109.73,1487.49 L11109.73,1615.19" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="9400.37" y="422.21" width="159.45" height="28.00" fill="white" />
       <text x="9480.10" y="436.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*graph/</text>
+      <rect x="9651.52" y="436.71" width="188.96" height="28.00" fill="white" />
       <text x="9746.00" y="450.71" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
+      <rect x="9902.30" y="451.21" width="219.21" height="28.00" fill="white" />
       <text x="10011.91" y="465.21" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
+      <rect x="9642.24" y="651.89" width="33.98" height="28.00" fill="white" />
       <text x="9659.23" y="665.89" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9729.01" y="730.95" width="33.98" height="28.00" fill="white" />
       <text x="9746.00" y="744.95" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9815.79" y="627.67" width="33.98" height="28.00" fill="white" />
       <text x="9832.78" y="641.67" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="370.73" y="1617.19" width="137.18" height="28.00" fill="white" />
       <text x="439.32" y="1631.19" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart/git_workflow.svg
@@ -22,9 +22,13 @@
       <path d="M924.69,62.00 L924.69,73.00 Q924.69,78.00 919.69,78.00 L85.87,78.00 Q80.87,78.00 80.87,73.00 L80.87,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="174.75" y="21.00" width="61.27" height="28.00" fill="white" />
       <text x="205.38" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="432.11" y="21.00" width="89.29" height="28.00" fill="white" />
       <text x="476.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="730.63" y="21.00" width="69.80" height="28.00" fill="white" />
       <text x="765.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="473.78" y="64.00" width="62.01" height="28.00" fill="white" />
       <text x="504.78" y="78.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart/git_workflow_td.svg
@@ -22,9 +22,13 @@
       <path d="M164.51,469.00 L171.51,469.00 Q176.51,469.00 176.51,464.00 L176.51,40.00 Q176.51,35.00 171.51,35.00 L163.13,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="55.62" y="85.00" width="61.27" height="28.00" fill="white" />
       <text x="86.26" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git add</text>
+      <rect x="41.61" y="213.00" width="89.29" height="28.00" fill="white" />
       <text x="86.26" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
+      <rect x="51.35" y="366.00" width="69.80" height="28.00" fill="white" />
       <text x="86.26" y="380.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
+      <rect x="145.51" y="235.31" width="62.01" height="28.00" fill="white" />
       <text x="176.51" y="249.31" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/http_request.svg
+++ b/tests/svg-snapshots/flowchart/http_request.svg
@@ -29,9 +29,13 @@
       <path d="M352.16,632.20 L436.49,632.20 Q441.49,632.20 441.49,627.20 L441.49,40.00 Q441.49,35.00 436.49,35.00 L320.89,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="211.44" y="85.00" width="109.71" height="28.00" fill="white" />
       <text x="266.29" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
+      <rect x="82.81" y="435.70" width="33.98" height="28.00" fill="white" />
       <text x="99.80" y="449.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="322.83" y="464.70" width="25.45" height="28.00" fill="white" />
       <text x="335.55" y="478.70" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="381.07" y="301.97" width="120.84" height="28.00" fill="white" />
       <text x="441.49" y="315.97" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/inline_edge_labels.svg
+++ b/tests/svg-snapshots/flowchart/inline_edge_labels.svg
@@ -24,9 +24,13 @@
       <path d="M57.58,521.00 L57.58,616.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="40.77" y="85.00" width="33.61" height="28.00" fill="white" />
       <text x="57.58" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="36.13" y="238.00" width="42.89" height="28.00" fill="white" />
       <text x="57.58" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="17.39" y="391.00" width="80.38" height="28.00" fill="white" />
       <text x="57.58" y="405.00" text-anchor="middle" dominant-baseline="middle" fill="#333">final step</text>
+      <rect x="45.04" y="544.00" width="25.08" height="28.00" fill="white" />
       <text x="57.58" y="558.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart/inline_label_flowchart.svg
@@ -76,14 +76,23 @@
       <path d="M412.63,1819.26 L412.63,1865.26" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="256.26" y="610.57" width="25.08" height="28.00" fill="white" />
       <text x="268.80" y="624.57" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="603.43" y="639.57" width="33.61" height="28.00" fill="white" />
       <text x="620.23" y="653.57" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="434.02" y="877.09" width="42.15" height="28.00" fill="white" />
       <text x="455.10" y="891.09" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <rect x="698.56" y="906.09" width="50.69" height="28.00" fill="white" />
       <text x="723.91" y="920.09" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <rect x="622.93" y="1571.25" width="25.08" height="28.00" fill="white" />
       <text x="635.47" y="1585.25" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="529.03" y="1512.71" width="33.61" height="28.00" fill="white" />
       <text x="545.84" y="1526.71" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="37.24" y="425.76" width="27.12" height="28.00" fill="white" />
       <text x="50.80" y="439.76" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="265.90" y="472.26" width="42.71" height="28.00" fill="white" />
       <text x="287.26" y="486.26" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="726.84" y="1332.59" width="44.01" height="28.00" fill="white" />
       <text x="748.85" y="1346.59" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart/label_spacing.svg
@@ -18,7 +18,9 @@
       <path d="M128.36,62.00 L128.36,73.30 Q128.36,78.30 133.36,78.30 L156.36,78.30 Q161.36,78.30 161.36,83.30 L161.36,157.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="21.01" y="70.50" width="42.89" height="28.00" fill="white" />
       <text x="42.45" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="133.33" y="99.50" width="56.07" height="28.00" fill="white" />
       <text x="161.36" y="113.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart/labeled_edges.svg
@@ -25,10 +25,15 @@
       <path d="M327.04,512.80 L334.04,512.80 Q339.04,512.80 339.04,507.80 L339.04,193.00 Q339.04,188.00 334.04,188.00 L162.58,188.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="2.00,4.00" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="72.71" y="85.00" width="71.29" height="28.00" fill="white" />
       <text x="108.35" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
+      <rect x="49.57" y="238.00" width="75.74" height="28.00" fill="white" />
       <text x="87.44" y="252.00" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <rect x="49.96" y="395.30" width="33.61" height="28.00" fill="white" />
       <text x="66.77" y="409.30" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="219.05" y="348.23" width="25.08" height="28.00" fill="white" />
       <text x="231.58" y="362.23" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="317.59" y="252.17" width="42.89" height="28.00" fill="white" />
       <text x="339.04" y="266.17" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart/multi_edge_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M42.45,215.00 L42.45,261.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="12.75" y="83.67" width="56.63" height="28.00" fill="white" />
       <text x="41.06" y="97.67" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="40.60" y="95.50" width="56.63" height="28.00" fill="white" />
       <text x="68.91" y="109.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>

--- a/tests/svg-snapshots/flowchart/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart/self_loop_labeled.svg
@@ -19,7 +19,9 @@
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="122.45" y="148.20" width="42.89" height="28.00" fill="white" />
       <text x="143.90" y="162.20" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="37.12" y="235.40" width="42.15" height="28.00" fill="white" />
       <text x="58.20" y="249.40" text-anchor="middle" dominant-baseline="middle" fill="#333">done</text>
     </g>
   </g>

--- a/tests/svg-snapshots/mmds/routed-basic.svg
+++ b/tests/svg-snapshots/mmds/routed-basic.svg
@@ -19,6 +19,7 @@
       <path d="M60.00,60.00 L77.76,95.53 Q80.00,100.00 76.46,103.54 L62.83,117.17" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="67.46" y="86.00" width="25.08" height="28.00" fill="white" />
       <text x="80.00" y="100.00" text-anchor="middle" dominant-baseline="middle" fill="#333">go</text>
     </g>
   </g>

--- a/tests/svg-snapshots/state/composite.svg
+++ b/tests/svg-snapshots/state/composite.svg
@@ -34,7 +34,9 @@
       <path d="M116.16,412.00 L116.16,493.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="122.05" y="262.42" width="50.69" height="28.00" fill="white" />
       <text x="147.39" y="276.42" text-anchor="middle" dominant-baseline="middle" fill="#333">pause</text>
+      <rect x="161.78" y="249.46" width="61.08" height="28.00" fill="white" />
       <text x="192.32" y="263.46" text-anchor="middle" dominant-baseline="middle" fill="#333">resume</text>
     </g>
   </g>

--- a/tests/svg-snapshots/state/descriptions.svg
+++ b/tests/svg-snapshots/state/descriptions.svg
@@ -22,6 +22,7 @@
       <path d="M104.29,279.00 L104.29,325.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="72.73" y="149.00" width="63.12" height="28.00" fill="white" />
       <text x="104.29" y="163.00" text-anchor="middle" dominant-baseline="middle" fill="#333">timeout</text>
     </g>
   </g>

--- a/tests/svg-snapshots/state/pseudo_states.svg
+++ b/tests/svg-snapshots/state/pseudo_states.svg
@@ -39,7 +39,9 @@
       <path d="M153.85,591.00 L153.85,597.40 Q153.85,602.40 148.85,602.40 L122.80,602.40 Q117.80,602.40 117.80,607.40 L117.80,637.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="29.39" y="446.50" width="33.61" height="28.00" fill="white" />
       <text x="46.20" y="460.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="160.06" y="475.50" width="25.08" height="28.00" fill="white" />
       <text x="172.60" y="489.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>

--- a/tests/svg-snapshots/state/self_transition.svg
+++ b/tests/svg-snapshots/state/self_transition.svg
@@ -23,6 +23,7 @@
       <path d="M62.63,280.00 L62.63,326.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="131.30" y="85.00" width="42.89" height="28.00" fill="white" />
       <text x="152.75" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>

--- a/tests/svg-snapshots/state/transitions.svg
+++ b/tests/svg-snapshots/state/transitions.svg
@@ -29,9 +29,13 @@
       <path d="M48.74,407.00 L48.74,427.00 Q48.74,432.00 53.74,432.00 L59.46,432.00 Q64.46,432.00 64.46,437.00 L64.46,453.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="edgeLabels">
+      <rect x="44.17" y="149.00" width="57.18" height="28.00" fill="white" />
       <text x="72.76" y="163.00" text-anchor="middle" dominant-baseline="middle" fill="#333">submit</text>
+      <rect x="3.13" y="262.50" width="74.26" height="28.00" fill="white" />
       <text x="40.26" y="276.50" text-anchor="middle" dominant-baseline="middle" fill="#333">complete</text>
+      <rect x="126.87" y="275.82" width="31.76" height="28.00" fill="white" />
       <text x="142.75" y="289.82" text-anchor="middle" dominant-baseline="middle" fill="#333">fail</text>
+      <rect x="178.34" y="183.15" width="42.89" height="28.00" fill="white" />
       <text x="199.79" y="197.15" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>


### PR DESCRIPTION
## Summary

- Adds a white (or theme-matched) background `<rect>` behind each SVG edge label so the label text is readable when it sits on top of an edge line
- Background color follows the palette: `white` for unthemed SVGs, `theme.roles.background` for themed output, with `fill:var(--bg)` for dynamic CSS themes
- Z-ordering is already correct (the `edgeLabels` group renders after `edgePaths`), so the background rects naturally occlude the edge lines beneath them

## Test plan

- [x] All 2290 tests pass
- [x] SVG snapshots regenerated across all routing styles (basis, step, straight, polyline, curved-step, smooth-step) and diagram types (flowchart, class, state, MMDS)
- [x] Architecture check passes
- [x] `just fix` passes (clippy + fmt)

Closes #185