### PR TITLE
chore: auto-detect terminal dark mode for view script

### DIFF
--- a/scripts/view
+++ b/scripts/view
@@ -12,48 +12,64 @@
 
 set -euo pipefail
 
-SCALE=2
-BG="white"
-
-# Query terminal background color via OSC 11 (works in Ghostty, Kitty, WezTerm, etc.)
-# Returns perceived luminance 0-255, or 255 (light) on failure.
+# Query terminal background luminance via OSC 11.
+# Uses Perl for reliable terminal I/O (TCSAFLUSH prevents response leaking).
+# Returns perceived luminance 0-254 on success, or 255 on failure.
 query_bg_lum() {
-    [[ -t 1 ]] || { echo 255; return; }
+    perl -e '
+        use strict;
+        use POSIX qw(:termios_h);
+        open(my $tty, "+<", "/dev/tty") or do { print 255; exit };
+        my $fd = fileno($tty);
+        my $old = POSIX::Termios->new();
+        $old->getattr($fd) or do { print 255; exit };
+        my $raw = POSIX::Termios->new();
+        $raw->getattr($fd);
+        $raw->setlflag($raw->getlflag & ~(ECHO | ICANON));
+        $raw->setcc(VMIN, 0);
+        $raw->setcc(VTIME, 0);
+        $raw->setattr($fd, TCSANOW);
+        syswrite($tty, "\e]11;?\e\\");
+        my $resp = "";
+        vec(my $rin = "", $fd, 1) = 1;
+        if (select(my $rout = $rin, undef, undef, 0.5)) {
+            sysread($tty, $resp, 256);
+        }
+        $old->setattr($fd, TCSAFLUSH);
+        close($tty);
+        if ($resp =~ /rgb:([0-9a-f]+)\/([0-9a-f]+)\/([0-9a-f]+)/i) {
+            my @c = map { hex(substr($_, 0, 2)) } ($1, $2, $3);
+            printf "%d", int(($c[0]*299 + $c[1]*587 + $c[2]*114) / 1000);
+        } else {
+            print 255;
+        }
+    ' 2>/dev/null || echo 255
+}
 
-    local old_stty response
-    old_stty=$(stty -g 2>/dev/null) || { echo 255; return; }
-    stty raw -echo min 0 time 0
-
-    # OSC 11 query: ESC ] 11 ; ? ST
-    printf '\033]11;?\033\\' >/dev/tty
-
-    # Read response with short timeout; terminals terminate with BEL or ST
-    response=""
-    IFS= read -r -t 0.3 -d $'\a' response </dev/tty 2>/dev/null \
-        || IFS= read -r -t 0.3 response </dev/tty 2>/dev/null \
-        || true
-
-    stty "$old_stty" 2>/dev/null
-
-    # Parse rgb:RRRR/GGGG/BBBB (16-bit components; take upper byte)
-    if [[ "$response" =~ rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+) ]]; then
-        local r g b
-        r=$(( 16#${BASH_REMATCH[1]:0:2} ))
-        g=$(( 16#${BASH_REMATCH[2]:0:2} ))
-        b=$(( 16#${BASH_REMATCH[3]:0:2} ))
-        echo $(( (r * 299 + g * 587 + b * 114) / 1000 ))
+# Detect dark mode: try OSC 11, then macOS system appearance, default to light.
+detect_dark_mode() {
+    local lum
+    lum=$(query_bg_lum)
+    if (( lum < 128 )); then
+        echo dark
+    elif (( lum < 255 )); then
+        echo light
+    elif [[ "$(uname -s)" == "Darwin" ]] \
+         && defaults read -g AppleInterfaceStyle &>/dev/null; then
+        echo dark
     else
-        echo 255
+        echo light
     fi
 }
 
-lum=$(query_bg_lum)
-if (( lum < 128 )); then
-    BG="black"
+if [[ "$(detect_dark_mode)" == "dark" ]]; then
+    SVG_THEME="dracula"
+else
+    SVG_THEME="zinc-light"
 fi
 
 # Default mmdflux flags (can be overridden by passing them explicitly)
-MMDFLUX_DEFAULTS=(-f svg --edge-preset step)
+MMDFLUX_DEFAULTS=(-f svg --edge-preset step --svg-theme "$SVG_THEME")
 
 # Split args: optional file, then optional -- extra-flags
 FILE=""
@@ -69,11 +85,10 @@ if [[ $# -gt 0 && "$1" == "--" ]]; then
     EXTRA_ARGS=("$@")
 fi
 
-# Pick display command: kitten icat in Kitty (graphics protocol), chafa elsewhere
+# Display pipeline: Kitty needs SVG→PNG via rsvg-convert; chafa handles SVG natively
+USE_KITTY=false
 if [[ -n "${KITTY_WINDOW_ID:-}" ]]; then
-    DISPLAY_CMD=(kitten icat)
-else
-    DISPLAY_CMD=(chafa)
+    USE_KITTY=true
 fi
 
 # Remove defaults that the user explicitly overrides
@@ -107,7 +122,13 @@ else
     INPUT_CMD=(cat)
 fi
 
-"${INPUT_CMD[@]}" \
-    | cargo run -q -- "${MERGED_ARGS[@]}" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \
-    | rsvg-convert --background-color="$BG" -z "$SCALE" \
-    | "${DISPLAY_CMD[@]}"
+if $USE_KITTY; then
+    "${INPUT_CMD[@]}" \
+        | cargo run -q -- "${MERGED_ARGS[@]}" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \
+        | rsvg-convert -z 2 \
+        | kitten icat
+else
+    "${INPUT_CMD[@]}" \
+        | cargo run -q -- "${MERGED_ARGS[@]}" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \
+        | chafa
+fi

--- a/scripts/view
+++ b/scripts/view
@@ -12,47 +12,123 @@
 
 set -euo pipefail
 
-# Query terminal background luminance via OSC 11.
-# Uses Perl for reliable terminal I/O (TCSAFLUSH prevents response leaking).
-# Returns perceived luminance 0-254 on success, or 255 on failure.
+# Query terminal background luminance via OSC 11 on /dev/tty.
+#
+# The script is often used in a pipeline (`cat a.svg | scripts/view`), so stdin
+# is not the terminal. We have to talk to /dev/tty directly, temporarily switch
+# it into a raw-ish mode, and then restore it with TCSAFLUSH so any unread OSC
+# reply bytes are discarded before echo is re-enabled.
+#
+# Bash `read` is the wrong tool here:
+# - delimiter-based reads lose ST-terminated replies (`ESC \`) if the first read
+#   is waiting for BEL;
+# - macOS bash 3.2 does not support fractional `read -t`;
+# - `stty` cannot restore with TCSAFLUSH, so partial replies can leak visibly.
+#
+# Returns perceived luminance 0-255 on success, or -1 on failure.
 query_bg_lum() {
-    perl -e '
-        use strict;
-        use POSIX qw(:termios_h);
-        open(my $tty, "+<", "/dev/tty") or do { print 255; exit };
-        my $fd = fileno($tty);
-        my $old = POSIX::Termios->new();
-        $old->getattr($fd) or do { print 255; exit };
-        my $raw = POSIX::Termios->new();
-        $raw->getattr($fd);
-        $raw->setlflag($raw->getlflag & ~(ECHO | ICANON));
-        $raw->setcc(VMIN, 0);
-        $raw->setcc(VTIME, 0);
-        $raw->setattr($fd, TCSANOW);
-        syswrite($tty, "\e]11;?\e\\");
-        my $resp = "";
-        vec(my $rin = "", $fd, 1) = 1;
-        if (select(my $rout = $rin, undef, undef, 0.5)) {
-            sysread($tty, $resp, 256);
-        }
-        $old->setattr($fd, TCSAFLUSH);
-        close($tty);
-        if ($resp =~ /rgb:([0-9a-f]+)\/([0-9a-f]+)\/([0-9a-f]+)/i) {
-            my @c = map { hex(substr($_, 0, 2)) } ($1, $2, $3);
-            printf "%d", int(($c[0]*299 + $c[1]*587 + $c[2]*114) / 1000);
-        } else {
-            print 255;
-        }
-    ' 2>/dev/null || echo 255
+    perl <<'PERL' 2>/dev/null || echo -1
+use strict;
+use warnings;
+use POSIX qw(:termios_h);
+use Time::HiRes qw(time);
+
+my $FAIL = -1;
+
+sub normalize_component {
+    my ($component) = @_;
+
+    return undef unless defined $component && $component =~ /\A[0-9a-f]+\z/i;
+
+    # Terminals commonly report either 8-bit rr/gg/bb or 16-bit rrrr/gggg/bbbb
+    # components. Scale any width back to 0..255 so luminance is comparable.
+    my $value = hex($component);
+    my $max = (16 ** length($component)) - 1;
+
+    return undef if $max <= 0;
+    return int(($value * 255 / $max) + 0.5);
 }
 
-# Detect dark mode: try OSC 11, then macOS system appearance, default to light.
+open(my $tty, "+<", "/dev/tty") or do {
+    print $FAIL;
+    exit 0;
+};
+
+my $fd = fileno($tty);
+my $old = POSIX::Termios->new();
+$old->getattr($fd) or do {
+    print $FAIL;
+    exit 0;
+};
+
+my $raw = POSIX::Termios->new();
+$raw->getattr($fd);
+$raw->setlflag($raw->getlflag & ~(ECHO | ICANON));
+$raw->setcc(VMIN, 0);
+$raw->setcc(VTIME, 0);
+$raw->setattr($fd, TCSANOW) or do {
+    print $FAIL;
+    exit 0;
+};
+
+my $ok = eval {
+    # Query default background color using an ST-terminated OSC 11 sequence.
+    my $written = syswrite($tty, "\e]11;?\e\\");
+    die "short write" unless defined $written;
+
+    my $resp = "";
+    my $deadline = time() + 0.5;
+
+    # Read until we see a complete OSC terminator or the deadline expires.
+    while (length($resp) < 1024) {
+        my $remaining = $deadline - time();
+        last if $remaining <= 0;
+
+        vec(my $rin = "", $fd, 1) = 1;
+        my $ready = select(my $rout = $rin, undef, undef, $remaining);
+        last unless $ready;
+
+        my $chunk = "";
+        my $read = sysread($tty, $chunk, 256);
+        last unless defined $read && $read > 0;
+
+        $resp .= $chunk;
+        last if $resp =~ /\a|\e\\/;
+    }
+
+    if ($resp =~ /rgb:([0-9a-f]+)\/([0-9a-f]+)\/([0-9a-f]+)/i) {
+        my @rgb = map { normalize_component($_) } ($1, $2, $3);
+        if (grep { !defined $_ } @rgb) {
+            print $FAIL;
+        } else {
+            printf "%d", int(($rgb[0] * 299 + $rgb[1] * 587 + $rgb[2] * 114) / 1000);
+        }
+    } else {
+        print $FAIL;
+    }
+
+    1;
+};
+
+# TCSAFLUSH is the critical piece: restore cooked mode and discard any unread
+# OSC response bytes atomically so the terminal never echoes them back later.
+$old->setattr($fd, TCSAFLUSH);
+close($tty);
+
+if (!$ok) {
+    print $FAIL;
+}
+PERL
+}
+
+# Detect dark mode: prefer the terminal's reported background, then fall back to
+# macOS system appearance as a heuristic when the terminal does not answer.
 detect_dark_mode() {
     local lum
     lum=$(query_bg_lum)
-    if (( lum < 128 )); then
+    if (( lum >= 0 && lum < 128 )); then
         echo dark
-    elif (( lum < 255 )); then
+    elif (( lum >= 0 )); then
         echo light
     elif [[ "$(uname -s)" == "Darwin" ]] \
          && defaults read -g AppleInterfaceStyle &>/dev/null; then


### PR DESCRIPTION
## Summary
- Detect terminal light/dark mode via OSC 11 query and auto-select SVG theme (zinc-light or dracula) in `scripts/view`
- Replace bash-based OSC 11 reader with Perl (TCSAFLUSH prevents response leaking to screen)
- Fall back to macOS system appearance (`defaults read -g AppleInterfaceStyle`) when OSC 11 is unavailable
- Fix Kitty display by piping through `rsvg-convert` for SVG→PNG (kitten icat can't render SVG directly)

## Test plan
- [ ] Run `scripts/view` in a dark-themed terminal — should pick dracula theme
- [ ] Run `scripts/view` in a light-themed terminal — should pick zinc-light theme
- [ ] Verify no OSC 11 response text leaks to screen
- [ ] Test in Kitty terminal (SVG→PNG via rsvg-convert path)
- [ ] Test `-- --svg-theme <name>` override still works