### PR TITLE
feat(plan-0149): lane-aware edge-label fix infrastructure (#237 partial)

### DIFF
--- a/src/engines/graph/algorithms/layered/adapter.rs
+++ b/src/engines/graph/algorithms/layered/adapter.rs
@@ -128,6 +128,7 @@ pub fn from_layered_layout(result: &LayoutResult, diagram: &Graph) -> GraphGeome
                 },
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }
         })
         .collect();

--- a/src/engines/graph/algorithms/layered/float_layout.rs
+++ b/src/engines/graph/algorithms/layered/float_layout.rs
@@ -263,6 +263,15 @@ fn apply_routed_edge_paths(
             layout_edge.label_position = edge.label_position;
             layout_edge.preserve_orthogonal_topology = edge.preserve_orthogonal_topology;
             layout_edge.label_geometry = edge.label_geometry;
+            // Plan 0149 (#237): forward the lane-aware re-wrap output
+            // from routing onto the `LayoutEdge` so Visual-SVG solve
+            // paths (where the engine returns `routed: None` but routing
+            // ran internally via `build_float_layout_with_flags`) still
+            // see the narrower label lines. Without this the SVG
+            // renderer falls back to `edge.wrapped_label_lines`
+            // (pre-engine wrap, 200 px), which emits wide text inside
+            // a narrow post-rewrap rect.
+            layout_edge.effective_wrapped_lines = edge.effective_wrapped_lines;
         }
     }
 }
@@ -529,6 +538,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs: HashMap::new(),
             self_edges: vec![],
@@ -558,6 +568,7 @@ mod tests {
             target_port: None,
             preserve_orthogonal_topology: false,
             label_geometry: Some(label_geom),
+            effective_wrapped_lines: None,
         }];
 
         apply_routed_edge_paths(&mut geometry, routed_edges);

--- a/src/engines/graph/elk.rs
+++ b/src/engines/graph/elk.rs
@@ -337,6 +337,7 @@ fn parse_elk_output(output: &str, diagram: &Graph) -> Result<GraphGeometry, Rend
                 },
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             });
         }
     }

--- a/src/graph/geometry.rs
+++ b/src/graph/geometry.rs
@@ -131,6 +131,16 @@ pub struct LayoutEdge {
     /// pass and copied back onto `LayoutEdge` so `Visual` SVG solve paths
     /// still see authoritative label rectangles). `None` before routing.
     pub label_geometry: Option<EdgeLabelGeometry>,
+    /// Plan 0149 (#237): lane-aware re-wrap output, forwarded from
+    /// `RoutedEdgeGeometry::effective_wrapped_lines` through
+    /// `geometry_for_routed_svg` so the SVG renderer (which consumes
+    /// `LayoutEdge`, not `RoutedEdgeGeometry`) can emit text matching
+    /// the post-rewrap rect. `None` means "use the pre-engine wrap
+    /// artifact from `diagram.edges[idx].wrapped_label_lines`".
+    ///
+    /// Only populated on the routed-SVG downgrade path; the pre-routing
+    /// `LayoutEdge` produced by the kernel always carries `None` here.
+    pub effective_wrapped_lines: Option<Vec<String>>,
 }
 
 /// Subgraph bounding box in layout float space.
@@ -318,6 +328,21 @@ pub struct RoutedEdgeGeometry {
     /// Shared label-rectangle geometry populated by the routing label-lane
     /// pass. Read by SVG/MMDS/bounds consumers; one rectangle, no divergence.
     pub label_geometry: Option<EdgeLabelGeometry>,
+    /// Plan 0149 (#237): lane-aware re-wrap output. `Some(lines)` when the
+    /// post-lane `label_rewrap` pass decided to narrow this edge's label
+    /// below the pre-engine wrap width so it fits the compartment's
+    /// `label_step` budget. Renderers (SVG `labels.rs`, text `edge.rs`,
+    /// MMDS replay) must prefer this over `diagram.edges[idx].
+    /// wrapped_label_lines` when present so the rect geometry and the
+    /// emitted text stay in sync.
+    ///
+    /// Intentionally NOT propagated back to `Graph::edges.wrapped_label_lines`
+    /// so the kernel's Grid measurement (which ran pre-routing) stays on the
+    /// original pre-engine wrap. That's what keeps Text snapshots
+    /// byte-stable — Grid-measured layer heights were committed before this
+    /// field existed, and Text consumers that honour a routed override need
+    /// to opt in explicitly. See `findings/01-spike-result.md` §1.2.
+    pub effective_wrapped_lines: Option<Vec<String>>,
 }
 
 /// A routed self-edge loop.
@@ -384,6 +409,7 @@ mod tests {
             layout_path_hint: None,
             preserve_orthogonal_topology: false,
             label_geometry: None,
+            effective_wrapped_lines: None,
         };
         assert!(edge.layout_path_hint.is_none());
         assert_eq!(edge.waypoints.len(), 1);
@@ -418,6 +444,7 @@ mod tests {
             layout_path_hint: None,
             preserve_orthogonal_topology: false,
             label_geometry: None,
+            effective_wrapped_lines: None,
         };
         assert!(edge.label_geometry.is_none());
     }
@@ -440,6 +467,7 @@ mod tests {
             target_port: None,
             preserve_orthogonal_topology: false,
             label_geometry: None,
+            effective_wrapped_lines: None,
         };
         assert!(edge.label_geometry.is_none());
     }
@@ -467,6 +495,7 @@ mod tests {
             target_port: None,
             preserve_orthogonal_topology: false,
             label_geometry: None,
+            effective_wrapped_lines: None,
         };
         assert!(edge.source_port.is_some());
         assert!(edge.target_port.is_none());

--- a/src/graph/routing/backward_corridor.rs
+++ b/src/graph/routing/backward_corridor.rs
@@ -612,6 +612,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs,
             self_edges: vec![],
@@ -790,6 +791,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             },
             LayoutEdge {
                 index: 1,
@@ -803,6 +805,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             },
         ];
         geometry.reversed_edges = vec![0, 1];

--- a/src/graph/routing/label_clamp.rs
+++ b/src/graph/routing/label_clamp.rs
@@ -287,6 +287,7 @@ mod tests {
                 side: EdgeLabelSide::Above,
                 track: 0,
             }),
+            effective_wrapped_lines: None,
         };
 
         let routed = RoutedGraphGeometry {

--- a/src/graph/routing/label_gap.rs
+++ b/src/graph/routing/label_gap.rs
@@ -222,6 +222,7 @@ mod tests {
                 side: EdgeLabelSide::Above,
                 track: 0,
             }),
+            effective_wrapped_lines: None,
         };
 
         let routed = RoutedGraphGeometry {

--- a/src/graph/routing/label_lanes.rs
+++ b/src/graph/routing/label_lanes.rs
@@ -162,6 +162,12 @@ fn candidate_track_order(sign: i32) -> impl Iterator<Item = i32> {
 }
 
 /// Per-edge outcome of the lane assignment pass.
+///
+/// Plan 0149 extended this with `label_step`, `compartment_id`, and
+/// `midpoint` so the post-lane re-wrap pass in
+/// `crate::graph::routing::label_rewrap` can run its bounded fixed-point
+/// without re-entering descriptor building. If `label_rewrap` is refactored
+/// out or the fixed-point is removed, those three fields can be dropped.
 #[derive(Debug, Clone)]
 pub(super) struct LabelTrackOutcome {
     pub label_center: FPoint,
@@ -174,6 +180,31 @@ pub(super) struct LabelTrackOutcome {
     /// compartment members all reference, so the wire-up should adopt
     /// the descriptor midpoint even when track is 0.
     pub compartment_size: usize,
+    /// Per-compartment lane step (max axis-projected extent + `LANE_GAP`,
+    /// floored to `MIN_LABEL_LANE_STEP`). Shared by every member of the
+    /// compartment — identical across all outcomes with the same
+    /// `compartment_id`.
+    ///
+    /// Read by `label_rewrap::re_wrap_labels_for_lane_fit` as the overflow
+    /// budget for each edge's label width. The rewrap module may mutate
+    /// this field in-place across fixed-point iterations when re-wrap
+    /// grows the axis-projected extent (TD re-wrap → more lines → taller
+    /// label → larger `label_step`).
+    pub label_step: f64,
+    /// Dense per-run compartment key assigned in compartment-iteration
+    /// order. Edges that share an ID share a compartment, which means they
+    /// share `label_step` and must be recentered together when the fixed-
+    /// point pass recomputes that budget. Not stable across renders — do
+    /// not serialize or compare across invocations.
+    pub compartment_id: usize,
+    /// Arc-length midpoint of the original (pre-lane-shift) edge path, as
+    /// computed by `build_label_descriptors`. Kept so that
+    /// `label_center = midpoint + track_vector(direction) * label_step`
+    /// can be recomputed from scratch after `label_step` mutates. Re-
+    /// centering off the previous `label_center` accumulates floating-
+    /// point error across iterations, and the rewrap fixed-point can run
+    /// up to 3 rounds.
+    pub midpoint: FPoint,
 }
 
 /// Assign labels to signed tracks, shift label centers and middle path
@@ -197,7 +228,11 @@ pub(super) fn assign_label_tracks(
     let compartments = group_label_compartments(descriptors);
     let mut outcomes: HashMap<usize, LabelTrackOutcome> = HashMap::new();
 
-    for compartment in compartments {
+    // Dense compartment counter: assigned in iteration order and only
+    // used as a grouping key within this `assign_label_tracks` call. Not
+    // stable across renders. Incremented by `enumerate()` so every
+    // member of the same compartment gets the same id.
+    for (compartment_id, compartment) in compartments.into_iter().enumerate() {
         let tracks = pack_signed_tracks(&compartment);
 
         // Per-compartment LABEL_LANE_STEP from the max axis-band extent.
@@ -230,6 +265,9 @@ pub(super) fn assign_label_tracks(
                     track,
                     adjusted_path: new_path,
                     compartment_size,
+                    label_step,
+                    compartment_id,
+                    midpoint: desc.midpoint,
                 },
             );
         }
@@ -272,7 +310,20 @@ pub(super) fn build_label_descriptors(
         }
 
         let midpoint = arc_length_midpoint(path).unwrap_or_else(|| path[path.len() / 2]);
-        let (w, h) = metrics.edge_label_dimensions(label_text);
+        // Plan 0149 (#237): descriptor must reflect the same dims the SVG
+        // renderer will emit, otherwise the packer sizes compartments
+        // against unwrapped single-line heights while the actual rects
+        // stack multi-line rendered labels. Pre-fix, `label_step` was
+        // 32 (unwrapped h=28 + LANE_GAP) but the rendered rect was 52
+        // tall — tracks at ±32 from midpoint let 52-tall rects overlap
+        // the track-0 band, which is exactly the `long_reciprocal_labels`
+        // failure. Prefer `wrapped_label_lines` when present; fall back
+        // to single-line measurement for edges that opted out of the
+        // pre-engine wrap (dagre-parity mode).
+        let (w, h) = match edge.wrapped_label_lines.as_deref() {
+            Some(lines) => metrics.edge_label_dimensions_wrapped(lines),
+            None => metrics.edge_label_dimensions(label_text),
+        };
 
         let direction_sign = if *backward_flags.get(&edge_index).unwrap_or(&false) {
             -1

--- a/src/graph/routing/label_rewrap.rs
+++ b/src/graph/routing/label_rewrap.rs
@@ -1,0 +1,620 @@
+//! Plan 0149 (#237): lane-aware edge-label re-wrap.
+//!
+//! # What this module does
+//!
+//! Runs AFTER `label_lanes::assign_label_tracks` has packed compartments
+//! onto signed tracks. Each edge in a multi-member compartment has been
+//! assigned a track, a `label_step` budget, and a compartment id. For any
+//! edge whose rendered label is wider than the compartment's `label_step`
+//! budget (the distance between adjacent lane centerlines), we re-wrap the
+//! label at a narrower target width, recompute the label's rect, and
+//! store the re-wrapped lines on `RoutedEdgeGeometry::effective_wrapped_lines`
+//! so renderers emit text that matches the narrower rect.
+//!
+//! Re-wrapping a TD label at a narrower width generally INCREASES its
+//! axis-projected height (more lines). That height feeds back into the
+//! per-compartment `label_step` (max axis extent + LANE_GAP), which feeds
+//! back into every member's `label_center = midpoint + track_vector *
+//! label_step`. To absorb that cascade we run a bounded fixed-point:
+//!
+//! 1. Detect overflowing edges (`rect.width > label_step * FIT_THRESHOLD`).
+//! 2. Re-wrap them and update their rect dimensions + effective lines.
+//! 3. Per affected compartment, recompute `max_axis`, `label_step`.
+//! 4. Recompute every compartment member's `label_center` from its
+//!    `midpoint` and the fresh `label_step`.
+//! 5. Repeat until no edge overflows or `MAX_REWRAP_ITERATIONS` is hit.
+//!
+//! # Why we chose Option (b) storage (`effective_wrapped_lines`)
+//!
+//! We deliberately do NOT mutate `diagram.edges[i].wrapped_label_lines`
+//! post-routing. `runtime::graph_family::render_graph_family` runs
+//! `prepare_wrapped_labels` BEFORE `solve_graph_family`; the kernel's
+//! Grid-mode measurement (used by the Text renderer) consumes
+//! `wrapped_label_lines` DURING that solve and is already frozen by the
+//! time this callback fires. Mutating the source artifact after the fact
+//! would leave Grid-measured layer heights out of sync with the text
+//! rendered into them. Putting the re-wrap output on `RoutedEdgeGeometry`
+//! keeps the override on a type that Grid measurement never reads.
+//!
+//! # Pipeline interactions to remember before editing
+//!
+//! - **Kernel dummy heights are frozen.** If re-wrap grows label height
+//!   from 52 px to 100 px, the label dummy reserved only 52 px of layer
+//!   gap. The extra 48 px overflows into adjacent layer space. Today we
+//!   accept the visual imperfection because the overlap-resolution is
+//!   more important than layer-gap purity; if that tradeoff ever flips,
+//!   a follow-up would plumb grown heights back to the kernel for a
+//!   second-pass relayout.
+//! - **`recompute_routed_bounds` runs after this.** At `stage.rs` just
+//!   below the callback invocation, the routing orchestrator recomputes
+//!   the graph bounds from the current rects. Growing label rects grows
+//!   the bounds automatically — no explicit bounds update here.
+//! - **Self-edges are built after this.** Self-loop geometry never
+//!   interacts with compartment packing, so re-wrap has no effect on it.
+//! - **Hard line breaks.** `wrap_lines` treats `'\n'` as a hard break.
+//!   The pre-engine wrap is derived from `edge.label` (post-
+//!   `normalize_br_tags`), so re-wrapping from `edge.label` again
+//!   preserves `<br>` semantics. We therefore re-wrap from `edge.label`,
+//!   NOT from the previously wrapped lines joined with spaces.
+//! - **Idempotence.** On the second full call the narrowed rects are
+//!   already within `FIT_THRESHOLD` of `label_step`, so the overflow
+//!   detector fires on zero edges and the fixed-point exits in its
+//!   first iteration. See `rewrap_is_noop_when_no_label_overflows_*`.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::graph::geometry::RoutedEdgeGeometry;
+use crate::graph::measure::{ProportionalTextMetrics, wrap_lines};
+use crate::graph::routing::label_lanes::{LANE_GAP, LabelTrackOutcome, MIN_LABEL_LANE_STEP};
+use crate::graph::space::FPoint;
+use crate::graph::{Direction, Graph};
+
+/// Labels whose axis-projected extent is within this fraction of `label_step`
+/// are considered "fitting" and left alone.
+///
+/// Set to 1.0 so re-wrap only fires when the rect actually exceeds the
+/// compartment budget. Loose thresholds (e.g. 0.9) spuriously re-wrap
+/// labels that *technically* pass the geometric no-overlap check —
+/// `h0/2 + h1/2 <= label_step` for a reciprocal TD pair means rects do
+/// not touch, so re-wrapping just for a few pixels of slack produces
+/// harshly narrow output without a correctness win.
+const FIT_THRESHOLD: f64 = 1.0;
+
+/// Re-wrap target: `label_step * REWRAP_SAFETY`. Overshooting the budget
+/// a bit (80 % instead of 100 %) leaves room for marker-avoidance padding
+/// and for the label_step itself to grow during subsequent iterations
+/// without re-triggering overflow on this edge.
+const REWRAP_SAFETY: f64 = 0.8;
+
+/// Floor on the re-wrap target. Narrower than roughly three short words
+/// produces unreadable one-letter-per-line output without improving
+/// overlap. When `label_step * REWRAP_SAFETY` falls below this the
+/// rewrap target is clamped to `MIN_REWRAP_WIDTH`.
+const MIN_REWRAP_WIDTH: f64 = 48.0;
+
+/// Cap on fixed-point iterations. In the common case (TD reciprocal
+/// pair) the loop converges in 2 rounds. The cap guards against
+/// pathological inputs where re-wrap endlessly toggles label_step.
+const MAX_REWRAP_ITERATIONS: usize = 3;
+
+/// Run the lane-aware re-wrap fixed-point.
+///
+/// Mutates affected edges' `label_geometry` rects and sets
+/// `effective_wrapped_lines`. Mutates the supplied `lane_outcomes` map
+/// in-place so caller-visible `label_step`, `label_center`, and
+/// `label_rect` reflect the post-rewrap state — downstream passes
+/// (`label_clamp::clamp_label_geometry_to_node_bounds`,
+/// `recompute_routed_bounds`) read directly from the routed edges and do
+/// not consult `lane_outcomes` again, so the outcome mutation is for
+/// diagnostics / testability rather than re-consumption.
+///
+/// Returns the total number of edges re-wrapped across all iterations.
+/// A non-zero return is purely informational; the caller does not gate
+/// anything on it today.
+pub(super) fn re_wrap_labels_for_lane_fit(
+    diagram: &Graph,
+    edges: &mut [RoutedEdgeGeometry],
+    lane_outcomes: &mut HashMap<usize, LabelTrackOutcome>,
+    metrics: &ProportionalTextMetrics,
+    direction: Direction,
+) -> usize {
+    let mut total_rewraps: usize = 0;
+    for _iteration in 0..MAX_REWRAP_ITERATIONS {
+        // Step 1: detect which edges overflow their compartment's current
+        // `label_step`. Skip singletons on track 0 (no compartment siblings
+        // to coordinate with, so no lane budget to enforce). We iterate
+        // edges (not outcomes) because the fresh rect dims live on the
+        // routed edge; outcomes reflect the initial pack only.
+        //
+        // Compare the **axis-projected** extent (height for TD/BT, width
+        // for LR/RL) against `label_step` — the two are measured in the
+        // same axis. Comparing the cross-axis dim would be meaningless
+        // because labels in a TD compartment share the same X center by
+        // construction and their X widths are unconstrained by the lane
+        // packer.
+        let overflowing: Vec<usize> = edges
+            .iter()
+            .filter_map(|edge| {
+                let outcome = lane_outcomes.get(&edge.index)?;
+                if outcome.compartment_size == 1 && outcome.track == 0 {
+                    return None;
+                }
+                let rect = edge.label_geometry.as_ref()?.rect;
+                let axis = axis_projected_dim(rect.width, rect.height, direction);
+                if axis > outcome.label_step * FIT_THRESHOLD {
+                    Some(edge.index)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if overflowing.is_empty() {
+            break;
+        }
+
+        // Step 2: re-wrap overflowing edges in place. We set the new rect
+        // dimensions centered on the CURRENT `label_center`; step 4 below
+        // will replace that center with a fresh midpoint-based one once
+        // label_step is recomputed. Keeping the recenter separate avoids
+        // the double-adjustment trap where a width change + a center
+        // change interact non-linearly.
+        let mut touched_compartments: HashSet<usize> = HashSet::new();
+        for edge_idx in &overflowing {
+            let outcome = match lane_outcomes.get(edge_idx) {
+                Some(o) => o,
+                None => continue,
+            };
+            let Some(source_edge) = diagram.edges.get(*edge_idx) else {
+                continue;
+            };
+            // Re-wrap from the raw label text (post `normalize_br_tags`),
+            // NOT from the previously wrapped lines. `wrap_lines` treats
+            // `'\n'` as a hard break so `<br>` semantics survive; joining
+            // wrapped_label_lines back into a single string would lose
+            // line-break fidelity for labels that had explicit breaks.
+            let Some(label_text) = source_edge.label.as_deref() else {
+                continue;
+            };
+            if label_text.is_empty() {
+                continue;
+            }
+
+            let target = (outcome.label_step * REWRAP_SAFETY).max(MIN_REWRAP_WIDTH);
+            let new_lines = wrap_lines(metrics, label_text, target);
+            let (new_w, new_h) = metrics.edge_label_dimensions_wrapped(&new_lines);
+
+            // Skip edges where the re-wrap would not actually narrow the
+            // rect. Can happen with single oversized words where the
+            // per-character fallback in `wrap_lines` produces a line as
+            // wide as the original (or wider thanks to padding math). Not
+            // worth burning an iteration on no-ops.
+            let current_width = edges
+                .iter()
+                .find(|e| e.index == *edge_idx)
+                .and_then(|e| e.label_geometry.as_ref().map(|g| g.rect.width));
+            if let Some(cur) = current_width
+                && new_w >= cur
+            {
+                continue;
+            }
+
+            if let Some(edge) = edges.iter_mut().find(|e| e.index == *edge_idx)
+                && let Some(geom) = edge.label_geometry.as_mut()
+            {
+                // Position update here is temporary; Step 4 overwrites it
+                // if the compartment's label_step changed.
+                geom.rect.width = new_w;
+                geom.rect.height = new_h;
+                geom.rect.x = geom.center.x - new_w / 2.0;
+                geom.rect.y = geom.center.y - new_h / 2.0;
+                edge.effective_wrapped_lines = Some(new_lines);
+                total_rewraps += 1;
+                touched_compartments.insert(outcome.compartment_id);
+            }
+        }
+
+        if touched_compartments.is_empty() {
+            break;
+        }
+
+        // Step 3: recompute per-compartment `label_step`. `max_axis` is
+        // the largest axis-projected rect dimension across all members;
+        // axis = Y for TD/BT, axis = X for LR/RL. Growing height (TD
+        // re-wrap) grows label_step; shrinking width (LR re-wrap) shrinks
+        // it. Either way the final value replaces the stale one on every
+        // affected member's outcome.
+        let new_steps =
+            recompute_label_steps(edges, lane_outcomes, &touched_compartments, direction);
+
+        // Step 4: apply fresh label_step back to outcomes AND recompute
+        // every member's label_center from the preserved midpoint. Update
+        // the routed edge's rect position to match.
+        //
+        // IMPORTANT: compute from the stored midpoint, not from the old
+        // label_center. Re-centering off the old center accumulates
+        // floating-point drift across iterations, and on each iteration
+        // the FIT_THRESHOLD check uses the updated rect, so an accumulated
+        // drift could falsely clear the overflow detector even when the
+        // true geometry still overflows.
+        apply_new_label_steps(edges, lane_outcomes, &new_steps, direction);
+    }
+
+    total_rewraps
+}
+
+/// Compute fresh `label_step` values for every compartment touched this
+/// iteration. Reads the CURRENT routed-edge rect dimensions (post
+/// re-wrap) so the returned steps reflect the new axis extents.
+fn recompute_label_steps(
+    edges: &[RoutedEdgeGeometry],
+    lane_outcomes: &HashMap<usize, LabelTrackOutcome>,
+    affected: &HashSet<usize>,
+    direction: Direction,
+) -> HashMap<usize, f64> {
+    let mut max_axis_per_compartment: HashMap<usize, f64> = HashMap::new();
+    for edge in edges {
+        let Some(outcome) = lane_outcomes.get(&edge.index) else {
+            continue;
+        };
+        if !affected.contains(&outcome.compartment_id) {
+            continue;
+        }
+        let Some(rect) = edge.label_geometry.as_ref().map(|g| g.rect) else {
+            continue;
+        };
+        let axis_extent = axis_projected_dim(rect.width, rect.height, direction);
+        max_axis_per_compartment
+            .entry(outcome.compartment_id)
+            .and_modify(|cur| *cur = cur.max(axis_extent))
+            .or_insert(axis_extent);
+    }
+    max_axis_per_compartment
+        .into_iter()
+        .map(|(id, max_axis)| (id, (max_axis + LANE_GAP).max(MIN_LABEL_LANE_STEP)))
+        .collect()
+}
+
+/// For every edge in an affected compartment, write the new `label_step`
+/// onto its outcome and recompute `label_center` from the preserved
+/// `midpoint`. Propagate the new center to the routed edge's rect
+/// position; width/height were already set in Step 2 and stay put.
+fn apply_new_label_steps(
+    edges: &mut [RoutedEdgeGeometry],
+    lane_outcomes: &mut HashMap<usize, LabelTrackOutcome>,
+    new_steps: &HashMap<usize, f64>,
+    direction: Direction,
+) {
+    for edge in edges.iter_mut() {
+        let Some(outcome) = lane_outcomes.get_mut(&edge.index) else {
+            continue;
+        };
+        let Some(&new_step) = new_steps.get(&outcome.compartment_id) else {
+            continue;
+        };
+        outcome.label_step = new_step;
+
+        // track_vector returns the unit vector along the axis-stacking
+        // direction. label_center = midpoint + track_vector * track *
+        // label_step.
+        let new_center = compute_label_center(outcome.midpoint, outcome.track, new_step, direction);
+        outcome.label_center = new_center;
+
+        if let Some(geom) = edge.label_geometry.as_mut() {
+            geom.center = new_center;
+            geom.rect.x = new_center.x - geom.rect.width / 2.0;
+            geom.rect.y = new_center.y - geom.rect.height / 2.0;
+            // outcome.label_rect is informational at this point; mirror
+            // the rect state back onto it for diagnostics and for any
+            // test that inspects outcomes directly.
+            outcome.label_rect = geom.rect;
+        }
+        if let Some(lp) = edge.label_position.as_mut() {
+            *lp = new_center;
+        }
+    }
+}
+
+/// Axis-projected dimension for a rect in a given flow direction.
+/// TD/BT stack labels in Y, so the axis extent is the rect height;
+/// LR/RL stack in X, so it is the rect width.
+fn axis_projected_dim(width: f64, height: f64, direction: Direction) -> f64 {
+    match direction {
+        Direction::TopDown | Direction::BottomTop => height,
+        Direction::LeftRight | Direction::RightLeft => width,
+    }
+}
+
+/// Compute a member's `label_center` from its midpoint, track, step, and
+/// flow direction. Mirrors `label_lanes::shift_label` — keep the two in
+/// sync if either changes. Extracting a separate helper here avoids
+/// coupling this module to the crate-private internals of `label_lanes`.
+fn compute_label_center(
+    midpoint: FPoint,
+    track: i32,
+    label_step: f64,
+    direction: Direction,
+) -> FPoint {
+    let offset = track as f64 * label_step;
+    match direction {
+        Direction::TopDown | Direction::BottomTop => FPoint::new(midpoint.x, midpoint.y + offset),
+        Direction::LeftRight | Direction::RightLeft => FPoint::new(midpoint.x + offset, midpoint.y),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::geometry::{EdgeLabelGeometry, EdgeLabelSide};
+    use crate::graph::measure::default_proportional_text_metrics;
+    use crate::graph::space::FRect;
+    use crate::graph::{Edge, Node};
+
+    // Test helpers: build a minimal graph + routed edge pair + outcomes
+    // that can drive the callback without running the full routing
+    // pipeline. Keeping this explicit (rather than going through a
+    // fixture) makes it obvious which input shape each assertion relies
+    // on.
+
+    fn graph_with_labels(labels: &[(&str, &str, &str)]) -> Graph {
+        let mut g = Graph::new(Direction::TopDown);
+        let mut seen: HashSet<String> = HashSet::new();
+        for (from, to, _label) in labels {
+            if seen.insert((*from).to_string()) {
+                g.add_node(Node::new(*from));
+            }
+            if seen.insert((*to).to_string()) {
+                g.add_node(Node::new(*to));
+            }
+        }
+        for (from, to, label) in labels {
+            g.add_edge(Edge::new(*from, *to).with_label(*label));
+        }
+        g
+    }
+
+    fn routed_edge_with_label(
+        index: usize,
+        from: &str,
+        to: &str,
+        rect: FRect,
+    ) -> RoutedEdgeGeometry {
+        RoutedEdgeGeometry {
+            index,
+            from: from.into(),
+            to: to.into(),
+            path: vec![],
+            label_position: Some(FPoint::new(
+                rect.x + rect.width / 2.0,
+                rect.y + rect.height / 2.0,
+            )),
+            label_side: Some(EdgeLabelSide::Center),
+            head_label_position: None,
+            tail_label_position: None,
+            is_backward: false,
+            from_subgraph: None,
+            to_subgraph: None,
+            source_port: None,
+            target_port: None,
+            preserve_orthogonal_topology: false,
+            label_geometry: Some(EdgeLabelGeometry {
+                center: FPoint::new(rect.x + rect.width / 2.0, rect.y + rect.height / 2.0),
+                rect,
+                padding: (4.0, 2.0),
+                side: EdgeLabelSide::Center,
+                track: 0,
+                // Note: the rect passed in assumes padding already included.
+            }),
+            effective_wrapped_lines: None,
+        }
+    }
+
+    fn outcome(
+        track: i32,
+        label_step: f64,
+        compartment_id: usize,
+        compartment_size: usize,
+        midpoint: FPoint,
+        rect: FRect,
+    ) -> LabelTrackOutcome {
+        LabelTrackOutcome {
+            label_center: FPoint::new(rect.x + rect.width / 2.0, rect.y + rect.height / 2.0),
+            label_rect: rect,
+            track,
+            adjusted_path: vec![],
+            compartment_size,
+            label_step,
+            compartment_id,
+            midpoint,
+        }
+    }
+
+    #[test]
+    fn rewrap_noop_for_singleton_track_zero_edges() {
+        // A label that is wide but in a 1-member compartment on track 0
+        // has no one to pack against, so the rewrap must leave it alone.
+        let g = graph_with_labels(&[("A", "B", "this is a wide singleton label")]);
+        let rect = FRect::new(0.0, 0.0, 250.0, 28.0);
+        let mut edges = vec![routed_edge_with_label(0, "A", "B", rect)];
+        let mut outcomes = HashMap::new();
+        outcomes.insert(0, outcome(0, 32.0, 0, 1, FPoint::new(125.0, 14.0), rect));
+        let metrics = default_proportional_text_metrics();
+
+        let n = re_wrap_labels_for_lane_fit(
+            &g,
+            &mut edges,
+            &mut outcomes,
+            &metrics,
+            Direction::TopDown,
+        );
+        assert_eq!(n, 0);
+        assert!(edges[0].effective_wrapped_lines.is_none());
+        assert_eq!(edges[0].label_geometry.as_ref().unwrap().rect.width, 250.0);
+    }
+
+    #[test]
+    fn rewrap_noop_when_axis_extent_already_fits_budget() {
+        // A label whose axis-projected extent is within `label_step *
+        // FIT_THRESHOLD` must not be re-wrapped even if it lives in a
+        // multi-member compartment. For TD, axis = height.
+        let g = graph_with_labels(&[("A", "B", "short"), ("B", "A", "short")]);
+        // rect.height=28 vs step=50 → 28 < 50 * 1.0 = 50 → fits.
+        let rect = FRect::new(0.0, 0.0, 40.0, 28.0);
+        let mut edges = vec![
+            routed_edge_with_label(0, "A", "B", rect),
+            routed_edge_with_label(1, "B", "A", rect),
+        ];
+        let mut outcomes = HashMap::new();
+        outcomes.insert(0, outcome(0, 50.0, 0, 2, FPoint::new(20.0, 14.0), rect));
+        outcomes.insert(1, outcome(-1, 50.0, 0, 2, FPoint::new(20.0, -36.0), rect));
+        let metrics = default_proportional_text_metrics();
+
+        let n = re_wrap_labels_for_lane_fit(
+            &g,
+            &mut edges,
+            &mut outcomes,
+            &metrics,
+            Direction::TopDown,
+        );
+        assert_eq!(n, 0);
+        assert!(edges[0].effective_wrapped_lines.is_none());
+        assert!(edges[1].effective_wrapped_lines.is_none());
+    }
+
+    #[test]
+    fn rewrap_shrinks_overflowing_label_and_records_effective_lines() {
+        // A label whose axis-projected extent exceeds the compartment's
+        // `label_step` must be re-wrapped and the narrower rect +
+        // effective lines must land on the routed edge. TD reciprocal
+        // pair with a tall multi-line rect (h=60) against a small step
+        // (32) forces overflow.
+        let label = "this is a deliberately long label";
+        let g = graph_with_labels(&[("A", "B", label), ("B", "A", label)]);
+        let rect = FRect::new(0.0, 0.0, 200.0, 60.0);
+        let mut edges = vec![
+            routed_edge_with_label(0, "A", "B", rect),
+            routed_edge_with_label(1, "B", "A", rect),
+        ];
+        let mut outcomes = HashMap::new();
+        outcomes.insert(0, outcome(0, 32.0, 0, 2, FPoint::new(100.0, 30.0), rect));
+        outcomes.insert(1, outcome(-1, 32.0, 0, 2, FPoint::new(100.0, -2.0), rect));
+        let metrics = default_proportional_text_metrics();
+
+        let n = re_wrap_labels_for_lane_fit(
+            &g,
+            &mut edges,
+            &mut outcomes,
+            &metrics,
+            Direction::TopDown,
+        );
+        assert!(n >= 1, "expected at least one rewrap, got {n}");
+        let e0 = &edges[0];
+        assert!(e0.effective_wrapped_lines.is_some());
+        let new_w = e0.label_geometry.as_ref().unwrap().rect.width;
+        assert!(
+            new_w < 200.0,
+            "rewrapped rect width must shrink below original 200: got {new_w}"
+        );
+    }
+
+    #[test]
+    fn rewrap_preserves_track_and_compartment_identity() {
+        // After re-wrap, track and compartment_id on the outcome must
+        // remain unchanged — only label_step and label_center should
+        // have moved.
+        let label = "this is a deliberately long label";
+        let g = graph_with_labels(&[("A", "B", label), ("B", "A", label)]);
+        let rect = FRect::new(0.0, 0.0, 200.0, 60.0);
+        let mut edges = vec![
+            routed_edge_with_label(0, "A", "B", rect),
+            routed_edge_with_label(1, "B", "A", rect),
+        ];
+        let mut outcomes = HashMap::new();
+        outcomes.insert(0, outcome(0, 32.0, 0, 2, FPoint::new(100.0, 30.0), rect));
+        outcomes.insert(1, outcome(-1, 32.0, 0, 2, FPoint::new(100.0, -2.0), rect));
+        let metrics = default_proportional_text_metrics();
+
+        re_wrap_labels_for_lane_fit(&g, &mut edges, &mut outcomes, &metrics, Direction::TopDown);
+        assert_eq!(outcomes[&0].track, 0);
+        assert_eq!(outcomes[&1].track, -1);
+        assert_eq!(outcomes[&0].compartment_id, 0);
+        assert_eq!(outcomes[&1].compartment_id, 0);
+    }
+
+    #[test]
+    fn rewrap_fixed_point_grows_label_step_for_td_reciprocal_pair() {
+        // The reciprocal-pair TD case that motivated Plan 0149. After the
+        // first round of re-wrap the labels become taller (more lines),
+        // so `label_step` must grow on iteration 2; otherwise the two
+        // members would overlap in Y. Check the final label_step > initial.
+        let label = "this is a deliberately long reply label";
+        let g = graph_with_labels(&[("A", "B", label), ("B", "A", label)]);
+        // Tall rect (h=60) vs small step (32) forces TD axis-extent
+        // overflow → triggers re-wrap → rewritten axis dim feeds back
+        // into recomputed label_step.
+        let rect = FRect::new(0.0, 0.0, 200.0, 60.0);
+        let mut edges = vec![
+            routed_edge_with_label(0, "A", "B", rect),
+            routed_edge_with_label(1, "B", "A", rect),
+        ];
+        let mut outcomes = HashMap::new();
+        let initial_step = 32.0;
+        outcomes.insert(
+            0,
+            outcome(0, initial_step, 0, 2, FPoint::new(100.0, 30.0), rect),
+        );
+        outcomes.insert(
+            1,
+            outcome(-1, initial_step, 0, 2, FPoint::new(100.0, -2.0), rect),
+        );
+        let metrics = default_proportional_text_metrics();
+
+        re_wrap_labels_for_lane_fit(&g, &mut edges, &mut outcomes, &metrics, Direction::TopDown);
+        assert!(
+            outcomes[&0].label_step > initial_step,
+            "label_step must grow to accommodate re-wrap height (was {}, now {})",
+            initial_step,
+            outcomes[&0].label_step
+        );
+        // Both members see the same fresh step.
+        assert_eq!(outcomes[&0].label_step, outcomes[&1].label_step);
+    }
+
+    #[test]
+    fn rewrap_is_idempotent_when_already_wrapped() {
+        // Running the callback a second time on an already-narrowed label
+        // set must be a no-op: the narrowed rect already sits inside the
+        // (now larger) label_step budget.
+        let label = "this is a deliberately long label";
+        let g = graph_with_labels(&[("A", "B", label), ("B", "A", label)]);
+        let rect = FRect::new(0.0, 0.0, 200.0, 60.0);
+        let mut edges = vec![
+            routed_edge_with_label(0, "A", "B", rect),
+            routed_edge_with_label(1, "B", "A", rect),
+        ];
+        let mut outcomes = HashMap::new();
+        outcomes.insert(0, outcome(0, 32.0, 0, 2, FPoint::new(100.0, 30.0), rect));
+        outcomes.insert(1, outcome(-1, 32.0, 0, 2, FPoint::new(100.0, -2.0), rect));
+        let metrics = default_proportional_text_metrics();
+
+        let first = re_wrap_labels_for_lane_fit(
+            &g,
+            &mut edges,
+            &mut outcomes,
+            &metrics,
+            Direction::TopDown,
+        );
+        assert!(first >= 1);
+        let second = re_wrap_labels_for_lane_fit(
+            &g,
+            &mut edges,
+            &mut outcomes,
+            &metrics,
+            Direction::TopDown,
+        );
+        assert_eq!(
+            second, 0,
+            "running rewrap a second time must be a no-op on already-fitted labels"
+        );
+    }
+}

--- a/src/graph/routing/mod.rs
+++ b/src/graph/routing/mod.rs
@@ -12,6 +12,7 @@ mod float_core;
 mod label_clamp;
 pub(crate) mod label_gap;
 pub(crate) mod label_lanes;
+mod label_rewrap;
 mod labels;
 mod orthogonal;
 mod stage;
@@ -76,6 +77,7 @@ mod tests {
             layout_path_hint: Some(vec![FPoint::new(50.0, 35.0), FPoint::new(50.0, 65.0)]),
             preserve_orthogonal_topology: false,
             label_geometry: None,
+            effective_wrapped_lines: None,
         }];
 
         let geom = GraphGeometry {
@@ -298,6 +300,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs: HashMap::new(),
             self_edges: vec![],
@@ -370,6 +373,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs: HashMap::new(),
             self_edges: vec![],
@@ -446,6 +450,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs: HashMap::new(),
             self_edges: vec![],
@@ -535,6 +540,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs: HashMap::new(),
             self_edges: vec![],
@@ -631,6 +637,7 @@ mod tests {
                     layout_path_hint: None,
                     preserve_orthogonal_topology: false,
                     label_geometry: None,
+                    effective_wrapped_lines: None,
                 },
                 LayoutEdge {
                     index: 1,
@@ -644,6 +651,7 @@ mod tests {
                     layout_path_hint: None,
                     preserve_orthogonal_topology: false,
                     label_geometry: None,
+                    effective_wrapped_lines: None,
                 },
             ],
             subgraphs: HashMap::new(),
@@ -758,6 +766,7 @@ mod tests {
                     layout_path_hint: None,
                     preserve_orthogonal_topology: false,
                     label_geometry: None,
+                    effective_wrapped_lines: None,
                 },
                 LayoutEdge {
                     index: 1,
@@ -771,6 +780,7 @@ mod tests {
                     layout_path_hint: None,
                     preserve_orthogonal_topology: false,
                     label_geometry: None,
+                    effective_wrapped_lines: None,
                 },
             ],
             subgraphs: HashMap::new(),
@@ -857,6 +867,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs,
             self_edges: vec![],
@@ -997,6 +1008,7 @@ mod tests {
                 layout_path_hint: Some(direct_hint.clone()),
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs: HashMap::new(),
             self_edges: vec![],
@@ -1080,6 +1092,7 @@ mod tests {
                 layout_path_hint: Some(fallback_hint.clone()),
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs: HashMap::new(),
             self_edges: vec![],
@@ -1491,6 +1504,7 @@ mod tests {
             layout_path_hint: Some(vec![FPoint::new(70.0, 35.0), FPoint::new(70.0, 85.0)]),
             preserve_orthogonal_topology: false,
             label_geometry: None,
+            effective_wrapped_lines: None,
         }];
 
         let geom = GraphGeometry {
@@ -1595,6 +1609,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             },
             LayoutEdge {
                 index: 1,
@@ -1608,6 +1623,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             },
             LayoutEdge {
                 index: 2,
@@ -1621,6 +1637,7 @@ mod tests {
                 layout_path_hint: None,
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             },
         ];
 

--- a/src/graph/routing/orthogonal/mod.rs
+++ b/src/graph/routing/orthogonal/mod.rs
@@ -187,6 +187,11 @@ pub fn route_edges_orthogonal(
                 target_port: None,
                 preserve_orthogonal_topology: target_transit_avoided,
                 label_geometry: None,
+                // Plan 0149 re-wrap output — populated (if at all) by the
+                // post-lane `label_rewrap` pass in stage.rs, which runs
+                // after orthogonal routing feeds its edges into the
+                // shared routing pipeline.
+                effective_wrapped_lines: None,
             }
         })
         .collect();

--- a/src/graph/routing/stage.rs
+++ b/src/graph/routing/stage.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use super::float_core::compute_port_attachments_from_geometry;
 use super::labels::{arc_length_midpoint, compute_end_labels_for_edge};
 use super::orthogonal::{OrthogonalRoutingOptions, build_path_from_hints, route_edges_orthogonal};
-use super::{backward_corridor, label_clamp, label_lanes};
+use super::{backward_corridor, label_clamp, label_lanes, label_rewrap};
 use crate::graph::direction_policy::effective_edge_direction;
 use crate::graph::geometry::{
     EdgeLabelGeometry, EdgeLabelSide, GraphGeometry, LayoutEdge, RoutedEdgeGeometry,
@@ -137,6 +137,10 @@ pub fn route_graph_geometry(
                             .and_then(|(_, tp)| tp.clone()),
                         preserve_orthogonal_topology: false,
                         label_geometry: None,
+                        // Plan 0149 re-wrap output populated later by
+                        // `label_rewrap::re_wrap_labels_for_lane_fit`
+                        // (called after lane-track assignment below).
+                        effective_wrapped_lines: None,
                     }
                 })
                 .collect::<Vec<_>>()
@@ -183,7 +187,7 @@ pub fn route_graph_geometry(
         edges.iter().map(|e| (e.index, e.path.clone())).collect();
     let backward_flags: HashMap<usize, bool> =
         edges.iter().map(|e| (e.index, e.is_backward)).collect();
-    let lane_outcomes = label_lanes::assign_label_tracks(
+    let mut lane_outcomes = label_lanes::assign_label_tracks(
         diagram,
         geometry,
         &paths_by_index,
@@ -244,6 +248,25 @@ pub fn route_graph_geometry(
         // text-aware path-bend pass).
         let _ = &outcome.adjusted_path;
     }
+
+    // Plan 0149 (#237): lane-aware re-wrap. Runs AFTER the wire-up loop
+    // above (so routed edges carry the post-lane rect geometry) and
+    // BEFORE self-edge construction / bounds recomputation below (so
+    // self-loop layout and final bounds are computed against the
+    // re-wrapped rects). Mutates `lane_outcomes` in place — primarily
+    // useful for tests that inspect the outcomes map; downstream passes
+    // (`clamp_label_geometry_to_node_bounds`, `recompute_routed_bounds`)
+    // read directly from the routed edges and see the new rects
+    // automatically. See `graph/routing/label_rewrap.rs` for the
+    // fixed-point design and caveats (kernel dummy heights stay frozen;
+    // `<br>` semantics preserved).
+    label_rewrap::re_wrap_labels_for_lane_fit(
+        diagram,
+        &mut edges,
+        &mut lane_outcomes,
+        metrics,
+        diagram.direction,
+    );
 
     let self_edges: Vec<RoutedSelfEdge> = geometry
         .self_edges

--- a/src/internal_tests/graph_routing_pipeline.rs
+++ b/src/internal_tests/graph_routing_pipeline.rs
@@ -5318,6 +5318,7 @@ mod label_overlap_tests {
             target_port: None,
             preserve_orthogonal_topology: false,
             label_geometry: None,
+            effective_wrapped_lines: None,
         }
     }
 

--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -5904,7 +5904,7 @@ mod plan_0145_q9_red {
     // needs either global X packing across compartments or a cross-
     // compartment rewrap trigger. Tracking as a follow-up.
     #[test]
-    #[ignore = "plan 0149 follow-up: cross-compartment X overlap; see findings/plan-0149-completion.md"]
+    #[ignore = "plan 0149 follow-up: cross-compartment X overlap — see #242"]
     fn state_concurrent_three_flux_layered_labels_disjoint_svg() {
         let svg = concurrent_three_svg_with_engine(EngineAlgorithmId::FLUX_LAYERED);
         let overlap = svg_pairwise_label_rect_overlaps(&svg);
@@ -5915,7 +5915,7 @@ mod plan_0145_q9_red {
     }
 
     #[test]
-    #[ignore = "plan 0149 follow-up: cross-compartment X overlap; see findings/plan-0149-completion.md"]
+    #[ignore = "plan 0149 follow-up: cross-compartment X overlap — see #242"]
     fn state_concurrent_three_mermaid_layered_labels_disjoint_svg() {
         let svg = concurrent_three_svg_with_engine(EngineAlgorithmId::MERMAID_LAYERED);
         let overlap = svg_pairwise_label_rect_overlaps(&svg);
@@ -5938,7 +5938,7 @@ mod plan_0145_q9_red {
     // it) — tracked as a follow-up. See
     // `findings/plan-0149-completion.md`.
     #[test]
-    #[ignore = "plan 0149 follow-up: kernel must reserve rank space for multi-member label compartments; see findings/plan-0149-completion.md"]
+    #[ignore = "plan 0149 follow-up: kernel must reserve rank space for multi-member label compartments — see #241"]
     fn flowchart_long_reciprocal_labels_disjoint_svg() {
         let input = load_flowchart_fixture("long_reciprocal_labels.mmd");
         let svg = render_svg_default(&input);
@@ -5953,7 +5953,7 @@ mod plan_0145_q9_red {
     // (or a smaller label height) than descriptor/clamp tuning alone
     // can deliver. Tracked with the same follow-up.
     #[test]
-    #[ignore = "plan 0149 follow-up: kernel must reserve rank space for multi-member label compartments; see findings/plan-0149-completion.md"]
+    #[ignore = "plan 0149 follow-up: kernel must reserve rank space for multi-member label compartments — see #241"]
     fn flowchart_multi_edge_labeled_same_direction_disjoint_svg() {
         let input = load_flowchart_fixture("multi_edge_labeled.mmd");
         let svg = render_svg_default(&input);
@@ -6033,7 +6033,7 @@ mod plan_0147_task_4_2 {
     /// pairwise-disjointness half requires kernel-level rank-space
     /// reservation; see `findings/plan-0149-completion.md`.
     #[test]
-    #[ignore = "plan 0149 follow-up: kernel must reserve rank space for multi-member label compartments; see findings/plan-0149-completion.md"]
+    #[ignore = "plan 0149 follow-up: kernel must reserve rank space for multi-member label compartments — see #241"]
     fn long_reciprocal_labels_elk_like_e2e() {
         let svg = long_reciprocal_svg();
         let viewbox_failures = svg_viewbox_contains_rects(&svg);

--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -1043,11 +1043,23 @@ pub(crate) fn svg_viewbox_contains_rects(svg: &str) -> Vec<String> {
     let Some((vx, vy, vw, vh)) = parse_svg_viewbox(svg) else {
         return vec!["no viewBox found".to_string()];
     };
+    // mmdflux's SVG wraps node/edge groups in a top-level
+    // `<g transform="translate(tx, ty)">` so geometry centred on zero
+    // still lands inside the positive viewBox. Label-bg `<rect>` elements
+    // are emitted inside that translated group — their raw `x`/`y`
+    // attributes are LOCAL coords, which must be offset by the parent
+    // translate before comparing against the viewBox. Without this
+    // adjustment lane-shifted labels that legitimately sit at local
+    // `x = -10` would falsely "escape" the viewBox even though the
+    // rendered SVG places them well inside it.
+    let (tx, ty) = parse_svg_main_translate(svg).unwrap_or((0.0, 0.0));
     let rects = extract_label_bg_rects(svg);
     let mut failures = Vec::new();
     for (x, y, w, h) in rects {
+        let ax = x + tx;
+        let ay = y + ty;
         let violates =
-            x + TOL < vx || y + TOL < vy || x + w > vx + vw + TOL || y + h > vy + vh + TOL;
+            ax + TOL < vx || ay + TOL < vy || ax + w > vx + vw + TOL || ay + h > vy + vh + TOL;
         if violates {
             failures.push(format!(
                 "rect ({x}, {y}, {w}x{h}) outside viewBox ({vx}, {vy}, {vw}x{vh})"
@@ -5883,8 +5895,16 @@ mod plan_0145_q9_red {
     // or a product tweak to `edge_label_max_width`. Marked `#[ignore]`
     // pending a follow-up plan — see
     // `.gumbo/plans/0147-elk-style-label-routing/findings/task-4.2-tier-a-insufficient.md`.
+    // Plan 0149 out of scope: per-compartment re-wrap does not address
+    // cross-compartment X overlap. The three concurrent regions each
+    // place a reciprocal-pair compartment; intra-compartment overlap is
+    // now resolved (descriptor uses wrapped dims; clamp exempts lane-
+    // shifted labels), but adjacent compartments at close midpoints can
+    // still have label rects whose X extents barely touch. Fixing this
+    // needs either global X packing across compartments or a cross-
+    // compartment rewrap trigger. Tracking as a follow-up.
     #[test]
-    #[ignore = "plan 0147 follow-up: wrapped-label overlap in narrow lanes; see findings/task-4.2-tier-a-insufficient.md"]
+    #[ignore = "plan 0149 follow-up: cross-compartment X overlap; see findings/plan-0149-completion.md"]
     fn state_concurrent_three_flux_layered_labels_disjoint_svg() {
         let svg = concurrent_three_svg_with_engine(EngineAlgorithmId::FLUX_LAYERED);
         let overlap = svg_pairwise_label_rect_overlaps(&svg);
@@ -5895,7 +5915,7 @@ mod plan_0145_q9_red {
     }
 
     #[test]
-    #[ignore = "plan 0147 follow-up: wrapped-label overlap in narrow lanes; see findings/task-4.2-tier-a-insufficient.md"]
+    #[ignore = "plan 0149 follow-up: cross-compartment X overlap; see findings/plan-0149-completion.md"]
     fn state_concurrent_three_mermaid_layered_labels_disjoint_svg() {
         let svg = concurrent_three_svg_with_engine(EngineAlgorithmId::MERMAID_LAYERED);
         let overlap = svg_pairwise_label_rect_overlaps(&svg);
@@ -5906,8 +5926,19 @@ mod plan_0145_q9_red {
     }
 
     // Task 1.6 — Q9 row #6: long reciprocal labels.
+    //
+    // Plan 0149 investigated this as the canary and found the root cause
+    // is structural, not in the scope of a post-routing re-wrap: two
+    // 52-tall wrapped labels cannot fit Y-separated inside a ~130-tall
+    // inter-node gap regardless of label_step. Any attempt to preserve
+    // the lane-shift makes at least one label sit inside a node rect,
+    // which regresses `label_rect_does_not_overlap_node_or_marker`.
+    // The structural fix lives in the layered kernel's dummy-sizing
+    // pass (reserve more rank space when multi-member compartments need
+    // it) — tracked as a follow-up. See
+    // `findings/plan-0149-completion.md`.
     #[test]
-    #[ignore = "plan 0147 follow-up: wrapped-label overlap in narrow lanes; see findings/task-4.2-tier-a-insufficient.md"]
+    #[ignore = "plan 0149 follow-up: kernel must reserve rank space for multi-member label compartments; see findings/plan-0149-completion.md"]
     fn flowchart_long_reciprocal_labels_disjoint_svg() {
         let input = load_flowchart_fixture("long_reciprocal_labels.mmd");
         let svg = render_svg_default(&input);
@@ -5916,8 +5947,13 @@ mod plan_0145_q9_red {
     }
 
     // Task 1.6 — Q9 row #7: multi-edge same-direction.
+    //
+    // Plan 0149 investigation: same underlying constraint as the long-
+    // reciprocal canary. The label pair needs a larger inter-node gap
+    // (or a smaller label height) than descriptor/clamp tuning alone
+    // can deliver. Tracked with the same follow-up.
     #[test]
-    #[ignore = "plan 0147 follow-up: wrapped-label overlap in narrow lanes; see findings/task-4.2-tier-a-insufficient.md"]
+    #[ignore = "plan 0149 follow-up: kernel must reserve rank space for multi-member label compartments; see findings/plan-0149-completion.md"]
     fn flowchart_multi_edge_labeled_same_direction_disjoint_svg() {
         let input = load_flowchart_fixture("multi_edge_labeled.mmd");
         let svg = render_svg_default(&input);
@@ -5936,7 +5972,6 @@ mod plan_0145_q9_red {
 
     // Task 1.6 — Q9 row #9 (concurrent_three, flux): viewBox covers label rects.
     #[test]
-    #[ignore = "plan 0147 follow-up: wrapped-label viewBox overrun; see findings/task-4.2-tier-a-insufficient.md"]
     fn svg_viewbox_covers_all_label_background_rects_concurrent_three() {
         let svg = concurrent_three_svg_with_engine(EngineAlgorithmId::FLUX_LAYERED);
         let failures = svg_viewbox_contains_rects(&svg);
@@ -5945,7 +5980,6 @@ mod plan_0145_q9_red {
 
     // Task 1.6 — Q9 row #9 (multi_edge_labeled): viewBox covers label rects.
     #[test]
-    #[ignore = "plan 0147 follow-up: wrapped-label viewBox overrun; see findings/task-4.2-tier-a-insufficient.md"]
     fn svg_viewbox_covers_all_label_background_rects_multi_edge() {
         let input = load_flowchart_fixture("multi_edge_labeled.mmd");
         let svg = render_svg_default(&input);
@@ -5994,14 +6028,12 @@ mod plan_0147_task_4_2 {
         }
     }
 
-    /// Full ELK-like E2E gate. Tier A alone cannot place 200-px-wide
-    /// wrapped labels into the narrow lane budget of a two-node TD
-    /// fixture — both rects overrun the viewBox and overlap each other.
-    /// Marked `#[ignore]` pending Algorithm C adjusted_path bending or a
-    /// product tweak to `edge_label_max_width`. See
-    /// `.gumbo/plans/0147-elk-style-label-routing/findings/task-4.2-tier-a-insufficient.md`.
+    /// Full ELK-like E2E gate. Plan 0149 resolved the viewBox half (via
+    /// label_geometry-aware bounds + transform-aware helper) but the
+    /// pairwise-disjointness half requires kernel-level rank-space
+    /// reservation; see `findings/plan-0149-completion.md`.
     #[test]
-    #[ignore = "plan 0147 follow-up: wrapped-label overlap + viewBox overrun; see findings/task-4.2-tier-a-insufficient.md"]
+    #[ignore = "plan 0149 follow-up: kernel must reserve rank space for multi-member label compartments; see findings/plan-0149-completion.md"]
     fn long_reciprocal_labels_elk_like_e2e() {
         let svg = long_reciprocal_svg();
         let viewbox_failures = svg_viewbox_contains_rects(&svg);

--- a/src/internal_tests/text_render_pipeline.rs
+++ b/src/internal_tests/text_render_pipeline.rs
@@ -132,6 +132,7 @@ fn smoke_graph_geometry() -> (Graph, GraphGeometry) {
             layout_path_hint: Some(vec![FPoint::new(50.0, 45.0), FPoint::new(50.0, 75.0)]),
             preserve_orthogonal_topology: false,
             label_geometry: None,
+            effective_wrapped_lines: None,
         }],
         subgraphs: HashMap::new(),
         self_edges: vec![],

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -592,6 +592,7 @@ fn build_layout_edges(output: &Output) -> (Vec<LayoutEdge>, Vec<SelfEdgeGeometry
             layout_path_hint: path,
             preserve_orthogonal_topology: false,
             label_geometry: None,
+            effective_wrapped_lines: None,
         });
     }
 

--- a/src/render/graph/mod.rs
+++ b/src/render/graph/mod.rs
@@ -146,6 +146,13 @@ fn geometry_for_routed_svg(diagram: &Graph, routed: &RoutedGraphGeometry) -> Gra
                 layout_path_hint: Some(edge.path.clone()),
                 preserve_orthogonal_topology: edge.preserve_orthogonal_topology,
                 label_geometry: edge.label_geometry,
+                // Plan 0149: forward the lane-aware re-wrap output from
+                // `RoutedEdgeGeometry` onto `LayoutEdge` so the SVG renderer
+                // (which consumes `LayoutEdge` via this downgrade path) can
+                // emit text matching the post-rewrap rect. Without this
+                // forward the routed-SVG path renders stale pre-engine
+                // wrap text inside a narrower rect.
+                effective_wrapped_lines: edge.effective_wrapped_lines.clone(),
             })
             .collect(),
         subgraphs: routed.subgraphs.clone(),
@@ -260,6 +267,7 @@ pub fn render_text_from_geometry(
 ///         layout_path_hint: None,
 ///         preserve_orthogonal_topology: false,
 ///         label_geometry: None,
+///         effective_wrapped_lines: None,
 ///     }],
 ///     subgraphs: HashMap::new(),
 ///     self_edges: vec![],

--- a/src/render/graph/svg/bounds.rs
+++ b/src/render/graph/svg/bounds.rs
@@ -202,6 +202,7 @@ mod tests {
                 layout_path_hint: Some(vec![FPoint::new(50.0, 0.0), FPoint::new(50.0, 100.0)]),
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs: HashMap::new(),
             self_edges: vec![],

--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -196,6 +196,21 @@ pub(super) fn render_edge_labels(
         let Some(point) = position else {
             continue;
         };
+        // Plan 0149 (#237): prefer the post-lane re-wrap output when
+        // the routing pass decided to narrow this edge's label. Falling
+        // back to `edge.wrapped_label_lines` (pre-engine wrap) when no
+        // re-wrap happened keeps non-overflowing edges byte-stable.
+        //
+        // Why not mutate `edge.wrapped_label_lines` upstream? The kernel's
+        // Grid-mode measurement reads that artifact during layout. By the
+        // time re-wrap fires (post-routing) layout is frozen; propagating
+        // the narrower lines back to the shared source would silently
+        // desynchronise Grid-measured heights from Text output. See the
+        // `graph/routing/label_rewrap.rs` module header for the full
+        // design note.
+        let wrap_lines = layout_edge
+            .and_then(|e| e.effective_wrapped_lines.as_deref())
+            .or(edge.wrapped_label_lines.as_deref());
         render_text_centered_with_wrap(
             writer,
             Point {
@@ -203,7 +218,7 @@ pub(super) fn render_edge_labels(
                 y: point.y * scale,
             },
             label,
-            edge.wrapped_label_lines.as_deref(),
+            wrap_lines,
             metrics,
             scale,
             TextRenderStyle {
@@ -402,6 +417,7 @@ mod tests {
                 layout_path_hint: Some(vec![FPoint::new(50.0, 0.0), FPoint::new(50.0, 100.0)]),
                 preserve_orthogonal_topology: false,
                 label_geometry: None,
+                effective_wrapped_lines: None,
             }],
             subgraphs: HashMap::new(),
             self_edges: vec![],

--- a/src/render/graph/text/regression_tests.rs
+++ b/src/render/graph/text/regression_tests.rs
@@ -57,6 +57,7 @@ fn smoke_graph_geometry() -> (Graph, GraphGeometry) {
             layout_path_hint: Some(vec![FPoint::new(50.0, 45.0), FPoint::new(50.0, 75.0)]),
             preserve_orthogonal_topology: false,
             label_geometry: None,
+            effective_wrapped_lines: None,
         }],
         subgraphs: HashMap::new(),
         self_edges: vec![],

--- a/tests/svg-snapshots/flowchart-basis/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-basis/long_reciprocal_labels.svg
@@ -19,9 +19,9 @@
       <rect x="-61.21" y="101.00" width="207.33" height="52.00" fill="white" />
       <text x="42.45" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
       <text x="42.45" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
-      <rect x="-35.27" y="69.00" width="195.46" height="52.00" fill="white" />
-      <text x="62.45" y="83.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
-      <text x="62.45" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
+      <rect x="-35.27" y="72.00" width="195.46" height="52.00" fill="white" />
+      <text x="62.45" y="86.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
+      <text x="62.45" y="110.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/long_reciprocal_labels.svg
@@ -16,9 +16,9 @@
       <text x="42.45" y="219.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-61.21" y="133.00" width="207.33" height="52.00" fill="white" />
-      <text x="42.45" y="147.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="42.45" y="171.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-61.21" y="130.00" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="168.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
       <rect x="-38.05" y="98.39" width="195.46" height="52.00" fill="white" />
       <text x="59.68" y="112.39" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
       <text x="59.68" y="136.39" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>

--- a/tests/svg-snapshots/flowchart-polyline/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-polyline/long_reciprocal_labels.svg
@@ -19,9 +19,9 @@
       <rect x="-61.21" y="101.00" width="207.33" height="52.00" fill="white" />
       <text x="42.45" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
       <text x="42.45" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
-      <rect x="-35.27" y="69.00" width="195.46" height="52.00" fill="white" />
-      <text x="62.45" y="83.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
-      <text x="62.45" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
+      <rect x="-35.27" y="72.00" width="195.46" height="52.00" fill="white" />
+      <text x="62.45" y="86.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
+      <text x="62.45" y="110.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/long_reciprocal_labels.svg
@@ -16,9 +16,9 @@
       <text x="42.45" y="219.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-61.21" y="133.00" width="207.33" height="52.00" fill="white" />
-      <text x="42.45" y="147.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="42.45" y="171.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-61.21" y="130.00" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="168.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
       <rect x="-38.05" y="98.39" width="195.46" height="52.00" fill="white" />
       <text x="59.68" y="112.39" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
       <text x="59.68" y="136.39" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>

--- a/tests/svg-snapshots/flowchart-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-step/long_reciprocal_labels.svg
@@ -16,9 +16,9 @@
       <text x="42.45" y="219.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-61.21" y="133.00" width="207.33" height="52.00" fill="white" />
-      <text x="42.45" y="147.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="42.45" y="171.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-61.21" y="130.00" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="168.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
       <rect x="-38.05" y="98.39" width="195.46" height="52.00" fill="white" />
       <text x="59.68" y="112.39" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
       <text x="59.68" y="136.39" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>

--- a/tests/svg-snapshots/flowchart-straight/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-straight/long_reciprocal_labels.svg
@@ -19,9 +19,9 @@
       <rect x="-73.62" y="99.00" width="207.33" height="52.00" fill="white" />
       <text x="30.05" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
       <text x="30.05" y="137.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
-      <rect x="-35.27" y="69.00" width="195.46" height="52.00" fill="white" />
-      <text x="62.45" y="83.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
-      <text x="62.45" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
+      <rect x="-35.27" y="72.00" width="195.46" height="52.00" fill="white" />
+      <text x="62.45" y="86.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
+      <text x="62.45" y="110.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart/long_reciprocal_labels.svg
@@ -16,9 +16,9 @@
       <text x="42.45" y="219.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-61.21" y="133.00" width="207.33" height="52.00" fill="white" />
-      <text x="42.45" y="147.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="42.45" y="171.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-61.21" y="130.00" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="168.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
       <rect x="-38.05" y="98.39" width="195.46" height="52.00" fill="white" />
       <text x="59.68" y="112.39" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
       <text x="59.68" y="136.39" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>


### PR DESCRIPTION
## Summary

Plan 0149 was intended to close #237 (7 ignored tests on label overlap / viewBox overrun) via a per-compartment re-wrap callback per research 0065 Q3. Implementation surfaced that the 7 tests split into three distinct failure modes and Q3 addresses only one — and even that one is mostly resolved by a correctness fix to `build_label_descriptors` rather than by the re-wrap itself. This PR ships the correctness fix, a test-helper bug fix that makes viewBox checks match browser semantics, and the full `effective_wrapped_lines` + `label_rewrap` plumbing so follow-up work has scaffolding in place.

**Closes 2 of 7 assertions on #237.** Remaining 5 re-ignored with reasons pointing to #241 (kernel rank-axis reservation — 3 tests) and #242 (cross-compartment X-overlap pass — 2 tests).

Full post-mortem: `.gumbo/plans/0149-lane-aware-rewrap/findings/plan-0149-completion.md` (not checked in; plans live at `~/.gumbo`).

## What changed

### Correctness

- **`label_lanes::build_label_descriptors` now uses wrapped dims.** The packer was sizing compartments against single-line unwrapped heights (28 px for a 2-line label) while `populate_label_geometry` used wrapped heights (52 px). `label_step` was 32 for rects that actually drew 52 tall — tracks packed with ~20 px of Y overlap. Now reads `edge.wrapped_label_lines` when present, falls back to single-line only when pre-engine wrap is disabled (dagre-parity mode).
- **`svg_viewbox_contains_rects` respects the top-level `<g transform=\"translate(...)\">`.** Previously compared raw SVG-local rect coords to the root viewBox, so lane-shifted labels that a browser renders well inside bounds got falsely flagged. Now offsets each rect by the parent translate before range-checking — matches what the browser sees.

### Infrastructure (low-impact today, scaffolding for #241 / #242)

- `LabelTrackOutcome` carries `label_step`, `compartment_id`, `midpoint` so post-lane passes can group outcomes and re-derive `label_center` after mutation.
- New `RoutedEdgeGeometry::effective_wrapped_lines` + matching `LayoutEdge::effective_wrapped_lines`, threaded through `apply_routed_edge_paths` (Visual SVG downgrade) and `geometry_for_routed_svg` (render-time downgrade). SVG `labels.rs` prefers it over the pre-engine wrap; Grid-mode measurement never sees it, so Text snapshots stay byte-stable.
- New `graph::routing::label_rewrap` module with a bounded fixed-point (≤3 iterations) that narrows axis-overflowing labels and recomputes `label_step` + `label_center` per compartment. With the descriptor fix in place the overflow check rarely fires on the current corpus; module is ready for the follow-up work.

### Snapshot churn

`tests/svg-snapshots/flowchart*/long_reciprocal_labels.svg` only (7 routing variants, 3-px Y shift on the forward label — a direct consequence of the descriptor fix producing the correct larger `label_step`). All other SVG, Text, Class, and Sequence snapshots byte-identical.

## Why not all 7 tests

Plan 0149 investigation found the 7 ignored tests split into 3 failure modes:

1. **Stale lane budget (FIXED):** the 2 viewBox containment tests. Descriptor fix + transform-aware helper — both cheap correctness wins.
2. **Structural — gap-insufficient compartments (deferred to #241):** `long_reciprocal_labels`, `multi_edge_labeled`, `long_reciprocal_labels_elk_like_e2e`. The inter-node rank gap is structurally too narrow to hold two lane-separated wrapped labels. Re-wrapping makes it worse (narrower labels are taller). Fix: compartment-aware rank-sep reservation in the layered kernel using existing `rank_sep_overrides` + label dummy primitives.
3. **Cross-compartment X overlap (deferred to #242):** the 2 `state_concurrent_three` tests. Rects in different compartments bleed X ranges at adjacent midpoints. Per-compartment re-wrap can't see across boundaries.

Research 0065 explicitly rejected ELK's compartment-widening pattern on the grounds it \"doesn't fit mmdflux's text-artifact wrap model\" — that reasoning conflated the cross-axis wrap (text-artifact model) with the rank-axis space problem (what ELK actually addresses). Memory note added to prevent the same misread on future label-overlap work.

## Test plan

- [x] `just fix` clean (fmt + clippy pass)
- [x] `just architecture-check` clean
- [x] `just test` — 2537 pass / 5 skipped (the 5 `#[ignore]`d tests pointing to #241 + #242)
- [x] SVG snapshots regenerated for `long_reciprocal_labels` (7 routing variants)
- [x] No Text / Class / Sequence snapshot churn
- [x] `label_rewrap` module has 6 unit tests covering noop paths, shrink-and-record, track/compartment preservation, bounded fixed-point, and idempotence

## Closes

- Partial on #237 — 2 of 7 assertions
- Opens #241 for the remaining 3 structural cases
- Opens #242 for the remaining 2 cross-compartment cases