### PR TITLE
fix: preserve authoritative label_rect through routed MMDS hydrate

### DIFF
--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -9,8 +9,8 @@ use serde_json::{Map, Value};
 
 use crate::graph::direction_policy::build_node_directions;
 use crate::graph::geometry::{
-    GraphGeometry, LayoutEdge, PositionedNode, RoutedGraphGeometry, SelfEdgeGeometry,
-    SubgraphGeometry,
+    EdgeLabelGeometry, EdgeLabelSide, GraphGeometry, LayoutEdge, PositionedNode,
+    RoutedGraphGeometry, SelfEdgeGeometry, SubgraphGeometry,
 };
 use crate::graph::measure::default_proportional_text_metrics;
 use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
@@ -354,12 +354,75 @@ pub fn hydrate_routed_geometry_from_output(
     // MMDS replay hydration: default metrics are sufficient since the MMDS
     // replay path does not carry a request-specific metrics handle (design §6.3).
     let metrics = default_proportional_text_metrics();
-    Ok(route_graph_geometry(
-        &diagram,
-        &geometry,
-        edge_routing,
-        &metrics,
-    ))
+    let mut routed = route_graph_geometry(&diagram, &geometry, edge_routing, &metrics);
+
+    // Plan 0151 Task 2.2: preserve authoritative routed label geometry by
+    // overwriting `label_geometry` on routed edges with the semantics carried
+    // by the MMDS payload. `route_graph_geometry` rebuilt `label_geometry`
+    // from `label_position` inside `populate_label_geometry`, which would
+    // silently lose the authoritative `label_rect` whenever `label_position`
+    // and `label_rect` disagree. See
+    // `.gumbo/plans/0151-routed-label-geometry-contract/findings/02-mmds-contract-choice.md`.
+    if output.geometry_level == "routed" {
+        overlay_authoritative_label_geometry(&mut routed, output, &metrics);
+    }
+
+    Ok(routed)
+}
+
+/// Replace synthesized `label_geometry` on routed edges with an
+/// authoritative version derived from the MMDS payload's `label_rect`
+/// and `label_side`.
+fn overlay_authoritative_label_geometry(
+    routed: &mut RoutedGraphGeometry,
+    output: &Output,
+    metrics: &crate::graph::measure::ProportionalTextMetrics,
+) {
+    let edges = sorted_output_edges(output);
+    for (routed_index, (_, mmds_edge)) in edges.into_iter().enumerate() {
+        let Some(mmds_rect) = mmds_edge.label_rect.as_ref() else {
+            continue;
+        };
+        let Some(routed_edge) = routed
+            .edges
+            .iter_mut()
+            .find(|edge| edge.index == routed_index)
+        else {
+            continue;
+        };
+        let side = parse_mmds_label_side(mmds_edge.label_side.as_deref())
+            .or(routed_edge.label_side)
+            .unwrap_or(EdgeLabelSide::Center);
+        let rect = FRect::new(mmds_rect.x, mmds_rect.y, mmds_rect.width, mmds_rect.height);
+        let center = FPoint::new(
+            mmds_rect.x + mmds_rect.width / 2.0,
+            mmds_rect.y + mmds_rect.height / 2.0,
+        );
+
+        routed_edge.label_side = Some(side);
+        routed_edge.label_position = Some(center);
+        routed_edge.label_geometry = Some(EdgeLabelGeometry {
+            center,
+            rect,
+            padding: (metrics.label_padding_x, metrics.label_padding_y),
+            side,
+            // Synthesized trust markers: replay consumers that gate on
+            // `track != 0 || compartment_size > 1` treat the hydrated
+            // center as authoritative, mirroring the direct-render
+            // path's lane-shifted-label trust branch.
+            track: 0,
+            compartment_size: 2,
+        });
+    }
+}
+
+fn parse_mmds_label_side(value: Option<&str>) -> Option<EdgeLabelSide> {
+    match value? {
+        "above" => Some(EdgeLabelSide::Above),
+        "below" => Some(EdgeLabelSide::Below),
+        "center" => Some(EdgeLabelSide::Center),
+        _ => None,
+    }
 }
 
 fn hydrate_geometry_parts(output: &Output) -> Result<(Graph, GraphGeometry), HydrationError> {
@@ -579,6 +642,7 @@ fn build_layout_edges(output: &Output) -> (Vec<LayoutEdge>, Vec<SelfEdgeGeometry
         } else {
             None
         };
+        let label_side = parse_mmds_label_side(edge.label_side.as_deref());
 
         layout_edges.push(LayoutEdge {
             index,
@@ -586,7 +650,7 @@ fn build_layout_edges(output: &Output) -> (Vec<LayoutEdge>, Vec<SelfEdgeGeometry
             to: edge.target.clone(),
             waypoints: Vec::new(),
             label_position,
-            label_side: None,
+            label_side,
             from_subgraph: edge.from_subgraph.clone(),
             to_subgraph: edge.to_subgraph.clone(),
             layout_path_hint: path,

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -1812,4 +1812,103 @@ mod plan_0151_routed_mmds_replay_contract {
             geom.center
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Task 2.3: replay SVG canaries prove the hydration contract reaches the
+    // rendered label, not just the internal `EdgeLabelGeometry`.
+    // -----------------------------------------------------------------------
+
+    fn extract_svg_text_anchor(svg: &str, label: &str) -> Option<(f64, f64)> {
+        for line in svg.lines() {
+            let line = line.trim();
+            if !line.starts_with("<text") {
+                continue;
+            }
+            if !line.contains(&format!(">{label}<")) {
+                continue;
+            }
+            let x = attr(line, " x=\"")?.parse::<f64>().ok()?;
+            let y = attr(line, " y=\"")?.parse::<f64>().ok()?;
+            return Some((x, y));
+        }
+        None
+    }
+
+    fn attr<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
+        let start = line.find(prefix)? + prefix.len();
+        let rest = &line[start..];
+        let end = rest.find('"')?;
+        Some(&rest[..end])
+    }
+
+    #[test]
+    fn synthetic_shifted_label_survives_routed_mmds_svg_replay() {
+        let output = poisoned_synthetic_routed_output();
+        let rect = output
+            .edges
+            .iter()
+            .find(|e| e.id == "e3")
+            .and_then(|e| e.label_rect.clone())
+            .expect("poisoned fixture carries label_rect");
+        let authoritative_center = (rect.x + rect.width / 2.0, rect.y + rect.height / 2.0);
+
+        let payload_json =
+            serde_json::to_string(&output).expect("synthetic output should serialize back to JSON");
+        let svg = render_mmds_input(&payload_json, OutputFormat::Svg, RenderConfig::default());
+        let anchor = extract_svg_text_anchor(&svg, "git pull")
+            .expect("replay SVG should emit a <text> element for git pull");
+
+        let dx = anchor.0 - authoritative_center.0;
+        let dy = anchor.1 - authoritative_center.1;
+        let drift = (dx * dx + dy * dy).sqrt();
+        assert!(
+            drift <= 0.5,
+            "replay SVG anchor {anchor:?} must track the authoritative rect center {authoritative_center:?}; drift {drift:.2} px. If SVG revalidation snaps this back toward the corridor midpoint, the hydration-synthesized `compartment_size = 2` trust signal is not reaching the emitter."
+        );
+    }
+
+    #[test]
+    fn git_workflow_routed_mmds_replay_svg_tracks_authoritative_rect() {
+        // The producer already emits an authoritative `label_rect` on this
+        // fixture. Replay must render the "git pull" label at that rect's
+        // center, without being snapped back to the rendered-path midpoint
+        // by SVG revalidation (the hydration-synthesized
+        // `compartment_size = 2` trust signal is the mechanism).
+        //
+        // This is intentionally *not* a direct-vs-replay parity check:
+        // direct SVG currently revalidates side-offset labels against the
+        // rendered path, so direct and replay legitimately disagree by the
+        // side-offset magnitude (~14 px). Converging that gap is out of
+        // scope for this plan — see the Non-Goals section of the plan.
+        let input = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests")
+                .join("fixtures")
+                .join("flowchart")
+                .join("git_workflow.mmd"),
+        )
+        .unwrap();
+        let routed_mmds = render_json_with_level(&input, GeometryLevel::Routed);
+        let output: Output = serde_json::from_str(&routed_mmds).unwrap();
+        let rect = output
+            .edges
+            .iter()
+            .find(|e| e.id == "e3")
+            .and_then(|e| e.label_rect.clone())
+            .expect("git_workflow e3 should carry routed label_rect after producer fix");
+        let authoritative = (rect.x + rect.width / 2.0, rect.y + rect.height / 2.0);
+
+        let replay_svg =
+            render_mmds_input(&routed_mmds, OutputFormat::Svg, RenderConfig::default());
+        let anchor = extract_svg_text_anchor(&replay_svg, "git pull")
+            .expect("replay SVG should carry git pull");
+
+        let dx = anchor.0 - authoritative.0;
+        let dy = anchor.1 - authoritative.1;
+        let drift = (dx * dx + dy * dy).sqrt();
+        assert!(
+            drift <= 0.5,
+            "replay SVG anchor {anchor:?} must track the authoritative label_rect center {authoritative:?}; drift {drift:.2} px"
+        );
+    }
 }

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -8,7 +8,8 @@ use std::path::Path;
 
 use mmdflux::graph::GeometryLevel;
 use mmdflux::mmds::{
-    Edge as MmdsEdge, Output, Rect as MmdsRect, SUPPORTED_PROFILES, evaluate_profiles, parse_input,
+    Edge as MmdsEdge, Output, Position as MmdsPosition, Rect as MmdsRect, SUPPORTED_PROFILES,
+    evaluate_profiles, hydrate_routed_geometry_from_output, parse_input,
 };
 use mmdflux::simplification::PathSimplification;
 use mmdflux::{EngineAlgorithmId, OutputFormat, RenderConfig, TextColorMode};
@@ -1715,6 +1716,100 @@ fn mmds_routed_to_layout_down_conversion_strips_routed_only_edge_fields() {
         assert!(
             edge.label_rect.is_none(),
             "label_rect must be stripped at layout level"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Plan 0151 Task 2.1: routed MMDS replay must preserve authoritative label
+// geometry, not snap back to a stale `label_position`.
+//
+// A routed MMDS payload carries both `label_rect` and `label_position`. The
+// authoritative truth is the rectangle — it was shaped by the producer
+// pipeline, including Plan 0151 Task 1.2's side-aware alignment. If an
+// adapter or a future producer change leaves the two fields disagreeing,
+// MMDS replay must prefer the rect.
+//
+// Today `hydrate_routed_geometry_from_output` rebuilds `label_geometry`
+// from `label_position` inside `populate_label_geometry`, ignoring the
+// serialized `label_rect`. Replay silently loses authoritative routed
+// label placement whenever the producer anchor and raw position disagree.
+//
+// Red: authoritative `label_rect` center vs. poisoned `label_position` 40 px
+// off. After hydration, `label_geometry.center` must track the rect, not
+// the position. Passes after Task 2.2 makes hydrate treat `label_rect` as
+// the authoritative source.
+// ---------------------------------------------------------------------------
+
+mod plan_0151_routed_mmds_replay_contract {
+    use super::*;
+
+    fn poisoned_synthetic_routed_output() -> Output {
+        let input = std::fs::read_to_string(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests")
+                .join("fixtures")
+                .join("flowchart")
+                .join("git_workflow.mmd"),
+        )
+        .unwrap();
+        let routed_json = render_json_with_level(&input, GeometryLevel::Routed);
+        let mut output: Output = serde_json::from_str(&routed_json).unwrap();
+
+        let e3 = output
+            .edges
+            .iter_mut()
+            .find(|e| e.id == "e3")
+            .expect("git_workflow routed output should expose edge e3 (git pull)");
+        let auth_rect = e3
+            .label_rect
+            .clone()
+            .expect("producer fix should have serialized label_rect");
+
+        // Poison `label_position` by shifting it 40 px off the authoritative
+        // rect center. `label_rect` stays untouched — it is the claim the
+        // replay contract must honor.
+        let rect_center_x = auth_rect.x + auth_rect.width / 2.0;
+        let rect_center_y = auth_rect.y + auth_rect.height / 2.0;
+        e3.label_position = Some(MmdsPosition {
+            x: rect_center_x,
+            y: rect_center_y - 40.0,
+        });
+
+        output
+    }
+
+    #[test]
+    fn hydrate_routed_geometry_preserves_authoritative_label_rect_when_label_position_disagrees() {
+        let output = poisoned_synthetic_routed_output();
+        let e3_rect = output
+            .edges
+            .iter()
+            .find(|e| e.id == "e3")
+            .and_then(|e| e.label_rect.clone())
+            .expect("poisoned fixture must still carry label_rect");
+        let expected_center_x = e3_rect.x + e3_rect.width / 2.0;
+        let expected_center_y = e3_rect.y + e3_rect.height / 2.0;
+
+        let routed = hydrate_routed_geometry_from_output(&output)
+            .expect("hydration should succeed for a valid routed payload");
+        let edge = routed
+            .edges
+            .iter()
+            .find(|e| e.from == "Remote" && e.to == "Working")
+            .expect("hydrated routed edges should include Remote -> Working");
+        let geom = edge
+            .label_geometry
+            .as_ref()
+            .expect("hydrated edge must carry label_geometry");
+
+        let dx = geom.center.x - expected_center_x;
+        let dy = geom.center.y - expected_center_y;
+        let drift = (dx * dx + dy * dy).sqrt();
+        assert!(
+            drift <= 0.5,
+            "replayed label_geometry.center {:?} must track the authoritative rect center ({expected_center_x}, {expected_center_y}); drift {drift:.2} px. The poisoned label_position was 40 px away — if hydration follows it, that failure mode is what this test pins.",
+            geom.center
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #250. Hydrate-time overlay preserves `label_side` and reconstructs `EdgeLabelGeometry` from the authoritative serialized `label_rect` instead of silently dropping back to `populate_label_geometry`'s rebuild from `label_position`.

No MMDS schema change. Hydration synthesizes `compartment_size = 2` as the trust signal so existing renderers skip revalidation during replay.

## Stack

- PR #253 — producer truth (Phase 1). Base.
- **PR B (this)** — MMDS replay contract (Phase 2). Closes #250.
- PR C (next) — corridor-aware text placement (Phase 3, closes #231). Stacked on this.

## The replay hole

Before this PR, `hydrate_routed_geometry_from_output`:
1. Called `build_layout_edges`, which built every `LayoutEdge` with `label_side: None` and `label_geometry: None` — dropping whatever side semantics the MMDS payload encoded.
2. Called `route_graph_geometry` with `EdgeRouting::EngineProvided`, which ran `populate_label_geometry` to rebuild `label_geometry.center` from `label_position` — which could be stale or absent.

End result: a routed MMDS payload with a valid `label_rect` at `(X, Y)` but `label_position` at `(X, Y − 40)` (e.g., an adapter that poisoned the anchor, or pre-PR-#253 producer output) would replay with the label at the poisoned position, losing the authoritative rect entirely.

## The fix

1. `build_layout_edges` now parses and preserves `edge.label_side` via `parse_mmds_label_side`.
2. `hydrate_routed_geometry_from_output` runs a post-pass `overlay_authoritative_label_geometry` that, for each routed edge with a serialized `label_rect`, reconstructs `EdgeLabelGeometry`:
   - `center = rect.midpoint()`
   - `rect = FRect::from(mmds_rect)`
   - `padding = metrics.default_padding()`
   - `side = hydrated label_side` (falling back to the routed edge's existing side, then Center)
   - `track = 0, compartment_size = 2` — synthesized trust markers

The `compartment_size = 2` value trips the SVG `track != 0 || compartment_size > 1` trust branch at `src/render/graph/svg/labels.rs:173-175`, so replay-SVG treats the hydrated center as authoritative and does not revalidate it against the rendered path.

## Why not add `label_track` / `label_compartment_size` to the MMDS schema

Considered and rejected. The MMDS spec at `docs/mmds.md:205` classifies additive optional edge fields as non-breaking, but the *minimal* replay contract is `label_rect + label_side + default padding`. Adapters (React Flow, Cytoscape, D3) consume `label_rect` and `label_side`; lane metadata is renderer-implementation detail. See the corresponding finding on plan 0152's side for the escalation path if a future adapter proves it needs the fields.

## Changes

- `src/mmds/hydrate.rs` — `parse_mmds_label_side`, `overlay_authoritative_label_geometry`, `label_side` preservation in `build_layout_edges`.
- `tests/mmds_json.rs` — two new test modules:
  - `hydrate_routed_geometry_preserves_authoritative_label_rect_when_label_position_disagrees` (unit-level)
  - `synthetic_shifted_label_survives_routed_mmds_svg_replay` and `git_workflow_routed_mmds_replay_svg_tracks_authoritative_rect` (end-to-end via replay-SVG emission)

Not touched: `docs/mmds.md`, `docs/mmds.schema.json`, cross-language contract fixtures.

## Test plan

- [x] Red-gate test passes: poisoned payload with 40 px drift hydrates with `label_geometry.center` within 0.5 px of the rect center
- [x] Synthetic replay SVG puts the label at the authoritative rect center (proves the trust signal reaches the emitter)
- [x] `git_workflow` round-trip: MMDS → Svg replay renders at producer's rect center
- [x] Full nextest suite: 2595/2595 passing
- [x] `just lint` clean
- [ ] Reviewer confirms the `compartment_size = 2` synthesis is an acceptable substitute for explicit schema metadata

## Supersedes

PR #252's Phase 2 commits.

Closes #250.