### PR TITLE
fix: render state self-loop edges in tldraw

### DIFF
--- a/packages/mmds-tldraw/src/convert.ts
+++ b/packages/mmds-tldraw/src/convert.ts
@@ -136,6 +136,70 @@ function toPoints(
   return path.map(([x, y]) => ({ x: x * scale, y: y * scale }));
 }
 
+function toLineShapePoints(points: Point[]) {
+  const first = points[0];
+  const linePoints: Record<
+    string,
+    { id: string; index: IndexKey; x: number; y: number }
+  > = {};
+  for (let i = 0; i < points.length; i++) {
+    const id = `a${i + 1}`;
+    linePoints[id] = {
+      id,
+      index: id as IndexKey,
+      x: points[i].x - first.x,
+      y: points[i].y - first.y,
+    };
+  }
+  return linePoints;
+}
+
+function midpointOfPath(path: Point[]): Point | undefined {
+  if (path.length === 0) return undefined;
+  if (path.length === 1) return path[0];
+
+  let total = 0;
+  const segmentLengths: number[] = [];
+  for (let i = 1; i < path.length; i++) {
+    const len = distance(path[i - 1], path[i]);
+    segmentLengths.push(len);
+    total += len;
+  }
+
+  if (total === 0) return path[Math.floor(path.length / 2)];
+
+  let remaining = total / 2;
+  for (let i = 1; i < path.length; i++) {
+    const segmentLength = segmentLengths[i - 1];
+    if (remaining <= segmentLength) {
+      const a = path[i - 1];
+      const b = path[i];
+      const t = segmentLength === 0 ? 0 : remaining / segmentLength;
+      return {
+        x: a.x + (b.x - a.x) * t,
+        y: a.y + (b.y - a.y) * t,
+      };
+    }
+    remaining -= segmentLength;
+  }
+
+  return path[path.length - 1];
+}
+
+function synthesizeSelfLoopPath(nodeRect: Rect): Point[] {
+  const right = nodeRect.x + nodeRect.w;
+  const loopWidth = Math.max(32, nodeRect.w * 0.45);
+  const top = nodeRect.y + nodeRect.h * 0.25;
+  const bottom = nodeRect.y + nodeRect.h * 0.75;
+
+  return [
+    { x: right, y: top },
+    { x: right + loopWidth, y: top },
+    { x: right + loopWidth, y: bottom },
+    { x: right, y: bottom },
+  ];
+}
+
 // Approximate char width for tldraw "draw" font at size "m" (~16px).
 // Ensures single-line labels don't wrap awkwardly when mmdflux sizes differ from tldraw metrics.
 const CHAR_WIDTH_EST = 14;
@@ -1186,8 +1250,116 @@ export function convertToTldraw(
     const src = normalized.node_by_id.get(edge.source);
     const tgt = normalized.node_by_id.get(edge.target);
     if (!src || !tgt) continue;
+    const srcRect = nodeRectById.get(edge.source);
+    const isSelfLoop = edge.source === edge.target;
 
     const routedPoints = toPoints(edge.path, positionScale);
+    if (isSelfLoop) {
+      const loopPath =
+        routedPoints.length >= 2
+          ? routedPoints
+          : srcRect
+            ? synthesizeSelfLoopPath(srcRect)
+            : [];
+
+      if (loopPath.length >= 2) {
+        const loopLinePoints =
+          loopPath.length > 2 ? loopPath.slice(0, -1) : loopPath;
+        const dash = mapDash(edge.stroke);
+        const size = mapSize(edge.stroke);
+
+        if (loopLinePoints.length >= 2) {
+          shapeRecords.push(
+            lineShape({
+              id: toShapeId("edgeloop", edge.id),
+              parentId: pageId,
+              x: loopLinePoints[0].x,
+              y: loopLinePoints[0].y,
+              dash,
+              color: "black",
+              size,
+              points: toLineShapePoints(loopLinePoints),
+            }),
+          );
+        }
+
+        const arrowStart = loopPath[Math.max(loopPath.length - 2, 0)];
+        const arrowEnd = loopPath[loopPath.length - 1];
+        shapeRecords.push({
+          id: edgeShapeId,
+          typeName: "shape",
+          type: "arrow",
+          parentId: pageId,
+          index: "",
+          x: arrowStart.x,
+          y: arrowStart.y,
+          rotation: 0,
+          isLocked: false,
+          opacity: 1,
+          props: {
+            kind: "arc",
+            labelColor: "black",
+            color: "black",
+            fill: "none",
+            dash,
+            size,
+            arrowheadStart: edge.is_backward
+              ? mapArrowhead(edge.arrow_end)
+              : mapArrowhead(edge.arrow_start),
+            arrowheadEnd: edge.is_backward
+              ? mapArrowhead(edge.arrow_start)
+              : mapArrowhead(edge.arrow_end),
+            font: "draw",
+            start: { x: 0, y: 0 },
+            end: {
+              x: arrowEnd.x - arrowStart.x,
+              y: arrowEnd.y - arrowStart.y,
+            },
+            bend: 0,
+            richText: toRichText(""),
+            labelPosition: 0.5,
+            scale: 1,
+            elbowMidPoint: 0.5,
+          },
+          meta: {},
+        } as TLRecord);
+
+        if (edge.label) {
+          const labelPos = edge.label_position
+            ? {
+                x: edge.label_position.x * positionScale,
+                y: edge.label_position.y * positionScale,
+              }
+            : (midpointOfPath(loopPath) ?? arrowStart);
+          shapeRecords.push({
+            id: toShapeId("edgelbl", edge.id),
+            typeName: "shape",
+            type: "text",
+            parentId: pageId,
+            index: "",
+            x: labelPos.x + 8,
+            y: labelPos.y - 12,
+            rotation: 0,
+            isLocked: false,
+            opacity: 1,
+            props: {
+              color: "black",
+              size: "s",
+              font: "draw",
+              textAlign: "start",
+              w: 200,
+              richText: toRichText(transformLabel(edge.label)),
+              scale: 1,
+              autoSize: true,
+            },
+            meta: {},
+          } as TLRecord);
+        }
+
+        continue;
+      }
+    }
+
     const hasRoutedPath = routedPoints.length >= 2;
     const start =
       routedPoints.length >= 2

--- a/packages/mmds-tldraw/src/convert.ts
+++ b/packages/mmds-tldraw/src/convert.ts
@@ -186,6 +186,18 @@ function midpointOfPath(path: Point[]): Point | undefined {
   return path[path.length - 1];
 }
 
+function findLastVisibleSegmentIndex(
+  path: Point[],
+  minSegmentLength = 8,
+): number | undefined {
+  for (let i = path.length - 1; i > 0; i--) {
+    if (distance(path[i - 1], path[i]) >= minSegmentLength) {
+      return i - 1;
+    }
+  }
+  return path.length >= 2 ? path.length - 2 : undefined;
+}
+
 function synthesizeSelfLoopPath(nodeRect: Rect): Point[] {
   const right = nodeRect.x + nodeRect.w;
   const loopWidth = Math.max(32, nodeRect.w * 0.45);
@@ -1263,8 +1275,13 @@ export function convertToTldraw(
             : [];
 
       if (loopPath.length >= 2) {
+        const arrowSegmentIndex = findLastVisibleSegmentIndex(loopPath);
+        const arrowStartIndex =
+          arrowSegmentIndex === undefined
+            ? Math.max(loopPath.length - 2, 0)
+            : arrowSegmentIndex;
         const loopLinePoints =
-          loopPath.length > 2 ? loopPath.slice(0, -1) : loopPath;
+          arrowStartIndex > 0 ? loopPath.slice(0, arrowStartIndex + 1) : [];
         const dash = mapDash(edge.stroke);
         const size = mapSize(edge.stroke);
 
@@ -1283,8 +1300,9 @@ export function convertToTldraw(
           );
         }
 
-        const arrowStart = loopPath[Math.max(loopPath.length - 2, 0)];
-        const arrowEnd = loopPath[loopPath.length - 1];
+        const arrowStart = loopPath[arrowStartIndex];
+        const arrowEnd =
+          loopPath[arrowStartIndex + 1] ?? loopPath[loopPath.length - 1];
         shapeRecords.push({
           id: edgeShapeId,
           typeName: "shape",

--- a/packages/mmds-tldraw/test/convert.test.mjs
+++ b/packages/mmds-tldraw/test/convert.test.mjs
@@ -2120,6 +2120,57 @@ test("state self-loop with a routed path preserves routed loop geometry", () => 
   assert.equal(arrow.props.end.y, 0);
 });
 
+test("flowchart self-loop with a tiny terminal stub uses the last visible segment for the arrow", () => {
+  const mmds = {
+    version: 1,
+    geometry_level: "routed",
+    metadata: { diagram_type: "flowchart", direction: "TD" },
+    nodes: [
+      {
+        id: "A",
+        label: "Process",
+        position: { x: 66.768, y: 35.0 },
+        size: { width: 117.536, height: 54.0 },
+        shape: "rectangle",
+      },
+    ],
+    edges: [
+      {
+        id: "e0",
+        source: "A",
+        target: "A",
+        path: [
+          [66.768, 62.0],
+          [66.768, 63.0],
+          [161.036, 63.0],
+          [161.036, 7.0],
+          [66.768, 7.0],
+          [66.768, 8.0],
+        ],
+      },
+    ],
+  };
+
+  const file = toTldrawFile(mmds);
+  assertParses(file);
+
+  const loopPath = file.records.find(
+    (record) =>
+      record.typeName === "shape" && record.id === "shape:edgeloop_e0",
+  );
+  const arrow = file.records.find(
+    (record) => record.typeName === "shape" && record.id === "shape:edge_e0",
+  );
+
+  assert.ok(loopPath, "expected the self-loop body to remain visible");
+  assert.ok(arrow, "expected a terminating arrow segment for the self-loop");
+  assert.ok(
+    arrow.props.end.x < 0,
+    "expected the arrow to terminate along the visible leftward segment",
+  );
+  assert.equal(arrow.props.end.y, 0);
+});
+
 // ── Sequence diagram tldraw conversion ──────────────────────────────
 
 test("sequence diagram produces valid tldraw file", () => {

--- a/packages/mmds-tldraw/test/convert.test.mjs
+++ b/packages/mmds-tldraw/test/convert.test.mjs
@@ -2022,6 +2022,104 @@ test("state diagram fixture produces parseable .tldr", () => {
   assert.ok(filledGeos.length >= 1, "should have filled start/end markers");
 });
 
+test("state self-loop without a routed path still emits visible loop records", () => {
+  const mmds = {
+    version: 1,
+    geometry_level: "layout",
+    metadata: { diagram_type: "state", direction: "TD" },
+    nodes: [
+      {
+        id: "Processing",
+        label: "Processing",
+        position: { x: 120, y: 80 },
+        size: { width: 120, height: 48 },
+        shape: "round",
+      },
+    ],
+    edges: [
+      {
+        id: "e0",
+        source: "Processing",
+        target: "Processing",
+        label: "retry",
+      },
+    ],
+  };
+
+  const file = toTldrawFile(mmds);
+  assertParses(file);
+
+  const loopPath = file.records.find(
+    (record) =>
+      record.typeName === "shape" && record.id === "shape:edgeloop_e0",
+  );
+  const arrow = file.records.find(
+    (record) => record.typeName === "shape" && record.id === "shape:edge_e0",
+  );
+  const label = file.records.find(
+    (record) => record.typeName === "shape" && record.id === "shape:edgelbl_e0",
+  );
+
+  assert.ok(loopPath, "expected a visible loop line for the self-transition");
+  assert.ok(arrow, "expected an arrowhead segment for the self-transition");
+  assert.ok(label, "expected a text label for the self-transition");
+  assert.notEqual(arrow.props.end.x, 0);
+  assert.match(JSON.stringify(label.props.richText), /retry/);
+});
+
+test("state self-loop with a routed path preserves routed loop geometry", () => {
+  const mmds = {
+    version: 1,
+    geometry_level: "routed",
+    metadata: { diagram_type: "state", direction: "TD" },
+    nodes: [
+      {
+        id: "Processing",
+        label: "Processing",
+        position: { x: 120, y: 80 },
+        size: { width: 120, height: 48 },
+        shape: "round",
+      },
+    ],
+    edges: [
+      {
+        id: "e0",
+        source: "Processing",
+        target: "Processing",
+        label: "retry",
+        path: [
+          [180, 70],
+          [220, 70],
+          [220, 120],
+          [180, 120],
+        ],
+      },
+    ],
+  };
+
+  const file = toTldrawFile(mmds);
+  assertParses(file);
+
+  const loopPath = file.records.find(
+    (record) =>
+      record.typeName === "shape" && record.id === "shape:edgeloop_e0",
+  );
+  const arrow = file.records.find(
+    (record) => record.typeName === "shape" && record.id === "shape:edge_e0",
+  );
+
+  assert.ok(loopPath, "expected the routed self-loop polyline to be preserved");
+  assert.equal(Object.keys(loopPath.props.points).length, 3);
+  assert.ok(loopPath.props.points.a2.x > 0);
+  assert.equal(loopPath.props.points.a2.y, 0);
+  assert.equal(loopPath.props.points.a3.x, loopPath.props.points.a2.x);
+  assert.ok(loopPath.props.points.a3.y > 0);
+  assert.ok(arrow.x > loopPath.x);
+  assert.ok(arrow.y >= loopPath.y);
+  assert.ok(arrow.props.end.x < 0);
+  assert.equal(arrow.props.end.y, 0);
+});
+
 // ── Sequence diagram tldraw conversion ──────────────────────────────
 
 test("sequence diagram produces valid tldraw file", () => {

--- a/src/mmds/output.rs
+++ b/src/mmds/output.rs
@@ -254,18 +254,27 @@ fn build_output(
             };
 
             // Add routed fields only at routed level
-            if let Some(routed) = routed
-                && let Some(re) = routed.edges.iter().find(|e| e.index == i)
-            {
-                let full_path: Vec<[f64; 2]> = re.path.iter().map(|p| [p.x, p.y]).collect();
-                mmds_edge.path = Some(
-                    path_simplification
-                        .simplify_with_coords(&full_path, |point| (point[0], point[1])),
-                );
-                mmds_edge.label_position = re.label_position.map(|p| Position { x: p.x, y: p.y });
-                mmds_edge.is_backward = Some(re.is_backward);
-                mmds_edge.source_port = re.source_port.as_ref().map(edge_port_to_mmds);
-                mmds_edge.target_port = re.target_port.as_ref().map(edge_port_to_mmds);
+            if let Some(routed) = routed {
+                if let Some(re) = routed.edges.iter().find(|e| e.index == i) {
+                    let full_path: Vec<[f64; 2]> = re.path.iter().map(|p| [p.x, p.y]).collect();
+                    mmds_edge.path = Some(
+                        path_simplification
+                            .simplify_with_coords(&full_path, |point| (point[0], point[1])),
+                    );
+                    mmds_edge.label_position =
+                        re.label_position.map(|p| Position { x: p.x, y: p.y });
+                    mmds_edge.is_backward = Some(re.is_backward);
+                    mmds_edge.source_port = re.source_port.as_ref().map(edge_port_to_mmds);
+                    mmds_edge.target_port = re.target_port.as_ref().map(edge_port_to_mmds);
+                } else if let Some(self_edge) = routed.self_edges.iter().find(|e| e.edge_index == i)
+                {
+                    let full_path: Vec<[f64; 2]> =
+                        self_edge.path.iter().map(|p| [p.x, p.y]).collect();
+                    mmds_edge.path = Some(
+                        path_simplification
+                            .simplify_with_coords(&full_path, |point| (point[0], point[1])),
+                    );
+                }
             }
 
             mmds_edge

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -1330,6 +1330,29 @@ fn state_mmds_has_nodes_and_edges() {
 }
 
 #[test]
+fn state_self_transition_routed_mmds_includes_self_edge_path() {
+    let input = "stateDiagram-v2\n    [*] --> Processing\n    Processing --> Processing : retry\n    Processing --> Done\n    Done --> [*]";
+    let output = render_json_with_level(input, GeometryLevel::Routed);
+    let json: Value = serde_json::from_str(&output).unwrap();
+
+    let self_edge = json["edges"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|edge| edge["source"] == edge["target"])
+        .expect("expected routed MMDS to include a self-transition edge");
+
+    let path = self_edge["path"]
+        .as_array()
+        .expect("expected routed self-transition to serialize a path");
+    assert!(
+        path.len() >= 4,
+        "expected routed self-transition path to contain loop geometry, got {path:?}"
+    );
+    assert_eq!(self_edge["label"], "retry");
+}
+
+#[test]
 fn mmds_layout_output_omits_edge_paths_regardless_of_engine() {
     let input = "graph TD\nA-->B";
     let config = RenderConfig {


### PR DESCRIPTION
Serialize routed self-edge paths into MMDS output so state self-transitions preserve loop geometry for downstream adapters. Update the tldraw adapter to emit visible self-loop line, arrowhead, and label records for same-node edges, using routed paths when available and a fallback loop otherwise. Add Rust and adapter regressions for state self-transitions, and verify with `cargo test --test mmds_json` and `npm test` in `packages/mmds-tldraw`. Closes #160.