### PR TITLE
fix: unify self-loop terminal direction across SVG, MMDS, and text

### DIFF
--- a/src/graph/routing/stage.rs
+++ b/src/graph/routing/stage.rs
@@ -9,7 +9,7 @@ use crate::graph::geometry::{
     GraphGeometry, LayoutEdge, RoutedEdgeGeometry, RoutedGraphGeometry, RoutedSelfEdge,
 };
 use crate::graph::space::{FPoint, FRect};
-use crate::graph::{Direction, Graph};
+use crate::graph::{Direction, Graph, Shape};
 
 /// Graph-family routed-path ownership mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -165,10 +165,17 @@ pub fn route_graph_geometry(
     let self_edges: Vec<RoutedSelfEdge> = geometry
         .self_edges
         .iter()
-        .map(|se| RoutedSelfEdge {
-            node_id: se.node_id.clone(),
-            edge_index: se.edge_index,
-            path: se.points.clone(),
+        .map(|se| {
+            let path = if let Some(node) = geometry.nodes.get(&se.node_id) {
+                canonical_self_loop_path(&node.rect, &se.points, geometry.direction, &node.shape)
+            } else {
+                se.points.clone()
+            };
+            RoutedSelfEdge {
+                node_id: se.node_id.clone(),
+                edge_index: se.edge_index,
+                path,
+            }
         })
         .collect();
 
@@ -563,6 +570,155 @@ fn nudge_for_direction(point: FPoint, direction: Direction) -> FPoint {
     match direction {
         Direction::TopDown | Direction::BottomTop => FPoint::new(point.x, point.y + DIRECT_STUB),
         Direction::LeftRight | Direction::RightLeft => FPoint::new(point.x + DIRECT_STUB, point.y),
+    }
+}
+
+/// Compute a canonical 4-point self-loop path.
+///
+/// Both exit and entry are offset from the corners along the node face.
+/// The loop extends between their positions so it does not reach the
+/// node border.  The terminal segment is axis-aligned (horizontal for
+/// TD/BT, vertical for LR/RL).
+///
+/// For diamond and hexagon shapes, attachment points are placed on the actual
+/// shape border rather than the bounding rect corners.
+fn canonical_self_loop_path(
+    rect: &FRect,
+    raw_points: &[FPoint],
+    direction: Direction,
+    shape: &Shape,
+) -> Vec<FPoint> {
+    const MIN_PAD: f64 = 8.0;
+
+    let right = rect.x + rect.width;
+    let bottom = rect.y + rect.height;
+
+    let (exit, entry) = self_loop_anchor_points(rect, direction, shape);
+
+    match direction {
+        Direction::TopDown | Direction::BottomTop => {
+            let loop_x = raw_points
+                .iter()
+                .map(|p| p.x)
+                .fold(right, f64::max)
+                .max(right + MIN_PAD);
+            vec![
+                exit,
+                FPoint::new(loop_x, exit.y),
+                FPoint::new(loop_x, entry.y),
+                entry,
+            ]
+        }
+        Direction::LeftRight | Direction::RightLeft => {
+            let loop_y = raw_points
+                .iter()
+                .map(|p| p.y)
+                .fold(bottom, f64::max)
+                .max(bottom + MIN_PAD);
+            vec![
+                exit,
+                FPoint::new(exit.x, loop_y),
+                FPoint::new(entry.x, loop_y),
+                entry,
+            ]
+        }
+    }
+}
+
+/// Compute exit and entry attachment points for a self-loop.
+///
+/// Both points are offset from the bounding-rect corners along the node
+/// face so the loop does not touch the border.
+fn self_loop_anchor_points(rect: &FRect, direction: Direction, shape: &Shape) -> (FPoint, FPoint) {
+    let left = rect.x;
+    let right = rect.x + rect.width;
+    let top = rect.y;
+    let bottom = rect.y + rect.height;
+
+    // Default face offset for rectangular shapes.
+    let face_offset = |face_len: f64| (8.0_f64).min(face_len / 4.0);
+
+    match shape {
+        Shape::Diamond => {
+            // Diamond edge parameter t=0.25 (exit) / t=0.75 (entry) gives
+            // 75 % height span while staying on the border.
+            let w8 = rect.width / 8.0;
+            let h8 = rect.height / 8.0;
+            match direction {
+                Direction::TopDown => (
+                    FPoint::new(right - 3.0 * w8, top + h8),
+                    FPoint::new(right - 3.0 * w8, bottom - h8),
+                ),
+                Direction::BottomTop => (
+                    FPoint::new(right - 3.0 * w8, bottom - h8),
+                    FPoint::new(right - 3.0 * w8, top + h8),
+                ),
+                Direction::LeftRight => (
+                    FPoint::new(right - w8, bottom - 3.0 * h8),
+                    FPoint::new(left + w8, bottom - 3.0 * h8),
+                ),
+                Direction::RightLeft => (
+                    FPoint::new(left + w8, bottom - 3.0 * h8),
+                    FPoint::new(right - w8, bottom - 3.0 * h8),
+                ),
+            }
+        }
+        Shape::Hexagon => {
+            // Hexagon right face: upper-right edge (right-indent,top)→(right,cy)
+            // and lower-right edge (right,cy)→(right-indent,bottom).
+            // At y = top+h8 (t=0.25), border x = right - 3*indent/4.
+            let indent = rect.width * 0.2;
+            let border_inset = 3.0 * indent / 4.0;
+            let h8 = rect.height / 8.0;
+            match direction {
+                Direction::TopDown => (
+                    FPoint::new(right - border_inset, top + h8),
+                    FPoint::new(right - border_inset, bottom - h8),
+                ),
+                Direction::BottomTop => (
+                    FPoint::new(right - border_inset, bottom - h8),
+                    FPoint::new(right - border_inset, top + h8),
+                ),
+                Direction::LeftRight => (
+                    FPoint::new(right - border_inset, bottom - h8),
+                    FPoint::new(left + border_inset, bottom - h8),
+                ),
+                Direction::RightLeft => (
+                    FPoint::new(left + border_inset, bottom - h8),
+                    FPoint::new(right - border_inset, bottom - h8),
+                ),
+            }
+        }
+        _ => match direction {
+            Direction::TopDown => {
+                let fo = face_offset(rect.height);
+                (
+                    FPoint::new(right, top + fo),
+                    FPoint::new(right, bottom - fo),
+                )
+            }
+            Direction::BottomTop => {
+                let fo = face_offset(rect.height);
+                (
+                    FPoint::new(right, bottom - fo),
+                    FPoint::new(right, top + fo),
+                )
+            }
+            Direction::LeftRight => {
+                let fo = face_offset(rect.width);
+                (
+                    FPoint::new(right - fo, bottom),
+                    FPoint::new(left + fo, bottom),
+                )
+            }
+            Direction::RightLeft => {
+                let fo = face_offset(rect.width);
+                (
+                    FPoint::new(left + fo, bottom),
+                    FPoint::new(right - fo, bottom),
+                )
+            }
+        },
     }
 }
 

--- a/src/internal_tests/cross_pipeline.rs
+++ b/src/internal_tests/cross_pipeline.rs
@@ -1019,6 +1019,76 @@ fn test_self_loop_ascii_mode() {
     );
 }
 
+// === Self-loop terminal direction consistency (issue #212) ===
+
+#[test]
+fn test_self_loop_svg_terminal_is_horizontal_td() {
+    let diagram = parse_and_build("self_loop.mmd");
+    let svg = render_diagram_with_config(&diagram, OutputFormat::Svg, &RenderConfig::default())
+        .expect("svg render should succeed");
+    // Extract the edge path from the edgePaths group.
+    let edge_path = svg
+        .split("edgePaths")
+        .nth(1)
+        .and_then(|s| s.split("d=\"").nth(1))
+        .and_then(|s| s.split('"').next())
+        .expect("should have an edge path d attribute");
+    // The last L-segment should be horizontal (terminal entry).  With exit
+    // and entry both offset from their corners, the terminal y is near but
+    // not at the node bottom.
+    let last_l = edge_path
+        .rsplit(" L")
+        .next()
+        .expect("should have L segments");
+    let coords: Vec<&str> = last_l.split(',').collect();
+    assert_eq!(coords.len(), 2, "should have x,y: {last_l}");
+    let y: f64 = coords[1].parse().expect("valid y");
+    // Entry should be on the right face, offset from bottom (8 ≤ bottom).
+    assert!(
+        y > 40.0 && y < 62.5,
+        "terminal y should be near node bottom but offset, got {y}"
+    );
+}
+
+#[test]
+fn test_self_loop_routed_geometry_terminal_is_horizontal_td() {
+    let diagram = parse_and_build("self_loop.mmd");
+    let result = solve_diagram(&diagram, OutputFormat::Svg, &RenderConfig::default())
+        .expect("solve should succeed");
+    let routed = route_graph_geometry(&diagram, &result.geometry, EdgeRouting::OrthogonalRoute);
+    // Self-loop should produce a 4-point canonical path (exit, loop@exit.y,
+    // loop@entry.y, entry).
+    assert_eq!(routed.self_edges.len(), 1);
+    let path = &routed.self_edges[0].path;
+    assert_eq!(path.len(), 4, "canonical self-loop should have 4 points");
+    // Terminal segment (last two points) should be horizontal (same y).
+    let p3 = &path[2];
+    let p4 = &path[3];
+    assert!(
+        (p3.y - p4.y).abs() < 0.01,
+        "terminal segment should be horizontal: p3.y={}, p4.y={}",
+        p3.y,
+        p4.y
+    );
+    // Exit (P1) and loop top (P2) should share y (no corner reaching border).
+    let p1 = &path[0];
+    let p2 = &path[1];
+    assert!(
+        (p1.y - p2.y).abs() < 0.01,
+        "exit and loop top should share y"
+    );
+}
+
+#[test]
+fn test_self_loop_text_arrow_points_left_td() {
+    let output = render_fixture("self_loop.mmd");
+    // The text renderer should show a left-pointing arrow for a TD self-loop.
+    assert!(
+        output.contains('◄'),
+        "TD self-loop should have left-pointing arrow: {output}"
+    );
+}
+
 // === Compound graph external node positioning tests ===
 
 #[test]

--- a/src/render/graph/svg/edges/basis.rs
+++ b/src/render/graph/svg/edges/basis.rs
@@ -97,6 +97,11 @@ pub(super) fn adapt_basis_anchor_points(
     if points.len() <= 2 {
         return points.to_vec();
     }
+    // Self-loop paths need all their points to form the loop shape;
+    // the rank-span heuristics below would collapse them to a line.
+    if edge.from == edge.to {
+        return dedup_consecutive_svg_points(points);
+    }
     if !points_are_axis_aligned(points) {
         return dedup_consecutive_svg_points(points);
     }

--- a/src/render/graph/svg/edges/mod.rs
+++ b/src/render/graph/svg/edges/mod.rs
@@ -139,7 +139,12 @@ pub(super) fn prepare_rendered_edge_paths(
         // reclip when endpoints detach from expected faces or use non-rect
         // shapes (diamond/hexagon).
         let rerouted = rerouted_edges.contains(&index);
-        let should_adjust = !matches!(edge_routing, EdgeRouting::EngineProvided)
+        let is_self_loop = edge.from == edge.to;
+        // Self-loop edges already have correct endpoints from
+        // adjust_self_edge_points — re-projecting through the node center
+        // would create diagonal segments that break the terminal direction.
+        let should_adjust = !is_self_loop
+            && !matches!(edge_routing, EdgeRouting::EngineProvided)
             && (!rerouted
                 || (matches!(edge_routing, EdgeRouting::OrthogonalRoute)
                     && should_adjust_rerouted_edge_endpoints(

--- a/src/render/graph/svg/self_edges.rs
+++ b/src/render/graph/svg/self_edges.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use super::{Point, Rect};
 use crate::graph::geometry::GraphGeometry;
 use crate::graph::measure::ProportionalTextMetrics;
-use crate::graph::{Direction, Graph};
+use crate::graph::{Direction, Graph, Shape};
 
 pub(super) fn compute_self_edge_paths(
     diagram: &Graph,
@@ -24,105 +24,253 @@ pub(super) fn compute_self_edge_paths(
         }
         let layout_rect: Rect = pos_node.rect;
         let layout_points: Vec<Point> = se.points.to_vec();
-        let adjusted =
-            adjust_self_edge_points(&layout_rect, &layout_points, diagram.direction, pad);
+        let adjusted = adjust_self_edge_points(
+            &layout_rect,
+            &layout_points,
+            diagram.direction,
+            pad,
+            &pos_node.shape,
+        );
         paths.insert(se.edge_index, adjusted);
     }
 
     paths
 }
 
+/// Build a 4-point rectangular self-loop path.
+///
+/// Both exit and entry are offset from the corners along the node face.
+/// The loop extends between their positions so it does not reach the
+/// node border.  The terminal segment is axis-aligned (horizontal for
+/// TD/BT, vertical for LR/RL).
+///
+/// For TD the shape is:
+/// ```text
+///    exit ───────────── loop_x
+///                        │
+///    entry ───────────── loop_x
+/// ```
 fn adjust_self_edge_points(
     rect: &Rect,
     points: &[Point],
     direction: Direction,
     pad: f64,
+    shape: &Shape,
 ) -> Vec<Point> {
     if points.len() < 2 {
         return points.to_vec();
     }
 
+    let right = rect.x + rect.width;
+    let bottom = rect.y + rect.height;
+
+    let (exit, entry) = self_loop_anchor_points(rect, direction, pad, shape);
+
+    match direction {
+        Direction::TopDown | Direction::BottomTop => {
+            let loop_x = points
+                .iter()
+                .map(|point| point.x)
+                .fold(right, f64::max)
+                .max(right + pad);
+            vec![
+                exit,
+                Point {
+                    x: loop_x,
+                    y: exit.y,
+                },
+                Point {
+                    x: loop_x,
+                    y: entry.y,
+                },
+                entry,
+            ]
+        }
+        Direction::LeftRight | Direction::RightLeft => {
+            let loop_y = points
+                .iter()
+                .map(|point| point.y)
+                .fold(bottom, f64::max)
+                .max(bottom + pad);
+            vec![
+                exit,
+                Point {
+                    x: exit.x,
+                    y: loop_y,
+                },
+                Point {
+                    x: entry.x,
+                    y: loop_y,
+                },
+                entry,
+            ]
+        }
+    }
+}
+
+/// Compute exit and entry attachment points for a self-loop.
+///
+/// Both points are offset from the bounding-rect corners along the node
+/// face so the loop does not touch the border.
+fn self_loop_anchor_points(
+    rect: &Rect,
+    direction: Direction,
+    pad: f64,
+    shape: &Shape,
+) -> (Point, Point) {
     let left = rect.x;
     let right = rect.x + rect.width;
     let top = rect.y;
     let bottom = rect.y + rect.height;
 
-    match direction {
-        Direction::TopDown => {
-            let loop_x = points
-                .iter()
-                .map(|point| point.x)
-                .fold(right, f64::max)
-                .max(right + pad);
-            vec![
-                Point { x: right, y: top },
-                Point { x: loop_x, y: top },
-                Point {
-                    x: loop_x,
-                    y: bottom,
-                },
-                Point {
-                    x: right,
-                    y: bottom,
-                },
-            ]
+    // Face offset: how far exit/entry are inset from the corner along
+    // the primary face.  Capped so it never exceeds a quarter of the face.
+    let face_offset = |face_len: f64| pad.min(face_len / 4.0);
+
+    match shape {
+        Shape::Diamond => {
+            // Diamond edge parameter t=0.25 (exit, near tip) / t=0.75 (entry,
+            // near tip) gives 75 % height span while staying on the border.
+            let w8 = rect.width / 8.0;
+            let h8 = rect.height / 8.0;
+            match direction {
+                Direction::TopDown => (
+                    Point {
+                        x: right - 3.0 * w8,
+                        y: top + h8,
+                    },
+                    Point {
+                        x: right - 3.0 * w8,
+                        y: bottom - h8,
+                    },
+                ),
+                Direction::BottomTop => (
+                    Point {
+                        x: right - 3.0 * w8,
+                        y: bottom - h8,
+                    },
+                    Point {
+                        x: right - 3.0 * w8,
+                        y: top + h8,
+                    },
+                ),
+                Direction::LeftRight => (
+                    Point {
+                        x: right - w8,
+                        y: bottom - 3.0 * h8,
+                    },
+                    Point {
+                        x: left + w8,
+                        y: bottom - 3.0 * h8,
+                    },
+                ),
+                Direction::RightLeft => (
+                    Point {
+                        x: left + w8,
+                        y: bottom - 3.0 * h8,
+                    },
+                    Point {
+                        x: right - w8,
+                        y: bottom - 3.0 * h8,
+                    },
+                ),
+            }
         }
-        Direction::BottomTop => {
-            let loop_x = points
-                .iter()
-                .map(|point| point.x)
-                .fold(right, f64::max)
-                .max(right + pad);
-            vec![
-                Point {
-                    x: right,
-                    y: bottom,
-                },
-                Point {
-                    x: loop_x,
-                    y: bottom,
-                },
-                Point { x: loop_x, y: top },
-                Point { x: right, y: top },
-            ]
+        Shape::Hexagon => {
+            // Hexagon right face: upper-right edge (right-indent,top)→(right,cy)
+            // and lower-right edge (right,cy)→(right-indent,bottom).
+            // At y = top+h8 (t=0.25), border x = right - 3*indent/4.
+            let indent = rect.width * 0.2;
+            let border_inset = 3.0 * indent / 4.0;
+            let h8 = rect.height / 8.0;
+            match direction {
+                Direction::TopDown => (
+                    Point {
+                        x: right - border_inset,
+                        y: top + h8,
+                    },
+                    Point {
+                        x: right - border_inset,
+                        y: bottom - h8,
+                    },
+                ),
+                Direction::BottomTop => (
+                    Point {
+                        x: right - border_inset,
+                        y: bottom - h8,
+                    },
+                    Point {
+                        x: right - border_inset,
+                        y: top + h8,
+                    },
+                ),
+                Direction::LeftRight => (
+                    Point {
+                        x: right - border_inset,
+                        y: bottom - h8,
+                    },
+                    Point {
+                        x: left + border_inset,
+                        y: bottom - h8,
+                    },
+                ),
+                Direction::RightLeft => (
+                    Point {
+                        x: left + border_inset,
+                        y: bottom - h8,
+                    },
+                    Point {
+                        x: right - border_inset,
+                        y: bottom - h8,
+                    },
+                ),
+            }
         }
-        Direction::LeftRight => {
-            let loop_y = points
-                .iter()
-                .map(|point| point.y)
-                .fold(bottom, f64::max)
-                .max(bottom + pad);
-            vec![
-                Point {
-                    x: right,
-                    y: bottom,
-                },
-                Point {
-                    x: right,
-                    y: loop_y,
-                },
-                Point { x: left, y: loop_y },
-                Point { x: left, y: bottom },
-            ]
-        }
-        Direction::RightLeft => {
-            let loop_y = points
-                .iter()
-                .map(|point| point.y)
-                .fold(bottom, f64::max)
-                .max(bottom + pad);
-            vec![
-                Point { x: left, y: bottom },
-                Point { x: left, y: loop_y },
-                Point {
-                    x: right,
-                    y: loop_y,
-                },
-                Point {
-                    x: right,
-                    y: bottom,
-                },
-            ]
+        _ => {
+            let fo = face_offset(rect.height);
+            let fo_w = face_offset(rect.width);
+            match direction {
+                Direction::TopDown => (
+                    Point {
+                        x: right,
+                        y: top + fo,
+                    },
+                    Point {
+                        x: right,
+                        y: bottom - fo,
+                    },
+                ),
+                Direction::BottomTop => (
+                    Point {
+                        x: right,
+                        y: bottom - fo,
+                    },
+                    Point {
+                        x: right,
+                        y: top + fo,
+                    },
+                ),
+                Direction::LeftRight => (
+                    Point {
+                        x: right - fo_w,
+                        y: bottom,
+                    },
+                    Point {
+                        x: left + fo_w,
+                        y: bottom,
+                    },
+                ),
+                Direction::RightLeft => (
+                    Point {
+                        x: left + fo_w,
+                        y: bottom,
+                    },
+                    Point {
+                        x: right - fo_w,
+                        y: bottom,
+                    },
+                ),
+            }
         }
     }
 }
@@ -130,10 +278,10 @@ fn adjust_self_edge_points(
 #[cfg(test)]
 mod tests {
     use super::{Point, Rect, adjust_self_edge_points};
-    use crate::graph::Direction;
+    use crate::graph::{Direction, Shape};
 
     #[test]
-    fn adjust_self_edge_points_top_down_loops_to_the_right() {
+    fn adjust_self_edge_points_top_down_four_point_path() {
         let rect = Rect {
             x: 10.0,
             y: 20.0,
@@ -142,17 +290,27 @@ mod tests {
         };
         let points = [Point { x: 45.0, y: 25.0 }, Point { x: 52.0, y: 60.0 }];
 
-        let adjusted = adjust_self_edge_points(&rect, &points, Direction::TopDown, 8.0);
+        let adjusted =
+            adjust_self_edge_points(&rect, &points, Direction::TopDown, 8.0, &Shape::Rectangle);
 
         assert_eq!(adjusted.len(), 4);
-        assert_eq!(adjusted[0], Point { x: 40.0, y: 20.0 });
-        assert_eq!(adjusted[1].x, adjusted[2].x);
+        // P1: exit on right face, offset from top corner
+        assert_eq!(adjusted[0].x, 40.0);
+        assert!(adjusted[0].y > 20.0, "exit should be offset from top");
+        // P2: loop extent at exit height
         assert!(adjusted[1].x >= 52.0);
-        assert_eq!(adjusted[3], Point { x: 40.0, y: 60.0 });
+        assert_eq!(adjusted[1].y, adjusted[0].y);
+        // P3: loop extent at entry height
+        assert_eq!(adjusted[2].x, adjusted[1].x);
+        assert!(adjusted[2].y < 60.0, "entry should be offset from bottom");
+        // P4: entry on right face, offset from bottom corner
+        assert_eq!(adjusted[3].x, 40.0);
+        assert!(adjusted[3].y < 60.0, "entry should be offset from bottom");
+        assert_eq!(adjusted[2].y, adjusted[3].y, "terminal must be horizontal");
     }
 
     #[test]
-    fn adjust_self_edge_points_left_right_loops_below_the_node() {
+    fn adjust_self_edge_points_left_right_four_point_path() {
         let rect = Rect {
             x: 10.0,
             y: 20.0,
@@ -161,13 +319,45 @@ mod tests {
         };
         let points = [Point { x: 42.0, y: 58.0 }, Point { x: 15.0, y: 70.0 }];
 
-        let adjusted = adjust_self_edge_points(&rect, &points, Direction::LeftRight, 6.0);
+        let adjusted =
+            adjust_self_edge_points(&rect, &points, Direction::LeftRight, 6.0, &Shape::Rectangle);
 
         assert_eq!(adjusted.len(), 4);
-        assert_eq!(adjusted[0], Point { x: 40.0, y: 60.0 });
-        assert_eq!(adjusted[1].x, 40.0);
+        // P1: exit on bottom face, offset from right corner
+        assert_eq!(adjusted[0].y, 60.0);
+        assert!(adjusted[0].x < 40.0, "exit should be offset from right");
+        // P2: loop extent at exit x
+        assert_eq!(adjusted[1].x, adjusted[0].x);
         assert!(adjusted[1].y >= 70.0);
+        // P3: loop extent at entry x
+        assert!(adjusted[2].x > 10.0, "entry should be offset from left");
         assert_eq!(adjusted[2].y, adjusted[1].y);
-        assert_eq!(adjusted[3], Point { x: 10.0, y: 60.0 });
+        // P4: entry on bottom face, offset from left corner
+        assert_eq!(adjusted[3].y, 60.0);
+        assert!(adjusted[3].x > 10.0, "entry should be offset from left");
+        assert_eq!(adjusted[2].x, adjusted[3].x, "terminal must be vertical");
+    }
+
+    #[test]
+    fn adjust_self_edge_points_diamond_td_attaches_on_shape_border() {
+        let rect = Rect {
+            x: 10.0,
+            y: 20.0,
+            width: 40.0,
+            height: 40.0,
+        };
+        let points = [Point { x: 55.0, y: 25.0 }, Point { x: 55.0, y: 55.0 }];
+
+        let adjusted =
+            adjust_self_edge_points(&rect, &points, Direction::TopDown, 8.0, &Shape::Diamond);
+
+        assert_eq!(adjusted.len(), 4);
+        // Diamond at t=0.25: exit x = right - 3*w/8 = 50 - 15 = 35, y = top + h/8 = 20 + 5 = 25
+        assert_eq!(adjusted[0], Point { x: 35.0, y: 25.0 });
+        // P2: loop extent at exit height
+        assert!(adjusted[1].x >= 55.0);
+        assert_eq!(adjusted[1].y, 25.0);
+        // Entry: x = 35, y = bottom - h/8 = 60 - 5 = 55
+        assert_eq!(adjusted[3], Point { x: 35.0, y: 55.0 });
     }
 }

--- a/tests/svg-snapshots/flowchart-basis/self_loop.svg
+++ b/tests/svg-snapshots/flowchart-basis/self_loop.svg
@@ -6,7 +6,7 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M125.54,18.17 L131.45,16.47 C137.37,14.78 149.20,11.39 155.12,18.69 C161.04,26.00 161.04,44.00 155.76,51.49 C150.48,58.98 139.93,55.96 134.66,54.44 L129.38,52.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,21.50 L131.45,21.50 C137.37,21.50 149.20,21.50 155.12,26.00 C161.04,30.50 161.04,39.50 155.79,44.00 C150.54,48.50 140.04,48.50 134.79,48.50 L129.54,48.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="8.00" y="8.00" width="117.54" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />

--- a/tests/svg-snapshots/flowchart-basis/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-basis/self_loop_labeled.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M58.20,62.00 L58.20,64.78 C58.20,67.56 58.20,73.11 58.20,78.67 C58.20,84.22 58.20,89.78 58.20,94.67 C58.20,99.56 58.20,103.78 58.20,105.89 L58.20,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M89.86,143.66 L98.86,138.38 C107.87,133.10 125.89,122.55 134.89,134.01 C143.90,145.47 143.90,178.93 135.47,190.73 C127.04,202.52 110.17,192.64 101.74,187.70 L93.31,182.77" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M70.75,124.55 L82.94,124.55 C95.13,124.55 119.52,124.55 131.71,137.10 C143.90,149.65 143.90,174.75 132.38,187.30 C120.85,199.85 97.80,199.85 86.27,199.85 L74.75,199.85" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M58.20,212.40 L58.20,220.40 L58.20,225.23 C58.20,230.07 58.20,239.73 58.20,252.90 C58.20,266.07 58.20,282.73 58.20,291.07 L58.20,299.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-basis/self_loop_with_others.svg
+++ b/tests/svg-snapshots/flowchart-basis/self_loop_with_others.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M66.77,62.00 L66.77,64.78 C66.77,67.56 66.77,73.11 66.77,78.67 C66.77,84.22 66.77,89.78 66.77,94.67 C66.77,99.56 66.77,103.78 66.77,105.89 L66.77,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M125.54,122.17 L131.45,120.47 C137.37,118.78 149.20,115.39 155.12,122.69 C161.04,130.00 161.04,148.00 155.76,155.49 C150.48,162.98 139.93,159.96 134.66,158.44 L129.38,156.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,125.50 L131.45,125.50 C137.37,125.50 149.20,125.50 155.12,130.00 C161.04,134.50 161.04,143.50 155.79,148.00 C150.54,152.50 140.04,152.50 134.79,152.50 L129.54,152.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M66.77,166.00 L66.77,168.78 C66.77,171.56 66.77,177.11 66.77,182.67 C66.77,188.22 66.77,193.78 66.77,198.67 C66.77,203.56 66.77,207.78 66.77,209.89 L66.77,212.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-curved-step/self_loop.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/self_loop.svg
@@ -6,7 +6,7 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M125.54,18.17 L131.45,16.47 C137.37,14.78 149.20,11.39 155.12,18.69 C161.04,26.00 161.04,44.00 155.76,51.49 C150.48,58.98 139.93,55.96 134.66,54.44 L129.38,52.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,21.50 L131.45,21.50 C137.37,21.50 149.20,21.50 155.12,26.00 C161.04,30.50 161.04,39.50 155.79,44.00 C150.54,48.50 140.04,48.50 134.79,48.50 L129.54,48.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="8.00" y="8.00" width="117.54" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />

--- a/tests/svg-snapshots/flowchart-curved-step/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/self_loop_labeled.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M58.20,62.00 L58.20,64.78 C58.20,67.56 58.20,73.11 58.20,78.11 C58.20,83.11 58.20,87.56 58.20,92.44 C58.20,97.33 58.20,102.67 58.20,105.33 L58.20,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M89.86,143.66 L98.86,138.38 C107.87,133.10 125.89,122.55 134.89,134.01 C143.90,145.47 143.90,178.93 135.47,190.73 C127.04,202.52 110.17,192.64 101.74,187.70 L93.31,182.77" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M70.75,124.55 L82.94,124.55 C95.13,124.55 119.52,124.55 131.71,137.10 C143.90,149.65 143.90,174.75 132.38,187.30 C120.85,199.85 97.80,199.85 86.27,199.85 L74.75,199.85" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M58.20,212.40 L58.20,245.40 L58.20,248.15 C58.20,250.90 58.20,256.40 58.20,261.90 C58.20,267.40 58.20,272.90 58.20,275.65 L58.20,278.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-curved-step/self_loop_with_others.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/self_loop_with_others.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M66.77,62.00 L66.77,64.78 C66.77,67.56 66.77,73.11 66.77,78.11 C66.77,83.11 66.77,87.56 66.77,92.44 C66.77,97.33 66.77,102.67 66.77,105.33 L66.77,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M125.54,122.17 L131.45,120.47 C137.37,118.78 149.20,115.39 155.12,122.69 C161.04,130.00 161.04,148.00 155.76,155.49 C150.48,162.98 139.93,159.96 134.66,158.44 L129.38,156.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,125.50 L131.45,125.50 C137.37,125.50 149.20,125.50 155.12,130.00 C161.04,134.50 161.04,143.50 155.79,148.00 C150.54,152.50 140.04,152.50 134.79,152.50 L129.54,152.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M66.77,166.00 L66.77,168.78 C66.77,171.56 66.77,177.11 66.77,182.11 C66.77,187.11 66.77,191.56 66.77,196.44 C66.77,201.33 66.77,206.67 66.77,209.33 L66.77,212.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-polyline/self_loop.svg
+++ b/tests/svg-snapshots/flowchart-polyline/self_loop.svg
@@ -6,7 +6,7 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M125.54,18.17 L161.04,8.00 L161.04,62.00 L129.38,52.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,21.50 L161.04,21.50 L161.04,48.50 L129.54,48.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="8.00" y="8.00" width="117.54" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />

--- a/tests/svg-snapshots/flowchart-polyline/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-polyline/self_loop_labeled.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M58.20,62.00 L58.20,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M89.86,143.66 L143.90,112.00 L143.90,212.40 L93.31,182.77" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M70.75,124.55 L143.90,124.55 L143.90,199.85 L74.75,199.85" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M58.20,212.40 L58.20,249.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-polyline/self_loop_with_others.svg
+++ b/tests/svg-snapshots/flowchart-polyline/self_loop_with_others.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M66.77,62.00 L66.77,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M125.54,122.17 L161.04,112.00 L161.04,166.00 L129.38,156.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,125.50 L161.04,125.50 L161.04,152.50 L129.54,152.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M66.77,166.00 L66.77,212.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-smooth-step/self_loop.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/self_loop.svg
@@ -6,7 +6,7 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M125.54,18.17 L125.54,13.00 Q125.54,8.00 130.54,8.00 L156.04,8.00 Q161.04,8.00 161.04,13.00 L161.04,57.00 Q161.04,62.00 156.04,62.00 L133.91,62.00 Q129.38,62.00 129.38,57.47 L129.38,52.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,21.50 L156.04,21.50 Q161.04,21.50 161.04,26.50 L161.04,43.50 Q161.04,48.50 156.04,48.50 L129.54,48.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="8.00" y="8.00" width="117.54" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />

--- a/tests/svg-snapshots/flowchart-smooth-step/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/self_loop_labeled.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M58.20,62.00 L58.20,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M89.86,143.66 L89.86,117.00 Q89.86,112.00 94.86,112.00 L138.90,112.00 Q143.90,112.00 143.90,117.00 L143.90,207.40 Q143.90,212.40 138.90,212.40 L98.31,212.40 Q93.31,212.40 93.31,207.40 L93.31,182.77" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M70.75,124.55 L138.90,124.55 Q143.90,124.55 143.90,129.55 L143.90,194.85 Q143.90,199.85 138.90,199.85 L74.75,199.85" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-smooth-step/self_loop_with_others.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/self_loop_with_others.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M66.77,62.00 L66.77,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M125.54,122.17 L125.54,117.00 Q125.54,112.00 130.54,112.00 L156.04,112.00 Q161.04,112.00 161.04,117.00 L161.04,161.00 Q161.04,166.00 156.04,166.00 L133.91,166.00 Q129.38,166.00 129.38,161.47 L129.38,156.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,125.50 L156.04,125.50 Q161.04,125.50 161.04,130.50 L161.04,147.50 Q161.04,152.50 156.04,152.50 L129.54,152.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M66.77,166.00 L66.77,212.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-step/self_loop.svg
+++ b/tests/svg-snapshots/flowchart-step/self_loop.svg
@@ -6,7 +6,7 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M125.54,18.17 L125.54,8.00 L161.04,8.00 L161.04,57.00 L158.86,57.00 L158.86,59.83 L156.23,59.83 L156.23,60.62 L129.38,60.62 L129.38,52.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,21.50 L161.04,21.50 L161.04,48.50 L129.54,48.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="8.00" y="8.00" width="117.54" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />

--- a/tests/svg-snapshots/flowchart-step/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-step/self_loop_labeled.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M58.20,62.00 L58.20,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M89.86,143.66 L89.86,112.00 L143.90,112.00 L143.90,207.40 L141.73,207.40 L141.73,210.23 L139.59,210.23 L93.31,210.23 L93.31,182.77" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M70.75,124.55 L143.90,124.55 L143.90,199.85 L74.75,199.85" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-step/self_loop_with_others.svg
+++ b/tests/svg-snapshots/flowchart-step/self_loop_with_others.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M66.77,62.00 L66.77,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M125.54,122.17 L125.54,112.00 L161.04,112.00 L161.04,161.00 L158.86,161.00 L158.86,163.83 L156.23,163.83 L156.23,164.62 L129.38,164.62 L129.38,156.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,125.50 L161.04,125.50 L161.04,152.50 L129.54,152.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M66.77,166.00 L66.77,212.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-straight/self_loop.svg
+++ b/tests/svg-snapshots/flowchart-straight/self_loop.svg
@@ -6,7 +6,7 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M125.54,18.17 L161.04,8.00 L161.04,57.00 L158.86,59.83 L156.23,60.62 L129.38,52.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,21.50 L161.04,21.50 L161.04,48.50 L129.54,48.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="8.00" y="8.00" width="117.54" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />

--- a/tests/svg-snapshots/flowchart-straight/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart-straight/self_loop_labeled.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M58.20,62.00 L58.20,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M89.86,143.66 L143.90,112.00 L143.90,207.40 L141.73,210.23 L139.59,209.87 L93.31,182.77" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M70.75,124.55 L143.90,124.55 L143.90,199.85 L74.75,199.85" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart-straight/self_loop_with_others.svg
+++ b/tests/svg-snapshots/flowchart-straight/self_loop_with_others.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M66.77,62.00 L66.77,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M125.54,122.17 L161.04,112.00 L161.04,161.00 L158.86,163.83 L156.23,164.62 L129.38,156.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,125.50 L161.04,125.50 L161.04,152.50 L129.54,152.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M66.77,166.00 L66.77,212.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart/self_loop.svg
+++ b/tests/svg-snapshots/flowchart/self_loop.svg
@@ -6,7 +6,7 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M125.54,18.17 L125.54,13.00 Q125.54,8.00 130.54,8.00 L156.04,8.00 Q161.04,8.00 161.04,13.00 L161.04,57.00 Q161.04,62.00 156.04,62.00 L133.91,62.00 Q129.38,62.00 129.38,57.47 L129.38,52.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,21.50 L156.04,21.50 Q161.04,21.50 161.04,26.50 L161.04,43.50 Q161.04,48.50 156.04,48.50 L129.54,48.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="8.00" y="8.00" width="117.54" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />

--- a/tests/svg-snapshots/flowchart/self_loop_labeled.svg
+++ b/tests/svg-snapshots/flowchart/self_loop_labeled.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M58.20,62.00 L58.20,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M89.86,143.66 L89.86,117.00 Q89.86,112.00 94.86,112.00 L138.90,112.00 Q143.90,112.00 143.90,117.00 L143.90,207.40 Q143.90,212.40 138.90,212.40 L98.31,212.40 Q93.31,212.40 93.31,207.40 L93.31,182.77" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M70.75,124.55 L138.90,124.55 Q143.90,124.55 143.90,129.55 L143.90,194.85 Q143.90,199.85 138.90,199.85 L74.75,199.85" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M58.20,212.40 L58.20,307.40" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/flowchart/self_loop_with_others.svg
+++ b/tests/svg-snapshots/flowchart/self_loop_with_others.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M66.77,62.00 L66.77,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M125.54,122.17 L125.54,117.00 Q125.54,112.00 130.54,112.00 L156.04,112.00 Q161.04,112.00 161.04,117.00 L161.04,161.00 Q161.04,166.00 156.04,166.00 L133.91,166.00 Q129.38,166.00 129.38,161.47 L129.38,156.93" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M125.54,125.50 L156.04,125.50 Q161.04,125.50 161.04,130.50 L161.04,147.50 Q161.04,152.50 156.04,152.50 L129.54,152.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M66.77,166.00 L66.77,212.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">

--- a/tests/svg-snapshots/state/self_transition.svg
+++ b/tests/svg-snapshots/state/self_transition.svg
@@ -7,7 +7,7 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M62.63,22.00 L62.63,68.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M117.25,82.64 L117.25,77.00 Q117.25,72.00 122.25,72.00 L147.75,72.00 Q152.75,72.00 152.75,77.00 L152.75,121.00 Q152.75,126.00 147.75,126.00 L125.83,126.00 Q121.08,126.00 121.08,121.26 L121.08,116.51" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M117.25,85.50 L147.75,85.50 Q152.75,85.50 152.75,90.50 L152.75,107.50 Q152.75,112.50 147.75,112.50 L121.25,112.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M62.63,126.00 L62.63,222.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M62.63,280.00 L62.63,326.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>


### PR DESCRIPTION
## Summary

- Skip `adjust_edge_points_for_shapes` for self-edges in SVG rendering — the center-based re-projection was creating diagonal segments that got orthogonalized into a vertical terminal, making the arrowhead point down instead of left
- Compute canonical 4-point rectangular loop paths for MMDS routed self-edges instead of passing through raw 6-point layout engine paths with a tiny 1px terminal stub
- All three renderers (text, SVG, MMDS) now agree on self-loop terminal direction: horizontal for TD/BT, vertical for LR/RL

## Test plan

- [x] 3 new regression tests in `cross_pipeline.rs` verifying terminal direction for SVG, routed geometry, and text
- [x] All 2395 tests pass (`just check`)
- [x] SVG snapshots regenerated for all self-loop fixtures across all curve styles
- [x] MMDS tests pass (180/180)

Closes #212