### PR TITLE
fix: match mermaid compound positioning parity

### DIFF
--- a/src/engines/graph/algorithms/layered/kernel/dagre_parity_tests.rs
+++ b/src/engines/graph/algorithms/layered/kernel/dagre_parity_tests.rs
@@ -310,6 +310,86 @@ mod compound_backward_disconnected {
             result.reversed_edges
         );
     }
+
+    #[test]
+    fn compound_backward_disconnected_dfs_only_layout_matches_raw_dagre() {
+        let input: InputGraph = load_json(INPUT_PATH);
+        let expected: DagreLayout = load_json(EXPECTED_PATH);
+        let graph = build_digraph_from_input(&input);
+        let config = LayoutConfig {
+            node_sep: 50.0,
+            edge_sep: 20.0,
+            rank_sep: 75.0,
+            margin: 8.0,
+            acyclic_policy: AcyclicPolicy::DfsOnly,
+            ..Default::default()
+        };
+
+        let result = layout(&graph, &config, |_, dims| *dims);
+        let tolerance = 0.001;
+
+        for expected_node in &expected.nodes {
+            let actual = if expected_node.is_compound {
+                result
+                    .subgraph_bounds
+                    .get(&expected_node.id)
+                    .unwrap_or_else(|| panic!("missing subgraph bounds for {}", expected_node.id))
+            } else {
+                result
+                    .nodes
+                    .get(&NodeId::from(expected_node.id.as_str()))
+                    .unwrap_or_else(|| panic!("missing node {}", expected_node.id))
+            };
+
+            assert!(
+                (actual.x - expected_node.x).abs() < tolerance,
+                "{} x mismatch: actual={}, expected={}",
+                expected_node.id,
+                actual.x,
+                expected_node.x
+            );
+            assert!(
+                (actual.y - expected_node.y).abs() < tolerance,
+                "{} y mismatch: actual={}, expected={}",
+                expected_node.id,
+                actual.y,
+                expected_node.y
+            );
+            assert!(
+                (actual.width - expected_node.width).abs() < tolerance,
+                "{} width mismatch: actual={}, expected={}",
+                expected_node.id,
+                actual.width,
+                expected_node.width
+            );
+            assert!(
+                (actual.height - expected_node.height).abs() < tolerance,
+                "{} height mismatch: actual={}, expected={}",
+                expected_node.id,
+                actual.height,
+                expected_node.height
+            );
+        }
+
+        for expected_edge in &expected.edges {
+            let actual = result
+                .edges
+                .iter()
+                .find(|edge| edge.index == expected_edge.index)
+                .unwrap_or_else(|| panic!("missing edge {}", expected_edge.index));
+            let actual_points: Vec<(f64, f64)> = actual
+                .points
+                .iter()
+                .map(|point| (point.x, point.y))
+                .collect();
+            assert_points_close(
+                &actual_points,
+                &expected_edge.points,
+                tolerance,
+                &format!("edge {}", expected_edge.index),
+            );
+        }
+    }
 }
 
 mod subgraph_bounds {

--- a/src/engines/graph/algorithms/layered/kernel/nesting.rs
+++ b/src/engines/graph/algorithms/layered/kernel/nesting.rs
@@ -7,7 +7,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::graph::LayoutGraph;
-use super::types::NodeId;
+use super::types::{AcyclicPolicy, NodeId};
 
 /// Compute the depth of each node in the compound parent hierarchy.
 /// Top-level nodes get depth 1, each nesting level adds 1.
@@ -76,7 +76,12 @@ fn compute_depth(lg: &LayoutGraph, node: usize, depth: i32, depths: &mut HashMap
 ///
 /// Also creates a nesting root node connected to all top-level nodes.
 /// Nesting edges use high weights to dominate ranking.
+#[cfg(test)]
 pub fn run(lg: &mut LayoutGraph) {
+    run_with_policy(lg, AcyclicPolicy::default());
+}
+
+pub fn run_with_policy(lg: &mut LayoutGraph, acyclic_policy: AcyclicPolicy) {
     if lg.compound_nodes.is_empty() {
         return;
     }
@@ -174,7 +179,7 @@ pub fn run(lg: &mut LayoutGraph) {
     // (border_bottom → target → … → internal_node → border_bottom) that
     // the ranker resolves by placing external nodes far above/below the
     // subgraph, producing layouts divergent from dagre.js.  See #173.
-    {
+    if matches!(acyclic_policy, AcyclicPolicy::SemanticCompoundFeedback) {
         // Build forward adjacency from original non-reversed edges.
         let mut fwd_adj: Vec<Vec<usize>> = vec![Vec::new(); lg.node_ids.len()];
         for ei in 0..orig_edge_count {

--- a/src/engines/graph/algorithms/layered/kernel/network_simplex.rs
+++ b/src/engines/graph/algorithms/layered/kernel/network_simplex.rs
@@ -92,9 +92,24 @@ fn build_adjacency(graph: &LayoutGraph) -> Vec<Vec<(usize, usize)>> {
     adj
 }
 
+fn is_rank_node(graph: &LayoutGraph, node: usize, exclude_compounds: bool) -> bool {
+    !exclude_compounds || !graph.compound_nodes.contains(&node)
+}
+
+fn rank_node_count(graph: &LayoutGraph, exclude_compounds: bool) -> usize {
+    (0..graph.node_count())
+        .filter(|&node| is_rank_node(graph, node, exclude_compounds))
+        .count()
+}
+
 /// DFS from all tree nodes, greedily adding neighbors connected by tight edges.
 /// Returns the number of nodes in the tree after this pass.
-fn tight_tree(tree: &mut SpanningTree, graph: &LayoutGraph, adj: &[Vec<(usize, usize)>]) -> usize {
+fn tight_tree(
+    tree: &mut SpanningTree,
+    graph: &LayoutGraph,
+    adj: &[Vec<(usize, usize)>],
+    exclude_compounds: bool,
+) -> usize {
     // DFS from each current tree node to find tight edges to non-tree nodes.
     // We iterate tree nodes via a stack to avoid borrowing issues.
     let tree_nodes: Vec<usize> = (0..tree.node_count())
@@ -104,7 +119,10 @@ fn tight_tree(tree: &mut SpanningTree, graph: &LayoutGraph, adj: &[Vec<(usize, u
     let mut stack: Vec<usize> = tree_nodes;
     while let Some(v) = stack.pop() {
         for &(w, edge_idx) in &adj[v] {
-            if !tree.in_tree[w] && slack(graph, edge_idx) == 0 {
+            if is_rank_node(graph, w, exclude_compounds)
+                && !tree.in_tree[w]
+                && slack(graph, edge_idx) == 0
+            {
                 tree.add_edge(v, w, edge_idx);
                 stack.push(w);
             }
@@ -118,12 +136,21 @@ fn tight_tree(tree: &mut SpanningTree, graph: &LayoutGraph, adj: &[Vec<(usize, u
 /// (one endpoint in tree, one outside). Returns Some((edge_idx, delta)) where delta
 /// is the value to add to all tree node ranks to make this edge tight.
 /// Returns None if no crossing edge exists (disconnected graph).
-fn find_min_slack_crossing(tree: &SpanningTree, graph: &LayoutGraph) -> Option<(usize, i32)> {
+fn find_min_slack_crossing(
+    tree: &SpanningTree,
+    graph: &LayoutGraph,
+    exclude_compounds: bool,
+) -> Option<(usize, i32)> {
     let edges = graph.effective_edges();
     let mut best_edge = None;
     let mut best_slack = i32::MAX;
 
     for (edge_idx, &(from, to)) in edges.iter().enumerate() {
+        if !is_rank_node(graph, from, exclude_compounds)
+            || !is_rank_node(graph, to, exclude_compounds)
+        {
+            continue;
+        }
         let from_in = tree.in_tree[from];
         let to_in = tree.in_tree[to];
         if from_in == to_in {
@@ -314,28 +341,45 @@ fn calc_cut_value(
 
 /// Construct a feasible spanning tree of tight edges.
 /// Modifies graph ranks to ensure the tree spans all nodes.
+#[cfg(test)]
 pub(crate) fn feasible_tree(graph: &mut LayoutGraph) -> SpanningTree {
+    feasible_tree_with_mode(graph, false)
+}
+
+pub(crate) fn feasible_tree_with_mode(
+    graph: &mut LayoutGraph,
+    exclude_compounds: bool,
+) -> SpanningTree {
     let n = graph.node_count();
     let mut tree = SpanningTree::new(n);
     let adj = build_adjacency(graph);
+    let rank_nodes = rank_node_count(graph, exclude_compounds);
+    if rank_nodes == 0 {
+        return tree;
+    }
 
-    // Start from node 0
-    tree.add_node(0);
+    // Start from first non-compound rank node, matching dagre asNonCompoundGraph.
+    let start = (0..n)
+        .find(|&node| is_rank_node(graph, node, exclude_compounds))
+        .unwrap_or(0);
+    tree.add_node(start);
 
     let max_iters = n * 2; // Safety limit
     let mut iters = 0;
     loop {
-        let size = tight_tree(&mut tree, graph, &adj);
-        if size >= n {
+        let size = tight_tree(&mut tree, graph, &adj, exclude_compounds);
+        if size >= rank_nodes {
             break;
         }
         // Find min-slack edge crossing tree boundary and shift ranks
-        match find_min_slack_crossing(&tree, graph) {
+        match find_min_slack_crossing(&tree, graph, exclude_compounds) {
             Some((_edge_idx, delta)) => {
                 if delta == 0 {
                     // No progress possible — force-add remaining nodes
                     for node in 0..n {
-                        tree.add_node(node);
+                        if is_rank_node(graph, node, exclude_compounds) {
+                            tree.add_node(node);
+                        }
                     }
                     break;
                 }
@@ -344,7 +388,9 @@ pub(crate) fn feasible_tree(graph: &mut LayoutGraph) -> SpanningTree {
             None => {
                 // Disconnected graph — add remaining nodes directly
                 for node in 0..n {
-                    tree.add_node(node);
+                    if is_rank_node(graph, node, exclude_compounds) {
+                        tree.add_node(node);
+                    }
                 }
                 break;
             }
@@ -353,7 +399,9 @@ pub(crate) fn feasible_tree(graph: &mut LayoutGraph) -> SpanningTree {
         if iters >= max_iters {
             // Safety: force-add remaining nodes
             for node in 0..n {
-                tree.add_node(node);
+                if is_rank_node(graph, node, exclude_compounds) {
+                    tree.add_node(node);
+                }
             }
             break;
         }
@@ -364,8 +412,13 @@ pub(crate) fn feasible_tree(graph: &mut LayoutGraph) -> SpanningTree {
 
 /// Run network simplex ranking on the graph.
 /// Assigns optimal ranks minimizing total weighted edge length.
+#[cfg(test)]
 pub(crate) fn run(graph: &mut LayoutGraph) {
-    let n = graph.node_count();
+    run_with_policy(graph, false);
+}
+
+pub(crate) fn run_with_policy(graph: &mut LayoutGraph, exclude_compounds: bool) {
+    let n = rank_node_count(graph, exclude_compounds);
     let edge_count = graph.effective_edges().len();
     if n <= 1 || edge_count == 0 {
         // No optimization possible — just use longest-path
@@ -373,11 +426,15 @@ pub(crate) fn run(graph: &mut LayoutGraph) {
         return;
     }
 
-    // Step 1: Get initial feasible ranking via longest-path
-    rank_core::longest_path(graph);
+    // Step 1: Get initial feasible ranking.
+    if exclude_compounds {
+        rank_core::dagre_longest_path(graph);
+    } else {
+        rank_core::longest_path(graph);
+    }
 
     // Step 2: Build feasible spanning tree of tight edges
-    let mut tree = feasible_tree(graph);
+    let mut tree = feasible_tree_with_mode(graph, exclude_compounds);
 
     // Step 3: Compute low/lim and cut values
     let root = tree.root();
@@ -389,19 +446,20 @@ pub(crate) fn run(graph: &mut LayoutGraph) {
     let mut iters = 0;
 
     while let Some(leave_node) = leave_edge(&tree) {
-        let enter_idx = match enter_edge(&tree, graph, leave_node) {
+        let enter_idx = match enter_edge(&tree, graph, leave_node, exclude_compounds) {
             Some(idx) => idx,
             None => break, // No crossing edge found — tree may have disconnected components
         };
-        exchange_edges(&mut tree, graph, leave_node, enter_idx);
+        exchange_edges(&mut tree, graph, leave_node, enter_idx, exclude_compounds);
         iters += 1;
         if iters >= max_iters {
             break; // Safety limit
         }
     }
 
-    // Normalize ranks to start at 0
-    rank_core::normalize(graph);
+    if !exclude_compounds {
+        rank_core::normalize(graph);
+    }
 }
 
 /// Find a tree edge with negative cut value. Returns the child node of that edge.
@@ -413,7 +471,12 @@ fn leave_edge(tree: &SpanningTree) -> Option<usize> {
 ///
 /// The entering edge must cross the same cut as the leaving edge.
 /// Follows Dagre.js enterEdge (lines 156-192).
-fn enter_edge(tree: &SpanningTree, graph: &LayoutGraph, leave_node: usize) -> Option<usize> {
+fn enter_edge(
+    tree: &SpanningTree,
+    graph: &LayoutGraph,
+    leave_node: usize,
+    exclude_compounds: bool,
+) -> Option<usize> {
     let edges = graph.effective_edges();
     let leave_edge_idx = tree.parent_edge[leave_node].unwrap();
 
@@ -431,6 +494,11 @@ fn enter_edge(tree: &SpanningTree, graph: &LayoutGraph, leave_node: usize) -> Op
     let mut best_slack = i32::MAX;
 
     for (edge_idx, &(e_from, e_to)) in edges.iter().enumerate() {
+        if !is_rank_node(graph, e_from, exclude_compounds)
+            || !is_rank_node(graph, e_to, exclude_compounds)
+        {
+            continue;
+        }
         if tree.tree_edges.contains(&edge_idx) {
             continue; // skip tree edges
         }
@@ -460,6 +528,7 @@ fn exchange_edges(
     graph: &mut LayoutGraph,
     leave_node: usize,
     enter_edge_idx: usize,
+    exclude_compounds: bool,
 ) {
     let leave_edge_idx = tree.parent_edge[leave_node].unwrap();
 
@@ -472,7 +541,7 @@ fn exchange_edges(
     tree.tree_edges.insert(enter_edge_idx);
 
     // Rebuild parent pointers from tree edges via DFS
-    rebuild_parent_pointers(tree, graph);
+    rebuild_parent_pointers(tree, graph, exclude_compounds);
 
     // Recompute low/lim and cut values
     let root = tree.root();
@@ -484,7 +553,7 @@ fn exchange_edges(
 }
 
 /// Rebuild parent pointers from the set of tree edges using DFS.
-fn rebuild_parent_pointers(tree: &mut SpanningTree, graph: &LayoutGraph) {
+fn rebuild_parent_pointers(tree: &mut SpanningTree, graph: &LayoutGraph, exclude_compounds: bool) {
     let n = tree.parent.len();
     let edges = graph.effective_edges();
 
@@ -503,7 +572,9 @@ fn rebuild_parent_pointers(tree: &mut SpanningTree, graph: &LayoutGraph) {
     }
 
     // DFS from root (node 0 or first in-tree node)
-    let root = (0..n).find(|&i| tree.in_tree[i]).unwrap_or(0);
+    let root = (0..n)
+        .find(|&i| tree.in_tree[i] && is_rank_node(graph, i, exclude_compounds))
+        .unwrap_or(0);
     let mut visited = vec![false; n];
     let mut stack = vec![root];
     visited[root] = true;

--- a/src/engines/graph/algorithms/layered/kernel/pipeline.rs
+++ b/src/engines/graph/algorithms/layered/kernel/pipeline.rs
@@ -87,7 +87,7 @@ where
     // Compound: add nesting structure (border top/bottom, nesting edges).
     // Multiplies all existing edge minlens by nodeSep = 2*height+1.
     if has_compound {
-        nesting::run(&mut lg);
+        nesting::run_with_policy(&mut lg, config.acyclic_policy);
     }
 
     // Phase 2: Assign ranks (layers)

--- a/src/engines/graph/algorithms/layered/kernel/rank.rs
+++ b/src/engines/graph/algorithms/layered/kernel/rank.rs
@@ -6,12 +6,15 @@
 
 use super::graph::LayoutGraph;
 use super::rank_core;
-use super::types::{LayoutConfig, Ranker};
+use super::types::{AcyclicPolicy, LayoutConfig, Ranker};
 
 /// Assign ranks to nodes by dispatching to the configured ranker.
 pub fn run(graph: &mut LayoutGraph, config: &LayoutConfig) {
     match config.ranker {
-        Ranker::NetworkSimplex => super::network_simplex::run(graph),
+        Ranker::NetworkSimplex => super::network_simplex::run_with_policy(
+            graph,
+            matches!(config.acyclic_policy, AcyclicPolicy::DfsOnly),
+        ),
         Ranker::LongestPath => rank_core::longest_path(graph),
     }
 }

--- a/src/engines/graph/algorithms/layered/kernel/rank_core.rs
+++ b/src/engines/graph/algorithms/layered/kernel/rank_core.rs
@@ -69,6 +69,53 @@ pub(crate) fn longest_path(graph: &mut LayoutGraph) {
     graph.ranks = ranks;
 }
 
+pub(crate) fn dagre_longest_path(graph: &mut LayoutGraph) {
+    let n = graph.node_ids.len();
+    if n == 0 {
+        return;
+    }
+
+    let edges = graph.effective_edges();
+    let mut out_edges: Vec<Vec<(usize, i32)>> = vec![Vec::new(); n];
+    let mut in_degree = vec![0usize; n];
+    for (edge_idx, &(from, to)) in edges.iter().enumerate() {
+        if graph.compound_nodes.contains(&from) || graph.compound_nodes.contains(&to) {
+            continue;
+        }
+        out_edges[from].push((to, graph.edge_minlens[edge_idx]));
+        in_degree[to] += 1;
+    }
+
+    let mut ranks: Vec<Option<i32>> = vec![None; n];
+
+    fn dfs(node: usize, out_edges: &[Vec<(usize, i32)>], ranks: &mut [Option<i32>]) -> i32 {
+        if let Some(rank) = ranks[node] {
+            return rank;
+        }
+
+        let rank = out_edges[node]
+            .iter()
+            .map(|&(to, minlen)| dfs(to, out_edges, ranks) - minlen)
+            .min()
+            .unwrap_or(0);
+        ranks[node] = Some(rank);
+        rank
+    }
+
+    for (node, degree) in in_degree.iter().enumerate() {
+        if !graph.compound_nodes.contains(&node) && *degree == 0 {
+            dfs(node, &out_edges, &mut ranks);
+        }
+    }
+    for node in 0..n {
+        if !graph.compound_nodes.contains(&node) && ranks[node].is_none() {
+            dfs(node, &out_edges, &mut ranks);
+        }
+    }
+
+    graph.ranks = ranks.into_iter().map(|rank| rank.unwrap_or(0)).collect();
+}
+
 /// Normalize ranks so minimum is 0.
 pub(crate) fn normalize(graph: &mut LayoutGraph) {
     // Prefer minimum rank among position nodes, fall back to all nodes

--- a/src/engines/graph/tests.rs
+++ b/src/engines/graph/tests.rs
@@ -746,16 +746,16 @@ fn assert_mermaid_tall_top_right_geometry(label: &str, result: &GraphSolveResult
     let sibling_max = middle.height.max(bottom.height);
 
     assert!(
-        top.x + top.width / 2.0 > bottom.x + bottom.width / 2.0,
-        "{label}: Top/A should shift right of Bottom/C for the DFS-only strict contract; Top={top:?} Bottom={bottom:?}"
+        top.x > middle.x && top.x > bottom.x,
+        "{label}: Top/A should be right of Middle/B and Bottom/C for the DFS-only strict contract; Top={top:?} Middle={middle:?} Bottom={bottom:?}"
     );
     assert!(
         top.height > sibling_max * 1.8,
         "{label}: Top/A should be tall relative to sibling subgraphs; Top={top:?} Middle={middle:?} Bottom={bottom:?}"
     );
     assert!(
-        middle.y < bottom.y,
-        "{label}: Middle/B should begin above Bottom/C in the DFS-only strict contract; Middle={middle:?} Bottom={bottom:?}"
+        middle.y + middle.height <= bottom.y,
+        "{label}: Middle/B should stack above Bottom/C without overlap in the DFS-only strict contract; Middle={middle:?} Bottom={bottom:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

- match Mermaid/Dagre compound positioning for the DfsOnly Mermaid profile by ranking the non-compound graph
- add a Dagre-style longest-path seed for Mermaid-profile network simplex
- keep Flux/default on the existing semantic compound-feedback path so checked-in snapshots stay stable
- strengthen the compound backward-disconnected canaries back to the strict Top-right / B-over-C geometry contract

## Root Cause

The parity gap was not in greedy FAS or Tarjan SCC handling. The missing behavior was later in ranking: Dagre runs network simplex over `asNonCompoundGraph`, seeds it with its recursive longest-path ranker, and leaves rank normalization to later pipeline phases. mmdflux was still ranking compound parent nodes for the Mermaid profile, which skewed the feasible tree and prevented the tall Top-right compound layout.

## Risk Notes

This touches the network-simplex ranker, which is a load-bearing kernel phase. The Dagre-compatible branches are gated behind the Mermaid/DfsOnly profile so Flux/default behavior remains on the existing semantic compound-feedback path. The recursive longest-path seed intentionally mirrors Dagre.js; pathological graph depths would have the same recursive-depth class of risk as Dagre.

## Validation

- `just lint`
- `cargo +stable nextest run` -> 2661 passed, 3 skipped
- `cargo +stable xtask architecture check --fresh`
- `git diff -- tests/snapshots tests/svg-snapshots` -> empty
