### PR TITLE
Add CLI SVG auto-theme detection and improve view rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "jsonschema",
+ "libc",
  "pest",
  "pest_derive",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = ["crates/mmdflux-wasm", "xtask"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"], optional = true }
+libc = { version = "0.2", optional = true }
 pest = "2.7"
 pest_derive = "2.7"
 serde = { version = "1", features = ["derive"] }
@@ -27,7 +28,7 @@ thiserror = "2"
 # Keep CLI behavior by default while allowing library/WASM users to opt out.
 default = ["cli"]
 # CLI-only dependency surface.
-cli = ["dep:clap"]
+cli = ["dep:clap", "dep:libc"]
 engine-elk = []
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,21 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Console",
+    "Win32_System_IO",
+    "Win32_System_Threading",
+], optional = true }
+
 [features]
 # Keep CLI behavior by default while allowing library/WASM users to opt out.
 default = ["cli"]
 # CLI-only dependency surface.
-cli = ["dep:clap", "dep:libc"]
+cli = ["dep:clap", "dep:libc", "dep:windows-sys"]
 engine-elk = []
 
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ mmdflux --format svg diagram.mmd -o diagram.svg
 # SVG output with a named theme
 mmdflux --format svg --svg-theme dark diagram.mmd -o diagram.svg
 
+# SVG output with terminal-aware light/dark theme selection
+mmdflux --format svg --svg-theme-auto diagram.mmd -o diagram.svg
+
 # Browser-oriented SVG with CSS variables plus hex fallbacks
 mmdflux --format svg --svg-theme dark --svg-theme-mode dynamic diagram.mmd -o diagram.svg
 
@@ -210,10 +213,12 @@ mmdflux --format svg --curve linear-rounded diagram.mmd -o diagram.svg
 SVG theming is opt-in and affects SVG output only.
 
 - **Explicit config wins.** CLI flags and `RenderConfig.svg_theme` take precedence over Mermaid source hints.
+- **Auto-theme is explicit.** `--svg-theme-auto` resolves to a concrete named theme before render, so Mermaid source hints stay suppressed when auto-theme is enabled.
 - **Mermaid hints are supported.** `config.theme` in YAML frontmatter and `%%{init: {"theme": "..."}}%%` both select a named SVG theme when no explicit SVG theme is supplied.
 - **Unthemed output stays available.** If no explicit theme or Mermaid hint is present, SVG rendering keeps the existing unthemed palette.
 - **Static mode is the default.** Static mode emits concrete hex colors for maximum rasterizer compatibility.
 - **Dynamic mode is additive.** `--svg-theme-mode dynamic` emits the same hex fallbacks plus root CSS variables and a `<style>` block for browser embedding.
+- **Default auto-theme mapping is `light:default,dark:dark`.** Override it with `--svg-theme-auto=light:zinc-light,dark:dracula` when a different light/dark pair is a better fit.
 
 ### Built-in themes
 

--- a/scripts/view
+++ b/scripts/view
@@ -4,6 +4,8 @@
 #
 # Defaults: -f svg --edge-preset step
 # Override any default by passing it explicitly after --
+# Set MMDFLUX_VIEW_RENDERER=chafa or MMDFLUX_VIEW_RENDERER=kitty to force a renderer.
+# Otherwise the script prefers chafa when installed, then falls back to kitten+rsvg-convert.
 #
 # Examples:
 #   scripts/view tests/fixtures/flowchart/simple.mmd
@@ -32,11 +34,7 @@ if [[ $# -gt 0 && "$1" == "--" ]]; then
     EXTRA_ARGS=("$@")
 fi
 
-# Display pipeline: Kitty needs SVG→PNG via rsvg-convert; chafa handles SVG natively
-USE_KITTY=false
-if [[ -n "${KITTY_WINDOW_ID:-}" ]]; then
-    USE_KITTY=true
-fi
+VIEW_RENDERER="${MMDFLUX_VIEW_RENDERER:-auto}"
 
 MERGED_ARGS=()
 
@@ -71,11 +69,87 @@ else
     INPUT_CMD=(cat)
 fi
 
-if $USE_KITTY; then
+kitty_target_raster_size() {
+    local window_size width height target_width target_height
+    window_size="$(kitten icat --print-window-size 2>/dev/null || true)"
+    width="${window_size%%x*}"
+    height="${window_size##*x}"
+
+    if [[ "$width" =~ ^[0-9]+$ ]] && [[ "$height" =~ ^[0-9]+$ ]] && (( width > 0 )) && (( height > 0 )); then
+        # Oversample to give icat a denser raster to downscale. Cap the raster
+        # size so very large HiDPI displays do not create excessive images.
+        target_width=$(( width * 2 ))
+        target_height=$(( height * 2 ))
+        if (( target_width > 4096 )); then
+            target_width=4096
+        fi
+        if (( target_height > 4096 )); then
+            target_height=4096
+        fi
+
+        printf '%s %s\n' "$target_width" "$target_height"
+        return 0
+    fi
+
+    return 1
+}
+
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+resolve_view_renderer() {
+    case "$VIEW_RENDERER" in
+        auto)
+            if command_exists chafa; then
+                printf '%s\n' chafa
+            elif command_exists kitten && command_exists rsvg-convert; then
+                printf '%s\n' kitty
+            else
+                echo "scripts/view: no supported renderer found; install chafa or both kitten and rsvg-convert" >&2
+                exit 1
+            fi
+            ;;
+        chafa)
+            if ! command_exists chafa; then
+                echo "scripts/view: MMDFLUX_VIEW_RENDERER=chafa requires chafa to be installed" >&2
+                exit 1
+            fi
+            printf '%s\n' chafa
+            ;;
+        kitty)
+            if ! command_exists kitten || ! command_exists rsvg-convert; then
+                echo "scripts/view: MMDFLUX_VIEW_RENDERER=kitty requires both kitten and rsvg-convert" >&2
+                exit 1
+            fi
+            printf '%s\n' kitty
+            ;;
+        *)
+            echo "scripts/view: unsupported MMDFLUX_VIEW_RENDERER=$VIEW_RENDERER (expected auto, chafa, or kitty)" >&2
+            exit 1
+            ;;
+    esac
+}
+
+VIEW_RENDERER="$(resolve_view_renderer)"
+
+if [[ "$VIEW_RENDERER" == "kitty" ]]; then
+    KITTEN_WIDTH=""
+    KITTEN_HEIGHT=""
+    if KITTEN_SIZE="$(kitty_target_raster_size || true)"; then
+        KITTEN_WIDTH="${KITTEN_SIZE%% *}"
+        KITTEN_HEIGHT="${KITTEN_SIZE##* }"
+    fi
+
+    RSVG_ARGS=()
+    if [[ -n "$KITTEN_WIDTH" && -n "$KITTEN_HEIGHT" ]]; then
+        RSVG_ARGS=(--width "$KITTEN_WIDTH" --height "$KITTEN_HEIGHT" --keep-aspect-ratio)
+    fi
+
     "${INPUT_CMD[@]}" \
         | cargo run -q -- "${MERGED_ARGS[@]}" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \
-        | rsvg-convert -z 2 \
-        | kitten icat
+        | rsvg-convert "${RSVG_ARGS[@]}" \
+        | kitten icat --stdin=yes --fit=both --scale-up
 else
     "${INPUT_CMD[@]}" \
         | cargo run -q -- "${MERGED_ARGS[@]}" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \

--- a/scripts/view
+++ b/scripts/view
@@ -12,140 +12,11 @@
 
 set -euo pipefail
 
-# Query terminal background luminance via OSC 11 on /dev/tty.
-#
-# The script is often used in a pipeline (`cat a.svg | scripts/view`), so stdin
-# is not the terminal. We have to talk to /dev/tty directly, temporarily switch
-# it into a raw-ish mode, and then restore it with TCSAFLUSH so any unread OSC
-# reply bytes are discarded before echo is re-enabled.
-#
-# Bash `read` is the wrong tool here:
-# - delimiter-based reads lose ST-terminated replies (`ESC \`) if the first read
-#   is waiting for BEL;
-# - macOS bash 3.2 does not support fractional `read -t`;
-# - `stty` cannot restore with TCSAFLUSH, so partial replies can leak visibly.
-#
-# Returns perceived luminance 0-255 on success, or -1 on failure.
-query_bg_lum() {
-    perl <<'PERL' 2>/dev/null || echo -1
-use strict;
-use warnings;
-use POSIX qw(:termios_h);
-use Time::HiRes qw(time);
-
-my $FAIL = -1;
-
-sub normalize_component {
-    my ($component) = @_;
-
-    return undef unless defined $component && $component =~ /\A[0-9a-f]+\z/i;
-
-    # Terminals commonly report either 8-bit rr/gg/bb or 16-bit rrrr/gggg/bbbb
-    # components. Scale any width back to 0..255 so luminance is comparable.
-    my $value = hex($component);
-    my $max = (16 ** length($component)) - 1;
-
-    return undef if $max <= 0;
-    return int(($value * 255 / $max) + 0.5);
-}
-
-open(my $tty, "+<", "/dev/tty") or do {
-    print $FAIL;
-    exit 0;
-};
-
-my $fd = fileno($tty);
-my $old = POSIX::Termios->new();
-$old->getattr($fd) or do {
-    print $FAIL;
-    exit 0;
-};
-
-my $raw = POSIX::Termios->new();
-$raw->getattr($fd);
-$raw->setlflag($raw->getlflag & ~(ECHO | ICANON));
-$raw->setcc(VMIN, 0);
-$raw->setcc(VTIME, 0);
-$raw->setattr($fd, TCSANOW) or do {
-    print $FAIL;
-    exit 0;
-};
-
-my $ok = eval {
-    # Query default background color using an ST-terminated OSC 11 sequence.
-    my $written = syswrite($tty, "\e]11;?\e\\");
-    die "short write" unless defined $written;
-
-    my $resp = "";
-    my $deadline = time() + 0.5;
-
-    # Read until we see a complete OSC terminator or the deadline expires.
-    while (length($resp) < 1024) {
-        my $remaining = $deadline - time();
-        last if $remaining <= 0;
-
-        vec(my $rin = "", $fd, 1) = 1;
-        my $ready = select(my $rout = $rin, undef, undef, $remaining);
-        last unless $ready;
-
-        my $chunk = "";
-        my $read = sysread($tty, $chunk, 256);
-        last unless defined $read && $read > 0;
-
-        $resp .= $chunk;
-        last if $resp =~ /\a|\e\\/;
-    }
-
-    if ($resp =~ /rgb:([0-9a-f]+)\/([0-9a-f]+)\/([0-9a-f]+)/i) {
-        my @rgb = map { normalize_component($_) } ($1, $2, $3);
-        if (grep { !defined $_ } @rgb) {
-            print $FAIL;
-        } else {
-            printf "%d", int(($rgb[0] * 299 + $rgb[1] * 587 + $rgb[2] * 114) / 1000);
-        }
-    } else {
-        print $FAIL;
-    }
-
-    1;
-};
-
-# TCSAFLUSH is the critical piece: restore cooked mode and discard any unread
-# OSC response bytes atomically so the terminal never echoes them back later.
-$old->setattr($fd, TCSAFLUSH);
-close($tty);
-
-if (!$ok) {
-    print $FAIL;
-}
-PERL
-}
-
-# Detect dark mode: prefer the terminal's reported background, then fall back to
-# macOS system appearance as a heuristic when the terminal does not answer.
-detect_dark_mode() {
-    local lum
-    lum=$(query_bg_lum)
-    if (( lum >= 0 && lum < 128 )); then
-        echo dark
-    elif (( lum >= 0 )); then
-        echo light
-    elif [[ "$(uname -s)" == "Darwin" ]] \
-         && defaults read -g AppleInterfaceStyle &>/dev/null; then
-        echo dark
-    else
-        echo light
-    fi
-}
-
-if [[ "$(detect_dark_mode)" == "dark" ]]; then
-    SVG_THEME="dracula"
-else
-    SVG_THEME="zinc-light"
-fi
-
-# Default mmdflux flags (can be overridden by passing them explicitly)
-MMDFLUX_DEFAULTS=(-f svg --edge-preset step --svg-theme "$SVG_THEME")
+# Keep view as the dev entrypoint, but let the CLI own terminal theme probing so
+# the rendering contract stays in one place.
+MMD_FORMAT_DEFAULT=(--format svg)
+MMD_EDGE_PRESET_DEFAULT=(--edge-preset step)
+MMD_THEME_DEFAULT=(--svg-theme-auto)
 
 # Split args: optional file, then optional -- extra-flags
 FILE=""
@@ -167,29 +38,31 @@ if [[ -n "${KITTY_WINDOW_ID:-}" ]]; then
     USE_KITTY=true
 fi
 
-# Remove defaults that the user explicitly overrides
 MERGED_ARGS=()
-for (( i=0; i<${#MMDFLUX_DEFAULTS[@]}; i++ )); do
-    flag="${MMDFLUX_DEFAULTS[i]}"
-    # Check if this flag appears in EXTRA_ARGS (user override wins)
-    override=false
-    for extra in "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"; do
-        if [[ "$extra" == "$flag" ]]; then
-            override=true
-            break
-        fi
+
+has_any_flag() {
+    local needle
+    for needle in "$@"; do
+        for extra in "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"; do
+            if [[ "$extra" == "$needle" || "$extra" == "$needle="* ]]; then
+                return 0
+            fi
+        done
     done
-    if $override; then
-        # Skip this default flag and its value
-        (( i++ )) || true
-    else
-        MERGED_ARGS+=("$flag")
-        if (( i + 1 < ${#MMDFLUX_DEFAULTS[@]} )) && [[ "${MMDFLUX_DEFAULTS[i+1]}" != --* ]]; then
-            (( i++ ))
-            MERGED_ARGS+=("${MMDFLUX_DEFAULTS[i]}")
-        fi
-    fi
-done
+    return 1
+}
+
+if ! has_any_flag -f --format; then
+    MERGED_ARGS+=("${MMD_FORMAT_DEFAULT[@]}")
+fi
+
+if ! has_any_flag --edge-preset; then
+    MERGED_ARGS+=("${MMD_EDGE_PRESET_DEFAULT[@]}")
+fi
+
+if ! has_any_flag --svg-theme --svg-theme-auto; then
+    MERGED_ARGS+=("${MMD_THEME_DEFAULT[@]}")
+fi
 
 # Run the pipeline
 if [[ -n "$FILE" ]]; then

--- a/src/cli_svg_theme_auto.rs
+++ b/src/cli_svg_theme_auto.rs
@@ -1,0 +1,729 @@
+//! CLI-only SVG auto-theme parsing and terminal appearance detection.
+//!
+//! This stays in the binary so runtime/WASM/library consumers keep a concrete
+//! `SvgThemeConfig` contract without inheriting terminal-specific behavior.
+
+#[cfg(unix)]
+use std::env;
+#[cfg(unix)]
+use std::fs::{File, OpenOptions};
+#[cfg(unix)]
+use std::io::Write;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, RawFd};
+#[cfg(unix)]
+use std::path::PathBuf;
+use std::process::Command;
+use std::str::FromStr;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
+
+pub(crate) const SVG_THEME_AUTO_DEFAULT_SPEC: &str = "light:default,dark:dark";
+#[cfg(unix)]
+const SVG_THEME_AUTO_DEBUG_ENV: &str = "MMDFLUX_DEBUG_SVG_THEME_AUTO";
+#[cfg(unix)]
+const OSC_11_QUERY: &[u8] = b"\x1b]11;?\x1b\\";
+#[cfg(unix)]
+const OSC_11_READ_DEADLINE: Duration = Duration::from_millis(500);
+#[cfg(unix)]
+const TRACE_POST_LOGICAL_RESTORE_WINDOW: Duration = Duration::from_millis(250);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SvgThemeAutoMap {
+    pub(crate) light: String,
+    pub(crate) dark: String,
+}
+
+impl Default for SvgThemeAutoMap {
+    fn default() -> Self {
+        Self {
+            light: "default".to_string(),
+            dark: "dark".to_string(),
+        }
+    }
+}
+
+impl FromStr for SvgThemeAutoMap {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut light = None;
+        let mut dark = None;
+
+        for entry in value.split(',') {
+            let entry = entry.trim();
+            if entry.is_empty() {
+                return Err(svg_theme_auto_map_error(
+                    "empty entry in --svg-theme-auto map",
+                ));
+            }
+
+            let (key, theme) = entry.split_once(':').ok_or_else(|| {
+                svg_theme_auto_map_error("expected entries in the form light:<theme>,dark:<theme>")
+            })?;
+
+            let key = key.trim();
+            let theme = theme.trim();
+            if theme.is_empty() {
+                return Err(svg_theme_auto_map_error(format!(
+                    "missing theme name for `{key}`"
+                )));
+            }
+
+            match key {
+                "light" => {
+                    if light.replace(theme.to_string()).is_some() {
+                        return Err(svg_theme_auto_map_error(
+                            "duplicate `light` entry in --svg-theme-auto map",
+                        ));
+                    }
+                }
+                "dark" => {
+                    if dark.replace(theme.to_string()).is_some() {
+                        return Err(svg_theme_auto_map_error(
+                            "duplicate `dark` entry in --svg-theme-auto map",
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(svg_theme_auto_map_error(format!(
+                        "unknown key `{key}` in --svg-theme-auto map (expected `light` or `dark`)"
+                    )));
+                }
+            }
+        }
+
+        let light = light.ok_or_else(|| {
+            svg_theme_auto_map_error("missing `light` entry in --svg-theme-auto map")
+        })?;
+        let dark = dark.ok_or_else(|| {
+            svg_theme_auto_map_error("missing `dark` entry in --svg-theme-auto map")
+        })?;
+
+        Ok(Self { light, dark })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TerminalAppearance {
+    Light,
+    Dark,
+}
+
+pub(crate) fn select_auto_theme_name(
+    map: &SvgThemeAutoMap,
+    terminal_appearance: Option<TerminalAppearance>,
+    macos_appearance: Option<TerminalAppearance>,
+) -> &str {
+    match terminal_appearance.or(macos_appearance) {
+        Some(TerminalAppearance::Dark) => map.dark.as_str(),
+        Some(TerminalAppearance::Light) | None => map.light.as_str(),
+    }
+}
+
+pub(crate) fn detect_terminal_appearance() -> Option<TerminalAppearance> {
+    detect_osc_terminal_appearance()
+}
+
+pub(crate) fn detect_macos_terminal_appearance() -> Option<TerminalAppearance> {
+    detect_macos_appearance()
+}
+
+fn svg_theme_auto_map_error(message: impl AsRef<str>) -> String {
+    format!(
+        "{} (expected {})",
+        message.as_ref(),
+        SVG_THEME_AUTO_DEFAULT_SPEC
+    )
+}
+
+#[cfg(unix)]
+fn detect_osc_terminal_appearance() -> Option<TerminalAppearance> {
+    let mut trace = ProbeTrace::from_env();
+    log_trace(&mut trace, "probe_mode", "rust-select-default");
+    detect_osc_terminal_appearance_rust(&mut trace)
+}
+
+#[cfg(not(unix))]
+fn detect_osc_terminal_appearance() -> Option<TerminalAppearance> {
+    None
+}
+
+#[cfg(unix)]
+fn detect_osc_terminal_appearance_rust(
+    trace: &mut Option<ProbeTrace>,
+) -> Option<TerminalAppearance> {
+    let tty = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .ok()?;
+    let fd = tty.as_raw_fd();
+    log_trace(trace, "open_tty", format!("fd={fd} path=/dev/tty"));
+
+    let mut termios = TermiosGuard::activate(fd, trace).ok()?;
+    let result = run_rust_probe(&tty, trace);
+    if let Err(error) = &result {
+        log_trace(trace, "probe_error", error.to_string());
+    }
+    let appearance = result
+        .as_ref()
+        .ok()
+        .and_then(|response| response.appearance);
+    log_trace(
+        trace,
+        "probe_result",
+        match appearance {
+            Some(TerminalAppearance::Dark) => "appearance=dark".to_string(),
+            Some(TerminalAppearance::Light) => "appearance=light".to_string(),
+            None => "appearance=unknown".to_string(),
+        },
+    );
+
+    if let Err(error) = termios.restore(trace) {
+        log_trace(trace, "restore_error", error.to_string());
+    }
+    drop(tty);
+
+    appearance
+}
+
+#[cfg(unix)]
+fn run_rust_probe(tty: &File, trace: &mut Option<ProbeTrace>) -> std::io::Result<ProbeResponse> {
+    let fd = tty.as_raw_fd();
+    let mut response = Vec::with_capacity(256);
+    let started = Instant::now();
+    let deadline = started + OSC_11_READ_DEADLINE;
+
+    log_trace(
+        trace,
+        "write_start",
+        format!(
+            "bytes={} escaped={}",
+            OSC_11_QUERY.len(),
+            escape_bytes(OSC_11_QUERY)
+        ),
+    );
+    write_all(fd, OSC_11_QUERY)?;
+    log_trace(
+        trace,
+        "write_end",
+        format!("deadline_ms={}", OSC_11_READ_DEADLINE.as_millis()),
+    );
+
+    let mut saw_readable = false;
+    while response.len() < 1024 {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            log_trace(trace, "select_timeout", "deadline expired".to_string());
+            break;
+        };
+
+        let ready = select_readable(fd, remaining)?;
+        if !ready {
+            log_trace(
+                trace,
+                "select_timeout",
+                format!("remaining_ms={}", remaining.as_millis()),
+            );
+            break;
+        }
+
+        if !saw_readable {
+            log_trace(
+                trace,
+                "first_readable",
+                format!("elapsed_us={}", started.elapsed().as_micros()),
+            );
+            saw_readable = true;
+        }
+
+        let chunk = read_chunk(fd)?;
+        if chunk.is_empty() {
+            log_trace(trace, "read_eof", "read returned 0 bytes".to_string());
+            break;
+        }
+
+        log_trace(
+            trace,
+            "read_chunk",
+            format!("len={} escaped={}", chunk.len(), escape_bytes(&chunk)),
+        );
+        response.extend_from_slice(&chunk);
+
+        if osc_11_response_terminated(&response) {
+            log_trace(
+                trace,
+                "terminator_detected",
+                format!("elapsed_us={}", started.elapsed().as_micros()),
+            );
+            break;
+        }
+    }
+
+    // Keep raw/no-echo active through a short quiet window after the reply so
+    // the terminal has time to finish delivering any in-flight OSC bytes
+    // before the original settings are restored.
+    log_trace(
+        trace,
+        "logical_restore_point",
+        format!(
+            "elapsed_us={} response_len={}",
+            started.elapsed().as_micros(),
+            response.len()
+        ),
+    );
+    let after_logical_restore = read_additional_chunks(
+        fd,
+        TRACE_POST_LOGICAL_RESTORE_WINDOW,
+        trace,
+        &mut response,
+        "post_logical_restore_chunk",
+    )?;
+    log_trace(
+        trace,
+        "post_logical_restore_summary",
+        format!(
+            "window_ms={} extra_bytes={}",
+            TRACE_POST_LOGICAL_RESTORE_WINDOW.as_millis(),
+            after_logical_restore
+        ),
+    );
+
+    let appearance = parse_terminal_appearance(&response);
+    log_trace(
+        trace,
+        "response_summary",
+        format!(
+            "total_len={} escaped={}",
+            response.len(),
+            escape_bytes(&response)
+        ),
+    );
+
+    Ok(ProbeResponse {
+        appearance,
+        raw_response: response,
+    })
+}
+
+#[cfg(unix)]
+fn read_additional_chunks(
+    fd: RawFd,
+    window: Duration,
+    trace: &mut Option<ProbeTrace>,
+    response: &mut Vec<u8>,
+    label: &str,
+) -> std::io::Result<usize> {
+    let deadline = Instant::now() + window;
+    let initial_len = response.len();
+
+    loop {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            break;
+        };
+
+        let ready = select_readable(fd, remaining)?;
+        if !ready {
+            break;
+        }
+
+        let chunk = read_chunk(fd)?;
+        if chunk.is_empty() {
+            break;
+        }
+
+        log_trace(
+            trace,
+            label,
+            format!("len={} escaped={}", chunk.len(), escape_bytes(&chunk)),
+        );
+        response.extend_from_slice(&chunk);
+    }
+
+    Ok(response.len().saturating_sub(initial_len))
+}
+
+#[cfg(unix)]
+fn parse_terminal_appearance(response: &[u8]) -> Option<TerminalAppearance> {
+    let (red, green, blue) = parse_rgb_triplet(response)?;
+    let luminance =
+        ((u32::from(red) * 299) + (u32::from(green) * 587) + (u32::from(blue) * 114)) / 1000;
+    if luminance < 128 {
+        Some(TerminalAppearance::Dark)
+    } else {
+        Some(TerminalAppearance::Light)
+    }
+}
+
+#[cfg(unix)]
+fn parse_rgb_triplet(response: &[u8]) -> Option<(u8, u8, u8)> {
+    let response = String::from_utf8_lossy(response);
+    let rgb = response.split_once("rgb:")?.1;
+    let mut components = rgb.split('/');
+    let red = normalize_component(leading_hex_component(components.next()?))?;
+    let green = normalize_component(leading_hex_component(components.next()?))?;
+    let blue = normalize_component(leading_hex_component(components.next()?))?;
+    Some((red, green, blue))
+}
+
+#[cfg(unix)]
+fn leading_hex_component(component: &str) -> &str {
+    let len = component
+        .bytes()
+        .take_while(|byte| byte.is_ascii_hexdigit())
+        .count();
+    &component[..len]
+}
+
+#[cfg(unix)]
+fn normalize_component(component: &str) -> Option<u8> {
+    if component.is_empty() || !component.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+
+    let value = u32::from_str_radix(component, 16).ok()?;
+    let max = (16_u32)
+        .checked_pow(component.len() as u32)?
+        .checked_sub(1)?;
+    let normalized = ((value * 255) + (max / 2)) / max;
+    u8::try_from(normalized).ok()
+}
+
+#[cfg(unix)]
+fn osc_11_response_terminated(response: &[u8]) -> bool {
+    response.contains(&0x07) || response.windows(2).any(|window| window == b"\x1b\\")
+}
+
+#[cfg(unix)]
+fn write_all(fd: RawFd, mut bytes: &[u8]) -> std::io::Result<()> {
+    while !bytes.is_empty() {
+        let written = unsafe { libc::write(fd, bytes.as_ptr().cast(), bytes.len()) };
+        if written < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        if written == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "tty write returned 0 bytes",
+            ));
+        }
+
+        bytes = &bytes[written as usize..];
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn read_chunk(fd: RawFd) -> std::io::Result<Vec<u8>> {
+    let mut buffer = [0_u8; 256];
+
+    loop {
+        let read = unsafe { libc::read(fd, buffer.as_mut_ptr().cast(), buffer.len()) };
+        if read < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+
+        return Ok(buffer[..read as usize].to_vec());
+    }
+}
+
+#[cfg(unix)]
+fn select_readable(fd: RawFd, timeout: Duration) -> std::io::Result<bool> {
+    loop {
+        let mut read_set = FdSet::new(fd)?;
+        let mut timeout = libc::timeval {
+            tv_sec: timeout.as_secs() as _,
+            tv_usec: timeout.subsec_micros() as _,
+        };
+        let result = unsafe {
+            libc::select(
+                fd + 1,
+                read_set.as_mut_ptr(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut timeout,
+            )
+        };
+
+        if result < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+
+        return Ok(result > 0);
+    }
+}
+
+#[cfg(unix)]
+fn escape_bytes(bytes: &[u8]) -> String {
+    let mut escaped = String::with_capacity(bytes.len());
+    for byte in bytes {
+        escaped.extend(std::ascii::escape_default(*byte).map(char::from));
+    }
+    escaped
+}
+
+#[cfg(unix)]
+fn log_trace(trace: &mut Option<ProbeTrace>, label: &str, detail: impl Into<String>) {
+    if let Some(trace) = trace.as_mut() {
+        trace.log(label, detail.into());
+    }
+}
+
+#[cfg(unix)]
+struct ProbeResponse {
+    appearance: Option<TerminalAppearance>,
+    #[allow(dead_code)]
+    raw_response: Vec<u8>,
+}
+
+#[cfg(unix)]
+struct ProbeTrace {
+    started: Instant,
+    file: File,
+}
+
+#[cfg(unix)]
+impl ProbeTrace {
+    fn from_env() -> Option<Self> {
+        let path = env::var_os(SVG_THEME_AUTO_DEBUG_ENV)?;
+        let path = PathBuf::from(path);
+        let mut file = File::create(&path).ok()?;
+        let _ = writeln!(
+            file,
+            "# MMDFLUX SVG auto-theme trace\n# path={}\n# query={}\n# logical_restore_window_ms={}",
+            path.display(),
+            escape_bytes(OSC_11_QUERY),
+            TRACE_POST_LOGICAL_RESTORE_WINDOW.as_millis()
+        );
+        Some(Self {
+            started: Instant::now(),
+            file,
+        })
+    }
+
+    fn log(&mut self, label: &str, detail: String) {
+        let _ = writeln!(
+            self.file,
+            "+{:>8}us {:<28} {}",
+            self.started.elapsed().as_micros(),
+            label,
+            detail
+        );
+        let _ = self.file.flush();
+    }
+}
+
+#[cfg(unix)]
+struct FdSet {
+    set: libc::fd_set,
+}
+
+#[cfg(unix)]
+impl FdSet {
+    fn new(fd: RawFd) -> std::io::Result<Self> {
+        if fd < 0 || fd as usize >= libc::FD_SETSIZE {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("fd {fd} is outside FD_SETSIZE"),
+            ));
+        }
+
+        let mut set = std::mem::MaybeUninit::uninit();
+        unsafe {
+            libc::FD_ZERO(set.as_mut_ptr());
+            let mut set = set.assume_init();
+            libc::FD_SET(fd, &mut set);
+            Ok(Self { set })
+        }
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut libc::fd_set {
+        &mut self.set
+    }
+}
+
+#[cfg(unix)]
+struct TermiosGuard {
+    fd: RawFd,
+    old: libc::termios,
+    restored: bool,
+}
+
+#[cfg(unix)]
+impl TermiosGuard {
+    fn activate(fd: RawFd, trace: &mut Option<ProbeTrace>) -> std::io::Result<Self> {
+        let old = tcgetattr(fd)?;
+        let mut raw = old;
+        raw.c_lflag &= !(libc::ECHO | libc::ICANON);
+        raw.c_cc[libc::VMIN] = 0;
+        raw.c_cc[libc::VTIME] = 0;
+
+        log_trace(trace, "set_raw_start", format!("fd={fd}"));
+        tcsetattr(fd, libc::TCSANOW, &raw)?;
+        log_trace(
+            trace,
+            "set_raw_end",
+            format!(
+                "lflag={} vmin={} vtime={}",
+                raw.c_lflag,
+                raw.c_cc[libc::VMIN],
+                raw.c_cc[libc::VTIME]
+            ),
+        );
+
+        Ok(Self {
+            fd,
+            old,
+            restored: false,
+        })
+    }
+
+    fn restore(&mut self, trace: &mut Option<ProbeTrace>) -> std::io::Result<()> {
+        if self.restored {
+            return Ok(());
+        }
+
+        log_trace(
+            trace,
+            "restore_start",
+            format!("action=TCSAFLUSH fd={}", self.fd),
+        );
+        tcsetattr(self.fd, libc::TCSAFLUSH, &self.old)?;
+        log_trace(trace, "restore_end", format!("fd={}", self.fd));
+        self.restored = true;
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+impl Drop for TermiosGuard {
+    fn drop(&mut self) {
+        if !self.restored {
+            let _ = tcsetattr(self.fd, libc::TCSAFLUSH, &self.old);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn tcgetattr(fd: RawFd) -> std::io::Result<libc::termios> {
+    loop {
+        let mut termios = std::mem::MaybeUninit::uninit();
+        let result = unsafe { libc::tcgetattr(fd, termios.as_mut_ptr()) };
+        if result == 0 {
+            return Ok(unsafe { termios.assume_init() });
+        }
+
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::Interrupted {
+            continue;
+        }
+        return Err(error);
+    }
+}
+
+#[cfg(unix)]
+fn tcsetattr(fd: RawFd, action: libc::c_int, termios: &libc::termios) -> std::io::Result<()> {
+    loop {
+        let result = unsafe { libc::tcsetattr(fd, action, termios) };
+        if result == 0 {
+            return Ok(());
+        }
+
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::Interrupted {
+            continue;
+        }
+        return Err(error);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn detect_macos_appearance() -> Option<TerminalAppearance> {
+    let output = Command::new("defaults")
+        .args(["read", "-g", "AppleInterfaceStyle"])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(TerminalAppearance::Dark)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn detect_macos_appearance() -> Option<TerminalAppearance> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        SVG_THEME_AUTO_DEFAULT_SPEC, SvgThemeAutoMap, TerminalAppearance, select_auto_theme_name,
+    };
+
+    #[test]
+    fn svg_theme_auto_map_parses_keyed_entries_in_any_order() {
+        let map: SvgThemeAutoMap = "dark:dracula, light:zinc-light".parse().unwrap();
+        assert_eq!(map.light, "zinc-light");
+        assert_eq!(map.dark, "dracula");
+    }
+
+    #[test]
+    fn svg_theme_auto_map_rejects_duplicate_keys() {
+        let error = "light:default,light:zinc-light,dark:dark"
+            .parse::<SvgThemeAutoMap>()
+            .unwrap_err();
+        assert!(error.contains("duplicate `light` entry"));
+    }
+
+    #[test]
+    fn svg_theme_auto_map_rejects_missing_entries() {
+        let error = "light:default".parse::<SvgThemeAutoMap>().unwrap_err();
+        assert!(error.contains("missing `dark` entry"));
+        assert!(error.contains(SVG_THEME_AUTO_DEFAULT_SPEC));
+    }
+
+    #[test]
+    fn svg_theme_auto_map_rejects_unknown_keys() {
+        let error = "light:default,auto:dark"
+            .parse::<SvgThemeAutoMap>()
+            .unwrap_err();
+        assert!(error.contains("unknown key `auto`"));
+    }
+
+    #[test]
+    fn select_auto_theme_name_prefers_terminal_then_macos_then_light() {
+        let map = SvgThemeAutoMap {
+            light: "default".to_string(),
+            dark: "dark".to_string(),
+        };
+
+        assert_eq!(
+            select_auto_theme_name(
+                &map,
+                Some(TerminalAppearance::Dark),
+                Some(TerminalAppearance::Light)
+            ),
+            "dark"
+        );
+        assert_eq!(
+            select_auto_theme_name(&map, None, Some(TerminalAppearance::Dark)),
+            "dark"
+        );
+        assert_eq!(select_auto_theme_name(&map, None, None), "default");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,17 @@
 //! mmdflux CLI — Mermaid diagram to text/SVG renderer.
 
+mod cli_svg_theme_auto;
+
 use std::ffi::OsStr;
 use std::io::{self, IsTerminal, Read};
 use std::path::PathBuf;
 use std::{env, fmt, fs};
 
 use clap::{Parser, ValueEnum};
+use cli_svg_theme_auto::{
+    SVG_THEME_AUTO_DEFAULT_SPEC, SvgThemeAutoMap, detect_macos_terminal_appearance,
+    detect_terminal_appearance, select_auto_theme_name,
+};
 use mmdflux::format::{Curve, EdgePreset, RoutingStyle};
 use mmdflux::graph::GeometryLevel;
 use mmdflux::simplification::PathSimplification;
@@ -123,7 +129,7 @@ impl fmt::Display for ValidationDiagnostic {
     }
 }
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(name = "mmdflux")]
 #[command(version)]
 #[command(about = "Convert Mermaid diagrams to text, SVG, or MMDS JSON")]
@@ -190,6 +196,18 @@ struct Cli {
     /// Named SVG theme to resolve before slot overrides.
     #[arg(long)]
     svg_theme: Option<String>,
+
+    /// Select a concrete SVG theme from terminal appearance before slot overrides.
+    /// Accepts light:<theme>,dark:<theme>; if omitted, defaults to light:default,dark:dark.
+    #[arg(
+        long,
+        conflicts_with = "svg_theme",
+        require_equals = true,
+        num_args = 0..=1,
+        default_missing_value = SVG_THEME_AUTO_DEFAULT_SPEC,
+        value_name = "MAP"
+    )]
+    svg_theme_auto: Option<SvgThemeAutoMap>,
 
     /// SVG theme output mode (static or dynamic).
     #[arg(long, value_enum)]
@@ -394,8 +412,9 @@ fn resolve_text_color_mode(
     ColorWhen::Auto.resolve(stdout_is_terminal)
 }
 
-fn svg_theme_from_cli(cli: &Cli) -> Option<SvgThemeConfig> {
-    let has_theme_input = cli.svg_theme.is_some()
+fn has_svg_theme_input(cli: &Cli) -> bool {
+    cli.svg_theme.is_some()
+        || cli.svg_theme_auto.is_some()
         || cli.svg_theme_mode.is_some()
         || cli.svg_theme_bg.is_some()
         || cli.svg_theme_fg.is_some()
@@ -403,14 +422,27 @@ fn svg_theme_from_cli(cli: &Cli) -> Option<SvgThemeConfig> {
         || cli.svg_theme_accent.is_some()
         || cli.svg_theme_muted.is_some()
         || cli.svg_theme_surface.is_some()
-        || cli.svg_theme_border.is_some();
+        || cli.svg_theme_border.is_some()
+}
 
-    if !has_theme_input {
+fn svg_theme_from_cli_with_appearance(
+    cli: &Cli,
+    terminal_appearance: Option<cli_svg_theme_auto::TerminalAppearance>,
+    macos_appearance: Option<cli_svg_theme_auto::TerminalAppearance>,
+) -> Option<SvgThemeConfig> {
+    if !has_svg_theme_input(cli) {
         return None;
     }
 
+    let name = match (&cli.svg_theme, &cli.svg_theme_auto) {
+        (_, Some(map)) => {
+            Some(select_auto_theme_name(map, terminal_appearance, macos_appearance).to_string())
+        }
+        (theme, None) => theme.clone(),
+    };
+
     Some(SvgThemeConfig {
-        name: cli.svg_theme.clone(),
+        name,
         mode: cli.svg_theme_mode.map(Into::into).unwrap_or_default(),
         bg: cli.svg_theme_bg.clone(),
         fg: cli.svg_theme_fg.clone(),
@@ -420,6 +452,14 @@ fn svg_theme_from_cli(cli: &Cli) -> Option<SvgThemeConfig> {
         surface: cli.svg_theme_surface.clone(),
         border: cli.svg_theme_border.clone(),
     })
+}
+
+fn svg_theme_from_cli(cli: &Cli) -> Option<SvgThemeConfig> {
+    svg_theme_from_cli_with_appearance(
+        cli,
+        detect_terminal_appearance(),
+        detect_macos_terminal_appearance(),
+    )
 }
 
 fn main() -> io::Result<()> {
@@ -584,7 +624,18 @@ fn main() -> io::Result<()> {
 mod tests {
     use std::ffi::OsStr;
 
+    use clap::error::ErrorKind;
+    use cli_svg_theme_auto::TerminalAppearance;
+
     use super::*;
+
+    fn parse_cli(args: &[&str]) -> Cli {
+        Cli::try_parse_from(args).expect("CLI args should parse")
+    }
+
+    fn render_svg_with_config(input: &str, config: RenderConfig) -> String {
+        render_diagram(input, OutputFormat::Svg, &config).expect("SVG render should succeed")
+    }
 
     #[test]
     fn color_auto_defaults_to_plain_when_stdout_is_not_a_terminal() {
@@ -628,5 +679,115 @@ mod tests {
             resolve_text_color_mode(Some(ColorWhen::Auto), true, Some(OsStr::new("1"))),
             TextColorMode::Ansi
         );
+    }
+
+    #[test]
+    fn cli_parses_bare_svg_theme_auto_as_default_map() {
+        let cli = parse_cli(&["mmdflux", "--svg-theme-auto"]);
+        assert_eq!(cli.svg_theme_auto, Some(SvgThemeAutoMap::default()));
+    }
+
+    #[test]
+    fn cli_parses_custom_svg_theme_auto_map() {
+        let cli = parse_cli(&["mmdflux", "--svg-theme-auto=dark:dracula, light:zinc-light"]);
+        assert_eq!(
+            cli.svg_theme_auto,
+            Some(SvgThemeAutoMap {
+                light: "zinc-light".to_string(),
+                dark: "dracula".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn cli_rejects_invalid_svg_theme_auto_maps() {
+        for value in [
+            "",
+            "light:default",
+            "light:default,dark:dark,dark:dracula",
+            "light:default,auto:dark",
+            "light:,dark:dark",
+        ] {
+            let error = Cli::try_parse_from(["mmdflux", &format!("--svg-theme-auto={value}")])
+                .expect_err("invalid svg auto theme map should fail");
+            assert_eq!(error.kind(), ErrorKind::ValueValidation);
+        }
+    }
+
+    #[test]
+    fn cli_rejects_svg_theme_and_svg_theme_auto_together() {
+        let error = Cli::try_parse_from(["mmdflux", "--svg-theme", "dark", "--svg-theme-auto"])
+            .expect_err("conflicting theme sources should fail");
+        assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn svg_theme_auto_resolves_to_explicit_theme_with_slot_overrides() {
+        let cli = parse_cli(&[
+            "mmdflux",
+            "--svg-theme-auto=light:zinc-light,dark:dracula",
+            "--svg-theme-mode",
+            "dynamic",
+            "--svg-theme-accent",
+            "#7dd3fc",
+        ]);
+
+        let theme = svg_theme_from_cli_with_appearance(
+            &cli,
+            Some(TerminalAppearance::Dark),
+            Some(TerminalAppearance::Light),
+        )
+        .expect("theme should resolve");
+
+        assert_eq!(theme.name.as_deref(), Some("dracula"));
+        assert_eq!(theme.mode, SvgThemeMode::Dynamic);
+        assert_eq!(theme.accent.as_deref(), Some("#7dd3fc"));
+    }
+
+    #[test]
+    fn svg_theme_auto_falls_back_from_terminal_to_macos_to_light_map() {
+        let cli = parse_cli(&["mmdflux", "--svg-theme-auto=light:zinc-light,dark:dracula"]);
+
+        let mac_dark =
+            svg_theme_from_cli_with_appearance(&cli, None, Some(TerminalAppearance::Dark))
+                .expect("theme should resolve");
+        assert_eq!(mac_dark.name.as_deref(), Some("dracula"));
+
+        let fallback_light =
+            svg_theme_from_cli_with_appearance(&cli, None, None).expect("theme should resolve");
+        assert_eq!(fallback_light.name.as_deref(), Some("zinc-light"));
+    }
+
+    #[test]
+    fn svg_theme_auto_suppresses_mermaid_theme_hints() {
+        let input = "%%{init: {\"theme\": \"forest\"}}%%\ngraph TD\nA-->B\n";
+        let cli = parse_cli(&["mmdflux", "--svg-theme-auto=light:default,dark:dark"]);
+
+        let auto_theme = svg_theme_from_cli_with_appearance(
+            &cli,
+            Some(TerminalAppearance::Dark),
+            Some(TerminalAppearance::Light),
+        )
+        .expect("theme should resolve");
+
+        let auto_output = render_svg_with_config(
+            input,
+            RenderConfig {
+                svg_theme: Some(auto_theme),
+                ..RenderConfig::default()
+            },
+        );
+        let explicit_output = render_svg_with_config(
+            input,
+            RenderConfig {
+                svg_theme: Some(SvgThemeConfig {
+                    name: Some("dark".to_string()),
+                    ..SvgThemeConfig::default()
+                }),
+                ..RenderConfig::default()
+            },
+        );
+
+        assert_eq!(auto_output, explicit_output);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,7 @@ use mmdflux::{
 };
 use serde::{Deserialize, Serialize};
 use svg_theme_auto::{SVG_THEME_AUTO_DEFAULT_SPEC, SvgThemeAutoMap, select_auto_theme_name};
-use terminal_appearance::{
-    TerminalAppearance, detect_macos_terminal_appearance, detect_terminal_appearance,
-};
+use terminal_appearance::{TerminalAppearance, detect_os_appearance, detect_terminal_appearance};
 
 const CURVE_CANONICAL_VALUES: &str = "basis, linear, linear-sharp, linear-rounded";
 const CURVE_ARG_HELP: &str = "SVG curve style (basis, linear, linear-sharp, or linear-rounded). \
@@ -429,7 +427,7 @@ fn has_svg_theme_input(cli: &Cli) -> bool {
 fn svg_theme_from_cli_with_appearance(
     cli: &Cli,
     terminal_appearance: Option<TerminalAppearance>,
-    macos_appearance: Option<TerminalAppearance>,
+    os_appearance: Option<TerminalAppearance>,
 ) -> Option<SvgThemeConfig> {
     if !has_svg_theme_input(cli) {
         return None;
@@ -437,7 +435,7 @@ fn svg_theme_from_cli_with_appearance(
 
     let name = match (&cli.svg_theme, &cli.svg_theme_auto) {
         (_, Some(map)) => {
-            Some(select_auto_theme_name(map, terminal_appearance, macos_appearance).to_string())
+            Some(select_auto_theme_name(map, terminal_appearance, os_appearance).to_string())
         }
         (theme, None) => theme.clone(),
     };
@@ -456,11 +454,7 @@ fn svg_theme_from_cli_with_appearance(
 }
 
 fn svg_theme_from_cli(cli: &Cli) -> Option<SvgThemeConfig> {
-    svg_theme_from_cli_with_appearance(
-        cli,
-        detect_terminal_appearance(),
-        detect_macos_terminal_appearance(),
-    )
+    svg_theme_from_cli_with_appearance(cli, detect_terminal_appearance(), detect_os_appearance())
 }
 
 fn main() -> io::Result<()> {
@@ -745,7 +739,7 @@ mod tests {
     }
 
     #[test]
-    fn svg_theme_auto_falls_back_from_terminal_to_macos_to_light_map() {
+    fn svg_theme_auto_falls_back_from_terminal_to_os_to_light_map() {
         let cli = parse_cli(&["mmdflux", "--svg-theme-auto=light:zinc-light,dark:dracula"]);
 
         let mac_dark =

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 //! mmdflux CLI — Mermaid diagram to text/SVG renderer.
 
-mod cli_svg_theme_auto;
+mod svg_theme_auto;
+mod terminal_appearance;
 
 use std::ffi::OsStr;
 use std::io::{self, IsTerminal, Read};
@@ -8,10 +9,6 @@ use std::path::PathBuf;
 use std::{env, fmt, fs};
 
 use clap::{Parser, ValueEnum};
-use cli_svg_theme_auto::{
-    SVG_THEME_AUTO_DEFAULT_SPEC, SvgThemeAutoMap, detect_macos_terminal_appearance,
-    detect_terminal_appearance, select_auto_theme_name,
-};
 use mmdflux::format::{Curve, EdgePreset, RoutingStyle};
 use mmdflux::graph::GeometryLevel;
 use mmdflux::simplification::PathSimplification;
@@ -21,6 +18,10 @@ use mmdflux::{
     validate_diagram,
 };
 use serde::{Deserialize, Serialize};
+use svg_theme_auto::{SVG_THEME_AUTO_DEFAULT_SPEC, SvgThemeAutoMap, select_auto_theme_name};
+use terminal_appearance::{
+    TerminalAppearance, detect_macos_terminal_appearance, detect_terminal_appearance,
+};
 
 const CURVE_CANONICAL_VALUES: &str = "basis, linear, linear-sharp, linear-rounded";
 const CURVE_ARG_HELP: &str = "SVG curve style (basis, linear, linear-sharp, or linear-rounded). \
@@ -427,8 +428,8 @@ fn has_svg_theme_input(cli: &Cli) -> bool {
 
 fn svg_theme_from_cli_with_appearance(
     cli: &Cli,
-    terminal_appearance: Option<cli_svg_theme_auto::TerminalAppearance>,
-    macos_appearance: Option<cli_svg_theme_auto::TerminalAppearance>,
+    terminal_appearance: Option<TerminalAppearance>,
+    macos_appearance: Option<TerminalAppearance>,
 ) -> Option<SvgThemeConfig> {
     if !has_svg_theme_input(cli) {
         return None;
@@ -625,7 +626,6 @@ mod tests {
     use std::ffi::OsStr;
 
     use clap::error::ErrorKind;
-    use cli_svg_theme_auto::TerminalAppearance;
 
     use super::*;
 

--- a/src/svg_theme_auto.rs
+++ b/src/svg_theme_auto.rs
@@ -88,9 +88,9 @@ impl FromStr for SvgThemeAutoMap {
 pub(crate) fn select_auto_theme_name(
     map: &SvgThemeAutoMap,
     terminal_appearance: Option<TerminalAppearance>,
-    macos_appearance: Option<TerminalAppearance>,
+    os_appearance: Option<TerminalAppearance>,
 ) -> &str {
-    match terminal_appearance.or(macos_appearance) {
+    match terminal_appearance.or(os_appearance) {
         Some(TerminalAppearance::Dark) => map.dark.as_str(),
         Some(TerminalAppearance::Light) | None => map.light.as_str(),
     }
@@ -140,7 +140,7 @@ mod tests {
     }
 
     #[test]
-    fn select_auto_theme_name_prefers_terminal_then_macos_then_light() {
+    fn select_auto_theme_name_prefers_terminal_then_os_then_light() {
         let map = SvgThemeAutoMap {
             light: "default".to_string(),
             dark: "dark".to_string(),

--- a/src/svg_theme_auto.rs
+++ b/src/svg_theme_auto.rs
@@ -1,0 +1,163 @@
+//! CLI-only SVG auto-theme parsing and selection helpers.
+//!
+//! This stays in the binary so runtime/WASM/library consumers keep a concrete
+//! `SvgThemeConfig` contract without inheriting terminal-specific behavior.
+
+use std::str::FromStr;
+
+use crate::terminal_appearance::TerminalAppearance;
+
+pub(crate) const SVG_THEME_AUTO_DEFAULT_SPEC: &str = "light:default,dark:dark";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SvgThemeAutoMap {
+    pub(crate) light: String,
+    pub(crate) dark: String,
+}
+
+impl Default for SvgThemeAutoMap {
+    fn default() -> Self {
+        Self {
+            light: "default".to_string(),
+            dark: "dark".to_string(),
+        }
+    }
+}
+
+impl FromStr for SvgThemeAutoMap {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut light = None;
+        let mut dark = None;
+
+        for entry in value.split(',') {
+            let entry = entry.trim();
+            if entry.is_empty() {
+                return Err(svg_theme_auto_map_error(
+                    "empty entry in --svg-theme-auto map",
+                ));
+            }
+
+            let (key, theme) = entry.split_once(':').ok_or_else(|| {
+                svg_theme_auto_map_error("expected entries in the form light:<theme>,dark:<theme>")
+            })?;
+
+            let key = key.trim();
+            let theme = theme.trim();
+            if theme.is_empty() {
+                return Err(svg_theme_auto_map_error(format!(
+                    "missing theme name for `{key}`"
+                )));
+            }
+
+            match key {
+                "light" => {
+                    if light.replace(theme.to_string()).is_some() {
+                        return Err(svg_theme_auto_map_error(
+                            "duplicate `light` entry in --svg-theme-auto map",
+                        ));
+                    }
+                }
+                "dark" => {
+                    if dark.replace(theme.to_string()).is_some() {
+                        return Err(svg_theme_auto_map_error(
+                            "duplicate `dark` entry in --svg-theme-auto map",
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(svg_theme_auto_map_error(format!(
+                        "unknown key `{key}` in --svg-theme-auto map (expected `light` or `dark`)"
+                    )));
+                }
+            }
+        }
+
+        let light = light.ok_or_else(|| {
+            svg_theme_auto_map_error("missing `light` entry in --svg-theme-auto map")
+        })?;
+        let dark = dark.ok_or_else(|| {
+            svg_theme_auto_map_error("missing `dark` entry in --svg-theme-auto map")
+        })?;
+
+        Ok(Self { light, dark })
+    }
+}
+
+pub(crate) fn select_auto_theme_name(
+    map: &SvgThemeAutoMap,
+    terminal_appearance: Option<TerminalAppearance>,
+    macos_appearance: Option<TerminalAppearance>,
+) -> &str {
+    match terminal_appearance.or(macos_appearance) {
+        Some(TerminalAppearance::Dark) => map.dark.as_str(),
+        Some(TerminalAppearance::Light) | None => map.light.as_str(),
+    }
+}
+
+fn svg_theme_auto_map_error(message: impl AsRef<str>) -> String {
+    format!(
+        "{} (expected {})",
+        message.as_ref(),
+        SVG_THEME_AUTO_DEFAULT_SPEC
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SVG_THEME_AUTO_DEFAULT_SPEC, SvgThemeAutoMap, select_auto_theme_name};
+    use crate::terminal_appearance::TerminalAppearance;
+
+    #[test]
+    fn svg_theme_auto_map_parses_keyed_entries_in_any_order() {
+        let map: SvgThemeAutoMap = "dark:dracula, light:zinc-light".parse().unwrap();
+        assert_eq!(map.light, "zinc-light");
+        assert_eq!(map.dark, "dracula");
+    }
+
+    #[test]
+    fn svg_theme_auto_map_rejects_duplicate_keys() {
+        let error = "light:default,light:zinc-light,dark:dark"
+            .parse::<SvgThemeAutoMap>()
+            .unwrap_err();
+        assert!(error.contains("duplicate `light` entry"));
+    }
+
+    #[test]
+    fn svg_theme_auto_map_rejects_missing_entries() {
+        let error = "light:default".parse::<SvgThemeAutoMap>().unwrap_err();
+        assert!(error.contains("missing `dark` entry"));
+        assert!(error.contains(SVG_THEME_AUTO_DEFAULT_SPEC));
+    }
+
+    #[test]
+    fn svg_theme_auto_map_rejects_unknown_keys() {
+        let error = "light:default,auto:dark"
+            .parse::<SvgThemeAutoMap>()
+            .unwrap_err();
+        assert!(error.contains("unknown key `auto`"));
+    }
+
+    #[test]
+    fn select_auto_theme_name_prefers_terminal_then_macos_then_light() {
+        let map = SvgThemeAutoMap {
+            light: "default".to_string(),
+            dark: "dark".to_string(),
+        };
+
+        assert_eq!(
+            select_auto_theme_name(
+                &map,
+                Some(TerminalAppearance::Dark),
+                Some(TerminalAppearance::Light)
+            ),
+            "dark"
+        );
+        assert_eq!(
+            select_auto_theme_name(&map, None, Some(TerminalAppearance::Dark)),
+            "dark"
+        );
+        assert_eq!(select_auto_theme_name(&map, None, None), "default");
+    }
+}

--- a/src/terminal_appearance.rs
+++ b/src/terminal_appearance.rs
@@ -1,18 +1,20 @@
 //! Binary-private terminal appearance detection.
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::env;
+#[cfg(any(unix, windows))]
+use std::fs::File;
 #[cfg(unix)]
-use std::fs::{File, OpenOptions};
-#[cfg(unix)]
+use std::fs::OpenOptions;
+#[cfg(any(unix, windows))]
 use std::io::Write;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, RawFd};
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::path::PathBuf;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", windows))]
 use std::process::Command;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::time::{Duration, Instant};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -21,21 +23,21 @@ pub(crate) enum TerminalAppearance {
     Dark,
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const SVG_THEME_AUTO_DEBUG_ENV: &str = "MMDFLUX_DEBUG_SVG_THEME_AUTO";
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const OSC_11_QUERY: &[u8] = b"\x1b]11;?\x1b\\";
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const OSC_11_READ_DEADLINE: Duration = Duration::from_millis(500);
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const TRACE_POST_LOGICAL_RESTORE_WINDOW: Duration = Duration::from_millis(250);
 
 pub(crate) fn detect_terminal_appearance() -> Option<TerminalAppearance> {
     detect_osc_terminal_appearance()
 }
 
-pub(crate) fn detect_macos_terminal_appearance() -> Option<TerminalAppearance> {
-    detect_macos_appearance()
+pub(crate) fn detect_os_appearance() -> Option<TerminalAppearance> {
+    detect_os_appearance_impl()
 }
 
 #[cfg(unix)]
@@ -45,7 +47,7 @@ fn detect_osc_terminal_appearance() -> Option<TerminalAppearance> {
     detect_osc_terminal_appearance_rust(&mut trace)
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn detect_osc_terminal_appearance() -> Option<TerminalAppearance> {
     None
 }
@@ -244,7 +246,7 @@ fn read_additional_chunks(
     Ok(response.len().saturating_sub(initial_len))
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn parse_terminal_appearance(response: &[u8]) -> Option<TerminalAppearance> {
     let (red, green, blue) = parse_rgb_triplet(response)?;
     let luminance =
@@ -256,7 +258,7 @@ fn parse_terminal_appearance(response: &[u8]) -> Option<TerminalAppearance> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn parse_rgb_triplet(response: &[u8]) -> Option<(u8, u8, u8)> {
     let response = String::from_utf8_lossy(response);
     let rgb = response.split_once("rgb:")?.1;
@@ -267,7 +269,7 @@ fn parse_rgb_triplet(response: &[u8]) -> Option<(u8, u8, u8)> {
     Some((red, green, blue))
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn leading_hex_component(component: &str) -> &str {
     let len = component
         .bytes()
@@ -276,7 +278,7 @@ fn leading_hex_component(component: &str) -> &str {
     &component[..len]
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn normalize_component(component: &str) -> Option<u8> {
     if component.is_empty() || !component.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return None;
@@ -290,7 +292,7 @@ fn normalize_component(component: &str) -> Option<u8> {
     u8::try_from(normalized).ok()
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn osc_11_response_terminated(response: &[u8]) -> bool {
     response.contains(&0x07) || response.windows(2).any(|window| window == b"\x1b\\")
 }
@@ -367,7 +369,7 @@ fn select_readable(fd: RawFd, timeout: Duration) -> std::io::Result<bool> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn escape_bytes(bytes: &[u8]) -> String {
     let mut escaped = String::with_capacity(bytes.len());
     for byte in bytes {
@@ -376,27 +378,27 @@ fn escape_bytes(bytes: &[u8]) -> String {
     escaped
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn log_trace(trace: &mut Option<ProbeTrace>, label: &str, detail: impl Into<String>) {
     if let Some(trace) = trace.as_mut() {
         trace.log(label, detail.into());
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 struct ProbeResponse {
     appearance: Option<TerminalAppearance>,
     #[allow(dead_code)]
     raw_response: Vec<u8>,
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 struct ProbeTrace {
     started: Instant,
     file: File,
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 impl ProbeTrace {
     fn from_env() -> Option<Self> {
         let path = env::var_os(SVG_THEME_AUTO_DEBUG_ENV)?;
@@ -552,7 +554,7 @@ fn tcsetattr(fd: RawFd, action: libc::c_int, termios: &libc::termios) -> std::io
 }
 
 #[cfg(target_os = "macos")]
-fn detect_macos_appearance() -> Option<TerminalAppearance> {
+fn detect_os_appearance_impl() -> Option<TerminalAppearance> {
     let output = Command::new("defaults")
         .args(["read", "-g", "AppleInterfaceStyle"])
         .output()
@@ -565,7 +567,478 @@ fn detect_macos_appearance() -> Option<TerminalAppearance> {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
-fn detect_macos_appearance() -> Option<TerminalAppearance> {
+#[cfg(not(any(target_os = "macos", windows)))]
+fn detect_os_appearance_impl() -> Option<TerminalAppearance> {
     None
+}
+
+// ---------------------------------------------------------------------------
+// Windows: OS-level appearance via registry
+// ---------------------------------------------------------------------------
+
+#[cfg(windows)]
+fn detect_os_appearance_impl() -> Option<TerminalAppearance> {
+    let output = Command::new("reg")
+        .args([
+            "query",
+            r"HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+            "/v",
+            "AppsUseLightTheme",
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Output format: "    AppsUseLightTheme    REG_DWORD    0x0"
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.starts_with("AppsUseLightTheme") {
+            if line.contains("0x0") {
+                return Some(TerminalAppearance::Dark);
+            } else {
+                return Some(TerminalAppearance::Light);
+            }
+        }
+    }
+
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Windows: OSC 11 terminal background probe via Console API
+// ---------------------------------------------------------------------------
+
+#[cfg(windows)]
+fn detect_osc_terminal_appearance() -> Option<TerminalAppearance> {
+    let mut trace = ProbeTrace::from_env();
+    log_trace(&mut trace, "probe_mode", "rust-windows-console");
+    detect_osc_terminal_appearance_windows(&mut trace)
+}
+
+#[cfg(windows)]
+fn detect_osc_terminal_appearance_windows(
+    trace: &mut Option<ProbeTrace>,
+) -> Option<TerminalAppearance> {
+    let (h_in, h_out) = open_console_handles(trace).ok()?;
+
+    let mut guard = match ConsoleModeGuard::activate(h_in, h_out, trace) {
+        Ok(guard) => guard,
+        Err(_) => {
+            log_trace(trace, "console_mode_error", "failed to set console mode");
+            unsafe {
+                windows_sys::Win32::Foundation::CloseHandle(h_in);
+                windows_sys::Win32::Foundation::CloseHandle(h_out);
+            }
+            return None;
+        }
+    };
+
+    let result = run_windows_probe(h_in, h_out, trace);
+    if let Err(error) = &result {
+        log_trace(trace, "probe_error", error.to_string());
+    }
+    let appearance = result
+        .as_ref()
+        .ok()
+        .and_then(|response| response.appearance);
+    log_trace(
+        trace,
+        "probe_result",
+        match appearance {
+            Some(TerminalAppearance::Dark) => "appearance=dark".to_string(),
+            Some(TerminalAppearance::Light) => "appearance=light".to_string(),
+            None => "appearance=unknown".to_string(),
+        },
+    );
+
+    if let Err(error) = guard.restore(trace) {
+        log_trace(trace, "restore_error", error.to_string());
+    }
+    unsafe {
+        windows_sys::Win32::Foundation::CloseHandle(h_in);
+        windows_sys::Win32::Foundation::CloseHandle(h_out);
+    }
+
+    appearance
+}
+
+#[cfg(windows)]
+fn open_console_handles(
+    trace: &mut Option<ProbeTrace>,
+) -> std::io::Result<(
+    windows_sys::Win32::Foundation::HANDLE,
+    windows_sys::Win32::Foundation::HANDLE,
+)> {
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+
+    let conin: Vec<u16> = "CONIN$\0".encode_utf16().collect();
+    let conout: Vec<u16> = "CONOUT$\0".encode_utf16().collect();
+
+    let h_in = unsafe {
+        CreateFileW(
+            conin.as_ptr(),
+            0x80000000 | 0x40000000, // GENERIC_READ | GENERIC_WRITE
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            0,
+            0,
+        )
+    };
+    if h_in == INVALID_HANDLE_VALUE {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    let h_out = unsafe {
+        CreateFileW(
+            conout.as_ptr(),
+            0x80000000 | 0x40000000, // GENERIC_READ | GENERIC_WRITE
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            0,
+            0,
+        )
+    };
+    if h_out == INVALID_HANDLE_VALUE {
+        unsafe { windows_sys::Win32::Foundation::CloseHandle(h_in) };
+        return Err(std::io::Error::last_os_error());
+    }
+
+    log_trace(trace, "open_console", "CONIN$+CONOUT$");
+
+    Ok((h_in, h_out))
+}
+
+#[cfg(windows)]
+struct ConsoleModeGuard {
+    input_handle: windows_sys::Win32::Foundation::HANDLE,
+    output_handle: windows_sys::Win32::Foundation::HANDLE,
+    old_input_mode: u32,
+    old_output_mode: u32,
+    restored: bool,
+}
+
+#[cfg(windows)]
+impl ConsoleModeGuard {
+    fn activate(
+        input_handle: windows_sys::Win32::Foundation::HANDLE,
+        output_handle: windows_sys::Win32::Foundation::HANDLE,
+        trace: &mut Option<ProbeTrace>,
+    ) -> std::io::Result<Self> {
+        use windows_sys::Win32::System::Console::{
+            ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT,
+            ENABLE_VIRTUAL_TERMINAL_PROCESSING, GetConsoleMode, SetConsoleMode,
+        };
+
+        let mut old_input_mode: u32 = 0;
+        let mut old_output_mode: u32 = 0;
+
+        if unsafe { GetConsoleMode(input_handle, &mut old_input_mode) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if unsafe { GetConsoleMode(output_handle, &mut old_output_mode) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let new_input_mode = (old_input_mode & !(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT))
+            | ENABLE_VIRTUAL_TERMINAL_INPUT;
+        let new_output_mode = old_output_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+
+        log_trace(
+            trace,
+            "set_console_mode_start",
+            format!(
+                "input=0x{:04x}->0x{:04x} output=0x{:04x}->0x{:04x}",
+                old_input_mode, new_input_mode, old_output_mode, new_output_mode
+            ),
+        );
+
+        if unsafe { SetConsoleMode(input_handle, new_input_mode) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if unsafe { SetConsoleMode(output_handle, new_output_mode) } == 0 {
+            // Restore input mode before returning error.
+            unsafe { SetConsoleMode(input_handle, old_input_mode) };
+            return Err(std::io::Error::last_os_error());
+        }
+
+        log_trace(trace, "set_console_mode_end", "ok");
+
+        Ok(Self {
+            input_handle,
+            output_handle,
+            old_input_mode,
+            old_output_mode,
+            restored: false,
+        })
+    }
+
+    fn restore(&mut self, trace: &mut Option<ProbeTrace>) -> std::io::Result<()> {
+        use windows_sys::Win32::System::Console::SetConsoleMode;
+
+        if self.restored {
+            return Ok(());
+        }
+
+        log_trace(trace, "restore_start", "restoring console modes");
+
+        if unsafe { SetConsoleMode(self.input_handle, self.old_input_mode) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if unsafe { SetConsoleMode(self.output_handle, self.old_output_mode) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        log_trace(trace, "restore_end", "ok");
+        self.restored = true;
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ConsoleModeGuard {
+    fn drop(&mut self) {
+        if !self.restored {
+            use windows_sys::Win32::System::Console::SetConsoleMode;
+            unsafe {
+                SetConsoleMode(self.input_handle, self.old_input_mode);
+                SetConsoleMode(self.output_handle, self.old_output_mode);
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+fn run_windows_probe(
+    h_in: windows_sys::Win32::Foundation::HANDLE,
+    h_out: windows_sys::Win32::Foundation::HANDLE,
+    trace: &mut Option<ProbeTrace>,
+) -> std::io::Result<ProbeResponse> {
+    let mut response = Vec::with_capacity(256);
+    let started = Instant::now();
+    let deadline = started + OSC_11_READ_DEADLINE;
+
+    log_trace(
+        trace,
+        "write_start",
+        format!(
+            "bytes={} escaped={}",
+            OSC_11_QUERY.len(),
+            escape_bytes(OSC_11_QUERY)
+        ),
+    );
+    win_write_all(h_out, OSC_11_QUERY)?;
+    log_trace(
+        trace,
+        "write_end",
+        format!("deadline_ms={}", OSC_11_READ_DEADLINE.as_millis()),
+    );
+
+    let mut saw_readable = false;
+    while response.len() < 1024 {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            log_trace(trace, "wait_timeout", "deadline expired".to_string());
+            break;
+        };
+
+        let ready = win_wait_readable(h_in, remaining)?;
+        if !ready {
+            log_trace(
+                trace,
+                "wait_timeout",
+                format!("remaining_ms={}", remaining.as_millis()),
+            );
+            break;
+        }
+
+        if !saw_readable {
+            log_trace(
+                trace,
+                "first_readable",
+                format!("elapsed_us={}", started.elapsed().as_micros()),
+            );
+            saw_readable = true;
+        }
+
+        let chunk = win_read_chunk(h_in)?;
+        if chunk.is_empty() {
+            log_trace(trace, "read_eof", "read returned 0 bytes".to_string());
+            break;
+        }
+
+        log_trace(
+            trace,
+            "read_chunk",
+            format!("len={} escaped={}", chunk.len(), escape_bytes(&chunk)),
+        );
+        response.extend_from_slice(&chunk);
+
+        if osc_11_response_terminated(&response) {
+            log_trace(
+                trace,
+                "terminator_detected",
+                format!("elapsed_us={}", started.elapsed().as_micros()),
+            );
+            break;
+        }
+    }
+
+    log_trace(
+        trace,
+        "logical_restore_point",
+        format!(
+            "elapsed_us={} response_len={}",
+            started.elapsed().as_micros(),
+            response.len()
+        ),
+    );
+    let after_logical_restore = win_read_additional_chunks(
+        h_in,
+        TRACE_POST_LOGICAL_RESTORE_WINDOW,
+        trace,
+        &mut response,
+        "post_logical_restore_chunk",
+    )?;
+    log_trace(
+        trace,
+        "post_logical_restore_summary",
+        format!(
+            "window_ms={} extra_bytes={}",
+            TRACE_POST_LOGICAL_RESTORE_WINDOW.as_millis(),
+            after_logical_restore
+        ),
+    );
+
+    let appearance = parse_terminal_appearance(&response);
+    log_trace(
+        trace,
+        "response_summary",
+        format!(
+            "total_len={} escaped={}",
+            response.len(),
+            escape_bytes(&response)
+        ),
+    );
+
+    Ok(ProbeResponse {
+        appearance,
+        raw_response: response,
+    })
+}
+
+#[cfg(windows)]
+fn win_write_all(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    mut bytes: &[u8],
+) -> std::io::Result<()> {
+    use windows_sys::Win32::Storage::FileSystem::WriteFile;
+
+    while !bytes.is_empty() {
+        let mut written: u32 = 0;
+        let ok = unsafe {
+            WriteFile(
+                handle,
+                bytes.as_ptr(),
+                bytes.len() as u32,
+                &mut written,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if written == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "console write returned 0 bytes",
+            ));
+        }
+        bytes = &bytes[written as usize..];
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn win_read_chunk(handle: windows_sys::Win32::Foundation::HANDLE) -> std::io::Result<Vec<u8>> {
+    use windows_sys::Win32::Storage::FileSystem::ReadFile;
+
+    let mut buffer = [0_u8; 256];
+    let mut read: u32 = 0;
+    let ok = unsafe {
+        ReadFile(
+            handle,
+            buffer.as_mut_ptr(),
+            buffer.len() as u32,
+            &mut read,
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    Ok(buffer[..read as usize].to_vec())
+}
+
+#[cfg(windows)]
+fn win_wait_readable(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    timeout: Duration,
+) -> std::io::Result<bool> {
+    use windows_sys::Win32::System::Threading::WaitForSingleObject;
+
+    let timeout_ms = timeout.as_millis().min(u32::MAX as u128) as u32;
+    let result = unsafe { WaitForSingleObject(handle, timeout_ms) };
+
+    match result {
+        0 => Ok(true),           // WAIT_OBJECT_0
+        0x00000102 => Ok(false), // WAIT_TIMEOUT
+        _ => Err(std::io::Error::last_os_error()),
+    }
+}
+
+#[cfg(windows)]
+fn win_read_additional_chunks(
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    window: Duration,
+    trace: &mut Option<ProbeTrace>,
+    response: &mut Vec<u8>,
+    label: &str,
+) -> std::io::Result<usize> {
+    let deadline = Instant::now() + window;
+    let initial_len = response.len();
+
+    loop {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            break;
+        };
+
+        let ready = win_wait_readable(handle, remaining)?;
+        if !ready {
+            break;
+        }
+
+        let chunk = win_read_chunk(handle)?;
+        if chunk.is_empty() {
+            break;
+        }
+
+        log_trace(
+            trace,
+            label,
+            format!("len={} escaped={}", chunk.len(), escape_bytes(&chunk)),
+        );
+        response.extend_from_slice(&chunk);
+    }
+
+    Ok(response.len().saturating_sub(initial_len))
 }

--- a/src/terminal_appearance.rs
+++ b/src/terminal_appearance.rs
@@ -1,7 +1,4 @@
-//! CLI-only SVG auto-theme parsing and terminal appearance detection.
-//!
-//! This stays in the binary so runtime/WASM/library consumers keep a concrete
-//! `SvgThemeConfig` contract without inheriting terminal-specific behavior.
+//! Binary-private terminal appearance detection.
 
 #[cfg(unix)]
 use std::env;
@@ -13,12 +10,17 @@ use std::io::Write;
 use std::os::fd::{AsRawFd, RawFd};
 #[cfg(unix)]
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::process::Command;
-use std::str::FromStr;
 #[cfg(unix)]
 use std::time::{Duration, Instant};
 
-pub(crate) const SVG_THEME_AUTO_DEFAULT_SPEC: &str = "light:default,dark:dark";
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TerminalAppearance {
+    Light,
+    Dark,
+}
+
 #[cfg(unix)]
 const SVG_THEME_AUTO_DEBUG_ENV: &str = "MMDFLUX_DEBUG_SVG_THEME_AUTO";
 #[cfg(unix)]
@@ -28,113 +30,12 @@ const OSC_11_READ_DEADLINE: Duration = Duration::from_millis(500);
 #[cfg(unix)]
 const TRACE_POST_LOGICAL_RESTORE_WINDOW: Duration = Duration::from_millis(250);
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct SvgThemeAutoMap {
-    pub(crate) light: String,
-    pub(crate) dark: String,
-}
-
-impl Default for SvgThemeAutoMap {
-    fn default() -> Self {
-        Self {
-            light: "default".to_string(),
-            dark: "dark".to_string(),
-        }
-    }
-}
-
-impl FromStr for SvgThemeAutoMap {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let mut light = None;
-        let mut dark = None;
-
-        for entry in value.split(',') {
-            let entry = entry.trim();
-            if entry.is_empty() {
-                return Err(svg_theme_auto_map_error(
-                    "empty entry in --svg-theme-auto map",
-                ));
-            }
-
-            let (key, theme) = entry.split_once(':').ok_or_else(|| {
-                svg_theme_auto_map_error("expected entries in the form light:<theme>,dark:<theme>")
-            })?;
-
-            let key = key.trim();
-            let theme = theme.trim();
-            if theme.is_empty() {
-                return Err(svg_theme_auto_map_error(format!(
-                    "missing theme name for `{key}`"
-                )));
-            }
-
-            match key {
-                "light" => {
-                    if light.replace(theme.to_string()).is_some() {
-                        return Err(svg_theme_auto_map_error(
-                            "duplicate `light` entry in --svg-theme-auto map",
-                        ));
-                    }
-                }
-                "dark" => {
-                    if dark.replace(theme.to_string()).is_some() {
-                        return Err(svg_theme_auto_map_error(
-                            "duplicate `dark` entry in --svg-theme-auto map",
-                        ));
-                    }
-                }
-                _ => {
-                    return Err(svg_theme_auto_map_error(format!(
-                        "unknown key `{key}` in --svg-theme-auto map (expected `light` or `dark`)"
-                    )));
-                }
-            }
-        }
-
-        let light = light.ok_or_else(|| {
-            svg_theme_auto_map_error("missing `light` entry in --svg-theme-auto map")
-        })?;
-        let dark = dark.ok_or_else(|| {
-            svg_theme_auto_map_error("missing `dark` entry in --svg-theme-auto map")
-        })?;
-
-        Ok(Self { light, dark })
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum TerminalAppearance {
-    Light,
-    Dark,
-}
-
-pub(crate) fn select_auto_theme_name(
-    map: &SvgThemeAutoMap,
-    terminal_appearance: Option<TerminalAppearance>,
-    macos_appearance: Option<TerminalAppearance>,
-) -> &str {
-    match terminal_appearance.or(macos_appearance) {
-        Some(TerminalAppearance::Dark) => map.dark.as_str(),
-        Some(TerminalAppearance::Light) | None => map.light.as_str(),
-    }
-}
-
 pub(crate) fn detect_terminal_appearance() -> Option<TerminalAppearance> {
     detect_osc_terminal_appearance()
 }
 
 pub(crate) fn detect_macos_terminal_appearance() -> Option<TerminalAppearance> {
     detect_macos_appearance()
-}
-
-fn svg_theme_auto_map_error(message: impl AsRef<str>) -> String {
-    format!(
-        "{} (expected {})",
-        message.as_ref(),
-        SVG_THEME_AUTO_DEFAULT_SPEC
-    )
 }
 
 #[cfg(unix)]
@@ -667,63 +568,4 @@ fn detect_macos_appearance() -> Option<TerminalAppearance> {
 #[cfg(not(target_os = "macos"))]
 fn detect_macos_appearance() -> Option<TerminalAppearance> {
     None
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        SVG_THEME_AUTO_DEFAULT_SPEC, SvgThemeAutoMap, TerminalAppearance, select_auto_theme_name,
-    };
-
-    #[test]
-    fn svg_theme_auto_map_parses_keyed_entries_in_any_order() {
-        let map: SvgThemeAutoMap = "dark:dracula, light:zinc-light".parse().unwrap();
-        assert_eq!(map.light, "zinc-light");
-        assert_eq!(map.dark, "dracula");
-    }
-
-    #[test]
-    fn svg_theme_auto_map_rejects_duplicate_keys() {
-        let error = "light:default,light:zinc-light,dark:dark"
-            .parse::<SvgThemeAutoMap>()
-            .unwrap_err();
-        assert!(error.contains("duplicate `light` entry"));
-    }
-
-    #[test]
-    fn svg_theme_auto_map_rejects_missing_entries() {
-        let error = "light:default".parse::<SvgThemeAutoMap>().unwrap_err();
-        assert!(error.contains("missing `dark` entry"));
-        assert!(error.contains(SVG_THEME_AUTO_DEFAULT_SPEC));
-    }
-
-    #[test]
-    fn svg_theme_auto_map_rejects_unknown_keys() {
-        let error = "light:default,auto:dark"
-            .parse::<SvgThemeAutoMap>()
-            .unwrap_err();
-        assert!(error.contains("unknown key `auto`"));
-    }
-
-    #[test]
-    fn select_auto_theme_name_prefers_terminal_then_macos_then_light() {
-        let map = SvgThemeAutoMap {
-            light: "default".to_string(),
-            dark: "dark".to_string(),
-        };
-
-        assert_eq!(
-            select_auto_theme_name(
-                &map,
-                Some(TerminalAppearance::Dark),
-                Some(TerminalAppearance::Light)
-            ),
-            "dark"
-        );
-        assert_eq!(
-            select_auto_theme_name(&map, None, Some(TerminalAppearance::Dark)),
-            "dark"
-        );
-        assert_eq!(select_auto_theme_name(&map, None, None), "default");
-    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -81,6 +81,42 @@ fn cli_accepts_svg_theme_flags_for_svg_output() {
 }
 
 #[test]
+fn cli_accepts_svg_theme_auto_without_a_custom_map() {
+    mmdflux()
+        .args(["--format", "svg", "--svg-theme-auto"])
+        .write_stdin("graph TD\nA-->B")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("<svg"));
+}
+
+#[test]
+fn cli_accepts_svg_theme_auto_with_a_custom_map() {
+    mmdflux()
+        .args([
+            "--format",
+            "svg",
+            "--svg-theme-auto=light:default,dark:dracula",
+        ])
+        .write_stdin("graph TD\nA-->B")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("<svg"));
+}
+
+#[test]
+fn cli_rejects_svg_theme_auto_when_svg_theme_is_also_set() {
+    mmdflux()
+        .args(["--format", "svg", "--svg-theme", "dark", "--svg-theme-auto"])
+        .write_stdin("graph TD\nA-->B")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "the argument '--svg-theme <SVG_THEME>' cannot be used with '--svg-theme-auto[=<MAP>]'",
+        ));
+}
+
+#[test]
 fn cli_rejects_invalid_svg_theme_mode() {
     mmdflux()
         .args(["--format", "svg", "--svg-theme-mode", "animated"])

--- a/tests/wasm_cli_contract.rs
+++ b/tests/wasm_cli_contract.rs
@@ -198,6 +198,16 @@ fn runtime_config_input_parses_nested_svg_theme() {
 }
 
 #[test]
+fn runtime_config_input_rejects_cli_only_svg_theme_auto_field() {
+    use mmdflux::RuntimeConfigInput;
+
+    let err =
+        serde_json::from_str::<RuntimeConfigInput>(r#"{"svgThemeAuto":"light:default,dark:dark"}"#)
+            .unwrap_err();
+    assert!(err.to_string().contains("unknown field"));
+}
+
+#[test]
 fn wasm_adapter_contains_no_private_config_mirror_types() {
     let source = std::fs::read_to_string("crates/mmdflux-wasm/src/lib.rs").unwrap();
     assert!(


### PR DESCRIPTION
## Summary

This PR moves SVG theme auto-selection into the `mmdflux` CLI, removes the old shell-owned terminal theme logic from `scripts/view`, and tightens the terminal preview pipeline so the default renderer picks the best available tool automatically.

## What Changed

- added `--svg-theme-auto[=light:<theme>,dark:<theme>]` to the CLI
  - bare usage defaults to `light:default,dark:dark`
  - custom mappings are parsed in the binary only
  - `--svg-theme-auto` conflicts with `--svg-theme`
- resolved auto-theme input to a concrete SVG theme before render
  - runtime and WASM contracts remain concrete-theme-only
  - Mermaid source theme hints are still used unless an explicit CLI theme or auto-theme is set
- added a binary-private terminal appearance probe using `/dev/tty`
  - detects terminal background via OSC 11 on Unix
  - keeps a macOS appearance fallback for cases where the OSC probe does not answer
  - leaves `MMDFLUX_DEBUG_SVG_THEME_AUTO=<path>` available for trace capture
- split the original auto-theme module into two clearer binary-only modules
  - `src/svg_theme_auto.rs` owns parsing and theme selection
  - `src/terminal_appearance.rs` owns terminal probing and appearance detection
- simplified `scripts/view`
  - removed shell-side theme probing logic
  - defaults to `chafa` when available
  - falls back to `kitten icat` plus `rsvg-convert` when `chafa` is missing
  - allows `MMDFLUX_VIEW_RENDERER=chafa|kitty` to force a renderer
  - tunes the Kitty path to rasterize against the current window size instead of using a fixed zoom factor
- updated docs and tests for the new CLI flag and contract boundaries

## Why

The old `scripts/view` pipeline owned terminal background detection in shell/Perl, which made the behavior harder to reuse and reason about. Moving theme auto-selection into the CLI keeps the rendering contract in one place and lets the view script stay a thin preview helper.

During the move, the first pure-Rust OSC 11 probe regressed in live terminals and leaked reply bytes to the screen. The fix in this branch keeps raw/no-echo active through a short quiet window after the reply before restoring the original termios state. Repeated live runs in iTerm and Kitty stayed clean after that adjustment.

## User Impact

- `mmdflux` can now auto-select a concrete SVG theme directly from the CLI
- `scripts/view` no longer depends on the old local Perl probe
- terminal preview defaults are simpler
  - `chafa` is preferred when installed
  - the Kitty path is still available and now renders at a better size
- runtime/WASM consumers do not gain new auto-theme fields or implicit terminal behavior

## Validation

- `cargo test --bin mmdflux --test cli --test wasm_cli_contract`
- `cargo xtask architecture check`
- `bash -n scripts/view`
- repeated live runs of:
  - `cat tests/fixtures/flowchart/simple.mmd | scripts/view`
  - `cat tests/fixtures/flowchart/simple.mmd | MMDFLUX_VIEW_RENDERER=kitty scripts/view`
  - `cat tests/fixtures/flowchart/simple.mmd | MMDFLUX_DEBUG_SVG_THEME_AUTO=/tmp/mmdflux-svg-theme-auto.log scripts/view`

## Notes

- the Gumbo implementation plan for this work was tracked separately in the `.gumbo` repo
- this PR stays scoped to the code changes in `mmdflux` only