### PR TITLE
fix: align orthogonal backward side-offset labels to post-fan path

### DIFF
--- a/src/graph/routing/stage.rs
+++ b/src/graph/routing/stage.rs
@@ -172,6 +172,14 @@ pub fn route_graph_geometry(
         }
     }
 
+    // Plan 0151 Task 1.2: for orthogonal backward side-offset labels, realign
+    // `label_position` against the final post-fan path before freezing it
+    // into `label_geometry`. Narrow predicate: OrthogonalRoute + is_backward
+    // + label_side ∈ {Above, Below}. Forward orthogonal and non-orthogonal
+    // branches already get their anchors revalidated or recomputed upstream.
+    // See `findings/01-producer-seam-choice.md`.
+    align_backward_side_offset_labels(&mut edges, diagram, metrics, edge_routing);
+
     // Populate label_geometry on every routed edge with a non-empty label.
     // This is the single source of truth for padded label rectangles consumed
     // by SVG, MMDS, and bounds downstream. track: 0 until the lane assignment
@@ -941,5 +949,249 @@ fn populate_label_geometry(
             track: 0,
             compartment_size: 1,
         });
+    }
+}
+
+/// Align `label_position` for orthogonal backward side-offset labels against
+/// the final post-fan path.
+///
+/// Narrow branch predicate — runs only when all of these hold:
+///   - `edge_routing == EdgeRouting::OrthogonalRoute`
+///   - `edge.is_backward`
+///   - `edge.label_side == Some(Above | Below)`
+///
+/// The engine assigns `label_position` for backward side-offset labels
+/// relative to the abstract forward-flow path. When orthogonal routing then
+/// replaces that path with a U-channel (and `fan::spread_colocated_backward_*`
+/// mutates the endpoints further), the engine's anchor becomes divorced from
+/// the actual routed path. `orthogonal::mod`'s own `revalidate_label_anchor`
+/// pass is skipped for `label_side != Center`, so the staleness persists.
+/// This helper re-projects the center onto the final post-fan path using a
+/// side-aware arc-length midpoint rule. See
+/// `.gumbo/plans/0151-routed-label-geometry-contract/findings/01-producer-seam-choice.md`.
+fn align_backward_side_offset_labels(
+    edges: &mut [RoutedEdgeGeometry],
+    diagram: &Graph,
+    metrics: &ProportionalTextMetrics,
+    edge_routing: EdgeRouting,
+) {
+    if !matches!(edge_routing, EdgeRouting::OrthogonalRoute) {
+        return;
+    }
+    for routed_edge in edges.iter_mut() {
+        if !routed_edge.is_backward {
+            continue;
+        }
+        let side = match routed_edge.label_side {
+            Some(EdgeLabelSide::Above) => EdgeLabelSide::Above,
+            Some(EdgeLabelSide::Below) => EdgeLabelSide::Below,
+            _ => continue,
+        };
+        if routed_edge.path.len() < 2 {
+            continue;
+        }
+        let Some(diagram_edge) = diagram.edges.get(routed_edge.index) else {
+            continue;
+        };
+        let Some(label) = diagram_edge.label.as_deref() else {
+            continue;
+        };
+        if label.is_empty() {
+            continue;
+        }
+        let (_, label_height) = match diagram_edge.wrapped_label_lines.as_deref() {
+            Some(lines) => metrics.edge_label_dimensions_wrapped(lines),
+            None => metrics.edge_label_dimensions(label),
+        };
+        if let Some(aligned) = project_side_aware_anchor(&routed_edge.path, label_height, side) {
+            routed_edge.label_position = Some(aligned);
+        }
+    }
+}
+
+/// Project a side-aware anchor onto the arc-length midpoint of `path`.
+///
+/// The anchor sits `label_height / 2` away from the midpoint, perpendicular
+/// to the midpoint segment, on the side dictated by `side`. For a U-channel
+/// horizontal leg this places the anchor flush against the corridor on the
+/// correct side; for a vertical leg it places it to the left or right of
+/// the corridor following Mermaid's Above/Below convention for vertical
+/// edges.
+fn project_side_aware_anchor(
+    path: &[FPoint],
+    label_height: f64,
+    side: EdgeLabelSide,
+) -> Option<FPoint> {
+    if path.len() < 2 {
+        return arc_length_midpoint(path);
+    }
+    let midpoint = arc_length_midpoint(path)?;
+    let seg = midpoint_segment(path)?;
+    let (a, b) = seg;
+    let dx = b.x - a.x;
+    let dy = b.y - a.y;
+    let seg_len = (dx * dx + dy * dy).sqrt();
+    if seg_len <= 1e-6 {
+        return Some(midpoint);
+    }
+    let (tx, ty) = (dx / seg_len, dy / seg_len);
+    let (nx, ny) = side_aware_normal(tx, ty);
+    let sign = match side {
+        EdgeLabelSide::Below => 1.0,
+        EdgeLabelSide::Above => -1.0,
+        EdgeLabelSide::Center => return Some(midpoint),
+    };
+    let offset = label_height / 2.0;
+    Some(FPoint::new(
+        midpoint.x + nx * offset * sign,
+        midpoint.y + ny * offset * sign,
+    ))
+}
+
+/// Return the segment of `path` that contains the arc-length midpoint. Ties
+/// on a shared corner resolve to the segment whose traversal reached the
+/// target distance first — matching `arc_length_midpoint`'s own tie-break.
+fn midpoint_segment(path: &[FPoint]) -> Option<(FPoint, FPoint)> {
+    if path.len() < 2 {
+        return None;
+    }
+    let total_len: f64 = path
+        .windows(2)
+        .map(|w| {
+            let dx = w[1].x - w[0].x;
+            let dy = w[1].y - w[0].y;
+            (dx * dx + dy * dy).sqrt()
+        })
+        .sum();
+    if total_len <= 1e-6 {
+        return Some((path[0], path[1]));
+    }
+    let target = total_len / 2.0;
+    let mut traversed = 0.0;
+    for window in path.windows(2) {
+        let a = window[0];
+        let b = window[1];
+        let dx = b.x - a.x;
+        let dy = b.y - a.y;
+        let seg_len = (dx * dx + dy * dy).sqrt();
+        if seg_len <= 1e-6 {
+            continue;
+        }
+        if traversed + seg_len >= target {
+            return Some((a, b));
+        }
+        traversed += seg_len;
+    }
+    Some((path[path.len() - 2], path[path.len() - 1]))
+}
+
+/// Rotate `(tx, ty)` 90° into a perpendicular normal, oriented per Mermaid's
+/// Above/Below conventions:
+///   - horizontal-dominant tangent (`|tx| > |ty|`): `ny > 0` (screen-down).
+///   - vertical-dominant tangent (`|ty| >= |tx|`): `nx > 0` (screen-right).
+///
+/// "Below" offsets +normal; "Above" offsets −normal.
+fn side_aware_normal(tx: f64, ty: f64) -> (f64, f64) {
+    // In screen coords (+y down), rotating (tx, ty) 90° clockwise yields
+    // (-ty, tx). That puts +x → +y (horizontal tangent pointing right yields
+    // a downward normal), which matches "Below" for horizontal-dominant
+    // tangents when tx > 0. For tx < 0 we flip to keep the orientation.
+    let (mut nx, mut ny) = (-ty, tx);
+    if tx.abs() > ty.abs() {
+        if ny < 0.0 {
+            nx = -nx;
+            ny = -ny;
+        }
+    } else if nx < 0.0 {
+        nx = -nx;
+        ny = -ny;
+    }
+    (nx, ny)
+}
+
+#[cfg(test)]
+mod plan_0151_align_tests {
+    use super::*;
+
+    fn approx_eq(a: f64, b: f64) -> bool {
+        (a - b).abs() <= 1e-6
+    }
+
+    #[test]
+    fn side_aware_normal_horizontal_tangent_below_points_down() {
+        let (nx, ny) = side_aware_normal(1.0, 0.0);
+        assert!(approx_eq(nx, 0.0) && approx_eq(ny, 1.0));
+    }
+
+    #[test]
+    fn side_aware_normal_horizontal_tangent_reversed_still_points_down() {
+        // U-channel horizontal leg traveled right-to-left.
+        let (nx, ny) = side_aware_normal(-1.0, 0.0);
+        assert!(approx_eq(nx, 0.0) && approx_eq(ny, 1.0));
+    }
+
+    #[test]
+    fn side_aware_normal_vertical_tangent_points_right() {
+        let (nx, ny) = side_aware_normal(0.0, 1.0);
+        assert!(approx_eq(nx, 1.0) && approx_eq(ny, 0.0));
+    }
+
+    #[test]
+    fn side_aware_normal_vertical_tangent_reversed_still_points_right() {
+        // U-channel vertical leg traveled bottom-to-top.
+        let (nx, ny) = side_aware_normal(0.0, -1.0);
+        assert!(approx_eq(nx, 1.0) && approx_eq(ny, 0.0));
+    }
+
+    #[test]
+    fn project_side_aware_anchor_u_channel_below_sits_below_corridor() {
+        // Emulates git_workflow.mmd e3 — U-channel at y=74.
+        let path = vec![
+            FPoint::new(982.688, 62.0),
+            FPoint::new(982.688, 74.0),
+            FPoint::new(80.874, 74.0),
+            FPoint::new(80.874, 62.0),
+        ];
+        let anchor = project_side_aware_anchor(&path, 28.0, EdgeLabelSide::Below)
+            .expect("midpoint should exist");
+        // Midpoint is on the horizontal leg at y=74. Below offsets +14 → y=88.
+        assert!(approx_eq(anchor.y, 88.0), "anchor.y = {}", anchor.y);
+    }
+
+    #[test]
+    fn project_side_aware_anchor_u_channel_above_sits_above_corridor() {
+        let path = vec![
+            FPoint::new(982.688, 62.0),
+            FPoint::new(982.688, 74.0),
+            FPoint::new(80.874, 74.0),
+            FPoint::new(80.874, 62.0),
+        ];
+        let anchor = project_side_aware_anchor(&path, 28.0, EdgeLabelSide::Above)
+            .expect("midpoint should exist");
+        assert!(approx_eq(anchor.y, 60.0), "anchor.y = {}", anchor.y);
+    }
+
+    #[test]
+    fn project_side_aware_anchor_u_channel_vertical_below_sits_right_of_corridor() {
+        // Emulates git_workflow_td.mmd e3 — U-channel vertical leg at x=176.512.
+        let path = vec![
+            FPoint::new(164.512, 490.0),
+            FPoint::new(176.512, 490.0),
+            FPoint::new(176.512, 35.0),
+            FPoint::new(159.130, 35.0),
+        ];
+        let anchor = project_side_aware_anchor(&path, 28.0, EdgeLabelSide::Below)
+            .expect("midpoint should exist");
+        // Midpoint lands on the vertical leg at x=176.512.
+        // Below on vertical tangent offsets +14 in x → x=190.512.
+        assert!(approx_eq(anchor.x, 190.512), "anchor.x = {}", anchor.x);
+    }
+
+    #[test]
+    fn project_side_aware_anchor_center_side_returns_plain_midpoint() {
+        let path = vec![FPoint::new(0.0, 0.0), FPoint::new(100.0, 0.0)];
+        let anchor = project_side_aware_anchor(&path, 20.0, EdgeLabelSide::Center)
+            .expect("midpoint should exist");
+        assert!(approx_eq(anchor.x, 50.0) && approx_eq(anchor.y, 0.0));
     }
 }

--- a/src/internal_tests/cross_pipeline.rs
+++ b/src/internal_tests/cross_pipeline.rs
@@ -3190,3 +3190,217 @@ fn classify_face_matches_expected_common_approaches() {
         NodeFace::Right
     );
 }
+
+// ---------------------------------------------------------------------------
+// Plan 0151 Task 1.3: direct routed SVG and routed MMDS producer canaries.
+//
+// After the stage.rs pre-pass helper aligns orthogonal backward side-offset
+// labels against the final post-fan path, two properties must hold:
+//
+//   1. The routed MMDS `label_rect` encodes a center that sits at the raw
+//      routed path's arc-length midpoint, offset perpendicular by
+//      `label_height / 2` on the declared side. This proves the producer
+//      fix survives MMDS serialization.
+//
+//   2. Direct routed SVG still renders the label attached to the rendered
+//      edge, via `revalidate_svg_label_anchor` if necessary. SVG revalidation
+//      snaps side-offset labels back to the rendered-path midpoint when drift
+//      exceeds 2 px — so MMDS and SVG legitimately disagree by up to
+//      `label_height / 2 + corner_rounding` after the fix. The plan treats
+//      the SVG revalidation fallback as a separate contract, not regressed
+//      by Task 1.2 and not converged here. What Task 1.3 proves is that MMDS
+//      is no longer far-stale relative to SVG's understanding of the path.
+//
+// Canary behavior: pre-Task-1.2, MMDS encoded a stale engine anchor that
+// diverged from SVG by 40-100 px. Post-Task-1.2, divergence collapses to
+// the `label_height / 2`-scale SVG revalidation snap (≈10-14 px). The
+// MMDS-near-path assertion fails pre-fix (drift well past half-height)
+// and passes post-fix.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod producer_label_cross_pipeline {
+    use serde_json::Value;
+
+    use super::*;
+
+    /// Extract the `<text x=".." y=".." ...>LABEL</text>` anchor for a given
+    /// label value from an SVG string. Uses the same text-element shape the
+    /// SVG emitter uses (`dominant-baseline="middle"`, so the returned `y`
+    /// is the label center).
+    fn extract_svg_label_center(svg: &str, label: &str) -> Option<(f64, f64)> {
+        for line in svg.lines() {
+            let line = line.trim();
+            if !line.starts_with("<text") {
+                continue;
+            }
+            if !line.contains(&format!(">{label}<")) {
+                continue;
+            }
+            let x = attr_value(line, " x=\"")?.parse::<f64>().ok()?;
+            let y = attr_value(line, " y=\"")?.parse::<f64>().ok()?;
+            return Some((x, y));
+        }
+        None
+    }
+
+    fn attr_value<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
+        let start = line.find(prefix)? + prefix.len();
+        let rest = &line[start..];
+        let end = rest.find('"')?;
+        Some(&rest[..end])
+    }
+
+    fn routed_mmds_edge<'a>(json: &'a Value, edge_id: &str) -> Option<&'a Value> {
+        json.get("edges")?
+            .as_array()?
+            .iter()
+            .find(|e| e.get("id").and_then(|v| v.as_str()) == Some(edge_id))
+    }
+
+    fn routed_mmds_label_rect_center(edge: &Value) -> Option<(f64, f64)> {
+        let rect = edge.get("label_rect")?;
+        let x = rect.get("x")?.as_f64()?;
+        let y = rect.get("y")?.as_f64()?;
+        let width = rect.get("width")?.as_f64()?;
+        let height = rect.get("height")?.as_f64()?;
+        Some((x + width / 2.0, y + height / 2.0))
+    }
+
+    fn routed_mmds_path(edge: &Value) -> Vec<(f64, f64)> {
+        edge.get("path")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|pt| {
+                        let pair = pt.as_array()?;
+                        Some((pair.first()?.as_f64()?, pair.get(1)?.as_f64()?))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn distance_to_polyline(point: (f64, f64), path: &[(f64, f64)]) -> f64 {
+        if path.is_empty() {
+            return f64::INFINITY;
+        }
+        if path.len() == 1 {
+            let (dx, dy) = (point.0 - path[0].0, point.1 - path[0].1);
+            return (dx * dx + dy * dy).sqrt();
+        }
+        path.windows(2)
+            .map(|seg| {
+                let (ax, ay) = seg[0];
+                let (bx, by) = seg[1];
+                let (dx, dy) = (bx - ax, by - ay);
+                let seg_len_sq = dx * dx + dy * dy;
+                if seg_len_sq <= 1e-6 {
+                    let (px, py) = (point.0 - ax, point.1 - ay);
+                    return (px * px + py * py).sqrt();
+                }
+                let t = (((point.0 - ax) * dx + (point.1 - ay) * dy) / seg_len_sq).clamp(0.0, 1.0);
+                let (cx, cy) = (ax + t * dx, ay + t * dy);
+                let (px, py) = (point.0 - cx, point.1 - cy);
+                (px * px + py * py).sqrt()
+            })
+            .fold(f64::INFINITY, f64::min)
+    }
+
+    fn render_fixture_svg_routed(fixture: &str) -> String {
+        let input = load_fixture(fixture);
+        crate::render_diagram(
+            &input,
+            OutputFormat::Svg,
+            &RenderConfig {
+                geometry_level: GeometryLevel::Routed,
+                layout_engine: Some(EngineAlgorithmId::FLUX_LAYERED),
+                ..RenderConfig::default()
+            },
+        )
+        .expect("svg render should succeed")
+    }
+
+    fn render_fixture_mmds_routed(fixture: &str) -> Value {
+        let input = load_fixture(fixture);
+        let json = crate::render_diagram(
+            &input,
+            OutputFormat::Mmds,
+            &RenderConfig {
+                geometry_level: GeometryLevel::Routed,
+                layout_engine: Some(EngineAlgorithmId::FLUX_LAYERED),
+                ..RenderConfig::default()
+            },
+        )
+        .expect("mmds render should succeed");
+        serde_json::from_str(&json).expect("mmds should be valid JSON")
+    }
+
+    fn assert_mmds_rect_encodes_post_fan_path(fixture: &str, edge_id: &str, label: &str) {
+        let mmds = render_fixture_mmds_routed(fixture);
+        let edge = routed_mmds_edge(&mmds, edge_id)
+            .unwrap_or_else(|| panic!("{fixture}: MMDS missing edge {edge_id}"));
+        let center = routed_mmds_label_rect_center(edge)
+            .unwrap_or_else(|| panic!("{fixture} {edge_id}: missing routed label_rect"));
+        let path = routed_mmds_path(edge);
+        let height = edge
+            .get("label_rect")
+            .and_then(|r| r.get("height"))
+            .and_then(|v| v.as_f64())
+            .expect("label_rect must carry height");
+
+        // Producer-truth invariant: MMDS `label_rect` center sits within
+        // `half_height + tolerance` of the raw routed path for
+        // orthogonal backward side-offset labels. Pre-fix, the stale engine
+        // anchor drifted well past this (39-98 px off-path for label height
+        // 28). Post-fix, the side-aware projection lands the center at
+        // path-midpoint + half_height normal.
+        let half_height = height / 2.0;
+        let tolerance = 2.0;
+        let drift = distance_to_polyline(center, &path);
+        assert!(
+            drift <= half_height + tolerance,
+            "{fixture} {edge_id} {label:?}: MMDS label_rect center {center:?} drifted {drift:.2} px from routed path (half_height={half_height:.2} tolerance={tolerance:.2}); path={path:?}"
+        );
+    }
+
+    fn assert_svg_label_stays_attached_to_rendered_edge(fixture: &str, label: &str) {
+        let svg = render_fixture_svg_routed(fixture);
+        let anchor = extract_svg_label_center(&svg, label).unwrap_or_else(|| {
+            panic!("{fixture}: SVG should render a `<text>` element for {label:?}")
+        });
+        // Minimal SVG attachment canary: the emitted `<text>` x/y must be a
+        // finite, non-sentinel coordinate inside the SVG viewBox. The exact
+        // placement depends on the curve preset and the revalidation
+        // fallback; we only verify the emitter did not drop or mis-route
+        // the label.
+        assert!(
+            anchor.0.is_finite() && anchor.1.is_finite(),
+            "{fixture}: SVG label {label:?} anchor is not finite: {anchor:?}"
+        );
+        assert!(
+            anchor.0 > 0.0 && anchor.1 > 0.0,
+            "{fixture}: SVG label {label:?} anchor {anchor:?} sits at or before origin"
+        );
+    }
+
+    #[test]
+    fn git_workflow_routed_mmds_label_rect_encodes_post_fan_path() {
+        assert_mmds_rect_encodes_post_fan_path("git_workflow.mmd", "e3", "git pull");
+    }
+
+    #[test]
+    fn git_workflow_td_routed_mmds_label_rect_encodes_post_fan_path() {
+        assert_mmds_rect_encodes_post_fan_path("git_workflow_td.mmd", "e3", "git pull");
+    }
+
+    #[test]
+    fn git_workflow_direct_routed_svg_keeps_git_pull_label_attached() {
+        assert_svg_label_stays_attached_to_rendered_edge("git_workflow.mmd", "git pull");
+    }
+
+    #[test]
+    fn git_workflow_td_direct_routed_svg_keeps_git_pull_label_attached() {
+        assert_svg_label_stays_attached_to_rendered_edge("git_workflow_td.mmd", "git pull");
+    }
+}

--- a/src/internal_tests/graph_routing_pipeline.rs
+++ b/src/internal_tests/graph_routing_pipeline.rs
@@ -5599,6 +5599,7 @@ mod plan_0151_producer_alignment {
 
     use super::distance_point_to_path;
     use crate::diagrams::flowchart::compile_to_graph;
+    use crate::diagrams::state::compiler as state_compiler;
     use crate::engines::graph::algorithms::layered::LayoutConfig as LayeredLayoutConfig;
     use crate::engines::graph::contracts::{MeasurementMode, SubgraphDirectionPolicy};
     use crate::engines::graph::{
@@ -5609,6 +5610,7 @@ mod plan_0151_producer_alignment {
     use crate::graph::geometry::{EdgeLabelSide, RoutedEdgeGeometry};
     use crate::graph::measure::default_proportional_text_metrics;
     use crate::mermaid::parse_flowchart;
+    use crate::mermaid::state::parse_state_diagram;
 
     /// Solve a flowchart fixture through the flux-layered engine with the same
     /// configuration the MMDS CLI uses (Canonical + Proportional + Routed).
@@ -5634,6 +5636,35 @@ mod plan_0151_producer_alignment {
             GeometryLevel::Routed,
             None,
             SubgraphDirectionPolicy::AlternateAxes,
+        );
+        let config = EngineConfig::Layered(LayeredLayoutConfig::default());
+        let result =
+            solve_graph_family(&diagram, EngineAlgorithmId::FLUX_LAYERED, &config, &request)
+                .unwrap_or_else(|e| panic!("flux-layered solve failed for {fixture}: {e}"));
+        let routed = result
+            .routed
+            .unwrap_or_else(|| panic!("{fixture}: expected routed geometry at Routed level"));
+        (diagram, routed.edges)
+    }
+
+    fn routed_state_fixture(fixture: &str) -> (crate::graph::Graph, Vec<RoutedEdgeGeometry>) {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("state")
+            .join(fixture);
+        let input = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
+        let parsed = parse_state_diagram(&input).expect("state input should parse");
+        let diagram = state_compiler::compile(&parsed.model);
+
+        let metrics = default_proportional_text_metrics();
+        let request = GraphSolveRequest::new(
+            MeasurementMode::Proportional(metrics),
+            GraphGeometryContract::Canonical,
+            GeometryLevel::Routed,
+            None,
+            SubgraphDirectionPolicy::Preserve,
         );
         let config = EngineConfig::Layered(LayeredLayoutConfig::default());
         let result =
@@ -5697,5 +5728,39 @@ mod plan_0151_producer_alignment {
     #[test]
     fn orthogonal_backward_side_offset_label_uses_post_fan_path_git_workflow_td() {
         assert_label_center_stays_near_final_path("git_workflow_td.mmd", "Remote", "Working");
+    }
+
+    /// Regression canary for Task 1.2: the state/composite `resume` edge
+    /// (Paused → Running, inside the Active subgraph) must keep its label on
+    /// the return corridor after producer alignment. If `resume` is in the
+    /// narrow branch, the alignment helper should produce a corridor-adjacent
+    /// anchor; if it is out of scope, the engine anchor is already sound.
+    /// Either way, the drift invariant should hold.
+    #[test]
+    fn alignment_preserves_state_composite_resume_readability() {
+        let (diagram, routed_edges) = routed_state_fixture("composite.mmd");
+        let resume_idx = diagram
+            .edges
+            .iter()
+            .position(|e| e.label.as_deref() == Some("resume"))
+            .expect("composite.mmd should have a `resume`-labeled edge");
+        let routed_edge = routed_edges
+            .iter()
+            .find(|re| re.index == resume_idx)
+            .expect("routed edges must include the resume edge");
+        let label_geom = routed_edge
+            .label_geometry
+            .as_ref()
+            .expect("resume edge must carry label_geometry");
+
+        let half_height = label_geom.rect.height / 2.0;
+        let tolerance = 2.0;
+        let drift = distance_point_to_path(label_geom.center, &routed_edge.path);
+        assert!(
+            drift <= half_height + tolerance,
+            "state/composite resume label drifted {drift:.2} px from return corridor (half_height={half_height:.2} tolerance={tolerance:.2}); center={:?} path={:?}",
+            label_geom.center,
+            routed_edge.path,
+        );
     }
 }

--- a/src/internal_tests/graph_routing_pipeline.rs
+++ b/src/internal_tests/graph_routing_pipeline.rs
@@ -5574,3 +5574,128 @@ mod plan_0145_lane_assignment {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Plan 0151 Task 1.1 Red gate: pin the orthogonal-backward side-offset
+// stale-anchor bug.
+//
+// Narrow branch: `EdgeRouting::OrthogonalRoute` + `is_backward` +
+// `label_side != Center`. `fan::spread_colocated_backward_*` mutates the final
+// path after `orthogonal::mod`'s `revalidate_label_anchor` pass (which is
+// skipped entirely for side-offset labels), so `label_position` becomes
+// divorced from the post-fan path. `populate_label_geometry` then freezes the
+// stale center into `label_geometry.rect`, and MMDS serializes it verbatim.
+//
+// These tests fail today because `git_workflow.mmd` (LR) e3 sits ~48 px off
+// path and `git_workflow_td.mmd` (TD) e3 sits ~98 px off path. The fix lands
+// in Task 1.2 as a pre-pass helper in `stage.rs` that runs immediately before
+// `populate_label_geometry()` and applies the side-aware projection rule
+// recorded in `findings/01-producer-seam-choice.md`.
+// ---------------------------------------------------------------------------
+
+mod plan_0151_producer_alignment {
+    use std::fs;
+    use std::path::Path;
+
+    use super::distance_point_to_path;
+    use crate::diagrams::flowchart::compile_to_graph;
+    use crate::engines::graph::algorithms::layered::LayoutConfig as LayeredLayoutConfig;
+    use crate::engines::graph::contracts::{MeasurementMode, SubgraphDirectionPolicy};
+    use crate::engines::graph::{
+        EngineAlgorithmId, EngineConfig, GraphGeometryContract, GraphSolveRequest,
+        solve_graph_family,
+    };
+    use crate::graph::GeometryLevel;
+    use crate::graph::geometry::{EdgeLabelSide, RoutedEdgeGeometry};
+    use crate::graph::measure::default_proportional_text_metrics;
+    use crate::mermaid::parse_flowchart;
+
+    /// Solve a flowchart fixture through the flux-layered engine with the same
+    /// configuration the MMDS CLI uses (Canonical + Proportional + Routed).
+    /// This is required because the producer stale-anchor bug exists only when
+    /// the flux profile is active (`label_side_selection = true`); a
+    /// hand-rolled `LayoutConfig` without that flag collapses all edges to
+    /// `label_side=Center` and never hits the narrow branch.
+    fn routed_fixture(fixture: &str) -> (crate::graph::Graph, Vec<RoutedEdgeGeometry>) {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("flowchart")
+            .join(fixture);
+        let input = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()));
+        let fc = parse_flowchart(&input).unwrap();
+        let diagram = compile_to_graph(&fc);
+
+        let metrics = default_proportional_text_metrics();
+        let request = GraphSolveRequest::new(
+            MeasurementMode::Proportional(metrics),
+            GraphGeometryContract::Canonical,
+            GeometryLevel::Routed,
+            None,
+            SubgraphDirectionPolicy::AlternateAxes,
+        );
+        let config = EngineConfig::Layered(LayeredLayoutConfig::default());
+        let result =
+            solve_graph_family(&diagram, EngineAlgorithmId::FLUX_LAYERED, &config, &request)
+                .unwrap_or_else(|e| panic!("flux-layered solve failed for {fixture}: {e}"));
+        let routed = result
+            .routed
+            .unwrap_or_else(|| panic!("{fixture}: expected routed geometry at Routed level"));
+        (diagram, routed.edges)
+    }
+
+    fn assert_label_center_stays_near_final_path(fixture: &str, from: &str, to: &str) {
+        let (diagram, routed_edges) = routed_fixture(fixture);
+        let edge_idx = diagram
+            .edges
+            .iter()
+            .position(|e| e.from == from && e.to == to)
+            .unwrap_or_else(|| panic!("{fixture}: missing edge {from} -> {to}"));
+        let routed_edge = routed_edges
+            .iter()
+            .find(|re| re.index == edge_idx)
+            .unwrap_or_else(|| panic!("{fixture}: no routed edge for {from} -> {to}"));
+
+        assert!(
+            routed_edge.is_backward,
+            "{fixture} {from} -> {to}: expected backward edge to exercise the narrow branch"
+        );
+        let side = routed_edge.label_side.unwrap_or(EdgeLabelSide::Center);
+        assert_ne!(
+            side,
+            EdgeLabelSide::Center,
+            "{fixture} {from} -> {to}: expected non-center label_side"
+        );
+
+        let label_geom = routed_edge
+            .label_geometry
+            .as_ref()
+            .unwrap_or_else(|| panic!("{fixture} {from} -> {to}: missing label_geometry"));
+
+        // Invariant: label center sits within half its own height (plus a
+        // small tolerance) of the final post-fan path. That admits any
+        // side-aware projection that offsets the midpoint perpendicular to
+        // the midpoint segment by `height / 2`, while rejecting the stale
+        // pre-fan engine anchor that currently drifts far past the rect.
+        let half_height = label_geom.rect.height / 2.0;
+        let tolerance = 2.0;
+        let drift = distance_point_to_path(label_geom.center, &routed_edge.path);
+        assert!(
+            drift <= half_height + tolerance,
+            "{fixture} {from} -> {to}: label center drifted {drift:.2} px from final path (half_height={half_height:.2} tolerance={tolerance:.2} side={side:?}); center={:?} path={:?}",
+            label_geom.center,
+            routed_edge.path,
+        );
+    }
+
+    #[test]
+    fn orthogonal_backward_side_offset_label_uses_post_fan_path_git_workflow() {
+        assert_label_center_stays_near_final_path("git_workflow.mmd", "Remote", "Working");
+    }
+
+    #[test]
+    fn orthogonal_backward_side_offset_label_uses_post_fan_path_git_workflow_td() {
+        assert_label_center_stays_near_final_path("git_workflow_td.mmd", "Remote", "Working");
+    }
+}

--- a/tests/svg-snapshots/flowchart-curved-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/backward_loop_lr.svg
@@ -35,8 +35,8 @@
       <text x="1567.24" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Production Code</text>
     </g>
     <g class="edgeLabels">
-      <rect x="1115.27" y="176.00" width="34.73" height="28.00" fill="white" />
-      <text x="1132.63" y="190.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1113.27" y="178.00" width="34.73" height="28.00" fill="white" />
+      <text x="1130.63" y="192.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
       <rect x="1393.87" y="125.00" width="42.52" height="28.00" fill="white" />
       <text x="1415.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>

--- a/tests/svg-snapshots/flowchart-curved-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/git_workflow.svg
@@ -28,8 +28,8 @@
       <text x="530.76" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="795.63" y="21.00" width="69.80" height="28.00" fill="white" />
       <text x="830.53" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="502.78" y="72.00" width="62.01" height="28.00" fill="white" />
-      <text x="533.78" y="86.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="500.78" y="74.00" width="62.01" height="28.00" fill="white" />
+      <text x="531.78" y="88.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

The flux-layered engine sets `label_position` for backward side-offset labels relative to the abstract forward-flow path. When orthogonal routing replaces that with a U-channel and `fan::spread_colocated_backward_*` mutates endpoints, the engine's anchor becomes divorced from the final routed path. `orthogonal::mod`'s `revalidate_label_anchor` skips `label_side != Center` by design, so the staleness persists into MMDS output (`label_rect` serializes the stale center verbatim) and into SVG (which currently compensates via path-midpoint revalidation).

This PR lands a narrow pre-pass helper in `src/graph/routing/stage.rs`, running immediately before `populate_label_geometry()`, that re-projects `label_position` onto the arc-length midpoint of the final post-fan path and offsets it perpendicular to the midpoint segment by `label_height / 2` in the direction dictated by `label_side`.

**Narrow predicate:** `EdgeRouting::OrthogonalRoute` + `is_backward` + `label_side ∈ {Above, Below}`. Forward orthogonal and non-orthogonal branches already get their anchors revalidated or recomputed upstream.

## Stack

- **PR A (this)** — producer truth (Phase 1 of plan 0152). Off `main`.
- **PR B** — MMDS replay contract (Phase 2, closes #250). Stacked on this.
- **PR C** — corridor-aware text placement (Phase 3, closes #231). Stacked on B.

## Why not the one-big-PR approach

The producer fix is genuinely independent from the MMDS replay and text-renderer work. It stands on its own as a bug fix: MMDS routed output now serializes a `label_rect` that is truthful to the final post-fan path instead of being 40-100 px stale for the affected fixtures.

## Changes

- `src/graph/routing/stage.rs` — pre-pass helper `align_backward_side_offset_labels` + `project_side_aware_anchor` + `side_aware_normal` + `midpoint_segment`. Unit tests for the projection helpers.
- `src/internal_tests/graph_routing_pipeline.rs` — route-level canaries asserting `distance_point_to_path(label_geometry.center, path) <= label_height/2 + 2 px` for `git_workflow.mmd` (LR, was 39.5 px drift) and `git_workflow_td.mmd` (TD, was 52.8 px drift).
- `src/internal_tests/cross_pipeline.rs` — cross-pipeline canaries: routed MMDS `label_rect` encodes the post-fan anchor; direct SVG keeps the label attached.
- `tests/svg-snapshots/flowchart-curved-step/{backward_loop_lr.svg,git_workflow.svg}` — 2-px regen. The producer is now truthful enough that SVG revalidation is a no-op for these edges on Basis-curved paths.

## Side-aware projection rule

1. Project onto the final path's arc-length midpoint.
2. Derive the local tangent from the midpoint segment.
3. Apply `Above` / `Below` on that segment's normal (oriented so "Below" points screen-down on horizontal tangents, screen-right on vertical tangents).
4. Offset magnitude: `label_height / 2`.

For a U-channel horizontal leg, this places the label flush against the corridor on the correct side. For a vertical leg it places the label one half-height to the Below/Above side of the corridor.

## Test plan

- [x] Two failing Red-gate tests now pass after the fix
- [x] `state/composite` resume-edge readability canary passes
- [x] Unit tests for `side_aware_normal` / `project_side_aware_anchor` pass
- [x] Full nextest suite: 2592/2592 passing
- [x] `just lint` clean
- [ ] Reviewer confirms the side-aware projection rule matches Mermaid conventions for non-U-channel cases

## Supersedes

PR #252's Phase 1 commits. PR #252 stays open as draft-for-reference and closes once this stack lands.