### PR TITLE
fix(mmds-tldraw): preserve arrowhead direction for backward edges with routed paths

### DIFF
--- a/packages/mmds-tldraw/src/convert.ts
+++ b/packages/mmds-tldraw/src/convert.ts
@@ -1321,12 +1321,14 @@ export function convertToTldraw(
             fill: "none",
             dash,
             size,
-            arrowheadStart: edge.is_backward
-              ? mapArrowhead(edge.arrow_end)
-              : mapArrowhead(edge.arrow_start),
-            arrowheadEnd: edge.is_backward
-              ? mapArrowhead(edge.arrow_start)
-              : mapArrowhead(edge.arrow_end),
+            arrowheadStart:
+              edge.is_backward && routedPoints.length < 2
+                ? mapArrowhead(edge.arrow_end)
+                : mapArrowhead(edge.arrow_start),
+            arrowheadEnd:
+              edge.is_backward && routedPoints.length < 2
+                ? mapArrowhead(edge.arrow_start)
+                : mapArrowhead(edge.arrow_end),
             font: "draw",
             start: { x: 0, y: 0 },
             end: {
@@ -1458,12 +1460,14 @@ export function convertToTldraw(
         fill: "none",
         dash: mapDash(edge.stroke),
         size: mapSize(edge.stroke),
-        arrowheadStart: edge.is_backward
-          ? mapArrowhead(edge.arrow_end)
-          : mapArrowhead(edge.arrow_start),
-        arrowheadEnd: edge.is_backward
-          ? mapArrowhead(edge.arrow_start)
-          : mapArrowhead(edge.arrow_end),
+        arrowheadStart:
+          edge.is_backward && !hasRoutedPath
+            ? mapArrowhead(edge.arrow_end)
+            : mapArrowhead(edge.arrow_start),
+        arrowheadEnd:
+          edge.is_backward && !hasRoutedPath
+            ? mapArrowhead(edge.arrow_start)
+            : mapArrowhead(edge.arrow_end),
         font: "draw",
         start: { x: 0, y: 0 },
         end: { x: end.x - start.x, y: end.y - start.y },

--- a/packages/mmds-tldraw/test/convert.test.mjs
+++ b/packages/mmds-tldraw/test/convert.test.mjs
@@ -1345,7 +1345,7 @@ test("SUPPORTED_DIAGRAM_TYPES is exported and contains expected types", () => {
 
 // ── Phase 3: Backward edge arrowhead swap ───────────────────────────
 
-test("swaps arrowheads for backward edges", () => {
+test("swaps arrowheads for backward edges without routed path", () => {
   const mmds = {
     version: 1,
     geometry_level: "layout",
@@ -1393,6 +1393,63 @@ test("swaps arrowheads for backward edges", () => {
   // Arrowheads should be swapped: start gets "arrow" (from end's "normal"), end gets "none"
   assert.equal(arrow.props.arrowheadStart, "arrow");
   assert.equal(arrow.props.arrowheadEnd, "none");
+});
+
+test("preserves arrowheads for backward edges with routed path", () => {
+  const mmds = {
+    version: 2,
+    geometry_level: "routed",
+    defaults: {
+      node: { shape: "rectangle" },
+      edge: {
+        stroke: "solid",
+        arrow_start: "none",
+        arrow_end: "normal",
+        minlen: 1,
+      },
+    },
+    metadata: { diagram_type: "state", direction: "TD" },
+    nodes: [
+      {
+        id: "Running",
+        label: "Running",
+        position: { x: 50, y: 0 },
+        size: { width: 80, height: 30 },
+      },
+      {
+        id: "Paused",
+        label: "Paused",
+        position: { x: 50, y: 100 },
+        size: { width: 80, height: 30 },
+      },
+    ],
+    edges: [
+      {
+        id: "e0",
+        source: "Paused",
+        target: "Running",
+        label: "resume",
+        arrow_start: "none",
+        arrow_end: "normal",
+        is_backward: true,
+        path: [
+          [90, 100],
+          [120, 50],
+          [90, 0],
+        ],
+      },
+    ],
+  };
+  const converted = convertToTldraw(mmds);
+  const arrow = converted.records.find(
+    (r) =>
+      r.typeName === "shape" && r.type === "arrow" && r.id === "shape:edge_e0",
+  );
+  assert.ok(arrow);
+  // With a routed path, arrowheads should NOT be swapped — the path already
+  // defines the correct visual direction (Paused → Running).
+  assert.equal(arrow.props.arrowheadStart, "none");
+  assert.equal(arrow.props.arrowheadEnd, "arrow");
 });
 
 test("preserves arrowheads for non-backward edges", () => {


### PR DESCRIPTION
## Summary
- Fix backward edge arrowhead direction in tldraw adapter for state diagram composite transitions
- Only swap arrowheads when `is_backward=true` AND no routed path exists (layout-level fallback)
- When a routed path is present, the path coordinates already define the correct visual direction — arrowheads follow `arrow_start`/`arrow_end` directly

## Test plan
- [x] New test: "preserves arrowheads for backward edges with routed path"
- [x] Existing test renamed and still passes: "swaps arrowheads for backward edges without routed path"
- [x] All 80 mmds-tldraw tests pass
- [x] All 2396 Rust tests pass

Closes #161