### PR TITLE
fix(mmds-tldraw): apply note styling and dashed edges

### DIFF
--- a/packages/mmds-core/src/normalize.ts
+++ b/packages/mmds-core/src/normalize.ts
@@ -22,6 +22,7 @@ const DEFAULT_MINLEN = 1;
 
 const EDGE_STROKES = new Set<MmdsEdgeStroke>([
   "solid",
+  "dashed",
   "dotted",
   "thick",
   "invisible",

--- a/packages/mmds-core/src/types.ts
+++ b/packages/mmds-core/src/types.ts
@@ -1,7 +1,12 @@
 export type MmdsDirection = "TD" | "BT" | "LR" | "RL";
 export type MmdsGeometryLevel = "layout" | "routed";
 
-export type MmdsEdgeStroke = "solid" | "dotted" | "thick" | "invisible";
+export type MmdsEdgeStroke =
+  | "solid"
+  | "dashed"
+  | "dotted"
+  | "thick"
+  | "invisible";
 export type MmdsArrow =
   | "none"
   | "normal"

--- a/packages/mmds-tldraw/src/convert.ts
+++ b/packages/mmds-tldraw/src/convert.ts
@@ -251,15 +251,123 @@ function transformLabel(label: string): string {
     .join("\n");
 }
 
-/** Return fill/color overrides for shapes that should be filled (state start markers, fork/join bars). */
+/** Return fill/color overrides for shapes that should be filled. */
 function mapNodeFill(shape: string): { fill?: string; color?: string } {
   switch (shape) {
     case "small_circle":
     case "fork_join":
       return { fill: "solid", color: "black" };
+    case "note_rect":
+      return { fill: "solid", color: "yellow" };
     default:
       return {};
   }
+}
+
+/** Parse a hex color string (#RGB or #RRGGBB) into [r, g, b], or null. */
+function parseHex(hex: string): [number, number, number] | null {
+  const m = /^#?([0-9a-f]{3,8})$/i.exec(hex);
+  if (!m) return null;
+  const h = m[1];
+  if (h.length === 3) {
+    return [
+      parseInt(h[0] + h[0], 16),
+      parseInt(h[1] + h[1], 16),
+      parseInt(h[2] + h[2], 16),
+    ];
+  }
+  if (h.length >= 6) {
+    return [
+      parseInt(h.slice(0, 2), 16),
+      parseInt(h.slice(2, 4), 16),
+      parseInt(h.slice(4, 6), 16),
+    ];
+  }
+  return null;
+}
+
+/** Map a hex color to the nearest tldraw named color using hue-based matching. */
+function hexToTldrawColor(hex: string): string | null {
+  const rgb = parseHex(hex);
+  if (!rgb) return null;
+  const [r, g, b] = rgb;
+
+  const max = Math.max(r, g, b) / 255;
+  const min = Math.min(r, g, b) / 255;
+  const l = (max + min) / 2;
+  const d = max - min;
+
+  // Achromatic — match on lightness
+  if (d < 0.05) {
+    if (l > 0.75) return "white";
+    if (l < 0.25) return "black";
+    return "grey";
+  }
+
+  // Compute hue in degrees
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  let h: number;
+  if (max === rn) h = ((gn - bn) / d) % 6;
+  else if (max === gn) h = (bn - rn) / d + 2;
+  else h = (rn - gn) / d + 4;
+  h = h * 60;
+  if (h < 0) h += 360;
+
+  const s = d / (1 - Math.abs(2 * l - 1));
+
+  // Map hue ranges to tldraw palette names
+  if (h < 15 || h >= 345) return s > 0.4 ? "red" : "light-red";
+  if (h < 40) return "orange";
+  if (h < 75) return "yellow";
+  if (h < 160) return s > 0.4 ? "green" : "light-green";
+  if (h < 260) return s > 0.4 ? "blue" : "light-blue";
+  if (h < 345) return s > 0.4 ? "violet" : "light-violet";
+  return "black";
+}
+
+interface NodeStyleOverrides {
+  fill?: string;
+  color?: string;
+  labelColor?: string;
+}
+
+/**
+ * Parse per-node style overrides from the `org.mmdflux.node-style.v1` extension.
+ * Maps hex fill/stroke/color values to the nearest tldraw named colors.
+ */
+function parseNodeStyleExtension(
+  extensions?: Record<string, unknown>,
+): Map<string, NodeStyleOverrides> {
+  const result = new Map<string, NodeStyleOverrides>();
+  if (!extensions) return result;
+
+  const ext = extensions["org.mmdflux.node-style.v1"] as
+    | { nodes?: Record<string, Record<string, string>> }
+    | undefined;
+  if (!ext?.nodes) return result;
+
+  for (const [nodeId, style] of Object.entries(ext.nodes)) {
+    const overrides: NodeStyleOverrides = {};
+    if (style.fill) {
+      const mapped = hexToTldrawColor(style.fill);
+      if (mapped) {
+        overrides.fill = "solid";
+        overrides.color = mapped;
+      }
+    }
+    if (style.color) {
+      const mapped = hexToTldrawColor(style.color);
+      if (mapped) {
+        overrides.labelColor = mapped;
+      }
+    }
+    if (overrides.fill || overrides.color || overrides.labelColor) {
+      result.set(nodeId, overrides);
+    }
+  }
+  return result;
 }
 
 /**
@@ -470,8 +578,10 @@ function mapGeoShape(mmdsShape: string): GeoStyle {
   }
 }
 
-function mapDash(stroke: string): "solid" | "dotted" {
-  return stroke === "dotted" ? "dotted" : "solid";
+function mapDash(stroke: string): "solid" | "dashed" | "dotted" {
+  if (stroke === "dotted") return "dotted";
+  if (stroke === "dashed") return "dashed";
+  return "solid";
 }
 
 function mapSize(stroke: string): "m" | "l" {
@@ -1040,6 +1150,8 @@ export function convertToTldraw(
     return convertSequenceToTldraw(mmds, scale);
   }
 
+  const nodeStyleOverrides = parseNodeStyleExtension(normalized.extensions);
+
   const adaptiveRatio = computeAdaptiveGrowthRatio(normalized.nodes, scale);
   const nodeSpacing = options.nodeSpacing ?? adaptiveRatio;
   const positionScale = autoPositionScale(
@@ -1227,7 +1339,8 @@ export function convertToTldraw(
       } as TLRecord);
     } else {
       const geo = mapGeoShape(node.shape);
-      const fillOverrides = mapNodeFill(node.shape);
+      const extOverrides = nodeStyleOverrides.get(node.id);
+      const shapeFallback = mapNodeFill(node.shape);
       geoByShapeId.set(shapeId, geo);
       shapeRecords.push({
         ...common,
@@ -1240,9 +1353,9 @@ export function convertToTldraw(
           h: absRect.h,
           growY: 0,
           scale: 1,
-          labelColor: "black",
-          color: fillOverrides.color ?? "black",
-          fill: fillOverrides.fill ?? "none",
+          labelColor: extOverrides?.labelColor ?? "black",
+          color: extOverrides?.color ?? shapeFallback.color ?? "black",
+          fill: extOverrides?.fill ?? shapeFallback.fill ?? "none",
           size: "m",
           font: "draw",
           align: "middle",

--- a/packages/mmds-tldraw/test/convert.test.mjs
+++ b/packages/mmds-tldraw/test/convert.test.mjs
@@ -2003,6 +2003,101 @@ test("state fork_join gets filled style", () => {
   assert.equal(geo.props.color, "black");
 });
 
+test("note_rect with node-style extension gets yellow fill from extension", () => {
+  const mmds = {
+    version: 2,
+    metadata: { diagram_type: "state" },
+    profiles: ["mmds-core-v1", "mmdflux-node-style-v1"],
+    extensions: {
+      "org.mmdflux.node-style.v1": {
+        nodes: {
+          n1: { fill: "#fff5ad", stroke: "#aaaa33", color: "#333" },
+        },
+      },
+    },
+    nodes: [
+      {
+        id: "n1",
+        label: "A note",
+        position: { x: 150, y: 50 },
+        size: { width: 80, height: 30 },
+        shape: "note_rect",
+      },
+    ],
+    edges: [],
+  };
+  const converted = convertToTldraw(mmds);
+  const geo = converted.records.find(
+    (r) => r.typeName === "shape" && r.type === "geo",
+  );
+  assert.ok(geo);
+  assert.equal(geo.props.fill, "solid");
+  assert.equal(geo.props.color, "yellow");
+  assert.equal(geo.props.labelColor, "black");
+});
+
+test("note_rect without extension falls back to yellow fill", () => {
+  const mmds = {
+    version: 2,
+    metadata: { diagram_type: "state" },
+    nodes: [
+      {
+        id: "n1",
+        label: "A note",
+        position: { x: 150, y: 50 },
+        size: { width: 80, height: 30 },
+        shape: "note_rect",
+      },
+    ],
+    edges: [],
+  };
+  const converted = convertToTldraw(mmds);
+  const geo = converted.records.find(
+    (r) => r.typeName === "shape" && r.type === "geo",
+  );
+  assert.ok(geo);
+  assert.equal(geo.props.fill, "solid");
+  assert.equal(geo.props.color, "yellow");
+});
+
+test("dashed edge stroke produces dashed arrow", () => {
+  const mmds = {
+    version: 2,
+    metadata: { diagram_type: "state" },
+    nodes: [
+      {
+        id: "s1",
+        label: "S1",
+        position: { x: 0, y: 50 },
+        size: { width: 60, height: 30 },
+      },
+      {
+        id: "n1",
+        label: "A note",
+        position: { x: 150, y: 50 },
+        size: { width: 80, height: 30 },
+        shape: "note_rect",
+      },
+    ],
+    edges: [
+      {
+        id: "e0",
+        source: "s1",
+        target: "n1",
+        stroke: "dashed",
+        arrow_start: "none",
+        arrow_end: "none",
+      },
+    ],
+  };
+  const converted = convertToTldraw(mmds);
+  const arrow = converted.records.find(
+    (r) => r.typeName === "shape" && r.type === "arrow",
+  );
+  assert.ok(arrow);
+  assert.equal(arrow.props.dash, "dashed");
+});
+
 test("invisible subgraphs are not rendered as frames", () => {
   const mmds = {
     version: 2,

--- a/src/diagrams/state/compiler.rs
+++ b/src/diagrams/state/compiler.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::graph::style::NodeStyle;
+use crate::graph::style::{ColorToken, NodeStyle};
 use crate::graph::{Arrow, Direction, Edge, Graph, Node, NotePosition, Shape, Stroke, Subgraph};
 use crate::mermaid::state::{
     StateDecl, StateModel, StateStatement, StateStereotype, StateTransition,
@@ -129,6 +129,7 @@ fn add_note_node(
         .with_label(text)
         .with_shape(Shape::NoteRect);
     note_node.parent = state_parent.clone();
+    note_node.style = note_style();
     graph.add_node(note_node);
 
     // Add note to the same parent subgraph's children list.
@@ -149,6 +150,13 @@ fn add_note_node(
             .with_stroke(Stroke::Dashed)
             .with_arrows(Arrow::None, Arrow::None),
     );
+}
+
+fn note_style() -> NodeStyle {
+    NodeStyle::default()
+        .with_fill(ColorToken::parse("#fff5ad").unwrap())
+        .with_stroke(ColorToken::parse("#aaaa33").unwrap())
+        .with_color(ColorToken::parse("#333").unwrap())
 }
 
 fn direction_from_str(dir: Option<&str>) -> Direction {


### PR DESCRIPTION
## Summary

- State diagram notes now render with yellow fill and dashed constraint edges in tldraw output
- The tldraw adapter reads `org.mmdflux.node-style.v1` MMDS extension data, mapping hex colors to the nearest tldraw named color via hue-based matching, with a shape-based fallback for `note_rect`
- Adds `"dashed"` to `MmdsEdgeStroke` type in mmds-core (was silently normalized to `"solid"`)
- State note nodes now carry `NodeStyle` with fill/stroke/color so the MMDS extension is emitted

## Test plan

- [x] All 2401 Rust tests pass
- [x] All 80 mmds-tldraw tests pass
- [x] Architecture check passes
- [ ] Verify tldraw rendering of `tests/fixtures/state/notes.mmd` shows yellow notes and dashed edges

Closes #162