### PR TITLE
fix: coordinate parallel-label clusters with shared anchor and symmetric offsets

### DIFF
--- a/src/engines/graph/algorithms/layered/float_layout.rs
+++ b/src/engines/graph/algorithms/layered/float_layout.rs
@@ -522,6 +522,7 @@ mod tests {
             padding: (4.0, 2.0),
             side: EdgeLabelSide::Above,
             track: 0,
+            compartment_size: 1,
         };
 
         let mut geometry = GraphGeometry {

--- a/src/graph/geometry.rs
+++ b/src/graph/geometry.rs
@@ -190,6 +190,15 @@ pub struct EdgeLabelGeometry {
     /// Signed lane-assignment track. `0` means no lane displacement was
     /// applied; `±1, ±2, ...` encode lane rank (sign encodes direction).
     pub track: i32,
+    /// Number of members in the lane-assignment compartment this edge was
+    /// placed in. `1` means singleton (no compartment coordination); `≥2`
+    /// means the label was placed as part of a multi-edge group and
+    /// consumers must trust `center` / `rect` exactly — they were chosen
+    /// relative to the compartment's shared anchor and may sit off the
+    /// edge's own arc-length midpoint by more than a revalidation
+    /// tolerance. Pre-lane placeholders use the `Default` value of `1` so
+    /// singleton behaviour is preserved when no lane pass has run.
+    pub compartment_size: usize,
 }
 
 impl Default for EdgeLabelGeometry {
@@ -200,6 +209,7 @@ impl Default for EdgeLabelGeometry {
             padding: (0.0, 0.0),
             side: EdgeLabelSide::Center,
             track: 0,
+            compartment_size: 1,
         }
     }
 }
@@ -423,6 +433,7 @@ mod tests {
             padding: (4.0, 2.0),
             side: EdgeLabelSide::Above,
             track: 1,
+            compartment_size: 1,
         };
         assert_eq!(g.center.x, 10.0);
         assert_eq!(g.center.y, 20.0);

--- a/src/graph/routing/label_clamp.rs
+++ b/src/graph/routing/label_clamp.rs
@@ -286,6 +286,7 @@ mod tests {
                 padding: (4.0, 2.0),
                 side: EdgeLabelSide::Above,
                 track: 0,
+                compartment_size: 1,
             }),
             effective_wrapped_lines: None,
         };

--- a/src/graph/routing/label_gap.rs
+++ b/src/graph/routing/label_gap.rs
@@ -221,6 +221,7 @@ mod tests {
                 padding: (4.0, 2.0),
                 side: EdgeLabelSide::Above,
                 track: 0,
+                compartment_size: 1,
             }),
             effective_wrapped_lines: None,
         };

--- a/src/graph/routing/label_lanes.rs
+++ b/src/graph/routing/label_lanes.rs
@@ -178,12 +178,24 @@ pub(super) struct LabelTrackOutcome {
     pub label_rect: FRect,
     pub track: i32,
     pub adjusted_path: Vec<FPoint>,
-    /// Number of members in the compartment this edge belongs to.
-    /// `1` means singleton (track 0 with nothing to compare against);
-    /// `>= 2` means the lane pass picked a centered position the
-    /// compartment members all reference, so the wire-up should adopt
-    /// the descriptor midpoint even when track is 0.
+    /// Number of members in the **axis-conflict sub-cluster** this edge
+    /// belongs to. `1` means singleton sub-cluster (nothing axis-conflicts
+    /// with it, so the lane pass picked track 0 with no displacement);
+    /// `>= 2` means the lane pass placed it as part of a coordinated
+    /// stack. Forwarded onto `EdgeLabelGeometry.compartment_size` so the
+    /// SVG renderer can distinguish singleton track-0 (revalidate
+    /// against the edge path) from coordinated multi-member track-0
+    /// (trust the shared-anchor placement).
     pub compartment_size: usize,
+    /// Number of members in the **cross-band compartment** this edge
+    /// belongs to, before the axis-conflict split. Used by the wire-up
+    /// in `routing::stage` to decide whether to adopt the lane pass's
+    /// `label_center` (which for singleton sub-clusters equals the edge's
+    /// arc-length midpoint) or fall through to the engine's
+    /// `label_position`. Pre-split code conflated the two sizes; keeping
+    /// the cross-band size preserves wire-up semantics for singleton
+    /// sub-clusters that share a compartment with other labelled edges.
+    pub full_compartment_size: usize,
     /// Per-compartment lane step (max axis-projected extent + `LANE_GAP`,
     /// floored to `MIN_LABEL_LANE_STEP`). Shared by every member of the
     /// compartment — identical across all outcomes with the same
@@ -195,16 +207,37 @@ pub(super) struct LabelTrackOutcome {
     /// grows the axis-projected extent (TD re-wrap → more lines → taller
     /// label → larger `label_step`).
     pub label_step: f64,
+    /// Midpoint of the occupied track range for this compartment,
+    /// subtracted from `track` before scaling by `label_step` so the
+    /// sub-cluster sits symmetric around the shared anchor. Identical
+    /// across all outcomes with the same `compartment_id`.
+    ///
+    /// For a 2-member same-direction sub-cluster with tracks `[0, +1]`
+    /// this is `0.5`, producing centered tracks `[-0.5, +0.5]`. For a
+    /// reciprocal `[0, -1]` it is `-0.5`, producing `[+0.5, -0.5]`.
+    /// `[0, +1, -1]` stays `0.0` / `[0, +1, -1]` (unchanged). Singleton
+    /// sub-clusters always store `0.0`.
+    ///
+    /// `label_rewrap::apply_new_label_steps` must use this when
+    /// recomputing `label_center` after `label_step` mutates so the
+    /// re-wrap pass preserves the symmetrized layout.
+    pub track_center: f64,
     /// Dense per-run compartment key assigned in compartment-iteration
     /// order. Edges that share an ID share a compartment, which means they
     /// share `label_step` and must be recentered together when the fixed-
     /// point pass recomputes that budget. Not stable across renders — do
     /// not serialize or compare across invocations.
     pub compartment_id: usize,
-    /// Arc-length midpoint of the original (pre-lane-shift) edge path, as
-    /// computed by `build_label_descriptors`. Kept so that
+    /// Pre-lane-shift anchor used by `label_rewrap` to recompute
     /// `label_center = midpoint + track_vector(direction) * label_step`
-    /// can be recomputed from scratch after `label_step` mutates. Re-
+    /// from scratch after `label_step` mutates.
+    ///
+    /// For singleton compartments this is the edge path's
+    /// `arc_length_midpoint` as built by `build_label_descriptors`. For
+    /// multi-member compartments `recenter_compartment_to_shared_anchor`
+    /// overwrites the primary-axis coordinate with the mean across members
+    /// so all members share a common anchor; the cross-axis coordinate
+    /// stays per-edge. Re-
     /// centering off the previous `label_center` accumulates floating-
     /// point error across iterations, and the rewrap fixed-point can run
     /// up to 3 rounds.
@@ -232,52 +265,170 @@ pub(super) fn assign_label_tracks(
     let compartments = group_label_compartments(descriptors);
     let mut outcomes: HashMap<usize, LabelTrackOutcome> = HashMap::new();
 
-    // Dense compartment counter: assigned in iteration order and only
-    // used as a grouping key within this `assign_label_tracks` call. Not
-    // stable across renders. Incremented by `enumerate()` so every
-    // member of the same compartment gets the same id.
-    for (compartment_id, compartment) in compartments.into_iter().enumerate() {
-        let tracks = pack_signed_tracks(&compartment);
+    // Dense id counter assigned in iteration order. Each axis-conflict
+    // sub-cluster within a compartment gets its own id so `label_step` is
+    // sized per sub-cluster and the rewrap fixed-point groups the right
+    // members together. Not stable across renders.
+    let mut next_id: usize = 0;
+    for compartment in compartments {
+        let full_compartment_size = compartment.members.len();
+        for mut subcluster in split_into_axis_conflict_subclusters(compartment.members) {
+            let compartment_id = next_id;
+            next_id += 1;
 
-        // Per-compartment LABEL_LANE_STEP from the max axis-band extent.
-        // Labels stack along the primary axis (Y for TD/BU, X for LR/RL),
-        // so the step needs to clear the axis-projected dimension of the
-        // largest label (height for TD, width for LR) plus a small gap.
-        let max_axis = compartment
-            .members
-            .iter()
-            .map(|m| m.axis_max - m.axis_min)
-            .fold(0.0_f64, f64::max);
-        let label_step = (max_axis + LANE_GAP).max(MIN_LABEL_LANE_STEP);
-        let path_step = label_step * PATH_LANE_RATIO;
+            recenter_members_to_shared_anchor(&mut subcluster, direction);
+            let tracks = pack_signed_tracks_for_members(&subcluster);
 
-        let compartment_size = compartment.members.len();
-        for desc in &compartment.members {
-            let track = tracks[&desc.edge_index];
-            let label_offset = track as f64 * label_step;
-            let path_offset = track as f64 * path_step;
-            let (new_center, new_rect) = shift_label(desc, label_offset, direction);
-            let new_path = paths
-                .get(&desc.edge_index)
-                .map(|p| shift_middle_segment(p, path_offset, direction))
-                .unwrap_or_default();
-            outcomes.insert(
-                desc.edge_index,
-                LabelTrackOutcome {
-                    label_center: new_center,
-                    label_rect: new_rect,
-                    track,
-                    adjusted_path: new_path,
-                    compartment_size,
-                    label_step,
-                    compartment_id,
-                    midpoint: desc.midpoint,
-                },
-            );
+            // Per-sub-cluster LABEL_LANE_STEP from the max axis-band
+            // extent. Labels stack along the primary axis (Y for TD/BU,
+            // X for LR/RL), so the step needs to clear the axis-projected
+            // dimension of the largest label plus a small gap.
+            let max_axis = subcluster
+                .iter()
+                .map(|m| m.axis_max - m.axis_min)
+                .fold(0.0_f64, f64::max);
+            let label_step = (max_axis + LANE_GAP).max(MIN_LABEL_LANE_STEP);
+            let path_step = label_step * PATH_LANE_RATIO;
+
+            let compartment_size = subcluster.len();
+            // Symmetrize offsets around the midpoint of the occupied
+            // track range so the sub-cluster sits symmetric around the
+            // shared anchor. Without this, a 2-member same-direction
+            // sub-cluster packs to tracks [0, +1] — extent `label_step`
+            // above the anchor, zero below — and `label_clamp` can yank
+            // the +1 member back into the available gap, re-overlapping
+            // the other member. With the midpoint subtraction,
+            // [0, +1] becomes [-0.5, +0.5] and the sub-cluster stays
+            // centred. [-1, 0, +1] stays [-1, 0, +1] (unchanged);
+            // reciprocal [0, -1] becomes [+0.5, -0.5].
+            let track_center = if compartment_size > 1 {
+                let (min_track, max_track) = tracks
+                    .values()
+                    .fold((i32::MAX, i32::MIN), |(lo, hi), &t| (lo.min(t), hi.max(t)));
+                (min_track as f64 + max_track as f64) / 2.0
+            } else {
+                0.0
+            };
+            for desc in &subcluster {
+                let track = tracks[&desc.edge_index];
+                let centered_track = track as f64 - track_center;
+                let label_offset = centered_track * label_step;
+                let path_offset = centered_track * path_step;
+                let (new_center, new_rect) = shift_label(desc, label_offset, direction);
+                let new_path = paths
+                    .get(&desc.edge_index)
+                    .map(|p| shift_middle_segment(p, path_offset, direction))
+                    .unwrap_or_default();
+                outcomes.insert(
+                    desc.edge_index,
+                    LabelTrackOutcome {
+                        label_center: new_center,
+                        label_rect: new_rect,
+                        track,
+                        adjusted_path: new_path,
+                        compartment_size,
+                        full_compartment_size,
+                        label_step,
+                        track_center,
+                        compartment_id,
+                        midpoint: desc.midpoint,
+                    },
+                );
+            }
         }
     }
 
     outcomes
+}
+
+/// Split a compartment into axis-conflict sub-clusters via a sort-then-
+/// merge sweep along the primary axis. Two members conflict when their
+/// axis bands overlap with `LANE_GAP` slack; pack_signed_tracks would
+/// push them onto different tracks. Members that don't axis-conflict
+/// with anyone remain singletons even when the compartment has multiple
+/// members (their labels sit along the same cross-band but at distinct
+/// axis positions, so no lane coordination is needed).
+fn split_into_axis_conflict_subclusters(
+    mut members: Vec<LabelDescriptor>,
+) -> Vec<Vec<LabelDescriptor>> {
+    members.sort_by(|a, b| {
+        a.axis_min
+            .partial_cmp(&b.axis_min)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut clusters: Vec<Vec<LabelDescriptor>> = Vec::new();
+    let mut current: Vec<LabelDescriptor> = Vec::new();
+    let mut current_max: f64 = f64::NEG_INFINITY;
+    for desc in members {
+        if current.is_empty() || desc.axis_min <= current_max + LANE_GAP {
+            current_max = current_max.max(desc.axis_max);
+            current.push(desc);
+        } else {
+            clusters.push(std::mem::take(&mut current));
+            current_max = desc.axis_max;
+            current.push(desc);
+        }
+    }
+    if !current.is_empty() {
+        clusters.push(current);
+    }
+    clusters
+}
+
+fn pack_signed_tracks_for_members(members: &[LabelDescriptor]) -> HashMap<usize, i32> {
+    pack_signed_tracks(&LabelCompartment {
+        members: members.to_vec(),
+    })
+}
+
+fn recenter_members_to_shared_anchor(members: &mut [LabelDescriptor], direction: Direction) {
+    if members.len() < 2 {
+        return;
+    }
+    let n = members.len() as f64;
+    let anchor = members
+        .iter()
+        .map(|m| match direction {
+            Direction::TopDown | Direction::BottomTop => m.midpoint.y,
+            Direction::LeftRight | Direction::RightLeft => m.midpoint.x,
+        })
+        .sum::<f64>()
+        / n;
+
+    for member in members.iter_mut() {
+        let delta = anchor
+            - match direction {
+                Direction::TopDown | Direction::BottomTop => member.midpoint.y,
+                Direction::LeftRight | Direction::RightLeft => member.midpoint.x,
+            };
+        if delta == 0.0 {
+            continue;
+        }
+        match direction {
+            Direction::TopDown | Direction::BottomTop => {
+                member.midpoint = FPoint::new(member.midpoint.x, anchor);
+                member.label_rect = FRect::new(
+                    member.label_rect.x,
+                    member.label_rect.y + delta,
+                    member.label_rect.width,
+                    member.label_rect.height,
+                );
+                member.axis_min += delta;
+                member.axis_max += delta;
+            }
+            Direction::LeftRight | Direction::RightLeft => {
+                member.midpoint = FPoint::new(anchor, member.midpoint.y);
+                member.label_rect = FRect::new(
+                    member.label_rect.x + delta,
+                    member.label_rect.y,
+                    member.label_rect.width,
+                    member.label_rect.height,
+                );
+                member.axis_min += delta;
+                member.axis_max += delta;
+            }
+        }
+    }
 }
 
 /// Build label descriptors from diagram geometry and routed edge paths.
@@ -797,6 +948,161 @@ mod tests {
             has_x_shift,
             "interior should shift on cross axis (x for TD)"
         );
+    }
+
+    fn make_descriptor_midpoint(
+        edge_index: usize,
+        midpoint: FPoint,
+        label_w: f64,
+        label_h: f64,
+        sign: i32,
+        direction: Direction,
+    ) -> LabelDescriptor {
+        let (axis_dim, cross_dim, axis_center, cross_center) = match direction {
+            Direction::TopDown | Direction::BottomTop => (label_h, label_w, midpoint.y, midpoint.x),
+            Direction::LeftRight | Direction::RightLeft => {
+                (label_w, label_h, midpoint.x, midpoint.y)
+            }
+        };
+        LabelDescriptor {
+            edge_index,
+            scope_parent: None,
+            axis_min: axis_center - axis_dim / 2.0,
+            axis_max: axis_center + axis_dim / 2.0,
+            cross_min: cross_center - cross_dim / 2.0,
+            cross_max: cross_center + cross_dim / 2.0,
+            direction_sign: sign,
+            midpoint,
+            label_rect: FRect::new(
+                midpoint.x - label_w / 2.0,
+                midpoint.y - label_h / 2.0,
+                label_w,
+                label_h,
+            ),
+        }
+    }
+
+    #[test]
+    fn recenter_members_to_shared_anchor_is_noop_for_singleton() {
+        let d = make_descriptor_midpoint(
+            0,
+            FPoint::new(50.0, 100.0),
+            40.0,
+            20.0,
+            1,
+            Direction::TopDown,
+        );
+        let mut members = vec![d.clone()];
+        recenter_members_to_shared_anchor(&mut members, Direction::TopDown);
+        assert_eq!(members[0].midpoint, d.midpoint);
+        assert_eq!(members[0].axis_min, d.axis_min);
+        assert_eq!(members[0].axis_max, d.axis_max);
+    }
+
+    #[test]
+    fn recenter_members_to_shared_anchor_td_shifts_y_only() {
+        let a = make_descriptor_midpoint(
+            0,
+            FPoint::new(20.0, 100.0),
+            40.0,
+            28.0,
+            1,
+            Direction::TopDown,
+        );
+        let b = make_descriptor_midpoint(
+            1,
+            FPoint::new(80.0, 110.0),
+            40.0,
+            28.0,
+            1,
+            Direction::TopDown,
+        );
+        let mut members = vec![a.clone(), b.clone()];
+        recenter_members_to_shared_anchor(&mut members, Direction::TopDown);
+        assert_eq!(members[0].midpoint.y, 105.0, "anchor = mean(100, 110)");
+        assert_eq!(members[1].midpoint.y, 105.0);
+        assert_eq!(members[0].midpoint.x, 20.0, "x preserved per-edge");
+        assert_eq!(members[1].midpoint.x, 80.0, "x preserved per-edge");
+        // axis bands shift by the y delta
+        assert_eq!(members[0].axis_min, a.axis_min + 5.0);
+        assert_eq!(members[0].axis_max, a.axis_max + 5.0);
+        assert_eq!(members[1].axis_min, b.axis_min - 5.0);
+        assert_eq!(members[1].axis_max, b.axis_max - 5.0);
+    }
+
+    #[test]
+    fn recenter_members_to_shared_anchor_lr_shifts_x_only() {
+        let a = make_descriptor_midpoint(
+            0,
+            FPoint::new(100.0, 20.0),
+            28.0,
+            40.0,
+            1,
+            Direction::LeftRight,
+        );
+        let b = make_descriptor_midpoint(
+            1,
+            FPoint::new(110.0, 80.0),
+            28.0,
+            40.0,
+            1,
+            Direction::LeftRight,
+        );
+        let mut members = vec![a, b];
+        recenter_members_to_shared_anchor(&mut members, Direction::LeftRight);
+        assert_eq!(members[0].midpoint.x, 105.0);
+        assert_eq!(members[1].midpoint.x, 105.0);
+        assert_eq!(members[0].midpoint.y, 20.0);
+        assert_eq!(members[1].midpoint.y, 80.0);
+    }
+
+    #[test]
+    fn split_into_axis_conflict_subclusters_isolates_non_conflicting_members() {
+        // Two members in same compartment by cross-band but with Y bands
+        // 100 px apart — no axis conflict. Each becomes its own cluster.
+        let a = make_descriptor_midpoint(
+            0,
+            FPoint::new(50.0, 100.0),
+            40.0,
+            28.0,
+            1,
+            Direction::TopDown,
+        );
+        let b = make_descriptor_midpoint(
+            1,
+            FPoint::new(60.0, 250.0),
+            40.0,
+            28.0,
+            1,
+            Direction::TopDown,
+        );
+        let clusters = split_into_axis_conflict_subclusters(vec![a, b]);
+        assert_eq!(clusters.len(), 2);
+        assert_eq!(clusters[0].len(), 1);
+        assert_eq!(clusters[1].len(), 1);
+    }
+
+    #[test]
+    fn split_into_axis_conflict_subclusters_merges_overlapping_axis_bands() {
+        let a = make_descriptor_midpoint(
+            0,
+            FPoint::new(50.0, 100.0),
+            40.0,
+            28.0,
+            1,
+            Direction::TopDown,
+        );
+        let b = make_descriptor_midpoint(
+            1,
+            FPoint::new(60.0, 110.0),
+            40.0,
+            28.0,
+            1,
+            Direction::TopDown,
+        );
+        let clusters = split_into_axis_conflict_subclusters(vec![a, b]);
+        assert_eq!(clusters.len(), 1);
+        assert_eq!(clusters[0].len(), 2);
     }
 
     #[test]

--- a/src/graph/routing/label_rewrap.rs
+++ b/src/graph/routing/label_rewrap.rs
@@ -295,9 +295,20 @@ fn apply_new_label_steps(
         outcome.label_step = new_step;
 
         // track_vector returns the unit vector along the axis-stacking
-        // direction. label_center = midpoint + track_vector * track *
-        // label_step.
-        let new_center = compute_label_center(outcome.midpoint, outcome.track, new_step, direction);
+        // direction. label_center = midpoint + track_vector *
+        // (track - track_center) * label_step. The `track_center`
+        // subtraction mirrors the symmetrization that
+        // `label_lanes::assign_label_tracks` applies — without it the
+        // rewrap pass would undo the shared-anchor placement for
+        // multi-member clusters whose track range is asymmetric around
+        // zero (e.g. 2-member same-direction `[0, +1]`).
+        let new_center = compute_label_center(
+            outcome.midpoint,
+            outcome.track,
+            outcome.track_center,
+            new_step,
+            direction,
+        );
         outcome.label_center = new_center;
 
         if let Some(geom) = edge.label_geometry.as_mut() {
@@ -325,17 +336,19 @@ fn axis_projected_dim(width: f64, height: f64, direction: Direction) -> f64 {
     }
 }
 
-/// Compute a member's `label_center` from its midpoint, track, step, and
-/// flow direction. Mirrors `label_lanes::shift_label` — keep the two in
-/// sync if either changes. Extracting a separate helper here avoids
-/// coupling this module to the crate-private internals of `label_lanes`.
+/// Compute a member's `label_center` from its midpoint, track,
+/// track_center, step, and flow direction. Mirrors the offset math in
+/// `label_lanes::assign_label_tracks` — keep the two in sync if either
+/// changes. Extracting a separate helper here avoids coupling this
+/// module to the crate-private internals of `label_lanes`.
 fn compute_label_center(
     midpoint: FPoint,
     track: i32,
+    track_center: f64,
     label_step: f64,
     direction: Direction,
 ) -> FPoint {
-    let offset = track as f64 * label_step;
+    let offset = (track as f64 - track_center) * label_step;
     match direction {
         Direction::TopDown | Direction::BottomTop => FPoint::new(midpoint.x, midpoint.y + offset),
         Direction::LeftRight | Direction::RightLeft => FPoint::new(midpoint.x + offset, midpoint.y),
@@ -403,6 +416,7 @@ mod tests {
                 padding: (4.0, 2.0),
                 side: EdgeLabelSide::Center,
                 track: 0,
+                compartment_size: 1,
                 // Note: the rect passed in assumes padding already included.
             }),
             effective_wrapped_lines: None,
@@ -417,13 +431,35 @@ mod tests {
         midpoint: FPoint,
         rect: FRect,
     ) -> LabelTrackOutcome {
+        outcome_with_track_center(
+            track,
+            0.0,
+            label_step,
+            compartment_id,
+            compartment_size,
+            midpoint,
+            rect,
+        )
+    }
+
+    fn outcome_with_track_center(
+        track: i32,
+        track_center: f64,
+        label_step: f64,
+        compartment_id: usize,
+        compartment_size: usize,
+        midpoint: FPoint,
+        rect: FRect,
+    ) -> LabelTrackOutcome {
         LabelTrackOutcome {
             label_center: FPoint::new(rect.x + rect.width / 2.0, rect.y + rect.height / 2.0),
             label_rect: rect,
             track,
             adjusted_path: vec![],
             compartment_size,
+            full_compartment_size: compartment_size,
             label_step,
+            track_center,
             compartment_id,
             midpoint,
         }
@@ -578,6 +614,73 @@ mod tests {
         );
         // Both members see the same fresh step.
         assert_eq!(outcomes[&0].label_step, outcomes[&1].label_step);
+    }
+
+    #[test]
+    fn rewrap_preserves_track_center_symmetry_for_asymmetric_tracks() {
+        // A 2-member same-direction sub-cluster packs to tracks [0, +1]
+        // with track_center = 0.5, so the symmetrized offsets are
+        // [-0.5, +0.5] * label_step. When re-wrap fires and
+        // `apply_new_label_steps` recomputes centers, it must preserve
+        // that symmetric layout — otherwise the track-0 member collapses
+        // back to the anchor and the track-+1 member overshoots, which
+        // is exactly the [0, +1] asymmetry that `label_clamp` couldn't
+        // accommodate and that motivated the symmetrization fix.
+        let label = "this is a deliberately long label";
+        let g = graph_with_labels(&[("A", "B", label), ("A", "B", label)]);
+        let rect = FRect::new(0.0, 0.0, 200.0, 60.0);
+        let mut edges = vec![
+            routed_edge_with_label(0, "A", "B", rect),
+            routed_edge_with_label(1, "A", "B", rect),
+        ];
+        // Same-direction pair: tracks [0, +1], shared anchor at y=30,
+        // initial label_step=32. track_center=0.5 so centered tracks
+        // become [-0.5, +0.5].
+        let anchor = FPoint::new(100.0, 30.0);
+        let initial_step = 32.0;
+        let track_center = 0.5;
+        let mut outcomes = HashMap::new();
+        outcomes.insert(
+            0,
+            outcome_with_track_center(0, track_center, initial_step, 0, 2, anchor, rect),
+        );
+        outcomes.insert(
+            1,
+            outcome_with_track_center(1, track_center, initial_step, 0, 2, anchor, rect),
+        );
+        let metrics = default_proportional_text_metrics();
+
+        re_wrap_labels_for_lane_fit(&g, &mut edges, &mut outcomes, &metrics, Direction::TopDown);
+
+        // After re-wrap, label_step changed but the two members must
+        // remain equidistant from the anchor on opposite sides.
+        let step_after = outcomes[&0].label_step;
+        let c0 = outcomes[&0].label_center;
+        let c1 = outcomes[&1].label_center;
+        let expected_c0_y = anchor.y + (0.0 - track_center) * step_after;
+        let expected_c1_y = anchor.y + (1.0 - track_center) * step_after;
+        assert!(
+            (c0.y - expected_c0_y).abs() < 1e-6,
+            "track-0 center drifted: got {}, expected {}",
+            c0.y,
+            expected_c0_y
+        );
+        assert!(
+            (c1.y - expected_c1_y).abs() < 1e-6,
+            "track-+1 center drifted: got {}, expected {}",
+            c1.y,
+            expected_c1_y
+        );
+        // The two centers must still be exactly one step apart and
+        // symmetric about the anchor.
+        assert!(
+            ((c1.y - c0.y) - step_after).abs() < 1e-6,
+            "centers must be exactly one label_step apart after rewrap"
+        );
+        assert!(
+            ((c0.y + c1.y) / 2.0 - anchor.y).abs() < 1e-6,
+            "midpoint of centers must equal the compartment anchor"
+        );
     }
 
     #[test]

--- a/src/graph/routing/stage.rs
+++ b/src/graph/routing/stage.rs
@@ -199,18 +199,24 @@ pub fn route_graph_geometry(
         let Some(outcome) = lane_outcomes.get(&routed_edge.index) else {
             continue;
         };
-        // Skip the wire-up for singleton compartments on track 0 — the
-        // lane pass had nothing to displace and nothing to coordinate
-        // with, so preserve whatever populate_label_geometry placed for
-        // the edge (the orchestrator's arc-midpoint can differ from the
-        // engine's label_position by a few pixels for unrelated edges,
-        // and we don't want that churn). For multi-member compartments
-        // (track 0 or otherwise), apply the outcome unconditionally so
-        // every compartment member shares a consistent reference point —
-        // otherwise a track-0 forward at the engine's anchor and a
-        // track±1 reverse at the descriptor midpoint can end up only a
-        // few pixels apart when the engine pre-shifted the forward.
-        if outcome.compartment_size == 1 {
+        // Skip the wire-up for singleton cross-band compartments on
+        // track 0 — the lane pass had nothing to displace and nothing to
+        // coordinate with, so preserve whatever populate_label_geometry
+        // placed for the edge (the orchestrator's arc-midpoint can
+        // differ from the engine's label_position by a few pixels for
+        // unrelated edges, and we don't want that churn). For any
+        // member of a multi-member cross-band compartment (track 0 or
+        // otherwise, axis-conflicting or not), apply the outcome
+        // unconditionally so every compartment member shares a
+        // consistent reference point — otherwise a track-0 forward at
+        // the engine's anchor and a track±1 reverse at the descriptor
+        // midpoint can end up only a few pixels apart when the engine
+        // pre-shifted the forward. Keyed off `full_compartment_size`
+        // (not `compartment_size`) so singleton axis-conflict
+        // sub-clusters inside a multi-labelled cross-band compartment
+        // still get the wire-up — their arc-midpoint is the consistent
+        // reference, not the engine anchor.
+        if outcome.full_compartment_size == 1 {
             continue;
         }
         // Preserve padding/side from populate_label_geometry's output so the
@@ -232,6 +238,7 @@ pub fn route_graph_geometry(
             padding: existing_padding,
             side: existing_side,
             track: outcome.track,
+            compartment_size: outcome.compartment_size,
         });
         // Note: Algorithm C produces an `adjusted_path` that bows the path
         // around lane-displaced labels. We deliberately do NOT apply it
@@ -932,6 +939,7 @@ fn populate_label_geometry(
             padding: (metrics.label_padding_x, metrics.label_padding_y),
             side,
             track: 0,
+            compartment_size: 1,
         });
     }
 }

--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -5782,6 +5782,7 @@ fn render_svg_from_routed_geometry_preserves_label_geometry_rect() {
         padding: base.padding,
         side: base.side,
         track: 1,
+        compartment_size: base.compartment_size,
     });
     // Leave `label_position` at its pre-shift location — the two sources now
     // disagree, and the fix must forward `label_geometry`, not fall back.
@@ -5991,7 +5992,6 @@ mod plan_0145_q9_red {
     // is needed to close this fully. See
     // findings/phase-5-multi-edge-labeled-residual-overlap.md.
     #[test]
-    #[ignore = "plan 0150 residual: 2-px overlap after kernel reservation; needs routing-side compartment-shared midpoint — see #245 and findings/phase-5-multi-edge-labeled-residual-overlap.md"]
     fn flowchart_multi_edge_labeled_same_direction_disjoint_svg() {
         let input = load_flowchart_fixture("multi_edge_labeled.mmd");
         let svg = render_svg_default(&input);

--- a/src/render/graph/svg/bounds.rs
+++ b/src/render/graph/svg/bounds.rs
@@ -232,6 +232,7 @@ mod tests {
             padding: (4.0, 2.0),
             side: EdgeLabelSide::Above,
             track: 0,
+            compartment_size: 1,
         });
 
         let bounds = compute_svg_bounds(&diagram, &geom, &metrics, &empty_map, &empty_map);

--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -159,17 +159,19 @@ pub(super) fn render_edge_labels(
         // once label_lanes populates label_geometry for all edges.
         let layout_edge = geom.edges.iter().find(|e| e.index == edge_idx);
         let label_geom = layout_edge.and_then(|e| e.label_geometry.as_ref());
-        // The lane-assignment pass writes `label_geometry` with `track != 0`
-        // for labels intentionally displaced from the path (multi-member
-        // compartment shifts). For those, trust the center directly —
-        // revalidating would snap the lane-shifted label back to the path
-        // midpoint and undo the shift. For `track == 0` (singleton
-        // compartments where the lane pass made no change), the center is
-        // just the engine-supplied label_position, which can be off-path
-        // due to upstream side-adjustment passes; keep the revalidation
-        // fallback so those labels render attached to their edge.
+        // The lane-assignment pass writes `label_geometry` with either
+        // `track != 0` (numerical displacement) or `compartment_size > 1`
+        // (coordinated placement inside a multi-edge group, even when the
+        // member happens to sit on track 0 relative to the shared anchor).
+        // For either signal, trust the center directly — revalidating
+        // would snap the coordinated label back to this edge's own path
+        // midpoint and undo the shared-anchor placement. For singleton
+        // track-0 edges (`compartment_size == 1`), the center is just the
+        // engine-supplied label_position, which can be off-path due to
+        // upstream side-adjustment passes; keep the revalidation fallback
+        // so those labels render attached to their edge.
         let lane_shifted_center = label_geom
-            .filter(|g| g.track != 0 && use_precomputed)
+            .filter(|g| (g.track != 0 || g.compartment_size > 1) && use_precomputed)
             .map(|g| g.center);
         let position = if let Some(center) = lane_shifted_center {
             Some(center)
@@ -444,6 +446,7 @@ mod tests {
             padding: (4.0, 2.0),
             side: EdgeLabelSide::Above,
             track: 0,
+            compartment_size: 1,
         });
 
         // resolve_edge_label_center should prefer label_geometry.center.

--- a/tests/svg-snapshots/flowchart-basis/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-basis/backward_label_asymmetric_markers.svg
@@ -19,10 +19,10 @@
       <text x="94.24" y="211.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Entity</text>
     </g>
     <g class="edgeLabels">
-      <rect x="40.31" y="109.00" width="107.85" height="28.00" fill="white" />
-      <text x="94.24" y="123.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
-      <rect x="61.24" y="77.00" width="106.00" height="28.00" fill="white" />
-      <text x="114.24" y="91.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
+      <rect x="40.31" y="125.00" width="107.85" height="28.00" fill="white" />
+      <text x="94.24" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
+      <rect x="61.24" y="93.00" width="106.00" height="28.00" fill="white" />
+      <text x="114.24" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-basis/compound_backward_cross_boundary.svg
@@ -59,12 +59,12 @@
       <text x="158.20" y="426.11" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
       <rect x="212.86" y="654.36" width="50.13" height="28.00" fill="white" />
       <text x="237.93" y="668.36" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
-      <rect x="347.62" y="712.11" width="27.12" height="28.00" fill="white" />
-      <text x="361.17" y="726.11" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="347.62" y="738.26" width="27.12" height="28.00" fill="white" />
+      <text x="361.17" y="752.26" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <rect x="201.07" y="914.36" width="73.70" height="28.00" fill="white" />
       <text x="237.93" y="928.36" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
-      <rect x="324.70" y="700.40" width="42.89" height="28.00" fill="white" />
-      <text x="346.14" y="714.40" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="324.70" y="706.26" width="42.89" height="28.00" fill="white" />
+      <text x="346.14" y="720.26" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-basis/label_clamp_bt_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="44.95" y="202.00" width="16.54" height="28.00" fill="white" />
-      <text x="53.22" y="216.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="56.41" y="121.00" width="33.61" height="52.00" fill="white" />
-      <text x="73.22" y="135.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="73.22" y="159.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="44.95" y="176.50" width="16.54" height="28.00" fill="white" />
+      <text x="53.22" y="190.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="56.41" y="108.50" width="33.61" height="52.00" fill="white" />
+      <text x="73.22" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="73.22" y="146.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-basis/long_reciprocal_labels.svg
@@ -16,12 +16,12 @@
       <text x="42.45" y="283.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-61.21" y="133.00" width="207.33" height="52.00" fill="white" />
-      <text x="42.45" y="147.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="42.45" y="171.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
-      <rect x="-35.27" y="77.00" width="195.46" height="52.00" fill="white" />
-      <text x="62.45" y="91.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
-      <text x="62.45" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
+      <rect x="-61.21" y="161.00" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="175.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="199.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-35.27" y="105.00" width="195.46" height="52.00" fill="white" />
+      <text x="62.45" y="119.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
+      <text x="62.45" y="143.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/backward_label_asymmetric_markers.svg
@@ -19,10 +19,10 @@
       <text x="94.24" y="211.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Entity</text>
     </g>
     <g class="edgeLabels">
-      <rect x="40.31" y="109.00" width="107.85" height="28.00" fill="white" />
-      <text x="94.24" y="123.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
-      <rect x="88.36" y="77.00" width="106.00" height="28.00" fill="white" />
-      <text x="141.36" y="91.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
+      <rect x="40.31" y="125.00" width="107.85" height="28.00" fill="white" />
+      <text x="94.24" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
+      <rect x="88.36" y="93.00" width="106.00" height="28.00" fill="white" />
+      <text x="141.36" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compound_backward_cross_boundary.svg
@@ -59,12 +59,12 @@
       <text x="113.07" y="443.50" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
       <rect x="212.86" y="654.36" width="50.13" height="28.00" fill="white" />
       <text x="237.93" y="668.36" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
-      <rect x="312.31" y="687.93" width="27.12" height="28.00" fill="white" />
-      <text x="325.87" y="701.93" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="347.62" y="745.82" width="27.12" height="28.00" fill="white" />
+      <text x="361.17" y="759.82" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <rect x="197.89" y="942.86" width="73.70" height="28.00" fill="white" />
       <text x="234.75" y="956.86" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
-      <rect x="328.70" y="702.40" width="42.89" height="28.00" fill="white" />
-      <text x="350.14" y="716.40" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="328.70" y="713.82" width="42.89" height="28.00" fill="white" />
+      <text x="350.14" y="727.82" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/label_clamp_bt_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="44.95" y="189.00" width="16.54" height="28.00" fill="white" />
-      <text x="53.22" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="61.91" y="121.00" width="33.61" height="52.00" fill="white" />
-      <text x="78.72" y="135.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="78.72" y="159.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="44.95" y="161.00" width="16.54" height="28.00" fill="white" />
+      <text x="53.22" y="175.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="61.91" y="93.00" width="33.61" height="52.00" fill="white" />
+      <text x="78.72" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="78.72" y="131.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/label_clamp_rl_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="191.51" y="40.50" width="16.54" height="28.00" fill="white" />
-      <text x="199.78" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="142.79" y="44.50" width="33.61" height="52.00" fill="white" />
-      <text x="159.59" y="58.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="159.59" y="82.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="169.53" y="40.50" width="16.54" height="28.00" fill="white" />
+      <text x="177.80" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="123.38" y="38.79" width="33.61" height="52.00" fill="white" />
+      <text x="140.19" y="52.79" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="140.19" y="76.79" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/long_reciprocal_labels.svg
@@ -16,12 +16,12 @@
       <text x="42.45" y="283.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-61.21" y="189.00" width="207.33" height="52.00" fill="white" />
-      <text x="42.45" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="42.45" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
-      <rect x="-38.05" y="130.39" width="195.46" height="52.00" fill="white" />
-      <text x="59.68" y="144.39" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
-      <text x="59.68" y="168.39" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
+      <rect x="-61.21" y="159.69" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="173.69" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="197.69" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-38.05" y="103.69" width="195.46" height="52.00" fill="white" />
+      <text x="59.68" y="117.69" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
+      <text x="59.68" y="141.69" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/multi_edge_labeled.svg
@@ -19,10 +19,10 @@
       <text x="46.31" y="299.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
     </g>
     <g class="edgeLabels">
-      <rect x="8.08" y="97.25" width="56.63" height="28.00" fill="white" />
-      <text x="36.39" y="111.25" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
-      <rect x="44.45" y="130.00" width="56.63" height="28.00" fill="white" />
-      <text x="72.77" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
+      <rect x="-10.09" y="92.50" width="56.63" height="28.00" fill="white" />
+      <text x="18.23" y="106.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="44.45" y="124.50" width="56.63" height="28.00" fill="white" />
+      <text x="72.77" y="138.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/three_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/three_parallel_labels.svg
@@ -19,10 +19,10 @@
     <g class="edgeLabels">
       <rect x="19.28" y="99.00" width="33.61" height="28.00" fill="white" />
       <text x="36.09" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
-      <rect x="44.81" y="101.00" width="35.47" height="28.00" fill="white" />
-      <text x="62.54" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
-      <rect x="66.25" y="130.00" width="45.49" height="28.00" fill="white" />
-      <text x="89.00" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">three</text>
+      <rect x="44.81" y="94.75" width="35.47" height="28.00" fill="white" />
+      <text x="62.54" y="108.75" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
+      <rect x="66.25" y="126.75" width="45.49" height="28.00" fill="white" />
+      <text x="89.00" y="140.75" text-anchor="middle" dominant-baseline="middle" fill="#333">three</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-polyline/backward_label_asymmetric_markers.svg
@@ -19,10 +19,10 @@
       <text x="94.24" y="211.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Entity</text>
     </g>
     <g class="edgeLabels">
-      <rect x="40.31" y="109.00" width="107.85" height="28.00" fill="white" />
-      <text x="94.24" y="123.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
-      <rect x="61.24" y="77.00" width="106.00" height="28.00" fill="white" />
-      <text x="114.24" y="91.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
+      <rect x="40.31" y="125.00" width="107.85" height="28.00" fill="white" />
+      <text x="94.24" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
+      <rect x="61.24" y="93.00" width="106.00" height="28.00" fill="white" />
+      <text x="114.24" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compound_backward_cross_boundary.svg
@@ -59,12 +59,12 @@
       <text x="158.20" y="426.11" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
       <rect x="212.86" y="654.36" width="50.13" height="28.00" fill="white" />
       <text x="237.93" y="668.36" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
-      <rect x="347.62" y="712.11" width="27.12" height="28.00" fill="white" />
-      <text x="361.17" y="726.11" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="347.62" y="738.26" width="27.12" height="28.00" fill="white" />
+      <text x="361.17" y="752.26" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <rect x="201.07" y="914.36" width="73.70" height="28.00" fill="white" />
       <text x="237.93" y="928.36" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
-      <rect x="324.70" y="700.40" width="42.89" height="28.00" fill="white" />
-      <text x="346.14" y="714.40" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="324.70" y="706.26" width="42.89" height="28.00" fill="white" />
+      <text x="346.14" y="720.26" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-polyline/label_clamp_bt_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="44.95" y="202.00" width="16.54" height="28.00" fill="white" />
-      <text x="53.22" y="216.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="56.41" y="121.00" width="33.61" height="52.00" fill="white" />
-      <text x="73.22" y="135.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="73.22" y="159.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="44.95" y="176.50" width="16.54" height="28.00" fill="white" />
+      <text x="53.22" y="190.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="56.41" y="108.50" width="33.61" height="52.00" fill="white" />
+      <text x="73.22" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="73.22" y="146.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-polyline/long_reciprocal_labels.svg
@@ -16,12 +16,12 @@
       <text x="42.45" y="283.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-61.21" y="133.00" width="207.33" height="52.00" fill="white" />
-      <text x="42.45" y="147.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="42.45" y="171.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
-      <rect x="-35.27" y="77.00" width="195.46" height="52.00" fill="white" />
-      <text x="62.45" y="91.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
-      <text x="62.45" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
+      <rect x="-61.21" y="161.00" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="175.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="199.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-35.27" y="105.00" width="195.46" height="52.00" fill="white" />
+      <text x="62.45" y="119.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
+      <text x="62.45" y="143.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/backward_label_asymmetric_markers.svg
@@ -19,10 +19,10 @@
       <text x="94.24" y="211.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Entity</text>
     </g>
     <g class="edgeLabels">
-      <rect x="26.31" y="107.00" width="107.85" height="28.00" fill="white" />
-      <text x="80.24" y="121.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
-      <rect x="88.36" y="77.00" width="106.00" height="28.00" fill="white" />
-      <text x="141.36" y="91.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
+      <rect x="40.31" y="125.00" width="107.85" height="28.00" fill="white" />
+      <text x="94.24" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
+      <rect x="88.36" y="93.00" width="106.00" height="28.00" fill="white" />
+      <text x="141.36" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compound_backward_cross_boundary.svg
@@ -59,12 +59,12 @@
       <text x="113.07" y="443.50" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
       <rect x="212.86" y="654.36" width="50.13" height="28.00" fill="white" />
       <text x="237.93" y="668.36" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
-      <rect x="347.62" y="725.24" width="27.12" height="28.00" fill="white" />
-      <text x="361.17" y="739.24" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="347.62" y="745.82" width="27.12" height="28.00" fill="white" />
+      <text x="361.17" y="759.82" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <rect x="197.89" y="942.86" width="73.70" height="28.00" fill="white" />
       <text x="234.75" y="956.86" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
-      <rect x="328.70" y="702.40" width="42.89" height="28.00" fill="white" />
-      <text x="350.14" y="716.40" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="328.70" y="713.82" width="42.89" height="28.00" fill="white" />
+      <text x="350.14" y="727.82" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/label_clamp_bt_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="44.95" y="189.00" width="16.54" height="28.00" fill="white" />
-      <text x="53.22" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="61.91" y="121.00" width="33.61" height="52.00" fill="white" />
-      <text x="78.72" y="135.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="78.72" y="159.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="44.95" y="161.00" width="16.54" height="28.00" fill="white" />
+      <text x="53.22" y="175.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="61.91" y="93.00" width="33.61" height="52.00" fill="white" />
+      <text x="78.72" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="78.72" y="131.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/label_clamp_rl_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="191.51" y="40.50" width="16.54" height="28.00" fill="white" />
-      <text x="199.78" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="139.44" y="47.50" width="33.61" height="52.00" fill="white" />
-      <text x="156.24" y="61.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="156.24" y="85.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="169.53" y="40.50" width="16.54" height="28.00" fill="white" />
+      <text x="177.80" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="123.38" y="38.79" width="33.61" height="52.00" fill="white" />
+      <text x="140.19" y="52.79" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="140.19" y="76.79" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/long_reciprocal_labels.svg
@@ -16,12 +16,12 @@
       <text x="42.45" y="283.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-61.21" y="189.00" width="207.33" height="52.00" fill="white" />
-      <text x="42.45" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="42.45" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
-      <rect x="-38.05" y="130.39" width="195.46" height="52.00" fill="white" />
-      <text x="59.68" y="144.39" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
-      <text x="59.68" y="168.39" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
+      <rect x="-61.21" y="159.69" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="173.69" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="197.69" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-38.05" y="103.69" width="195.46" height="52.00" fill="white" />
+      <text x="59.68" y="117.69" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
+      <text x="59.68" y="141.69" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/multi_edge_labeled.svg
@@ -19,10 +19,10 @@
       <text x="46.31" y="299.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-10.09" y="104.00" width="56.63" height="28.00" fill="white" />
-      <text x="18.23" y="118.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
-      <rect x="44.45" y="130.00" width="56.63" height="28.00" fill="white" />
-      <text x="72.77" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
+      <rect x="-10.09" y="92.50" width="56.63" height="28.00" fill="white" />
+      <text x="18.23" y="106.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="44.45" y="124.50" width="56.63" height="28.00" fill="white" />
+      <text x="72.77" y="138.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/three_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/three_parallel_labels.svg
@@ -19,10 +19,10 @@
     <g class="edgeLabels">
       <rect x="-8.81" y="99.00" width="33.61" height="28.00" fill="white" />
       <text x="8.00" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
-      <rect x="44.81" y="101.00" width="35.47" height="28.00" fill="white" />
-      <text x="62.54" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
-      <rect x="66.25" y="130.00" width="45.49" height="28.00" fill="white" />
-      <text x="89.00" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">three</text>
+      <rect x="44.81" y="94.75" width="35.47" height="28.00" fill="white" />
+      <text x="62.54" y="108.75" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
+      <rect x="66.25" y="126.75" width="45.49" height="28.00" fill="white" />
+      <text x="89.00" y="140.75" text-anchor="middle" dominant-baseline="middle" fill="#333">three</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-step/backward_label_asymmetric_markers.svg
@@ -19,10 +19,10 @@
       <text x="94.24" y="211.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Entity</text>
     </g>
     <g class="edgeLabels">
-      <rect x="26.31" y="107.00" width="107.85" height="28.00" fill="white" />
-      <text x="80.24" y="121.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
-      <rect x="88.36" y="77.00" width="106.00" height="28.00" fill="white" />
-      <text x="141.36" y="91.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
+      <rect x="40.31" y="125.00" width="107.85" height="28.00" fill="white" />
+      <text x="94.24" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
+      <rect x="88.36" y="93.00" width="106.00" height="28.00" fill="white" />
+      <text x="141.36" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-step/compound_backward_cross_boundary.svg
@@ -59,12 +59,12 @@
       <text x="113.07" y="443.50" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
       <rect x="212.86" y="654.36" width="50.13" height="28.00" fill="white" />
       <text x="237.93" y="668.36" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
-      <rect x="347.62" y="725.24" width="27.12" height="28.00" fill="white" />
-      <text x="361.17" y="739.24" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="347.62" y="745.82" width="27.12" height="28.00" fill="white" />
+      <text x="361.17" y="759.82" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <rect x="197.89" y="942.86" width="73.70" height="28.00" fill="white" />
       <text x="234.75" y="956.86" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
-      <rect x="328.70" y="702.40" width="42.89" height="28.00" fill="white" />
-      <text x="350.14" y="716.40" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="328.70" y="713.82" width="42.89" height="28.00" fill="white" />
+      <text x="350.14" y="727.82" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-step/label_clamp_bt_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="44.95" y="189.00" width="16.54" height="28.00" fill="white" />
-      <text x="53.22" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="61.91" y="121.00" width="33.61" height="52.00" fill="white" />
-      <text x="78.72" y="135.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="78.72" y="159.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="44.95" y="161.00" width="16.54" height="28.00" fill="white" />
+      <text x="53.22" y="175.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="61.91" y="93.00" width="33.61" height="52.00" fill="white" />
+      <text x="78.72" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="78.72" y="131.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-step/label_clamp_rl_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="191.51" y="40.50" width="16.54" height="28.00" fill="white" />
-      <text x="199.78" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="139.44" y="47.50" width="33.61" height="52.00" fill="white" />
-      <text x="156.24" y="61.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="156.24" y="85.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="169.53" y="40.50" width="16.54" height="28.00" fill="white" />
+      <text x="177.80" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="123.38" y="38.79" width="33.61" height="52.00" fill="white" />
+      <text x="140.19" y="52.79" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="140.19" y="76.79" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-step/long_reciprocal_labels.svg
@@ -16,12 +16,12 @@
       <text x="42.45" y="283.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-61.21" y="189.00" width="207.33" height="52.00" fill="white" />
-      <text x="42.45" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="42.45" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
-      <rect x="-38.05" y="130.39" width="195.46" height="52.00" fill="white" />
-      <text x="59.68" y="144.39" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
-      <text x="59.68" y="168.39" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
+      <rect x="-61.21" y="159.69" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="173.69" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="197.69" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-38.05" y="103.69" width="195.46" height="52.00" fill="white" />
+      <text x="59.68" y="117.69" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
+      <text x="59.68" y="141.69" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-step/multi_edge_labeled.svg
@@ -19,10 +19,10 @@
       <text x="46.31" y="299.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-10.09" y="104.00" width="56.63" height="28.00" fill="white" />
-      <text x="18.23" y="118.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
-      <rect x="44.45" y="130.00" width="56.63" height="28.00" fill="white" />
-      <text x="72.77" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
+      <rect x="-10.09" y="92.50" width="56.63" height="28.00" fill="white" />
+      <text x="18.23" y="106.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="44.45" y="124.50" width="56.63" height="28.00" fill="white" />
+      <text x="72.77" y="138.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/three_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-step/three_parallel_labels.svg
@@ -19,10 +19,10 @@
     <g class="edgeLabels">
       <rect x="-8.81" y="99.00" width="33.61" height="28.00" fill="white" />
       <text x="8.00" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
-      <rect x="44.81" y="101.00" width="35.47" height="28.00" fill="white" />
-      <text x="62.54" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
-      <rect x="66.25" y="130.00" width="45.49" height="28.00" fill="white" />
-      <text x="89.00" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">three</text>
+      <rect x="44.81" y="94.75" width="35.47" height="28.00" fill="white" />
+      <text x="62.54" y="108.75" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
+      <rect x="66.25" y="126.75" width="45.49" height="28.00" fill="white" />
+      <text x="89.00" y="140.75" text-anchor="middle" dominant-baseline="middle" fill="#333">three</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-straight/backward_label_asymmetric_markers.svg
@@ -19,10 +19,10 @@
       <text x="94.24" y="211.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Entity</text>
     </g>
     <g class="edgeLabels">
-      <rect x="26.31" y="107.00" width="107.85" height="28.00" fill="white" />
-      <text x="80.24" y="121.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
-      <rect x="61.24" y="77.00" width="106.00" height="28.00" fill="white" />
-      <text x="114.24" y="91.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
+      <rect x="40.31" y="125.00" width="107.85" height="28.00" fill="white" />
+      <text x="94.24" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
+      <rect x="61.24" y="93.00" width="106.00" height="28.00" fill="white" />
+      <text x="114.24" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-straight/label_clamp_bt_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="44.95" y="189.00" width="16.54" height="28.00" fill="white" />
-      <text x="53.22" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="56.41" y="121.00" width="33.61" height="52.00" fill="white" />
-      <text x="73.22" y="135.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="73.22" y="159.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="44.95" y="161.00" width="16.54" height="28.00" fill="white" />
+      <text x="53.22" y="175.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="56.41" y="93.00" width="33.61" height="52.00" fill="white" />
+      <text x="73.22" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="73.22" y="131.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-straight/label_clamp_rl_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="183.59" y="40.50" width="16.54" height="28.00" fill="white" />
-      <text x="191.86" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="137.44" y="28.50" width="33.61" height="52.00" fill="white" />
-      <text x="154.24" y="42.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="154.24" y="66.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="164.78" y="40.50" width="16.54" height="28.00" fill="white" />
+      <text x="173.05" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="118.63" y="28.50" width="33.61" height="52.00" fill="white" />
+      <text x="135.44" y="42.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="135.44" y="66.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-straight/long_reciprocal_labels.svg
@@ -16,12 +16,12 @@
       <text x="42.45" y="283.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-73.62" y="131.00" width="207.33" height="52.00" fill="white" />
-      <text x="30.05" y="145.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="30.05" y="169.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
-      <rect x="-35.27" y="77.00" width="195.46" height="52.00" fill="white" />
-      <text x="62.45" y="91.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
-      <text x="62.45" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
+      <rect x="-61.21" y="161.00" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="175.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="199.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-35.27" y="105.00" width="195.46" height="52.00" fill="white" />
+      <text x="62.45" y="119.00" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
+      <text x="62.45" y="143.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-straight/multi_edge_labeled.svg
@@ -19,10 +19,10 @@
       <text x="46.31" y="299.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
     </g>
     <g class="edgeLabels">
-      <rect x="18.00" y="101.00" width="56.63" height="28.00" fill="white" />
-      <text x="46.31" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
-      <rect x="18.00" y="130.00" width="56.63" height="28.00" fill="white" />
-      <text x="46.31" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
+      <rect x="18.00" y="85.00" width="56.63" height="28.00" fill="white" />
+      <text x="46.31" y="99.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="18.00" y="117.00" width="56.63" height="28.00" fill="white" />
+      <text x="46.31" y="131.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart/backward_label_asymmetric_markers.svg
@@ -19,10 +19,10 @@
       <text x="94.24" y="211.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Entity</text>
     </g>
     <g class="edgeLabels">
-      <rect x="26.31" y="107.00" width="107.85" height="28.00" fill="white" />
-      <text x="80.24" y="121.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
-      <rect x="88.36" y="77.00" width="106.00" height="28.00" fill="white" />
-      <text x="141.36" y="91.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
+      <rect x="40.31" y="125.00" width="107.85" height="28.00" fill="white" />
+      <text x="94.24" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">forward label</text>
+      <rect x="88.36" y="93.00" width="106.00" height="28.00" fill="white" />
+      <text x="141.36" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">reverse label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart/compound_backward_cross_boundary.svg
@@ -59,12 +59,12 @@
       <text x="113.07" y="443.50" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
       <rect x="212.86" y="654.36" width="50.13" height="28.00" fill="white" />
       <text x="237.93" y="668.36" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
-      <rect x="347.62" y="725.24" width="27.12" height="28.00" fill="white" />
-      <text x="361.17" y="739.24" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="347.62" y="745.82" width="27.12" height="28.00" fill="white" />
+      <text x="361.17" y="759.82" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
       <rect x="197.89" y="942.86" width="73.70" height="28.00" fill="white" />
       <text x="234.75" y="956.86" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
-      <rect x="328.70" y="702.40" width="42.89" height="28.00" fill="white" />
-      <text x="350.14" y="716.40" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="328.70" y="713.82" width="42.89" height="28.00" fill="white" />
+      <text x="350.14" y="727.82" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart/label_clamp_bt_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="44.95" y="189.00" width="16.54" height="28.00" fill="white" />
-      <text x="53.22" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="61.91" y="121.00" width="33.61" height="52.00" fill="white" />
-      <text x="78.72" y="135.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="78.72" y="159.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="44.95" y="161.00" width="16.54" height="28.00" fill="white" />
+      <text x="53.22" y="175.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="61.91" y="93.00" width="33.61" height="52.00" fill="white" />
+      <text x="78.72" y="107.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="78.72" y="131.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart/label_clamp_rl_review.svg
@@ -16,11 +16,11 @@
       <text x="53.22" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">Two</text>
     </g>
     <g class="edgeLabels">
-      <rect x="191.51" y="40.50" width="16.54" height="28.00" fill="white" />
-      <text x="199.78" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="139.44" y="47.50" width="33.61" height="52.00" fill="white" />
-      <text x="156.24" y="61.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="156.24" y="85.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="169.53" y="40.50" width="16.54" height="28.00" fill="white" />
+      <text x="177.80" y="54.50" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="123.38" y="38.79" width="33.61" height="52.00" fill="white" />
+      <text x="140.19" y="52.79" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="140.19" y="76.79" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart/long_reciprocal_labels.svg
@@ -16,12 +16,12 @@
       <text x="42.45" y="283.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-61.21" y="189.00" width="207.33" height="52.00" fill="white" />
-      <text x="42.45" y="203.00" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
-      <text x="42.45" y="227.00" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
-      <rect x="-38.05" y="130.39" width="195.46" height="52.00" fill="white" />
-      <text x="59.68" y="144.39" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
-      <text x="59.68" y="168.39" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
+      <rect x="-61.21" y="159.69" width="207.33" height="52.00" fill="white" />
+      <text x="42.45" y="173.69" text-anchor="middle" dominant-baseline="middle" fill="#333">this is a deliberately long</text>
+      <text x="42.45" y="197.69" text-anchor="middle" dominant-baseline="middle" fill="#333">label</text>
+      <rect x="-38.05" y="103.69" width="195.46" height="52.00" fill="white" />
+      <text x="59.68" y="117.69" text-anchor="middle" dominant-baseline="middle" fill="#333">another deliberately long</text>
+      <text x="59.68" y="141.69" text-anchor="middle" dominant-baseline="middle" fill="#333">reply label</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart/multi_edge_labeled.svg
@@ -19,10 +19,10 @@
       <text x="46.31" y="299.00" text-anchor="middle" dominant-baseline="middle" fill="#333">C</text>
     </g>
     <g class="edgeLabels">
-      <rect x="-10.09" y="104.00" width="56.63" height="28.00" fill="white" />
-      <text x="18.23" y="118.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
-      <rect x="44.45" y="130.00" width="56.63" height="28.00" fill="white" />
-      <text x="72.77" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
+      <rect x="-10.09" y="92.50" width="56.63" height="28.00" fill="white" />
+      <text x="18.23" y="106.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 1</text>
+      <rect x="44.45" y="124.50" width="56.63" height="28.00" fill="white" />
+      <text x="72.77" y="138.50" text-anchor="middle" dominant-baseline="middle" fill="#333">path 2</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/three_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart/three_parallel_labels.svg
@@ -19,10 +19,10 @@
     <g class="edgeLabels">
       <rect x="-8.81" y="99.00" width="33.61" height="28.00" fill="white" />
       <text x="8.00" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
-      <rect x="44.81" y="101.00" width="35.47" height="28.00" fill="white" />
-      <text x="62.54" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
-      <rect x="66.25" y="130.00" width="45.49" height="28.00" fill="white" />
-      <text x="89.00" y="144.00" text-anchor="middle" dominant-baseline="middle" fill="#333">three</text>
+      <rect x="44.81" y="94.75" width="35.47" height="28.00" fill="white" />
+      <text x="62.54" y="108.75" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
+      <rect x="66.25" y="126.75" width="45.49" height="28.00" fill="white" />
+      <text x="89.00" y="140.75" text-anchor="middle" dominant-baseline="middle" fill="#333">three</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/state/composite.svg
+++ b/tests/svg-snapshots/state/composite.svg
@@ -34,10 +34,10 @@
       <text x="116.16" y="15.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
     </g>
     <g class="edgeLabels">
-      <rect x="122.63" y="305.63" width="50.69" height="28.00" fill="white" />
-      <text x="147.97" y="319.63" text-anchor="middle" dominant-baseline="middle" fill="#333">pause</text>
-      <rect x="161.78" y="256.96" width="61.08" height="28.00" fill="white" />
-      <text x="192.32" y="270.96" text-anchor="middle" dominant-baseline="middle" fill="#333">resume</text>
+      <rect x="122.63" y="281.30" width="50.69" height="28.00" fill="white" />
+      <text x="147.97" y="295.30" text-anchor="middle" dominant-baseline="middle" fill="#333">pause</text>
+      <rect x="161.78" y="250.00" width="61.08" height="28.00" fill="white" />
+      <text x="192.32" y="264.00" text-anchor="middle" dominant-baseline="middle" fill="#333">resume</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/state/concurrent_nested.svg
+++ b/tests/svg-snapshots/state/concurrent_nested.svg
@@ -38,10 +38,10 @@
       <text x="121.97" y="15.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
     </g>
     <g class="edgeLabels">
-      <rect x="48.00" y="337.00" width="147.94" height="28.00" fill="white" />
-      <text x="121.97" y="351.00" text-anchor="middle" dominant-baseline="middle" fill="#333">EvNumLockPressed</text>
-      <rect x="80.94" y="305.00" width="147.94" height="28.00" fill="white" />
-      <text x="154.91" y="319.00" text-anchor="middle" dominant-baseline="middle" fill="#333">EvNumLockPressed</text>
+      <rect x="48.00" y="353.00" width="147.94" height="28.00" fill="white" />
+      <text x="121.97" y="367.00" text-anchor="middle" dominant-baseline="middle" fill="#333">EvNumLockPressed</text>
+      <rect x="80.94" y="321.00" width="147.94" height="28.00" fill="white" />
+      <text x="154.91" y="335.00" text-anchor="middle" dominant-baseline="middle" fill="#333">EvNumLockPressed</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/state/concurrent_three.svg
+++ b/tests/svg-snapshots/state/concurrent_three.svg
@@ -46,18 +46,18 @@
       <text x="127.35" y="15.00" text-anchor="middle" dominant-baseline="middle" fill="#333"></text>
     </g>
     <g class="edgeLabels">
-      <rect x="52.43" y="369.00" width="147.94" height="28.00" fill="white" />
-      <text x="126.40" y="383.00" text-anchor="middle" dominant-baseline="middle" fill="#333">EvNumLockPressed</text>
-      <rect x="80.68" y="331.60" width="147.94" height="28.00" fill="white" />
-      <text x="154.65" y="345.60" text-anchor="middle" dominant-baseline="middle" fill="#333">EvNumLockPressed</text>
-      <rect x="217.91" y="367.41" width="152.03" height="28.00" fill="white" />
-      <text x="293.93" y="381.41" text-anchor="middle" dominant-baseline="middle" fill="#333">EvCapsLockPressed</text>
-      <rect x="248.08" y="332.00" width="152.03" height="28.00" fill="white" />
-      <text x="324.09" y="346.00" text-anchor="middle" dominant-baseline="middle" fill="#333">EvCapsLockPressed</text>
-      <rect x="389.51" y="337.00" width="158.71" height="28.00" fill="white" />
-      <text x="468.86" y="351.00" text-anchor="middle" dominant-baseline="middle" fill="#333">EvScrollLockPressed</text>
-      <rect x="425.14" y="305.00" width="158.71" height="28.00" fill="white" />
-      <text x="504.49" y="319.00" text-anchor="middle" dominant-baseline="middle" fill="#333">EvScrollLockPressed</text>
+      <rect x="52.43" y="350.30" width="147.94" height="28.00" fill="white" />
+      <text x="126.40" y="364.30" text-anchor="middle" dominant-baseline="middle" fill="#333">EvNumLockPressed</text>
+      <rect x="80.68" y="318.30" width="147.94" height="28.00" fill="white" />
+      <text x="154.65" y="332.30" text-anchor="middle" dominant-baseline="middle" fill="#333">EvNumLockPressed</text>
+      <rect x="217.91" y="349.70" width="152.03" height="28.00" fill="white" />
+      <text x="293.93" y="363.70" text-anchor="middle" dominant-baseline="middle" fill="#333">EvCapsLockPressed</text>
+      <rect x="248.08" y="317.70" width="152.03" height="28.00" fill="white" />
+      <text x="324.09" y="331.70" text-anchor="middle" dominant-baseline="middle" fill="#333">EvCapsLockPressed</text>
+      <rect x="389.51" y="353.00" width="158.71" height="28.00" fill="white" />
+      <text x="468.86" y="367.00" text-anchor="middle" dominant-baseline="middle" fill="#333">EvScrollLockPressed</text>
+      <rect x="425.14" y="321.00" width="158.71" height="28.00" fill="white" />
+      <text x="504.49" y="335.00" text-anchor="middle" dominant-baseline="middle" fill="#333">EvScrollLockPressed</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

Closes #245. Routing's lane pass computed each edge's midpoint independently, so parallel same-direction labels in one compartment drifted apart by less than one `label_step`. PR #244 sized the kernel rank reservation assuming shared midpoints, so the drift collapsed tracks 0 and +1 into a residual ~2 px overlap. The SVG renderer's per-edge revalidation further masked the lane pass by snapping track-0 labels back to their edge's own path.

## Fix

Rework `label_lanes` to operate on **axis-conflict sub-clusters** (members whose primary-axis bands actually overlap) rather than whole cross-band compartments. Within each sub-cluster:

- Recenter members to the mean primary-axis coordinate, preserving per-edge cross-axis (TD/BT shares Y, LR/RL shares X).
- Symmetrize `pack_signed_tracks` output around `(min_track + max_track) / 2.0` so `[0, +1]` becomes `[-0.5, +0.5]` and `label_clamp` no longer yanks the +1 member back into the gap.
- Size `label_step` and `adjusted_path` from the sub-cluster extent.

Extend `EdgeLabelGeometry` with `compartment_size: usize` (default 1) so the SVG renderer can distinguish singleton track-0 (revalidate against the edge path) from coordinated multi-member track-0 (trust the lane pass). Guard becomes `track != 0 || compartment_size > 1`.

## Test plan

- [x] Unignore `flowchart_multi_edge_labeled_same_direction_disjoint_svg`; now passes
- [x] `#241` canaries green: `long_reciprocal_labels_disjoint_svg`, `long_reciprocal_labels_elk_like_e2e`, `three_parallel_labels_disjoint_svg`, `nested_subgraph_parallel_labels_disjoint_svg`
- [x] `#242` canaries (`concurrent_three`) unchanged — still ignored, no new failures
- [x] `svg_orthogonal_orthogonal_route_inline_label_flowchart_labels_remain_attached_to_active_segments` passes (axis-conflict scoping keeps non-conflicting labels on their paths)
- [x] 5 new unit tests in `label_lanes.rs` for `recenter_members_to_shared_anchor` and `split_into_axis_conflict_subclusters`
- [x] `just check` green (2574 tests, lint, architecture)

## Snapshot churn

SVG snapshots regenerated for fixtures with reciprocal pairs or multi-member clusters (labels shift from `[0, -1]` to `[+0.5, -0.5]` offsets — symmetric around the compartment anchor). Text and MMDS snapshots byte-identical.