### PR TITLE
test: re-enable SVG overlap tests closed by axis-conflict symmetrization

### DIFF
--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -5874,7 +5874,6 @@ mod plan_0145_q9_red {
     // expose a flowchart-style `Graph` from this layer. Drift coverage
     // arrives in Task 1.10 alongside the routed companion (Q9 #2).
     #[test]
-    #[ignore = "plan 0150 residual: 1-px reciprocal-pair overlap needs text-renderer-aware split-gap reservation — see #246 and findings/phase-3-state-issue-222-regression.md"]
     fn state_issue_222_minimal_repro_labels_do_not_overlap_svg() {
         let svg = render_svg_default(state_issue_222_minimal_repro_input());
         let overlap = svg_pairwise_label_rect_overlaps(&svg);
@@ -5906,7 +5905,6 @@ mod plan_0145_q9_red {
     // needs either global X packing across compartments or a cross-
     // compartment rewrap trigger. Tracking as a follow-up.
     #[test]
-    #[ignore = "plan 0149 follow-up: cross-compartment X overlap — see #242"]
     fn state_concurrent_three_flux_layered_labels_disjoint_svg() {
         let svg = concurrent_three_svg_with_engine(EngineAlgorithmId::FLUX_LAYERED);
         let overlap = svg_pairwise_label_rect_overlaps(&svg);
@@ -5917,7 +5915,7 @@ mod plan_0145_q9_red {
     }
 
     #[test]
-    #[ignore = "plan 0149 follow-up: cross-compartment X overlap — see #242"]
+    #[ignore = "mermaid-layered parity: sibling concurrent regions pack too tight, label X-extents bleed across subgraph boundaries — see #248 (distinct from #242's cross-compartment pattern within a shared scope)"]
     fn state_concurrent_three_mermaid_layered_labels_disjoint_svg() {
         let svg = concurrent_three_svg_with_engine(EngineAlgorithmId::MERMAID_LAYERED);
         let overlap = svg_pairwise_label_rect_overlaps(&svg);


### PR DESCRIPTION
## Summary

- PR #247's axis-conflict symmetrization closed two SVG label-overlap tests that were previously `#[ignore]`d. Unignore both.
- Retarget the still-failing mermaid-layered variant to new issue #248 (distinct from #242 — it's cross-subgraph label-X-bleed between sibling concurrent regions, not cross-compartment within a shared scope).

## Tests re-enabled

- `state_issue_222_minimal_repro_labels_do_not_overlap_svg` — was `#[ignore]`d with a pointer to #246, now passes. #247's centered `[+0.5, -0.5]` tracks replaced the asymmetric `[0, -1]` that caused the 1-px SVG overlap.
- `state_concurrent_three_flux_layered_labels_disjoint_svg` — was `#[ignore]`d with a pointer to #242, now passes.

## Still ignored (retargeted)

- `state_concurrent_three_mermaid_layered_labels_disjoint_svg` — `#[ignore]` message now points at #248 instead of #242. Verification: mermaid-layered still runs `assign_label_tracks` unconditionally via `route_graph_geometry`, and `group_label_compartments` + `recenter_members_to_shared_anchor` + track symmetrization all fire. The remaining overlap is **horizontal, between different sibling subgraphs** (concurrent regions), not within a shared-scope compartment. `compute_compartment_rank_sep_overrides` is gated on `variable_rank_spacing` which mermaid-layered doesn't set, but that gate is orthogonal here (Y-axis).

## Test plan

- [x] `just check` — 2577 passed, 1 skipped (#248), lint clean
- [x] Canaries still green: `long_reciprocal_labels_disjoint_svg`, `three_parallel_labels_disjoint_svg`, `nested_subgraph_parallel_labels_disjoint_and_contained`, `flowchart_multi_edge_labeled_same_direction_disjoint_svg`
- [x] No text snapshot regressions

Closes #246
Refs #248