### PR TITLE
fix(mmds-tldraw): render fork/join pseudo-states as rectangular bars

### DIFF
--- a/packages/mmds-tldraw/src/convert.ts
+++ b/packages/mmds-tldraw/src/convert.ts
@@ -382,6 +382,7 @@ function computeAdaptiveGrowthRatio(
 ): number {
   let maxRatio = 1.0;
   for (const node of nodes) {
+    if (node.shape === "fork_join" && !node.label?.trim()) continue;
     const label = node.label ?? node.id;
     const tldrawMinWidth = tldrawEnforcedMinWidth(label);
     const scaledMmdsWidth = node.size.width * sizeScale;
@@ -401,17 +402,20 @@ function scaleNodeRect(
   let width = Math.max(8, node.size.width * sizeScale);
   let height = Math.max(8, node.size.height * sizeScale);
 
-  // Ensure minimum size for label so text doesn't wrap to single chars per line.
-  const minW = tldrawEnforcedMinWidth(node.label);
-  const minH = tldrawEnforcedMinHeight(node.label);
-  if (width < minW || height < minH) {
-    width = Math.max(width, minW);
-    height = Math.max(height, minH);
-    // Diamonds need square aspect; ellipses often look better square for short labels.
-    if (node.shape === "diamond") {
-      const side = Math.max(width, height);
-      width = side;
-      height = side;
+  // Unlabeled fork/join bars use exact MMDS dimensions — skip label-based minimums.
+  if (!(node.shape === "fork_join" && !node.label?.trim())) {
+    // Ensure minimum size for label so text doesn't wrap to single chars per line.
+    const minW = tldrawEnforcedMinWidth(node.label);
+    const minH = tldrawEnforcedMinHeight(node.label);
+    if (width < minW || height < minH) {
+      width = Math.max(width, minW);
+      height = Math.max(height, minH);
+      // Diamonds need square aspect; ellipses often look better square for short labels.
+      if (node.shape === "diamond") {
+        const side = Math.max(width, height);
+        width = side;
+        height = side;
+      }
     }
   }
 
@@ -444,11 +448,15 @@ function autoPositionScale(
 
   // Pre-compute fixed (scale-independent) node sizes.
   const sizes = nodes.map((n) => {
-    let w = Math.max(n.size.width * sizeScale, tldrawEnforcedMinWidth(n.label));
-    let h = Math.max(
-      n.size.height * sizeScale,
-      tldrawEnforcedMinHeight(n.label),
-    );
+    let w = n.size.width * sizeScale;
+    let h = n.size.height * sizeScale;
+    if (n.shape === "fork_join" && !n.label?.trim()) {
+      w = Math.max(w, 8);
+      h = Math.max(h, 8);
+    } else {
+      w = Math.max(w, tldrawEnforcedMinWidth(n.label));
+      h = Math.max(h, tldrawEnforcedMinHeight(n.label));
+    }
     if (n.shape === "diamond") {
       const side = Math.max(w, h);
       w = side;
@@ -566,6 +574,8 @@ function mapGeoShape(mmdsShape: string): GeoStyle {
       return "arrow-right";
     case "crossed_circle":
       return "x-box";
+    case "fork_join":
+      return "rectangle";
     case "round":
     case "circle":
     case "double_circle":

--- a/src/graph/measure.rs
+++ b/src/graph/measure.rs
@@ -207,6 +207,7 @@ pub fn proportional_node_dimensions(
         Shape::SmallCircle => (14.0, 14.0),
         Shape::FramedCircle => (28.0, 28.0),
         Shape::CrossedCircle => (60.0, 60.0),
+        Shape::ForkJoin if node.label.trim().is_empty() => (70.0, 7.0),
         Shape::TextBlock => (label_w, label_h),
         _ => (
             label_w + metrics.node_padding_x * 2.0,

--- a/src/render/graph/svg/nodes.rs
+++ b/src/render/graph/svg/nodes.rs
@@ -376,7 +376,7 @@ fn render_node_shape(
     node: &Node,
     rect: &Rect,
     scale: f64,
-    direction: Direction,
+    _direction: Direction,
     node_style: ResolvedSvgNodeStyle<'_>,
     palette: &GraphSvgPalette,
 ) {
@@ -903,39 +903,17 @@ fn render_node_shape(
             // Borderless: only text will be drawn.
         }
         Shape::ForkJoin => {
-            if matches!(direction, Direction::LeftRight | Direction::RightLeft) {
-                // Vertical bar for horizontal flow
-                let x = rect.x + rect.width / 2.0;
-                let stroke = format!(
-                    " stroke=\"{stroke}\" stroke-width=\"{stroke_width}\" stroke-linecap=\"square\"",
-                    stroke = stroke,
-                    stroke_width = fmt_f64((rect.width * 0.3).max(3.0 * scale))
-                );
-                let line = format!(
-                    "<line x1=\"{x}\" y1=\"{y1}\" x2=\"{x}\" y2=\"{y2}\"{stroke} />",
-                    x = fmt_f64(x),
-                    y1 = fmt_f64(rect.y),
-                    y2 = fmt_f64(rect.y + rect.height),
-                    stroke = stroke
-                );
-                writer.push_line(&line);
-            } else {
-                // Horizontal bar for vertical flow
-                let y = rect.y + rect.height / 2.0;
-                let stroke = format!(
-                    " stroke=\"{stroke}\" stroke-width=\"{stroke_width}\" stroke-linecap=\"square\"",
-                    stroke = stroke,
-                    stroke_width = fmt_f64((rect.height * 0.3).max(3.0 * scale))
-                );
-                let line = format!(
-                    "<line x1=\"{x1}\" y1=\"{y}\" x2=\"{x2}\" y2=\"{y}\"{stroke} />",
-                    x1 = fmt_f64(rect.x),
-                    x2 = fmt_f64(rect.x + rect.width),
-                    y = fmt_f64(y),
-                    stroke = stroke
-                );
-                writer.push_line(&line);
-            }
+            let bar = format!(
+                "<rect x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\" fill=\"{fill}\" stroke=\"{stroke}\" stroke-width=\"{sw}\" stroke-linejoin=\"round\" />",
+                x = fmt_f64(rect.x),
+                y = fmt_f64(rect.y),
+                w = fmt_f64(rect.width),
+                h = fmt_f64(rect.height),
+                fill = node_style.fill_or(stroke),
+                stroke = stroke,
+                sw = stroke_width,
+            );
+            writer.push_line(&bar);
         }
     }
 }

--- a/tests/svg-snapshots/flowchart-basis/shapes_special.svg
+++ b/tests/svg-snapshots/flowchart-basis/shapes_special.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 151.92 46.00" style="max-width: 151.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 104.92 86.00" style="max-width: 104.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -6,12 +6,12 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M62.00,23.00 L64.78,23.00 C67.56,23.00 73.11,23.00 78.67,23.00 C84.22,23.00 89.78,23.00 94.67,23.00 C99.56,23.00 103.78,23.00 105.89,23.00 L108.00,23.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M15.00,43.00 L17.78,43.00 C20.56,43.00 26.11,43.00 31.67,43.00 C37.22,43.00 42.78,43.00 47.67,43.00 C52.56,43.00 56.78,43.00 58.89,43.00 L61.00,43.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
-      <line x1="35.00" y1="8.00" x2="35.00" y2="38.00" stroke="#333" stroke-width="16.20" stroke-linecap="square" />
-      <text x="35.00" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
-      <text x="127.96" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
+      <rect x="8.00" y="8.00" width="7.00" height="70.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="11.50" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <text x="80.96" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-curved-step/shapes_special.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/shapes_special.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 151.92 46.00" style="max-width: 151.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 104.92 86.00" style="max-width: 104.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -6,12 +6,12 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M62.00,23.00 L64.78,23.00 C67.56,23.00 73.11,23.00 78.11,23.00 C83.11,23.00 87.56,23.00 92.44,23.00 C97.33,23.00 102.67,23.00 105.33,23.00 L108.00,23.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M15.00,43.00 L17.78,43.00 C20.56,43.00 26.11,43.00 31.11,43.00 C36.11,43.00 40.56,43.00 45.44,43.00 C50.33,43.00 55.67,43.00 58.33,43.00 L61.00,43.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
-      <line x1="35.00" y1="8.00" x2="35.00" y2="38.00" stroke="#333" stroke-width="16.20" stroke-linecap="square" />
-      <text x="35.00" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
-      <text x="127.96" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
+      <rect x="8.00" y="8.00" width="7.00" height="70.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="11.50" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <text x="80.96" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-polyline/shapes_special.svg
+++ b/tests/svg-snapshots/flowchart-polyline/shapes_special.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 151.92 46.00" style="max-width: 151.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 104.92 86.00" style="max-width: 104.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -6,12 +6,12 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M62.00,23.00 L108.00,23.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M15.00,43.00 L61.00,43.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
-      <line x1="35.00" y1="8.00" x2="35.00" y2="38.00" stroke="#333" stroke-width="16.20" stroke-linecap="square" />
-      <text x="35.00" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
-      <text x="127.96" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
+      <rect x="8.00" y="8.00" width="7.00" height="70.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="11.50" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <text x="80.96" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/shapes_special.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/shapes_special.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 151.92 46.00" style="max-width: 151.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 104.92 86.00" style="max-width: 104.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -6,12 +6,12 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M62.00,23.00 L108.00,23.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M15.00,43.00 L61.00,43.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
-      <line x1="35.00" y1="8.00" x2="35.00" y2="38.00" stroke="#333" stroke-width="16.20" stroke-linecap="square" />
-      <text x="35.00" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
-      <text x="127.96" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
+      <rect x="8.00" y="8.00" width="7.00" height="70.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="11.50" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <text x="80.96" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-step/shapes_special.svg
+++ b/tests/svg-snapshots/flowchart-step/shapes_special.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 151.92 46.00" style="max-width: 151.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 104.92 86.00" style="max-width: 104.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -6,12 +6,12 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M62.00,23.00 L108.00,23.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M15.00,43.00 L61.00,43.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
-      <line x1="35.00" y1="8.00" x2="35.00" y2="38.00" stroke="#333" stroke-width="16.20" stroke-linecap="square" />
-      <text x="35.00" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
-      <text x="127.96" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
+      <rect x="8.00" y="8.00" width="7.00" height="70.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="11.50" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <text x="80.96" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart-straight/shapes_special.svg
+++ b/tests/svg-snapshots/flowchart-straight/shapes_special.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 151.92 46.00" style="max-width: 151.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 104.92 86.00" style="max-width: 104.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -6,12 +6,12 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M62.00,23.00 L108.00,23.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M15.00,43.00 L61.00,43.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
-      <line x1="35.00" y1="8.00" x2="35.00" y2="38.00" stroke="#333" stroke-width="16.20" stroke-linecap="square" />
-      <text x="35.00" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
-      <text x="127.96" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
+      <rect x="8.00" y="8.00" width="7.00" height="70.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="11.50" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <text x="80.96" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/flowchart/shapes_special.svg
+++ b/tests/svg-snapshots/flowchart/shapes_special.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 151.92 46.00" style="max-width: 151.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 104.92 86.00" style="max-width: 104.92px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -6,12 +6,12 @@
   </defs>
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
-      <path d="M62.00,23.00 L108.00,23.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M15.00,43.00 L61.00,43.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
-      <line x1="35.00" y1="8.00" x2="35.00" y2="38.00" stroke="#333" stroke-width="16.20" stroke-linecap="square" />
-      <text x="35.00" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
-      <text x="127.96" y="23.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
+      <rect x="8.00" y="8.00" width="7.00" height="70.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="11.50" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <text x="80.96" y="43.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Note</text>
     </g>
     <g class="edgeLabels">
     </g>

--- a/tests/svg-snapshots/state/pseudo_states.svg
+++ b/tests/svg-snapshots/state/pseudo_states.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 218.80 677.00" style="max-width: 218.80px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 218.80 583.00" style="max-width: 218.80px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -7,42 +7,42 @@
   <g transform="translate(0.00,0.00)">
     <g class="edgePaths">
       <path d="M109.40,22.00 L109.40,68.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M100.40,126.00 L100.40,132.40 Q100.40,137.40 95.40,137.40 L67.61,137.40 Q62.61,137.40 62.61,142.40 L62.61,172.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M118.40,126.00 L118.40,132.40 Q118.40,137.40 123.40,137.40 L151.19,137.40 Q156.19,137.40 156.19,142.40 L156.19,172.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M62.61,230.00 L62.61,236.40 Q62.61,241.40 67.61,241.40 L95.40,241.40 Q100.40,241.40 100.40,246.40 L100.40,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M156.19,230.00 L156.19,236.40 Q156.19,241.40 151.19,241.40 L123.40,241.40 Q118.40,241.40 118.40,246.40 L118.40,276.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M109.40,334.00 L109.40,380.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M91.71,420.31 L51.20,420.31 Q46.20,420.31 46.20,425.31 L46.20,533.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M127.09,420.31 L167.60,420.31 Q172.60,420.31 172.60,425.31 L172.60,533.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M64.95,591.00 L64.95,597.40 Q64.95,602.40 69.95,602.40 L96.00,602.40 Q101.00,602.40 101.00,607.40 L101.00,637.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M153.85,591.00 L153.85,597.40 Q153.85,602.40 148.85,602.40 L122.80,602.40 Q117.80,602.40 117.80,607.40 L117.80,637.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M82.40,79.00 L82.40,85.40 Q82.40,90.40 77.40,90.40 L72.40,90.40 Q67.40,90.40 67.40,95.40 L67.40,125.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M136.40,79.00 L136.40,85.40 Q136.40,90.40 141.40,90.40 L146.40,90.40 Q151.40,90.40 151.40,95.40 L151.40,125.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M67.40,183.00 L67.40,189.40 Q67.40,194.40 72.40,194.40 L77.40,194.40 Q82.40,194.40 82.40,199.40 L82.40,229.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M151.40,183.00 L151.40,189.40 Q151.40,194.40 146.40,194.40 L141.40,194.40 Q136.40,194.40 136.40,199.40 L136.40,229.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M109.40,240.00 L109.40,286.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M91.71,326.31 L51.20,326.31 Q46.20,326.31 46.20,331.31 L46.20,439.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M127.09,326.31 L167.60,326.31 Q172.60,326.31 172.60,331.31 L172.60,439.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M64.95,497.00 L64.95,503.40 Q64.95,508.40 69.95,508.40 L96.00,508.40 Q101.00,508.40 101.00,513.40 L101.00,543.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M153.85,497.00 L153.85,503.40 Q153.85,508.40 148.85,508.40 L122.80,508.40 Q117.80,508.40 117.80,513.40 L117.80,543.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
-      <rect x="8.00" y="176.00" width="76.40" height="54.00" rx="5.00" ry="5.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="46.20" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">State2</text>
-      <rect x="134.40" y="176.00" width="76.40" height="54.00" rx="5.00" ry="5.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="172.60" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">State3</text>
-      <rect x="8.00" y="537.00" width="76.40" height="54.00" rx="5.00" ry="5.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="46.20" y="564.00" text-anchor="middle" dominant-baseline="middle" fill="#333">State4</text>
-      <rect x="134.40" y="537.00" width="76.40" height="54.00" rx="5.00" ry="5.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="172.60" y="564.00" text-anchor="middle" dominant-baseline="middle" fill="#333">State5</text>
-      <circle cx="109.40" cy="655.00" r="14.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <circle cx="109.40" cy="655.00" r="9.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="109.40" y="655.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <rect x="8.00" y="129.00" width="76.40" height="54.00" rx="5.00" ry="5.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="46.20" y="156.00" text-anchor="middle" dominant-baseline="middle" fill="#333">State2</text>
+      <rect x="134.40" y="129.00" width="76.40" height="54.00" rx="5.00" ry="5.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="172.60" y="156.00" text-anchor="middle" dominant-baseline="middle" fill="#333">State3</text>
+      <rect x="8.00" y="443.00" width="76.40" height="54.00" rx="5.00" ry="5.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="46.20" y="470.00" text-anchor="middle" dominant-baseline="middle" fill="#333">State4</text>
+      <rect x="134.40" y="443.00" width="76.40" height="54.00" rx="5.00" ry="5.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="172.60" y="470.00" text-anchor="middle" dominant-baseline="middle" fill="#333">State5</text>
+      <circle cx="109.40" cy="561.00" r="14.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <circle cx="109.40" cy="561.00" r="9.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="109.40" y="561.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
       <circle cx="109.40" cy="15.00" r="7.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
       <text x="109.40" y="15.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
-      <line x1="94.40" y1="99.00" x2="124.40" y2="99.00" stroke="#333" stroke-width="16.20" stroke-linecap="square" />
-      <text x="109.40" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
-      <polygon points="109.40,384.00 136.40,411.00 109.40,438.00 82.40,411.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
-      <text x="109.40" y="411.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
-      <line x1="94.40" y1="307.00" x2="124.40" y2="307.00" stroke="#333" stroke-width="16.20" stroke-linecap="square" />
-      <text x="109.40" y="307.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <rect x="74.40" y="72.00" width="70.00" height="7.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="109.40" y="75.50" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <polygon points="109.40,290.00 136.40,317.00 109.40,344.00 82.40,317.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="109.40" y="317.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
+      <rect x="74.40" y="233.00" width="70.00" height="7.00" fill="#333" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+      <text x="109.40" y="236.50" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
     </g>
     <g class="edgeLabels">
-      <rect x="29.39" y="446.50" width="33.61" height="28.00" fill="white" />
-      <text x="46.20" y="460.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="160.06" y="475.50" width="25.08" height="28.00" fill="white" />
-      <text x="172.60" y="489.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="29.39" y="352.50" width="33.61" height="28.00" fill="white" />
+      <text x="46.20" y="366.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="160.06" y="381.50" width="25.08" height="28.00" fill="white" />
+      <text x="172.60" y="395.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

- Added explicit `ForkJoin` proportional dimensions (100×10) in `measure.rs` instead of falling through to the default case (which produced 30×54)
- Added `fork_join` → `rectangle` mapping in the tldraw adapter's `mapGeoShape()`
- Excluded fork/join nodes from label-based minimum size enforcement, adaptive growth ratio, and overlap detection so bar dimensions are preserved
- Regenerated SVG snapshots for state and flowchart fixtures affected by the dimension change

## Test plan

- [x] 2401 Rust tests pass
- [x] 80 tldraw TypeScript tests pass
- [x] `just fix` clean
- [x] Architecture check passes

Closes #163