### PR TITLE
fix: apply linkStyle stroke color in ANSI text output

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ mmdflux --format mmds --geometry-level routed diagram.mmd
 mmdflux --lint diagram.mmd
 ```
 
+With ANSI enabled, text/ascii output maps Mermaid styling to terminal colors where it has a clear analogue: node `style`/`classDef` `fill`, `stroke`, and `color` drive node background, border, and label color; flowchart `linkStyle ... stroke:<color>` drives edge and arrow foreground color; SVG-specific properties such as `stroke-width` and `stroke-dasharray` remain no-ops in text/ascii output.
+
 See more examples in the sections below.
 
 ## What It Supports

--- a/src/internal_tests/text_render_pipeline.rs
+++ b/src/internal_tests/text_render_pipeline.rs
@@ -273,6 +273,39 @@ mod owner_local_fixture_regressions {
     }
 
     #[test]
+    fn text_render_applies_linkstyle_stroke_color_when_ansi_enabled() {
+        let input = "graph TD\nA --> B\nB --> C\nlinkStyle default stroke:#999\nlinkStyle 1 stroke:#ff0000,stroke-width:4px\n";
+        let plain = crate::render_diagram(
+            input,
+            OutputFormat::Text,
+            &RenderConfig {
+                text_color_mode: TextColorMode::Plain,
+                ..RenderConfig::default()
+            },
+        )
+        .expect("plain linkStyle text render should succeed");
+        let ansi = crate::render_diagram(
+            input,
+            OutputFormat::Text,
+            &RenderConfig {
+                text_color_mode: TextColorMode::Ansi,
+                ..RenderConfig::default()
+            },
+        )
+        .expect("ansi linkStyle text render should succeed");
+
+        assert!(
+            ansi.contains("\u{1b}[38;2;153;153;153m"),
+            "default linkStyle stroke color missing: {ansi:?}"
+        );
+        assert!(
+            ansi.contains("\u{1b}[38;2;255;0;0m"),
+            "targeted linkStyle stroke color missing: {ansi:?}"
+        );
+        assert_eq!(strip_ansi(&ansi), plain);
+    }
+
+    #[test]
     fn ascii_render_keeps_same_geometry_with_color_disabled() {
         let plain = render_flowchart_fixture_with_options(
             "style-basic.mmd",

--- a/src/render/graph/text/edge.rs
+++ b/src/render/graph/text/edge.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::graph::grid::{AttachDirection, Point, RoutedEdge, Segment};
 use crate::graph::{Arrow, Direction, Stroke};
-use crate::render::text::canvas::{Canvas, Connections};
+use crate::render::text::canvas::{Canvas, CellStyle, Connections};
 use crate::render::text::chars::CharSet;
 
 /// Calculate the label position at the midpoint of a routed path.
@@ -233,27 +233,35 @@ fn source_connection(direction: AttachDirection) -> Connections {
     }
 }
 
-fn draw_source_launch(canvas: &mut Canvas, routed: &RoutedEdge, charset: &CharSet) {
+fn draw_source_launch(
+    canvas: &mut Canvas,
+    routed: &RoutedEdge,
+    charset: &CharSet,
+    edge_color: Option<(u8, u8, u8)>,
+) {
     if routed.edge.arrow_start != Arrow::None || routed.is_self_edge || routed.segments.is_empty() {
         return;
     }
     let Some(direction) = routed.source_connection else {
         return;
     };
-    canvas.set_with_connection(
+    if canvas.set_with_connection(
         routed.start.x,
         routed.start.y,
         source_connection(direction),
         charset,
         routed.edge.stroke,
-    );
+    ) {
+        merge_edge_fg(canvas, routed.start.x, routed.start.y, edge_color);
+    }
 }
 
 fn draw_edge_path_and_arrows(canvas: &mut Canvas, routed: &RoutedEdge, charset: &CharSet) {
+    let edge_color = resolved_edge_stroke_color(routed);
     for segment in &routed.segments {
-        draw_segment(canvas, segment, routed.edge.stroke, charset);
+        draw_segment(canvas, segment, routed.edge.stroke, charset, edge_color);
     }
-    draw_source_launch(canvas, routed, charset);
+    draw_source_launch(canvas, routed, charset, edge_color);
 
     if routed.edge.arrow_end != Arrow::None {
         draw_arrow_with_entry(
@@ -262,6 +270,7 @@ fn draw_edge_path_and_arrows(canvas: &mut Canvas, routed: &RoutedEdge, charset: 
             routed.entry_direction,
             charset,
             routed.edge.arrow_end,
+            edge_color,
         );
     }
 
@@ -273,6 +282,7 @@ fn draw_edge_path_and_arrows(canvas: &mut Canvas, routed: &RoutedEdge, charset: 
             exit_direction,
             charset,
             routed.edge.arrow_start,
+            edge_color,
         );
     }
 }
@@ -871,8 +881,31 @@ fn select_label_segment_horizontal(segments: &[Segment]) -> Option<&Segment> {
     }
 }
 
+fn resolved_edge_stroke_color(routed: &RoutedEdge) -> Option<(u8, u8, u8)> {
+    routed
+        .edge
+        .style
+        .stroke
+        .as_ref()
+        .and_then(|color| color.to_rgb())
+}
+
+fn merge_edge_fg(canvas: &mut Canvas, x: usize, y: usize, rgb: Option<(u8, u8, u8)>) {
+    let Some((r, g, b)) = rgb else {
+        return;
+    };
+
+    canvas.merge_style(x, y, CellStyle::fg_rgb(r, g, b));
+}
+
 /// Draw a single segment on the canvas, honoring stroke style.
-fn draw_segment(canvas: &mut Canvas, segment: &Segment, stroke: Stroke, charset: &CharSet) {
+fn draw_segment(
+    canvas: &mut Canvas,
+    segment: &Segment,
+    stroke: Stroke,
+    charset: &CharSet,
+    edge_color: Option<(u8, u8, u8)>,
+) {
     match segment {
         Segment::Vertical { x, y_start, y_end } => {
             let (y_min, y_max) = if y_start < y_end {
@@ -888,7 +921,9 @@ fn draw_segment(canvas: &mut Canvas, segment: &Segment, stroke: Stroke, charset:
                     left: false,
                     right: false,
                 };
-                canvas.set_with_connection(*x, y, connections, charset, stroke);
+                if canvas.set_with_connection(*x, y, connections, charset, stroke) {
+                    merge_edge_fg(canvas, *x, y, edge_color);
+                }
             }
         }
         Segment::Horizontal { y, x_start, x_end } => {
@@ -905,7 +940,9 @@ fn draw_segment(canvas: &mut Canvas, segment: &Segment, stroke: Stroke, charset:
                     left: x > x_min,
                     right: x < x_max,
                 };
-                canvas.set_with_connection(x, *y, connections, charset, stroke);
+                if canvas.set_with_connection(x, *y, connections, charset, stroke) {
+                    merge_edge_fg(canvas, x, *y, edge_color);
+                }
             }
         }
     }
@@ -920,6 +957,7 @@ fn draw_arrow_with_entry(
     entry_direction: AttachDirection,
     charset: &CharSet,
     arrow_type: Arrow,
+    edge_color: Option<(u8, u8, u8)>,
 ) {
     // Protect node content from being overwritten by arrows
     if canvas
@@ -972,7 +1010,9 @@ fn draw_arrow_with_entry(
         _ => (point.x, point.y),
     };
 
-    canvas.set(ax, ay, arrow_char);
+    if canvas.set(ax, ay, arrow_char) {
+        merge_edge_fg(canvas, ax, ay, edge_color);
+    }
 }
 
 /// Draw an arrow at the given point for test-only assertions.
@@ -1531,6 +1571,7 @@ mod tests {
             AttachDirection::Top,
             &charset,
             Arrow::Normal,
+            None,
         );
 
         // The cell should still contain 'X', not an arrow
@@ -1552,6 +1593,7 @@ mod tests {
             AttachDirection::Top,
             &charset,
             Arrow::Normal,
+            None,
         );
 
         // Should succeed — arrow should be drawn
@@ -1573,6 +1615,7 @@ mod tests {
             AttachDirection::Top,
             &charset,
             Arrow::Cross,
+            None,
         );
         let cell = canvas.get(5, 5).unwrap();
         assert_eq!(cell.ch, 'x', "Cross arrow should render as 'x'");
@@ -1589,6 +1632,7 @@ mod tests {
             AttachDirection::Top,
             &charset,
             Arrow::Circle,
+            None,
         );
         let cell = canvas.get(5, 5).unwrap();
         assert_eq!(cell.ch, '○', "Circle arrow should render as '○'");
@@ -1605,6 +1649,7 @@ mod tests {
             AttachDirection::Top,
             &charset,
             Arrow::Cross,
+            None,
         );
         assert_eq!(canvas.get(5, 5).unwrap().ch, charset.arrow_cross_down);
 
@@ -1615,6 +1660,7 @@ mod tests {
             AttachDirection::Bottom,
             &charset,
             Arrow::Cross,
+            None,
         );
         assert_eq!(canvas.get(5, 5).unwrap().ch, charset.arrow_cross_up);
 
@@ -1625,6 +1671,7 @@ mod tests {
             AttachDirection::Left,
             &charset,
             Arrow::Cross,
+            None,
         );
         assert_eq!(canvas.get(5, 5).unwrap().ch, charset.arrow_cross_right);
 
@@ -1635,6 +1682,7 @@ mod tests {
             AttachDirection::Right,
             &charset,
             Arrow::Cross,
+            None,
         );
         assert_eq!(canvas.get(5, 5).unwrap().ch, charset.arrow_cross_left);
     }
@@ -1650,6 +1698,7 @@ mod tests {
             AttachDirection::Top,
             &charset,
             Arrow::Circle,
+            None,
         );
         assert_eq!(canvas.get(5, 5).unwrap().ch, charset.arrow_circle_down);
 
@@ -1660,6 +1709,7 @@ mod tests {
             AttachDirection::Bottom,
             &charset,
             Arrow::Circle,
+            None,
         );
         assert_eq!(canvas.get(5, 5).unwrap().ch, charset.arrow_circle_up);
 
@@ -1670,6 +1720,7 @@ mod tests {
             AttachDirection::Left,
             &charset,
             Arrow::Circle,
+            None,
         );
         assert_eq!(canvas.get(5, 5).unwrap().ch, charset.arrow_circle_right);
 
@@ -1680,6 +1731,7 @@ mod tests {
             AttachDirection::Right,
             &charset,
             Arrow::Circle,
+            None,
         );
         assert_eq!(canvas.get(5, 5).unwrap().ch, charset.arrow_circle_left);
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -336,6 +336,42 @@ fn cli_color_always_emits_ansi_for_styled_nodes() {
 }
 
 #[test]
+fn cli_color_always_emits_ansi_for_linkstyle_edges() {
+    let input = "graph TD\nA --> B\nB --> C\nlinkStyle default stroke:#999\nlinkStyle 1 stroke:#ff0000,stroke-width:4px\n";
+
+    let plain = mmdflux()
+        .args(["--color", "off"])
+        .write_stdin(input)
+        .output()
+        .expect("plain linkStyle render should execute");
+    assert!(
+        plain.status.success(),
+        "plain linkStyle render failed: stderr={}",
+        String::from_utf8_lossy(&plain.stderr)
+    );
+
+    let ansi = mmdflux()
+        .args(["--color", "always"])
+        .write_stdin(input)
+        .output()
+        .expect("ansi linkStyle render should execute");
+    assert!(
+        ansi.status.success(),
+        "ansi linkStyle render failed: stderr={}",
+        String::from_utf8_lossy(&ansi.stderr)
+    );
+
+    let plain_stdout =
+        String::from_utf8(plain.stdout).expect("plain linkStyle render should be utf-8");
+    let ansi_stdout =
+        String::from_utf8(ansi.stdout).expect("ansi linkStyle render should be utf-8");
+
+    assert!(ansi_stdout.contains("\u{1b}[38;2;153;153;153m"));
+    assert!(ansi_stdout.contains("\u{1b}[38;2;255;0;0m"));
+    assert_eq!(strip_ansi(&ansi_stdout), plain_stdout);
+}
+
+#[test]
 fn cli_color_auto_preserves_plain_output_for_same_fixture() {
     let input = include_str!("fixtures/flowchart/style-basic.mmd");
 


### PR DESCRIPTION
## Summary
- map Mermaid flowchart `linkStyle ... stroke:<color>` to ANSI text/ascii edge and arrow foreground color
- add text + CLI regressions for linkStyle ANSI rendering while preserving plain output geometry
- document the current text-mode style mapping and note that `stroke-width`/`stroke-dasharray` remain SVG-only

## Verification
- cargo fmt
- cargo test -q text_render_applies_linkstyle_stroke_color_when_ansi_enabled
- cargo test -q cli_color_always_emits_ansi_for_linkstyle_edges --test cli
- cargo test -q text_render_uses_stroke_fill_and_label_colors_when_ansi_enabled
- cargo test -q svg_render_applies_linkstyle_stroke_width_and_marker_color
- cargo xtask architecture check

Closes #214