### PR TITLE
feat: add parser warnings for unsupported/unrecognized constructs

### DIFF
--- a/src/diagrams/class/compiler.rs
+++ b/src/diagrams/class/compiler.rs
@@ -226,8 +226,8 @@ mod tests {
     use crate::mermaid::class::parse_class_diagram;
 
     fn compile_class(input: &str) -> Graph {
-        let model = parse_class_diagram(input).unwrap();
-        compile(&model)
+        let result = parse_class_diagram(input).unwrap();
+        compile(&result.model)
     }
 
     #[test]

--- a/src/diagrams/class/instance.rs
+++ b/src/diagrams/class/instance.rs
@@ -4,7 +4,7 @@
 //! then builds an owned graph-family payload for runtime dispatch.
 
 use super::compiler;
-use crate::errors::RenderError;
+use crate::errors::{ParseDiagnostic, RenderError};
 use crate::graph::Graph;
 use crate::mermaid::class::parse_class_diagram;
 use crate::registry::{DiagramInstance, ParsedDiagram};
@@ -28,10 +28,17 @@ impl DiagramInstance for ClassInstance {
         self: Box<Self>,
         input: &str,
     ) -> Result<Box<dyn ParsedDiagram>, Box<dyn std::error::Error + Send + Sync>> {
-        let model = parse_class_diagram(input)?;
+        let result = parse_class_diagram(input)?;
         Ok(Box::new(ParsedClass {
-            diagram: compiler::compile(&model),
+            diagram: compiler::compile(&result.model),
         }))
+    }
+
+    fn validation_warnings(&self, input: &str) -> Vec<ParseDiagnostic> {
+        match parse_class_diagram(input) {
+            Ok(result) => result.warnings,
+            Err(_) => Vec::new(),
+        }
     }
 }
 

--- a/src/diagrams/state/compiler.rs
+++ b/src/diagrams/state/compiler.rs
@@ -562,8 +562,8 @@ mod tests {
     use crate::mermaid::state::parse_state_diagram;
 
     fn compile_state(input: &str) -> Graph {
-        let model = parse_state_diagram(input).unwrap();
-        compile(&model)
+        let result = parse_state_diagram(input).unwrap();
+        compile(&result.model)
     }
 
     #[test]

--- a/src/diagrams/state/instance.rs
+++ b/src/diagrams/state/instance.rs
@@ -4,7 +4,7 @@
 //! then builds an owned graph-family payload for runtime dispatch.
 
 use super::compiler;
-use crate::errors::RenderError;
+use crate::errors::{ParseDiagnostic, RenderError};
 use crate::graph::Graph;
 use crate::mermaid::state::parse_state_diagram;
 use crate::registry::{DiagramInstance, ParsedDiagram};
@@ -28,10 +28,17 @@ impl DiagramInstance for StateInstance {
         self: Box<Self>,
         input: &str,
     ) -> Result<Box<dyn ParsedDiagram>, Box<dyn std::error::Error + Send + Sync>> {
-        let model = parse_state_diagram(input)?;
+        let result = parse_state_diagram(input)?;
         Ok(Box::new(ParsedState {
-            diagram: compiler::compile(&model),
+            diagram: compiler::compile(&result.model),
         }))
+    }
+
+    fn validation_warnings(&self, input: &str) -> Vec<ParseDiagnostic> {
+        match parse_state_diagram(input) {
+            Ok(result) => result.warnings,
+            Err(_) => Vec::new(),
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::{env, fmt, fs};
 
 use clap::{Parser, ValueEnum};
+use mmdflux::builtins::default_registry;
 use mmdflux::format::{Curve, EdgePreset, RoutingStyle};
 use mmdflux::graph::GeometryLevel;
 use mmdflux::simplification::PathSimplification;
@@ -179,6 +180,10 @@ struct Cli {
     /// Validate input and report diagnostics (no rendering)
     #[arg(long)]
     lint: bool,
+
+    /// Suppress warnings during rendering
+    #[arg(short, long)]
+    quiet: bool,
 
     /// Show node IDs alongside labels (e.g., "A: Start")
     #[arg(long)]
@@ -598,6 +603,22 @@ fn main() -> io::Result<()> {
 
     if cli.debug {
         eprintln!("Detected diagram type: {}", diagram_id);
+    }
+
+    // Collect and print warnings to stderr (unless --quiet).
+    if !cli.quiet
+        && let Some(instance) = default_registry().create(diagram_id)
+    {
+        let warnings = instance.validation_warnings(&input);
+        for w in &warnings {
+            let diag = ValidationDiagnostic {
+                severity: w.severity.clone(),
+                line: w.line,
+                column: w.column,
+                message: w.message.clone(),
+            };
+            eprintln!("{diag}");
+        }
     }
 
     // Render through the shared facade contract.

--- a/src/mermaid/class/mod.rs
+++ b/src/mermaid/class/mod.rs
@@ -8,6 +8,19 @@ pub mod ast;
 
 use ast::{ClassDecl, ClassModel, ClassNamespace, ClassRelation, ClassRelationType};
 
+use crate::errors::ParseDiagnostic;
+
+/// Result of parsing a class diagram.
+///
+/// Contains the parsed model and any warnings collected during parsing.
+#[derive(Debug)]
+pub struct ClassParseResult {
+    /// Parsed class model.
+    pub model: ClassModel,
+    /// Warnings collected during parsing (e.g., skipped lines).
+    pub warnings: Vec<ParseDiagnostic>,
+}
+
 /// Ensure a class exists in the classes list, merging metadata if it already does.
 ///
 /// Uses `class_index` to track position of each class in `classes` for O(1) lookup.
@@ -61,7 +74,7 @@ fn namespace_id(parent: Option<&str>, name: &str) -> String {
 /// Expects the input to start with `classDiagram` (case-insensitive).
 pub fn parse_class_diagram(
     input: &str,
-) -> Result<ClassModel, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<ClassParseResult, Box<dyn std::error::Error + Send + Sync>> {
     let mut classes: Vec<ClassDecl> = Vec::new();
     let mut relations: Vec<ClassRelation> = Vec::new();
     let mut direction: Option<String> = None;
@@ -69,15 +82,16 @@ pub fn parse_class_diagram(
     let mut namespace_stack: Vec<OpenNamespace> = Vec::new();
     let mut class_index: std::collections::HashMap<String, usize> =
         std::collections::HashMap::new();
+    let mut warnings: Vec<ParseDiagnostic> = Vec::new();
 
-    let mut lines = input.lines().peekable();
+    let mut lines = input.lines().enumerate().peekable();
 
     // Skip frontmatter
-    if let Some(first) = lines.peek()
+    if let Some((_, first)) = lines.peek()
         && first.trim() == "---"
     {
         lines.next();
-        for line in lines.by_ref() {
+        for (_, line) in lines.by_ref() {
             if line.trim() == "---" {
                 break;
             }
@@ -86,7 +100,7 @@ pub fn parse_class_diagram(
 
     // Skip leading comments and whitespace, then consume header
     let mut found_header = false;
-    while let Some(line) = lines.peek() {
+    while let Some((_, line)) = lines.peek() {
         let trimmed = line.trim();
         if trimmed.is_empty() || trimmed.starts_with("%%") {
             lines.next();
@@ -111,7 +125,7 @@ pub fn parse_class_diagram(
     let mut current_annotations: Vec<String> = Vec::new();
     let mut current_members: Vec<String> = Vec::new();
 
-    for line in lines {
+    for (line_num, line) in lines {
         let trimmed = line.trim();
 
         // Skip empty lines and comments
@@ -265,7 +279,12 @@ pub fn parse_class_diagram(
             }
         }
 
-        // Permissive: skip unrecognized lines (style, note, click, etc.)
+        // Permissive: skip unrecognized lines but collect a warning
+        warnings.push(ParseDiagnostic::warning(
+            Some(line_num + 1), // 1-indexed
+            None,
+            format!("skipped unrecognized line: {trimmed}"),
+        ));
     }
 
     // Handle unclosed class body
@@ -289,11 +308,14 @@ pub fn parse_class_diagram(
         });
     }
 
-    Ok(ClassModel {
-        classes,
-        relations,
-        direction,
-        namespaces,
+    Ok(ClassParseResult {
+        model: ClassModel {
+            classes,
+            relations,
+            direction,
+            namespaces,
+        },
+        warnings,
     })
 }
 
@@ -599,96 +621,107 @@ mod tests {
 
     #[test]
     fn parse_empty_class_diagram() {
-        let model = parse_class_diagram("classDiagram\n").unwrap();
-        assert!(model.classes.is_empty());
-        assert!(model.relations.is_empty());
+        let result = parse_class_diagram("classDiagram\n").unwrap();
+        assert!(result.model.classes.is_empty());
+        assert!(result.model.relations.is_empty());
     }
 
     #[test]
     fn parse_single_class() {
-        let model = parse_class_diagram("classDiagram\nclass User").unwrap();
-        assert_eq!(model.classes.len(), 1);
-        assert_eq!(model.classes[0].name, "User");
-        assert!(model.classes[0].annotations.is_empty());
+        let result = parse_class_diagram("classDiagram\nclass User").unwrap();
+        assert_eq!(result.model.classes.len(), 1);
+        assert_eq!(result.model.classes[0].name, "User");
+        assert!(result.model.classes[0].annotations.is_empty());
     }
 
     #[test]
     fn parse_backtick_class_name() {
-        let model = parse_class_diagram("classDiagram\nclass `A B`").unwrap();
-        assert!(model.classes.iter().any(|c| c.name == "A B"));
+        let result = parse_class_diagram("classDiagram\nclass `A B`").unwrap();
+        assert!(result.model.classes.iter().any(|c| c.name == "A B"));
     }
 
     #[test]
     fn parse_class_display_label() {
-        let model = parse_class_diagram("classDiagram\nclass User[\"App User\"]").unwrap();
-        let user = model.classes.iter().find(|c| c.name == "User").unwrap();
+        let result = parse_class_diagram("classDiagram\nclass User[\"App User\"]").unwrap();
+        let user = result
+            .model
+            .classes
+            .iter()
+            .find(|c| c.name == "User")
+            .unwrap();
         assert_eq!(user.display_label.as_deref(), Some("App User"));
     }
 
     #[test]
     fn parse_dotted_and_hyphenated_class_name() {
-        let model = parse_class_diagram("classDiagram\nclass HTTP.Client-Parser").unwrap();
-        assert!(model.classes.iter().any(|c| c.name == "HTTP.Client-Parser"));
+        let result = parse_class_diagram("classDiagram\nclass HTTP.Client-Parser").unwrap();
+        assert!(
+            result
+                .model
+                .classes
+                .iter()
+                .any(|c| c.name == "HTTP.Client-Parser")
+        );
     }
 
     #[test]
     fn parse_multiple_classes() {
         let input = "classDiagram\nclass User\nclass Order\nclass Product";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes.len(), 3);
-        assert_eq!(model.classes[0].name, "User");
-        assert_eq!(model.classes[1].name, "Order");
-        assert_eq!(model.classes[2].name, "Product");
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 3);
+        assert_eq!(result.model.classes[0].name, "User");
+        assert_eq!(result.model.classes[1].name, "Order");
+        assert_eq!(result.model.classes[2].name, "Product");
     }
 
     #[test]
     fn parse_class_with_body() {
         let input = "classDiagram\nclass User {\n  +String name\n  +login()\n}";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes.len(), 1);
-        assert_eq!(model.classes[0].name, "User");
-        assert!(model.classes[0].annotations.is_empty());
-        assert_eq!(model.classes[0].members.len(), 2);
-        assert_eq!(model.classes[0].members[0], "+String name");
-        assert_eq!(model.classes[0].members[1], "+login()");
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 1);
+        assert_eq!(result.model.classes[0].name, "User");
+        assert!(result.model.classes[0].annotations.is_empty());
+        assert_eq!(result.model.classes[0].members.len(), 2);
+        assert_eq!(result.model.classes[0].members[0], "+String name");
+        assert_eq!(result.model.classes[0].members[1], "+login()");
     }
 
     #[test]
     fn parse_class_with_inline_annotation() {
         let input = "classDiagram\nclass Logger <<interface>>";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes.len(), 1);
-        assert_eq!(model.classes[0].name, "Logger");
-        assert_eq!(model.classes[0].annotations, vec!["interface"]);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 1);
+        assert_eq!(result.model.classes[0].name, "Logger");
+        assert_eq!(result.model.classes[0].annotations, vec!["interface"]);
     }
 
     #[test]
     fn parse_annotation_statement() {
         let input = "classDiagram\nclass Logger\n<<interface>> Logger";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes.len(), 1);
-        assert_eq!(model.classes[0].annotations, vec!["interface"]);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 1);
+        assert_eq!(result.model.classes[0].annotations, vec!["interface"]);
     }
 
     #[test]
     fn parse_annotation_in_class_body() {
         let input = "classDiagram\nclass Logger {\n  <<interface>>\n  +log(message)\n}";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes.len(), 1);
-        assert_eq!(model.classes[0].annotations, vec!["interface"]);
-        assert_eq!(model.classes[0].members, vec!["+log(message)"]);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 1);
+        assert_eq!(result.model.classes[0].annotations, vec!["interface"]);
+        assert_eq!(result.model.classes[0].members, vec!["+log(message)"]);
     }
 
     #[test]
     fn parse_inheritance_relation() {
         let input = "classDiagram\nAnimal <|-- Dog";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.relations.len(), 1);
-        assert_eq!(model.relations[0].from, "Animal");
-        assert_eq!(model.relations[0].to, "Dog");
-        assert!(model.relations[0].marker_start);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.relations.len(), 1);
+        assert_eq!(result.model.relations[0].from, "Animal");
+        assert_eq!(result.model.relations[0].to, "Dog");
+        assert!(result.model.relations[0].marker_start);
         assert_eq!(
-            model.relations[0].relation_type,
+            result.model.relations[0].relation_type,
             ClassRelationType::Inheritance
         );
     }
@@ -696,10 +729,10 @@ mod tests {
     #[test]
     fn parse_composition_relation() {
         let input = "classDiagram\nCar *-- Engine";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.relations.len(), 1);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.relations.len(), 1);
         assert_eq!(
-            model.relations[0].relation_type,
+            result.model.relations[0].relation_type,
             ClassRelationType::Composition
         );
     }
@@ -707,10 +740,10 @@ mod tests {
     #[test]
     fn parse_aggregation_relation() {
         let input = "classDiagram\nLibrary o-- Book";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.relations.len(), 1);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.relations.len(), 1);
         assert_eq!(
-            model.relations[0].relation_type,
+            result.model.relations[0].relation_type,
             ClassRelationType::Aggregation
         );
     }
@@ -718,12 +751,12 @@ mod tests {
     #[test]
     fn parse_dependency_relation() {
         let input = "classDiagram\nService ..> Repository";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.relations.len(), 1);
-        assert_eq!(model.relations[0].from, "Service");
-        assert_eq!(model.relations[0].to, "Repository");
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.relations.len(), 1);
+        assert_eq!(result.model.relations[0].from, "Service");
+        assert_eq!(result.model.relations[0].to, "Repository");
         assert_eq!(
-            model.relations[0].relation_type,
+            result.model.relations[0].relation_type,
             ClassRelationType::DirectedDependency
         );
     }
@@ -731,22 +764,22 @@ mod tests {
     #[test]
     fn parse_realization_relation() {
         let input = "classDiagram\nLogger <|.. ConsoleLogger";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.relations.len(), 1);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.relations.len(), 1);
         assert_eq!(
-            model.relations[0].relation_type,
+            result.model.relations[0].relation_type,
             ClassRelationType::Realization
         );
-        assert!(model.relations[0].marker_start);
+        assert!(result.model.relations[0].marker_start);
     }
 
     #[test]
     fn parse_association_directed() {
         let input = "classDiagram\nA --> B";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.relations.len(), 1);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.relations.len(), 1);
         assert_eq!(
-            model.relations[0].relation_type,
+            result.model.relations[0].relation_type,
             ClassRelationType::DirectedAssociation
         );
     }
@@ -754,10 +787,10 @@ mod tests {
     #[test]
     fn parse_association_undirected() {
         let input = "classDiagram\nA -- B";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.relations.len(), 1);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.relations.len(), 1);
         assert_eq!(
-            model.relations[0].relation_type,
+            result.model.relations[0].relation_type,
             ClassRelationType::Association
         );
     }
@@ -765,72 +798,79 @@ mod tests {
     #[test]
     fn parse_relation_with_label() {
         let input = "classDiagram\nA --> B : uses";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.relations[0].label, Some("uses".to_string()));
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.relations[0].label, Some("uses".to_string()));
     }
 
     #[test]
     fn parse_lollipop_relations_do_not_drop_classes() {
         let input = "classDiagram\nClass01 --() bar\nClass02 --() bar\nfoo ()-- Class01";
-        let model = parse_class_diagram(input).unwrap();
+        let result = parse_class_diagram(input).unwrap();
 
-        assert!(model.classes.iter().any(|c| c.name == "Class02"));
-        assert!(model.classes.iter().any(|c| c.name == "foo"));
+        assert!(result.model.classes.iter().any(|c| c.name == "Class02"));
+        assert!(result.model.classes.iter().any(|c| c.name == "foo"));
         assert!(
-            model
+            result
+                .model
                 .relations
                 .iter()
                 .all(|r| r.relation_type == ClassRelationType::Lollipop)
         );
-        assert!(model.relations[0].marker_end);
-        assert!(model.relations[2].marker_start);
+        assert!(result.model.relations[0].marker_end);
+        assert!(result.model.relations[2].marker_start);
     }
 
     #[test]
     fn parse_cardinality_relation_with_label_without_strict_spaces() {
         let input = "classDiagram\nA \"1\" --> \"*\" B:uses";
-        let model = parse_class_diagram(input).unwrap();
+        let result = parse_class_diagram(input).unwrap();
 
-        assert_eq!(model.relations.len(), 1);
-        assert_eq!(model.relations[0].cardinality_from, Some("1".to_string()));
-        assert_eq!(model.relations[0].cardinality_to, Some("*".to_string()));
-        assert_eq!(model.relations[0].label, Some("uses".to_string()));
+        assert_eq!(result.model.relations.len(), 1);
+        assert_eq!(
+            result.model.relations[0].cardinality_from,
+            Some("1".to_string())
+        );
+        assert_eq!(
+            result.model.relations[0].cardinality_to,
+            Some("*".to_string())
+        );
+        assert_eq!(result.model.relations[0].label, Some("uses".to_string()));
     }
 
     #[test]
     fn parse_two_way_relation_operator() {
         let input = "classDiagram\nA <|--|> B";
-        let model = parse_class_diagram(input).unwrap();
+        let result = parse_class_diagram(input).unwrap();
 
-        assert_eq!(model.relations.len(), 1);
+        assert_eq!(result.model.relations.len(), 1);
         assert_eq!(
-            model.relations[0].relation_type,
+            result.model.relations[0].relation_type,
             ClassRelationType::Inheritance
         );
-        assert!(model.relations[0].marker_start);
-        assert!(model.relations[0].marker_end);
+        assert!(result.model.relations[0].marker_start);
+        assert!(result.model.relations[0].marker_end);
     }
 
     #[test]
     fn parse_relation_creates_implicit_classes() {
         let input = "classDiagram\nA --> B";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes.len(), 2);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 2);
     }
 
     #[test]
     fn parse_class_declared_and_in_relation() {
         let input = "classDiagram\nclass A\nA --> B";
-        let model = parse_class_diagram(input).unwrap();
+        let result = parse_class_diagram(input).unwrap();
         // A declared explicitly, B implicitly via relation
-        assert_eq!(model.classes.len(), 2);
+        assert_eq!(result.model.classes.len(), 2);
     }
 
     #[test]
     fn parse_skips_comments() {
         let input = "classDiagram\n%% comment\nclass User";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes.len(), 1);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 1);
     }
 
     #[test]
@@ -841,26 +881,26 @@ mod tests {
 
     #[test]
     fn parse_case_insensitive_header() {
-        let model = parse_class_diagram("CLASSDIAGRAM\nclass User").unwrap();
-        assert_eq!(model.classes.len(), 1);
+        let result = parse_class_diagram("CLASSDIAGRAM\nclass User").unwrap();
+        assert_eq!(result.model.classes.len(), 1);
     }
 
     #[test]
     fn parse_class_direction_lr() {
-        let model = parse_class_diagram("classDiagram\ndirection LR\nA --> B").unwrap();
-        assert_eq!(model.direction, Some("LR".into()));
+        let result = parse_class_diagram("classDiagram\ndirection LR\nA --> B").unwrap();
+        assert_eq!(result.model.direction, Some("LR".into()));
     }
 
     #[test]
     fn parse_class_direction_defaults_when_absent() {
-        let model = parse_class_diagram("classDiagram\nA --> B").unwrap();
-        assert!(model.direction.is_none());
+        let result = parse_class_diagram("classDiagram\nA --> B").unwrap();
+        assert!(result.model.direction.is_none());
     }
 
     #[test]
     fn parse_class_direction_ignores_invalid_values() {
-        let model = parse_class_diagram("classDiagram\ndirection DIAGONAL\nA --> B").unwrap();
-        assert!(model.direction.is_none());
+        let result = parse_class_diagram("classDiagram\ndirection DIAGONAL\nA --> B").unwrap();
+        assert!(result.model.direction.is_none());
     }
 
     #[test]
@@ -873,15 +913,33 @@ namespace BaseShapes {
     class Rectangle
   }
 }";
-        let model = parse_class_diagram(input).unwrap();
+        let result = parse_class_diagram(input).unwrap();
 
-        assert!(model.namespaces.iter().any(|ns| ns.name == "BaseShapes"));
-        assert!(model.namespaces.iter().any(|ns| ns.name == "Primitives"));
+        assert!(
+            result
+                .model
+                .namespaces
+                .iter()
+                .any(|ns| ns.name == "BaseShapes")
+        );
+        assert!(
+            result
+                .model
+                .namespaces
+                .iter()
+                .any(|ns| ns.name == "Primitives")
+        );
 
-        let triangle = model.classes.iter().find(|c| c.name == "Triangle").unwrap();
+        let triangle = result
+            .model
+            .classes
+            .iter()
+            .find(|c| c.name == "Triangle")
+            .unwrap();
         assert!(triangle.namespace.is_some());
 
-        let rectangle = model
+        let rectangle = result
+            .model
             .classes
             .iter()
             .find(|c| c.name == "Rectangle")
@@ -892,39 +950,44 @@ namespace BaseShapes {
     #[test]
     fn parse_class_with_generic_annotation() {
         let input = "classDiagram\nclass List~T~";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes[0].name, "List");
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes[0].name, "List");
     }
 
     #[test]
     fn parse_inline_member_with_space() {
         let input = "classDiagram\nAnimal : +int age";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes.len(), 1);
-        assert_eq!(model.classes[0].name, "Animal");
-        assert_eq!(model.classes[0].members, vec!["+int age"]);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 1);
+        assert_eq!(result.model.classes[0].name, "Animal");
+        assert_eq!(result.model.classes[0].members, vec!["+int age"]);
     }
 
     #[test]
     fn parse_inline_member_without_space() {
         let input = "classDiagram\nAnimal: +isMammal()";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes[0].members, vec!["+isMammal()"]);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes[0].members, vec!["+isMammal()"]);
     }
 
     #[test]
     fn parse_multiple_inline_members() {
         let input = "classDiagram\nAnimal : +int age\nAnimal : +String gender\nAnimal: +mate()";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes.len(), 1);
-        assert_eq!(model.classes[0].members.len(), 3);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 1);
+        assert_eq!(result.model.classes[0].members.len(), 3);
     }
 
     #[test]
     fn parse_relation_before_class_body_preserves_members() {
         let input = "classDiagram\nAnimal <|-- Dog\nclass Dog {\n  +bark()\n}";
-        let model = parse_class_diagram(input).unwrap();
-        let dog = model.classes.iter().find(|c| c.name == "Dog").unwrap();
+        let result = parse_class_diagram(input).unwrap();
+        let dog = result
+            .model
+            .classes
+            .iter()
+            .find(|c| c.name == "Dog")
+            .unwrap();
         assert_eq!(dog.members, vec!["+bark()"]);
     }
 
@@ -937,10 +1000,20 @@ classDiagram
     class Duck{
       +swim()
     }";
-        let model = parse_class_diagram(input).unwrap();
-        let animal = model.classes.iter().find(|c| c.name == "Animal").unwrap();
+        let result = parse_class_diagram(input).unwrap();
+        let animal = result
+            .model
+            .classes
+            .iter()
+            .find(|c| c.name == "Animal")
+            .unwrap();
         assert_eq!(animal.members, vec!["+int age"]);
-        let duck = model.classes.iter().find(|c| c.name == "Duck").unwrap();
+        let duck = result
+            .model
+            .classes
+            .iter()
+            .find(|c| c.name == "Duck")
+            .unwrap();
         assert_eq!(duck.members, vec!["+swim()"]);
     }
 
@@ -955,10 +1028,27 @@ classDiagram
     class Dog
     Animal <|-- Dog
     Dog --> Bone : chews";
-        let model = parse_class_diagram(input).unwrap();
-        assert_eq!(model.classes.len(), 3); // Animal, Dog, Bone
-        assert_eq!(model.relations.len(), 2);
-        assert_eq!(model.classes[0].name, "Animal");
-        assert_eq!(model.classes[0].members.len(), 2);
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 3); // Animal, Dog, Bone
+        assert_eq!(result.model.relations.len(), 2);
+        assert_eq!(result.model.classes[0].name, "Animal");
+        assert_eq!(result.model.classes[0].members.len(), 2);
+    }
+
+    #[test]
+    fn parse_skipped_lines_produce_warnings() {
+        let input = "classDiagram\nclass User\nstyle User fill:#f00\nnote for User \"A note\"";
+        let result = parse_class_diagram(input).unwrap();
+        assert_eq!(result.model.classes.len(), 1);
+        assert_eq!(result.warnings.len(), 2);
+        assert!(result.warnings[0].message.contains("style User fill:#f00"));
+        assert!(result.warnings[1].message.contains("note for User"));
+    }
+
+    #[test]
+    fn parse_no_warnings_for_clean_input() {
+        let input = "classDiagram\nclass User\nclass Order\nUser --> Order";
+        let result = parse_class_diagram(input).unwrap();
+        assert!(result.warnings.is_empty());
     }
 }

--- a/src/mermaid/state/mod.rs
+++ b/src/mermaid/state/mod.rs
@@ -4,11 +4,23 @@
 //! Supports states, transitions, `[*]` pseudo-states, composite `state { }`
 //! blocks, stereotypes, direction overrides, and state descriptions.
 
+use crate::errors::ParseDiagnostic;
 use crate::graph::style::{
     parse_class_apply_statement, parse_classdef_statement_multi, parse_node_style_statement,
 };
 use crate::mermaid::ast::{ClassApplyStatement, ClassDefStatement, NodeStyleStatement};
 use crate::mermaid::flowchart::strip_frontmatter;
+
+/// Result of parsing a state diagram.
+///
+/// Contains the parsed model and any warnings collected during parsing.
+#[derive(Debug)]
+pub struct StateParseResult {
+    /// Parsed state model.
+    pub model: StateModel,
+    /// Warnings collected during parsing (e.g., skipped lines).
+    pub warnings: Vec<ParseDiagnostic>,
+}
 
 /// Parsed state diagram model.
 #[derive(Debug, Clone)]
@@ -101,11 +113,19 @@ pub struct StateTransition {
 /// Returns an error if the `stateDiagram-v2` header is missing.
 pub fn parse_state_diagram(
     input: &str,
-) -> Result<StateModel, Box<dyn std::error::Error + Send + Sync>> {
-    let input = strip_frontmatter(input);
-    let lines: Vec<&str> = input.lines().collect();
+) -> Result<StateParseResult, Box<dyn std::error::Error + Send + Sync>> {
+    let stripped = strip_frontmatter(input);
+    // Count lines consumed by frontmatter so warnings report original line numbers.
+    let frontmatter_lines = if std::ptr::eq(stripped.as_ptr(), input.as_ptr()) {
+        0
+    } else {
+        let consumed = stripped.as_ptr() as usize - input.as_ptr() as usize;
+        input[..consumed].lines().count()
+    };
+    let lines: Vec<&str> = stripped.lines().collect();
     let mut pos = 0;
     let mut direction: Option<String> = None;
+    let mut warnings: Vec<ParseDiagnostic> = Vec::new();
 
     // Skip leading comments and whitespace, then consume header.
     while pos < lines.len() {
@@ -126,11 +146,23 @@ pub fn parse_state_diagram(
         return Err("Missing 'stateDiagram' header".into());
     }
 
-    let statements = parse_body(&lines, &mut pos, &mut direction);
+    let statements = parse_body(&lines, &mut pos, &mut direction, &mut warnings);
 
-    Ok(StateModel {
-        direction,
-        statements,
+    // Adjust warning line numbers to account for stripped frontmatter.
+    if frontmatter_lines > 0 {
+        for warning in &mut warnings {
+            if let Some(line) = &mut warning.line {
+                *line += frontmatter_lines;
+            }
+        }
+    }
+
+    Ok(StateParseResult {
+        model: StateModel {
+            direction,
+            statements,
+        },
+        warnings,
     })
 }
 
@@ -139,6 +171,7 @@ fn parse_body(
     lines: &[&str],
     pos: &mut usize,
     direction: &mut Option<String>,
+    warnings: &mut Vec<ParseDiagnostic>,
 ) -> Vec<StateStatement> {
     let mut statements = Vec::new();
 
@@ -236,13 +269,18 @@ fn parse_body(
             // Composite state: `state Id { ... }`
             if trimmed.trim_end().ends_with('{') {
                 let mut inner_dir = None;
-                decl.children = parse_body(lines, pos, &mut inner_dir);
+                decl.children = parse_body(lines, pos, &mut inner_dir, warnings);
             }
             statements.push(StateStatement::State(decl));
             continue;
         }
 
-        // Permissive: skip unrecognized lines.
+        // Permissive: skip unrecognized lines but collect a warning.
+        warnings.push(ParseDiagnostic::warning(
+            Some(*pos + 1), // 1-indexed
+            None,
+            format!("skipped unrecognized line: {trimmed}"),
+        ));
         *pos += 1;
     }
 
@@ -537,9 +575,9 @@ mod tests {
 
     #[test]
     fn parse_empty_state_diagram() {
-        let model = parse_state_diagram("stateDiagram-v2\n").unwrap();
-        assert!(model.statements.is_empty());
-        assert!(model.direction.is_none());
+        let result = parse_state_diagram("stateDiagram-v2\n").unwrap();
+        assert!(result.model.statements.is_empty());
+        assert!(result.model.direction.is_none());
     }
 
     #[test]
@@ -550,9 +588,9 @@ mod tests {
 
     #[test]
     fn parse_basic_transition() {
-        let model = parse_state_diagram("stateDiagram-v2\n    A --> B").unwrap();
-        assert_eq!(model.statements.len(), 1);
-        let StateStatement::Transition(t) = &model.statements[0] else {
+        let result = parse_state_diagram("stateDiagram-v2\n    A --> B").unwrap();
+        assert_eq!(result.model.statements.len(), 1);
+        let StateStatement::Transition(t) = &result.model.statements[0] else {
             panic!("expected transition");
         };
         assert_eq!(t.from, "A");
@@ -562,8 +600,8 @@ mod tests {
 
     #[test]
     fn parse_transition_with_label() {
-        let model = parse_state_diagram("stateDiagram-v2\n    A --> B : submit").unwrap();
-        let StateStatement::Transition(t) = &model.statements[0] else {
+        let result = parse_state_diagram("stateDiagram-v2\n    A --> B : submit").unwrap();
+        let StateStatement::Transition(t) = &result.model.statements[0] else {
             panic!("expected transition");
         };
         assert_eq!(t.label, Some("submit".to_string()));
@@ -571,15 +609,15 @@ mod tests {
 
     #[test]
     fn parse_star_markers() {
-        let model =
+        let result =
             parse_state_diagram("stateDiagram-v2\n    [*] --> Idle\n    Done --> [*]").unwrap();
-        assert_eq!(model.statements.len(), 2);
-        let StateStatement::Transition(t0) = &model.statements[0] else {
+        assert_eq!(result.model.statements.len(), 2);
+        let StateStatement::Transition(t0) = &result.model.statements[0] else {
             panic!("expected transition");
         };
         assert_eq!(t0.from, "[*]");
         assert_eq!(t0.to, "Idle");
-        let StateStatement::Transition(t1) = &model.statements[1] else {
+        let StateStatement::Transition(t1) = &result.model.statements[1] else {
             panic!("expected transition");
         };
         assert_eq!(t1.from, "Done");
@@ -588,15 +626,15 @@ mod tests {
 
     #[test]
     fn parse_direction_directive() {
-        let model = parse_state_diagram("stateDiagram-v2\n    direction LR\n    A --> B").unwrap();
-        assert_eq!(model.direction, Some("LR".to_string()));
+        let result = parse_state_diagram("stateDiagram-v2\n    direction LR\n    A --> B").unwrap();
+        assert_eq!(result.model.direction, Some("LR".to_string()));
     }
 
     #[test]
     fn parse_state_declaration_with_description() {
-        let model =
+        let result =
             parse_state_diagram("stateDiagram-v2\n    state \"Waiting\" as waiting").unwrap();
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.id, "waiting");
@@ -606,20 +644,20 @@ mod tests {
 
     #[test]
     fn parse_skips_comments() {
-        let model = parse_state_diagram("stateDiagram-v2\n    %% comment\n    A --> B\n").unwrap();
-        assert_eq!(model.statements.len(), 1);
+        let result = parse_state_diagram("stateDiagram-v2\n    %% comment\n    A --> B\n").unwrap();
+        assert_eq!(result.model.statements.len(), 1);
     }
 
     #[test]
     fn parse_case_insensitive_header() {
-        let model = parse_state_diagram("STATEDIAGRAM-V2\n    A --> B").unwrap();
-        assert_eq!(model.statements.len(), 1);
+        let result = parse_state_diagram("STATEDIAGRAM-V2\n    A --> B").unwrap();
+        assert_eq!(result.model.statements.len(), 1);
     }
 
     #[test]
     fn parse_stereotype_fork() {
-        let model = parse_state_diagram("stateDiagram-v2\n    state forkNode <<fork>>").unwrap();
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let result = parse_state_diagram("stateDiagram-v2\n    state forkNode <<fork>>").unwrap();
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.id, "forkNode");
@@ -634,8 +672,8 @@ stateDiagram-v2
     Idle --> Processing : submit
     Processing --> Done : complete
     Done --> [*]";
-        let model = parse_state_diagram(input).unwrap();
-        assert_eq!(model.statements.len(), 4);
+        let result = parse_state_diagram(input).unwrap();
+        assert_eq!(result.model.statements.len(), 4);
     }
 
     #[test]
@@ -648,10 +686,10 @@ stateDiagram-v2
         Running --> [*]
     }
     Active --> [*]";
-        let model = parse_state_diagram(input).unwrap();
+        let result = parse_state_diagram(input).unwrap();
         // [*] --> Active, state Active { ... }, Active --> [*]
-        assert_eq!(model.statements.len(), 3);
-        let StateStatement::State(decl) = &model.statements[1] else {
+        assert_eq!(result.model.statements.len(), 3);
+        let StateStatement::State(decl) = &result.model.statements[1] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.id, "Active");
@@ -667,8 +705,8 @@ stateDiagram-v2
         [*] --> Validating
         Validating --> [*]
     }";
-        let model = parse_state_diagram(input).unwrap();
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let result = parse_state_diagram(input).unwrap();
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.id, "Processing");
@@ -683,8 +721,8 @@ stateDiagram-v2
     #[test]
     fn parse_inline_description() {
         let input = "stateDiagram-v2\n    Active : The system is active";
-        let model = parse_state_diagram(input).unwrap();
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let result = parse_state_diagram(input).unwrap();
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.id, "Active");
@@ -699,24 +737,30 @@ stateDiagram-v2
     class Error badState
     style Active fill:green
     A --> B";
-        let model = parse_state_diagram(input).unwrap();
-        assert_eq!(model.statements.len(), 4); // classDef + class + style + transition
-        assert!(matches!(&model.statements[0], StateStatement::ClassDef(_)));
+        let result = parse_state_diagram(input).unwrap();
+        assert_eq!(result.model.statements.len(), 4); // classDef + class + style + transition
         assert!(matches!(
-            &model.statements[1],
+            &result.model.statements[0],
+            StateStatement::ClassDef(_)
+        ));
+        assert!(matches!(
+            &result.model.statements[1],
             StateStatement::ClassApply(_)
         ));
-        assert!(matches!(&model.statements[2], StateStatement::Style(_)));
         assert!(matches!(
-            &model.statements[3],
+            &result.model.statements[2],
+            StateStatement::Style(_)
+        ));
+        assert!(matches!(
+            &result.model.statements[3],
             StateStatement::Transition(_)
         ));
     }
 
     #[test]
     fn parse_stereotype_join() {
-        let model = parse_state_diagram("stateDiagram-v2\n    state jn <<join>>").unwrap();
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let result = parse_state_diagram("stateDiagram-v2\n    state jn <<join>>").unwrap();
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.stereotype, Some(StateStereotype::Join));
@@ -724,8 +768,8 @@ stateDiagram-v2
 
     #[test]
     fn parse_stereotype_choice() {
-        let model = parse_state_diagram("stateDiagram-v2\n    state ch <<choice>>").unwrap();
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let result = parse_state_diagram("stateDiagram-v2\n    state ch <<choice>>").unwrap();
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.stereotype, Some(StateStereotype::Choice));
@@ -733,8 +777,8 @@ stateDiagram-v2
 
     #[test]
     fn parse_bracket_stereotype_fork() {
-        let model = parse_state_diagram("stateDiagram-v2\n    state fk [[fork]]").unwrap();
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let result = parse_state_diagram("stateDiagram-v2\n    state fk [[fork]]").unwrap();
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.stereotype, Some(StateStereotype::Fork));
@@ -742,8 +786,8 @@ stateDiagram-v2
 
     #[test]
     fn parse_bracket_stereotype_join() {
-        let model = parse_state_diagram("stateDiagram-v2\n    state jn [[join]]").unwrap();
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let result = parse_state_diagram("stateDiagram-v2\n    state jn [[join]]").unwrap();
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.stereotype, Some(StateStereotype::Join));
@@ -751,8 +795,8 @@ stateDiagram-v2
 
     #[test]
     fn parse_bracket_stereotype_choice() {
-        let model = parse_state_diagram("stateDiagram-v2\n    state ch [[choice]]").unwrap();
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let result = parse_state_diagram("stateDiagram-v2\n    state ch [[choice]]").unwrap();
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.stereotype, Some(StateStereotype::Choice));
@@ -760,8 +804,8 @@ stateDiagram-v2
 
     #[test]
     fn parse_v1_header() {
-        let model = parse_state_diagram("stateDiagram\n    A --> B").unwrap();
-        assert_eq!(model.statements.len(), 1);
+        let result = parse_state_diagram("stateDiagram\n    A --> B").unwrap();
+        assert_eq!(result.model.statements.len(), 1);
     }
 
     #[test]
@@ -775,9 +819,9 @@ stateDiagram-v2
     #[test]
     fn parse_note_single_line() {
         let input = "stateDiagram-v2\n    note right of State1 : Important info";
-        let model = parse_state_diagram(input).unwrap();
-        assert_eq!(model.statements.len(), 1);
-        let StateStatement::Note(note) = &model.statements[0] else {
+        let result = parse_state_diagram(input).unwrap();
+        assert_eq!(result.model.statements.len(), 1);
+        let StateStatement::Note(note) = &result.model.statements[0] else {
             panic!("expected note");
         };
         assert_eq!(note.state_id, "State1");
@@ -788,8 +832,8 @@ stateDiagram-v2
     #[test]
     fn parse_note_left_of() {
         let input = "stateDiagram-v2\n    note left of State2 : Left note";
-        let model = parse_state_diagram(input).unwrap();
-        let StateStatement::Note(note) = &model.statements[0] else {
+        let result = parse_state_diagram(input).unwrap();
+        let StateStatement::Note(note) = &result.model.statements[0] else {
             panic!("expected note");
         };
         assert_eq!(note.position, NotePosition::Left);
@@ -804,8 +848,8 @@ stateDiagram-v2
         Line one
         Line two
     end note";
-        let model = parse_state_diagram(input).unwrap();
-        let StateStatement::Note(note) = &model.statements[0] else {
+        let result = parse_state_diagram(input).unwrap();
+        let StateStatement::Note(note) = &result.model.statements[0] else {
             panic!("expected note");
         };
         assert_eq!(note.state_id, "State1");
@@ -816,8 +860,8 @@ stateDiagram-v2
     #[test]
     fn parse_transition_with_class_annotation_to() {
         let input = "stateDiagram-v2\n    [*] --> Active:::running\n";
-        let model = parse_state_diagram(input).unwrap();
-        let StateStatement::Transition(t) = &model.statements[0] else {
+        let result = parse_state_diagram(input).unwrap();
+        let StateStatement::Transition(t) = &result.model.statements[0] else {
             panic!("expected transition");
         };
         assert_eq!(t.to, "Active");
@@ -828,8 +872,8 @@ stateDiagram-v2
     #[test]
     fn parse_transition_with_class_annotation_from() {
         let input = "stateDiagram-v2\n    Active:::running --> Done\n";
-        let model = parse_state_diagram(input).unwrap();
-        let StateStatement::Transition(t) = &model.statements[0] else {
+        let result = parse_state_diagram(input).unwrap();
+        let StateStatement::Transition(t) = &result.model.statements[0] else {
             panic!("expected transition");
         };
         assert_eq!(t.from, "Active");
@@ -840,8 +884,8 @@ stateDiagram-v2
     #[test]
     fn parse_transition_no_class_annotation() {
         let input = "stateDiagram-v2\n    [*] --> Active\n";
-        let model = parse_state_diagram(input).unwrap();
-        let StateStatement::Transition(t) = &model.statements[0] else {
+        let result = parse_state_diagram(input).unwrap();
+        let StateStatement::Transition(t) = &result.model.statements[0] else {
             panic!("expected transition");
         };
         assert_eq!(t.from_class, None);
@@ -851,10 +895,10 @@ stateDiagram-v2
     #[test]
     fn parse_still_discards_click() {
         let input = "stateDiagram-v2\n    click Idle callback\n    [*] --> Idle\n";
-        let model = parse_state_diagram(input).unwrap();
-        assert_eq!(model.statements.len(), 1);
+        let result = parse_state_diagram(input).unwrap();
+        assert_eq!(result.model.statements.len(), 1);
         assert!(matches!(
-            &model.statements[0],
+            &result.model.statements[0],
             StateStatement::Transition(_)
         ));
     }
@@ -862,9 +906,9 @@ stateDiagram-v2
     #[test]
     fn parse_state_decl_class_annotation() {
         let input = "stateDiagram-v2\n    state Running:::active\n";
-        let model = parse_state_diagram(input).unwrap();
-        assert_eq!(model.statements.len(), 1);
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let result = parse_state_diagram(input).unwrap();
+        assert_eq!(result.model.statements.len(), 1);
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.id, "Running");
@@ -874,12 +918,41 @@ stateDiagram-v2
     #[test]
     fn parse_state_decl_alias_class_annotation() {
         let input = "stateDiagram-v2\n    state \"Running\" as R:::active\n";
-        let model = parse_state_diagram(input).unwrap();
-        assert_eq!(model.statements.len(), 1);
-        let StateStatement::State(decl) = &model.statements[0] else {
+        let result = parse_state_diagram(input).unwrap();
+        assert_eq!(result.model.statements.len(), 1);
+        let StateStatement::State(decl) = &result.model.statements[0] else {
             panic!("expected state decl");
         };
         assert_eq!(decl.id, "R");
         assert_eq!(decl.class_name.as_deref(), Some("active"));
+    }
+
+    #[test]
+    fn parse_skipped_lines_produce_warnings() {
+        let input = "stateDiagram-v2\n    [*] --> Idle\n    unknown directive here\n";
+        let result = parse_state_diagram(input).unwrap();
+        assert_eq!(result.model.statements.len(), 1);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(
+            result.warnings[0]
+                .message
+                .contains("unknown directive here")
+        );
+    }
+
+    #[test]
+    fn parse_skipped_line_with_frontmatter_reports_original_line_number() {
+        let input = "---\nconfig:\n  theme: dark\n---\nstateDiagram-v2\n    [*] --> Idle\n    unknown line\n";
+        let result = parse_state_diagram(input).unwrap();
+        assert_eq!(result.warnings.len(), 1);
+        // "unknown line" is on physical line 7 (1-indexed), not line 3.
+        assert_eq!(result.warnings[0].line, Some(7));
+    }
+
+    #[test]
+    fn parse_no_warnings_for_clean_input() {
+        let input = "stateDiagram-v2\n    [*] --> Idle\n    Idle --> Done\n    Done --> [*]\n";
+        let result = parse_state_diagram(input).unwrap();
+        assert!(result.warnings.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Add warning collection to class and state parsers for lines that are silently skipped during permissive parsing, with 1-indexed line numbers and the unrecognized content
- Implement `validation_warnings()` on `ClassInstance` and `StateInstance` (matching the existing sequence parser pattern)
- Print warnings to stderr during normal CLI rendering; add `--quiet`/`-q` flag to suppress

Closes #103

## Test plan

- [x] All 2400 existing tests pass (`just check`)
- [x] Architecture boundaries pass
- [x] New unit tests for class parser skipped-line warnings
- [x] New unit tests for state parser skipped-line warnings
- [x] Manual: `echo 'classDiagram\nclass User\nstyle User fill:#f00' | cargo run` shows warning on stderr
- [x] Manual: `echo 'stateDiagram-v2\n[*] --> Idle\nunknown line' | cargo run` shows warning on stderr
- [x] Manual: `--quiet` suppresses warnings
- [x] Manual: `--lint` flow still works with new warnings
- [x] Clean input produces no warnings