### PR TITLE
fix: use route direction for mmds ports

### DIFF
--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -162,8 +162,8 @@ mmdflux --format mmds diagram.mmd
 
 Explicit opt-in via `--geometry-level routed`. Includes everything from layout plus:
 
-- **Edge paths**: polyline coordinates as `[x, y]` pairs
-- **Edge metadata**: `label_position`, `is_backward`, `source_port`, `target_port`
+- **Edge paths**: `edge.path` polyline coordinates as `[x, y]` pairs; this is the authoritative visible geometry for routed edge shape and endpoints
+- **Edge metadata**: `label_position`, `is_backward`, `source_port`, `target_port`; ports are logical route-intent anchors, not the visible path itself
 - **Subgraph bounds**: width and height of each subgraph
 
 ```bash
@@ -303,23 +303,27 @@ Rules:
 | `arrow_start`    | string        | both   | `"none"`, `"normal"`, `"cross"`, `"circle"`, `"open_triangle"`, `"diamond"`, `"open_diamond"`; omitted when equal to `defaults.edge.arrow_start` |
 | `arrow_end`      | string        | both   | `"none"`, `"normal"`, `"cross"`, `"circle"`, `"open_triangle"`, `"diamond"`, `"open_diamond"`; omitted when equal to `defaults.edge.arrow_end`   |
 | `minlen`         | integer       | both   | Minimum rank separation; omitted when equal to `defaults.edge.minlen`                                                                            |
-| `path`           | `[[x,y],...]` | routed | Polyline path coordinates                                                                                                                        |
+| `path`           | `[[x,y],...]` | routed | Authoritative visible routed polyline path coordinates. Consumers should use `edge.path` for visible edge geometry and endpoints.                 |
 | `label_position` | `{x, y}`      | routed | Label center                                                                                                                                     |
 | `is_backward`    | boolean       | routed | Flows backward in layout                                                                                                                         |
-| `source_port`    | Port?         | routed | Source endpoint attachment (see Port below)                                                                                                      |
-| `target_port`    | Port?         | routed | Target endpoint attachment (see Port below)                                                                                                      |
+| `source_port`    | Port?         | routed | Logical source port anchor metadata describing route intent (see Port below)                                                                     |
+| `target_port`    | Port?         | routed | Logical target port anchor metadata describing route intent (see Port below)                                                                     |
 | `label_side`     | string?       | both   | `"above"`, `"below"`, or `"center"`; present at both layout and routed levels when the engine has assigned a side, omitted otherwise             |
 | `label_rect`     | Rect?         | routed | Padded label rectangle `{x, y, width, height}` including `label_padding_x`/`label_padding_y` padding; omitted when the engine has not assigned a rectangle |
 
 ### Port
 
-Port metadata describes where an edge attaches to a node boundary.
+Port metadata describes a logical route-intent anchor on a node boundary. It is
+metadata for choosing and grouping a boundary face, not a replacement for
+`edge.path` as visible geometry. A port may differ from `edge.path[0]` or
+`edge.path[-1]`; consumers that need the visible rendered endpoint should read
+the routed path.
 
 | Field        | Type     | Description                                                                                             |
 | ------------ | -------- | ------------------------------------------------------------------------------------------------------- |
-| `face`       | string   | Node boundary face: `"top"`, `"bottom"`, `"left"`, or `"right"`                                         |
-| `fraction`   | number   | Position along the face (0.0 = start, 1.0 = end). Top/bottom: left-to-right. Left/right: top-to-bottom. |
-| `position`   | `{x, y}` | Absolute attachment point in MMDS coordinate space                                                      |
+| `face`       | string   | Logical node boundary face for route intent: `"top"`, `"bottom"`, `"left"`, or `"right"`                |
+| `fraction`   | number   | Position along the logical face (0.0 = start, 1.0 = end). Top/bottom: left-to-right. Left/right: top-to-bottom. |
+| `position`   | `{x, y}` | Logical anchor coordinate derived from face, fraction, and node bounds. It is not guaranteed to equal a visible path endpoint. |
 | `group_size` | integer  | Number of edges sharing this face on this node                                                          |
 
 ### Subgraph

--- a/docs/mmds.schema.json
+++ b/docs/mmds.schema.json
@@ -306,7 +306,7 @@
             "minItems": 2,
             "maxItems": 2
           },
-          "description": "Routed edge path as [x, y] coordinate pairs in unitless MMDS coordinate space. In current mmdflux output, values are SVG-pixel-aligned. Routed level only."
+          "description": "Authoritative visible routed edge path as [x, y] coordinate pairs in unitless MMDS coordinate space. Consumers should use this path for visible edge shape and endpoints. In current mmdflux output, values are SVG-pixel-aligned. Routed level only."
         },
         "label_position": {
           "$ref": "#/$defs/Position",
@@ -318,11 +318,11 @@
         },
         "source_port": {
           "$ref": "#/$defs/Port",
-          "description": "Source endpoint attachment metadata. Routed level only."
+          "description": "Logical source port anchor metadata describing route intent. This may differ from the visible path endpoint. Routed level only."
         },
         "target_port": {
           "$ref": "#/$defs/Port",
-          "description": "Target endpoint attachment metadata. Routed level only."
+          "description": "Logical target port anchor metadata describing route intent. This may differ from the visible path endpoint. Routed level only."
         },
         "label_side": {
           "enum": ["above", "below", "center"],
@@ -373,7 +373,7 @@
       "properties": {
         "face": {
           "enum": ["top", "bottom", "left", "right"],
-          "description": "Node boundary face where the edge attaches."
+          "description": "Logical node boundary face for route intent."
         },
         "fraction": {
           "type": "number",
@@ -383,7 +383,7 @@
         },
         "position": {
           "$ref": "#/$defs/Position",
-          "description": "Computed position on the node boundary in MMDS coordinate space."
+          "description": "Logical anchor coordinate derived from face, fraction, and node bounds in MMDS coordinate space. Not guaranteed to equal the visible path endpoint."
         },
         "group_size": {
           "type": "integer",

--- a/src/graph/direction_policy.rs
+++ b/src/graph/direction_policy.rs
@@ -82,6 +82,41 @@ pub fn cross_boundary_edge_direction(
         .unwrap_or(fallback)
 }
 
+/// Resolve the route direction for a concrete node-to-node edge.
+///
+/// This wraps ordinary same-direction behavior, same-override internal edges,
+/// and true override-boundary edges in one policy helper so routing and MMDS
+/// port planning choose faces from the same route intent.
+pub fn node_to_node_route_direction(
+    diagram: &Graph,
+    node_directions: &HashMap<String, Direction>,
+    override_nodes: &HashMap<String, String>,
+    from: &str,
+    to: &str,
+    fallback: Direction,
+) -> Direction {
+    let from_sg = override_nodes.get(from);
+    let to_sg = override_nodes.get(to);
+
+    match (from_sg, to_sg) {
+        (None, None) => effective_edge_direction(node_directions, from, to, fallback),
+        (Some(sg_a), Some(sg_b)) if sg_a == sg_b => diagram
+            .subgraphs
+            .get(sg_a.as_str())
+            .and_then(|sg| sg.dir)
+            .unwrap_or_else(|| effective_edge_direction(node_directions, from, to, fallback)),
+        _ => cross_boundary_edge_direction(
+            diagram,
+            node_directions,
+            from_sg,
+            to_sg,
+            from,
+            to,
+            fallback,
+        ),
+    }
+}
+
 /// Build the override node map: node_id -> subgraph_id.
 pub fn build_override_node_map(diagram: &Graph) -> HashMap<String, String> {
     let mut override_nodes = HashMap::new();

--- a/src/graph/routing/float_core.rs
+++ b/src/graph/routing/float_core.rs
@@ -6,22 +6,23 @@ use crate::graph::attachment::{
     AttachmentCandidate, AttachmentSide, EdgePort, Face, LARGE_HORIZONTAL_OFFSET_THRESHOLD,
     edge_faces, plan_attachment_candidates, point_on_face_float,
 };
+use crate::graph::direction_policy::{build_override_node_map, node_to_node_route_direction};
 use crate::graph::geometry::GraphGeometry;
 use crate::graph::space::{FPoint, FRect};
-use crate::graph::{Direction, Edge, Shape, Stroke};
+use crate::graph::{Direction, Graph, Shape, Stroke};
 
 /// Compute port attachments for all edges using float-coordinate `GraphGeometry`.
 ///
 /// Called from the routing stage to make port data available in
 /// `RoutedEdgeGeometry` for MMDS serialization.
 pub(crate) fn compute_port_attachments_from_geometry(
-    edges: &[Edge],
+    diagram: &Graph,
     geometry: &GraphGeometry,
-    fallback_direction: Direction,
 ) -> HashMap<usize, (Option<EdgePort>, Option<EdgePort>)> {
-    let mut candidates: Vec<AttachmentCandidate> = Vec::with_capacity(edges.len() * 2);
+    let override_nodes = build_override_node_map(diagram);
+    let mut candidates: Vec<AttachmentCandidate> = Vec::with_capacity(diagram.edges.len() * 2);
 
-    for (idx, edge) in edges.iter().enumerate() {
+    for (idx, edge) in diagram.edges.iter().enumerate() {
         if edge.from == edge.to || edge.stroke == Stroke::Invisible {
             continue;
         }
@@ -49,11 +50,14 @@ pub(crate) fn compute_port_attachments_from_geometry(
             .and_then(|wps| wps.last().copied())
             .unwrap_or(src_center);
 
-        let edge_dir = geometry
-            .node_directions
-            .get(&edge.from)
-            .copied()
-            .unwrap_or(fallback_direction);
+        let edge_dir = node_to_node_route_direction(
+            diagram,
+            &geometry.node_directions,
+            &override_nodes,
+            &edge.from,
+            &edge.to,
+            diagram.direction,
+        );
 
         let is_backward = geometry.reversed_edges.contains(&idx);
 
@@ -91,7 +95,7 @@ pub(crate) fn compute_port_attachments_from_geometry(
 
     let mut result: HashMap<usize, (Option<EdgePort>, Option<EdgePort>)> = HashMap::new();
     for (edge_index, attachments) in plan.attachments() {
-        let edge = &edges[*edge_index];
+        let edge = &diagram.edges[*edge_index];
 
         let source_port = attachments.source.map(|att| {
             let src_id = edge.from_subgraph.as_deref().unwrap_or(edge.from.as_str());

--- a/src/graph/routing/orthogonal/mod.rs
+++ b/src/graph/routing/orthogonal/mod.rs
@@ -13,8 +13,6 @@ pub(crate) mod hints;
 pub(crate) mod overlap;
 pub(crate) mod path_utils;
 
-use std::collections::HashMap;
-
 use self::endpoints::{
     anchor_path_endpoints_to_endpoint_faces, endpoint_is_on_policy_face,
     enforce_terminal_support_normal_to_face, ensure_endpoint_segments_axis_aligned,
@@ -29,9 +27,7 @@ use self::path_utils::{
 use super::float_core::normalize_orthogonal_route_contracts;
 use super::labels::compute_end_labels_for_edge;
 use crate::graph::attachment::Face;
-use crate::graph::direction_policy::{
-    build_override_node_map, cross_boundary_edge_direction, effective_edge_direction,
-};
+use crate::graph::direction_policy::{build_override_node_map, node_to_node_route_direction};
 use crate::graph::geometry::{GraphGeometry, RoutedEdgeGeometry};
 use crate::graph::space::FPoint;
 use crate::graph::{Direction, Graph};
@@ -76,7 +72,7 @@ pub fn route_edges_orthogonal(
         .iter()
         .map(|edge| {
             let is_backward = geometry.reversed_edges.contains(&edge.index);
-            let edge_direction = orthogonal_edge_direction(
+            let edge_direction = node_to_node_route_direction(
                 diagram,
                 &geometry.node_directions,
                 &override_nodes,
@@ -202,36 +198,6 @@ pub fn route_edges_orthogonal(
     fan::spread_colocated_backward_source_ports(&mut routed, geometry);
     fan::spread_colocated_backward_target_ports(&mut routed, geometry);
     routed
-}
-
-fn orthogonal_edge_direction(
-    diagram: &Graph,
-    node_directions: &HashMap<String, Direction>,
-    override_nodes: &HashMap<String, String>,
-    from: &str,
-    to: &str,
-    fallback: Direction,
-) -> Direction {
-    let from_sg = override_nodes.get(from);
-    let to_sg = override_nodes.get(to);
-
-    match (from_sg, to_sg) {
-        (None, None) => effective_edge_direction(node_directions, from, to, fallback),
-        (Some(sg_a), Some(sg_b)) if sg_a == sg_b => diagram
-            .subgraphs
-            .get(sg_a.as_str())
-            .and_then(|sg| sg.dir)
-            .unwrap_or_else(|| effective_edge_direction(node_directions, from, to, fallback)),
-        _ => cross_boundary_edge_direction(
-            diagram,
-            node_directions,
-            from_sg,
-            to_sg,
-            from,
-            to,
-            fallback,
-        ),
-    }
 }
 
 // Primary knob for TD/BT fan lane compaction near shared faces.

--- a/src/graph/routing/stage.rs
+++ b/src/graph/routing/stage.rs
@@ -38,8 +38,7 @@ pub fn route_graph_geometry(
     edge_routing: EdgeRouting,
     metrics: &ProportionalTextMetrics,
 ) -> RoutedGraphGeometry {
-    let port_attachments =
-        compute_port_attachments_from_geometry(&diagram.edges, geometry, diagram.direction);
+    let port_attachments = compute_port_attachments_from_geometry(diagram, geometry);
 
     let edges: Vec<RoutedEdgeGeometry> = match edge_routing {
         EdgeRouting::OrthogonalRoute => {

--- a/src/internal_tests/mod.rs
+++ b/src/internal_tests/mod.rs
@@ -7,6 +7,7 @@ mod label_node_overlap;
 mod layered_adapter_pipeline;
 mod mmds_output_serialization;
 mod mmds_roundtrip;
+mod port_attachment_observation;
 mod svg_render_pipeline;
 mod text_render_pipeline;
 

--- a/src/internal_tests/port_attachment_observation.rs
+++ b/src/internal_tests/port_attachment_observation.rs
@@ -1,0 +1,596 @@
+use std::fs;
+use std::path::Path;
+
+use crate::diagrams::flowchart::compile_to_graph;
+use crate::engines::graph::algorithms::layered::layout_building::layered_config_for_layout;
+use crate::engines::graph::contracts::{
+    EngineConfig, GraphEngine, GraphGeometryContract, GraphSolveRequest, MeasurementMode,
+};
+use crate::engines::graph::flux::FluxLayeredEngine;
+use crate::graph::grid::{
+    AttachDirection, GridLayout, GridLayoutConfig, TextPathFamily,
+    geometry_to_grid_layout_with_routed, route_edge_with_probe,
+};
+use crate::graph::{Edge, GeometryLevel, Graph};
+use crate::mermaid::parse_flowchart;
+use crate::mmds::{Edge as MmdsEdge, Node as MmdsNode, Output, Port};
+use crate::{OutputFormat, RenderConfig};
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+struct PortObservation {
+    fixture: String,
+    from: String,
+    to: String,
+    source_port: EndpointObservation,
+    target_port: EndpointObservation,
+    path_source: EndpointObservation,
+    path_target: EndpointObservation,
+    svg_source: Option<EndpointObservation>,
+    svg_target: Option<EndpointObservation>,
+    svg_rejection_reason: Option<String>,
+    text_source: Option<TextEndpointObservation>,
+    text_target: Option<TextEndpointObservation>,
+    text_path_family: Option<TextPathFamily>,
+    text_rejection_reason: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Default)]
+struct EndpointObservation {
+    face: Option<String>,
+    fraction: Option<f64>,
+    position: Option<(f64, f64)>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+struct TextEndpointObservation {
+    face: Option<String>,
+    cell: Option<(usize, usize)>,
+}
+
+#[derive(Debug, Clone)]
+struct ObservationMatrix {
+    observations: Vec<PortObservation>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NodeRect {
+    left: f64,
+    right: f64,
+    top: f64,
+    bottom: f64,
+}
+
+#[test]
+fn port_attachment_observation_reports_simple_td_edge() {
+    let obs = observe_fixture_edge("subgraph_direction_lr.mmd", "Start", "A");
+
+    assert_eq!(obs.source_port.face.as_deref(), Some("bottom"));
+    assert_eq!(obs.target_port.face.as_deref(), Some("top"));
+    assert_eq!(obs.path_source.face.as_deref(), Some("bottom"));
+    assert_eq!(obs.path_target.face.as_deref(), Some("top"));
+    assert_fraction_near(obs.source_port.fraction, 0.5, "source_port.fraction");
+    assert_fraction_near(obs.target_port.fraction, 0.5, "target_port.fraction");
+}
+
+#[test]
+fn port_attachment_observation_probe_covers_required_direction_override_fixtures() {
+    let matrix = observe_direction_override_probe_matrix();
+
+    assert!(matrix.contains_edge("subgraph_direction_lr.mmd", "C", "End"));
+    assert!(matrix.contains_edge("direction_override.mmd", "C", "End"));
+    assert!(matrix.contains_edge("subgraph_direction_cross_boundary.mmd", "B", "F"));
+    assert!(matrix.contains_edge("subgraph_direction_cross_boundary.mmd", "B", "D"));
+    assert!(matrix.contains_edge("subgraph_direction_nested_both.mmd", "A", "B"));
+    assert!(matrix.contains_edge("subgraph_direction_nested_both.mmd", "C", "A"));
+}
+
+#[test]
+fn port_attachment_observation_internal_override_edges_keep_lr_ports() {
+    let matrix = observe_direction_override_probe_matrix();
+
+    for (from, to) in [("A", "B"), ("B", "C")] {
+        let obs = matrix
+            .edge("subgraph_direction_lr.mmd", from, to)
+            .unwrap_or_else(|| panic!("missing probe observation for {from} -> {to}"));
+        assert_eq!(obs.source_port.face.as_deref(), Some("right"));
+        assert_eq!(obs.target_port.face.as_deref(), Some("left"));
+        assert_visible_shape_preserved(obs);
+    }
+}
+
+#[test]
+fn port_attachment_observation_visible_shape_guard_accepts_probe_matrix() {
+    let matrix = observe_direction_override_probe_matrix();
+
+    for obs in &matrix.observations {
+        assert_visible_shape_preserved(obs);
+    }
+}
+
+#[test]
+fn mmds_logical_ports_use_root_direction_for_subgraph_direction_lr_exit() {
+    let obs = observe_fixture_edge("subgraph_direction_lr.mmd", "C", "End");
+
+    assert_eq!(obs.source_port.face.as_deref(), Some("bottom"));
+    assert_eq!(obs.target_port.face.as_deref(), Some("top"));
+    assert_eq!(obs.path_source.face.as_deref(), Some("bottom"));
+    assert_eq!(obs.path_target.face.as_deref(), Some("top"));
+
+    assert_visible_shape_preserved(&obs);
+}
+
+#[test]
+fn mmds_logical_ports_use_root_direction_for_cross_boundary_override_exits() {
+    for (from, to) in [("B", "F"), ("B", "D")] {
+        let obs = observe_fixture_edge("subgraph_direction_cross_boundary.mmd", from, to);
+
+        assert_eq!(
+            obs.source_port.face.as_deref(),
+            Some("bottom"),
+            "{from} -> {to} source logical port should use root TD exit face"
+        );
+        assert_eq!(
+            obs.target_port.face.as_deref(),
+            Some("top"),
+            "{from} -> {to} target logical port should use root TD entry face"
+        );
+        assert_eq!(obs.path_source.face.as_deref(), Some("bottom"));
+        assert_eq!(obs.path_target.face.as_deref(), Some("top"));
+
+        assert_visible_shape_preserved(&obs);
+    }
+}
+
+#[test]
+fn nested_override_probe_classifies_confirmed_edges_without_mandating_a_to_b_fix() {
+    let c_to_a = observe_fixture_edge("subgraph_direction_nested_both.mmd", "C", "A");
+    assert_eq!(c_to_a.source_port.face.as_deref(), Some("right"));
+    assert_eq!(c_to_a.target_port.face.as_deref(), Some("left"));
+    assert_eq!(c_to_a.path_source.face.as_deref(), Some("right"));
+    assert_eq!(c_to_a.path_target.face.as_deref(), Some("left"));
+
+    let d_to_c = observe_fixture_edge("subgraph_direction_nested_both.mmd", "D", "C");
+    assert_eq!(d_to_c.source_port.face.as_deref(), Some("bottom"));
+    assert_eq!(d_to_c.target_port.face.as_deref(), Some("top"));
+
+    let a_to_b = observe_fixture_edge("subgraph_direction_nested_both.mmd", "A", "B");
+    assert_nested_known_unknown("A -> B", &a_to_b);
+}
+
+#[test]
+fn mmds_logical_port_fix_preserves_target_visible_geometry() {
+    for (fixture, from, to) in [
+        ("subgraph_direction_lr.mmd", "C", "End"),
+        ("subgraph_direction_cross_boundary.mmd", "B", "F"),
+        ("subgraph_direction_cross_boundary.mmd", "B", "D"),
+    ] {
+        let obs = observe_fixture_edge(fixture, from, to);
+
+        assert_eq!(
+            obs.path_source.face.as_deref(),
+            Some("bottom"),
+            "{fixture} {from} -> {to} should keep bottom-side visible source path"
+        );
+        assert_eq!(
+            obs.path_target.face.as_deref(),
+            Some("top"),
+            "{fixture} {from} -> {to} should keep top-side visible target path"
+        );
+        assert_visible_shape_preserved(&obs);
+    }
+}
+
+const DIRECTION_OVERRIDE_PROBE_EDGES: &[(&str, &[(&str, &str)])] = &[
+    (
+        "subgraph_direction_lr.mmd",
+        &[("Start", "A"), ("A", "B"), ("B", "C"), ("C", "End")],
+    ),
+    ("direction_override.mmd", &[("Start", "A"), ("C", "End")]),
+    (
+        "subgraph_direction_cross_boundary.mmd",
+        &[("E", "A"), ("C", "A"), ("B", "F"), ("B", "D")],
+    ),
+    (
+        "subgraph_direction_nested_both.mmd",
+        &[("A", "B"), ("C", "A"), ("D", "C")],
+    ),
+];
+
+impl ObservationMatrix {
+    fn contains_edge(&self, fixture: &str, from: &str, to: &str) -> bool {
+        self.edge(fixture, from, to).is_some()
+    }
+
+    fn edge(&self, fixture: &str, from: &str, to: &str) -> Option<&PortObservation> {
+        self.observations
+            .iter()
+            .find(|obs| obs.fixture == fixture && obs.from == from && obs.to == to)
+    }
+}
+
+fn observe_direction_override_probe_matrix() -> ObservationMatrix {
+    let observations = DIRECTION_OVERRIDE_PROBE_EDGES
+        .iter()
+        .flat_map(|(fixture, edges)| observe_fixture_edges(fixture, edges))
+        .collect();
+    ObservationMatrix { observations }
+}
+
+fn observe_fixture_edge(fixture: &str, from: &str, to: &str) -> PortObservation {
+    observe_fixture_edges(fixture, &[(from, to)])
+        .into_iter()
+        .next()
+        .expect("single-edge fixture observation should be present")
+}
+
+fn observe_fixture_edges(fixture: &str, edges: &[(&str, &str)]) -> Vec<PortObservation> {
+    let input = load_flowchart_fixture(fixture);
+    let output = render_routed_mmds(&input);
+    let text_context = build_text_context(&input);
+
+    edges
+        .iter()
+        .map(|(from, to)| observe_output_edge(fixture, &output, &text_context, from, to))
+        .collect()
+}
+
+fn observe_output_edge(
+    fixture: &str,
+    output: &Output,
+    text_context: &TextContext,
+    from: &str,
+    to: &str,
+) -> PortObservation {
+    let edge = find_edge(output, from, to);
+    let source_node = find_node(output, from);
+    let target_node = find_node(output, to);
+    let text = observe_text_edge(text_context, from, to);
+
+    let path = edge
+        .path
+        .as_ref()
+        .unwrap_or_else(|| panic!("edge {from} -> {to} should include routed path points"));
+    let path_source = path
+        .first()
+        .unwrap_or_else(|| panic!("edge {from} -> {to} should include a path source point"));
+    let path_target = path
+        .last()
+        .unwrap_or_else(|| panic!("edge {from} -> {to} should include a path target point"));
+
+    PortObservation {
+        fixture: fixture.to_string(),
+        from: from.to_string(),
+        to: to.to_string(),
+        source_port: edge
+            .source_port
+            .as_ref()
+            .map(port_observation)
+            .unwrap_or_default(),
+        target_port: edge
+            .target_port
+            .as_ref()
+            .map(port_observation)
+            .unwrap_or_default(),
+        path_source: infer_endpoint_observation((path_source[0], path_source[1]), source_node),
+        path_target: infer_endpoint_observation((path_target[0], path_target[1]), target_node),
+        svg_source: None,
+        svg_target: None,
+        svg_rejection_reason: Some(
+            "SVG endpoint observation unavailable: probe has no stable SVG edge-to-path mapping"
+                .to_string(),
+        ),
+        text_source: text.source,
+        text_target: text.target,
+        text_path_family: text.path_family,
+        text_rejection_reason: text.rejection_reason,
+    }
+}
+
+fn load_flowchart_fixture(name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("flowchart")
+        .join(name);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read fixture {}: {err}", path.display()))
+}
+
+fn render_routed_mmds(input: &str) -> Output {
+    let config = RenderConfig {
+        geometry_level: GeometryLevel::Routed,
+        ..RenderConfig::default()
+    };
+    let json = crate::render_diagram(input, OutputFormat::Mmds, &config)
+        .expect("routed MMDS render should succeed");
+    serde_json::from_str(&json).expect("routed MMDS output should deserialize")
+}
+
+struct TextContext {
+    diagram: Graph,
+    layout: GridLayout,
+}
+
+#[derive(Debug, Clone)]
+struct TextObservationResult {
+    source: Option<TextEndpointObservation>,
+    target: Option<TextEndpointObservation>,
+    path_family: Option<TextPathFamily>,
+    rejection_reason: Option<String>,
+}
+
+fn build_text_context(input: &str) -> TextContext {
+    let flowchart = parse_flowchart(input).expect("flowchart fixture should parse");
+    let diagram = compile_to_graph(&flowchart);
+    let grid_config = GridLayoutConfig::default();
+    let engine = FluxLayeredEngine::text();
+    let request = GraphSolveRequest::new(
+        MeasurementMode::Grid,
+        GraphGeometryContract::Canonical,
+        GeometryLevel::Layout,
+        None,
+        Default::default(),
+    );
+    let result = engine
+        .solve(
+            &diagram,
+            &EngineConfig::Layered(layered_config_for_layout(&diagram, &grid_config)),
+            &request,
+        )
+        .expect("text observation layout solve should succeed");
+    let layout = geometry_to_grid_layout_with_routed(
+        &diagram,
+        &result.geometry,
+        result.routed.as_ref(),
+        &grid_config,
+    );
+
+    TextContext { diagram, layout }
+}
+
+fn observe_text_edge(context: &TextContext, from: &str, to: &str) -> TextObservationResult {
+    let edge = find_graph_edge(&context.diagram, from, to);
+    let Some(result) = route_edge_with_probe(
+        edge,
+        &context.layout,
+        context.diagram.direction,
+        None,
+        None,
+        false,
+    ) else {
+        return TextObservationResult {
+            source: None,
+            target: None,
+            path_family: None,
+            rejection_reason: Some("route_edge_with_probe returned None".to_string()),
+        };
+    };
+
+    TextObservationResult {
+        source: Some(TextEndpointObservation {
+            face: result
+                .routed
+                .source_connection
+                .map(source_face_from_connection)
+                .map(ToOwned::to_owned),
+            cell: Some((result.routed.start.x, result.routed.start.y)),
+        }),
+        target: Some(TextEndpointObservation {
+            face: Some(target_face_from_entry(result.routed.entry_direction).to_string()),
+            cell: Some((result.routed.end.x, result.routed.end.y)),
+        }),
+        path_family: Some(result.probe.path_family),
+        rejection_reason: result
+            .probe
+            .rejection_reason
+            .map(|reason| format!("{reason:?}")),
+    }
+}
+
+fn find_graph_edge<'a>(diagram: &'a Graph, from: &str, to: &str) -> &'a Edge {
+    let mut matches = diagram
+        .edges
+        .iter()
+        .filter(|edge| edge.from == from && edge.to == to);
+    let edge = matches
+        .next()
+        .unwrap_or_else(|| panic!("missing graph edge {from} -> {to}"));
+    assert!(
+        matches.next().is_none(),
+        "duplicate graph edges found for {from} -> {to}; add an edge-indexed observation helper"
+    );
+    edge
+}
+
+fn source_face_from_connection(connection: AttachDirection) -> &'static str {
+    match connection {
+        AttachDirection::Top => "bottom",
+        AttachDirection::Bottom => "top",
+        AttachDirection::Left => "right",
+        AttachDirection::Right => "left",
+    }
+}
+
+fn target_face_from_entry(entry: AttachDirection) -> &'static str {
+    match entry {
+        AttachDirection::Top => "top",
+        AttachDirection::Bottom => "bottom",
+        AttachDirection::Left => "left",
+        AttachDirection::Right => "right",
+    }
+}
+
+fn find_edge<'a>(output: &'a Output, from: &str, to: &str) -> &'a MmdsEdge {
+    let mut matches = output
+        .edges
+        .iter()
+        .filter(|edge| edge.source == from && edge.target == to);
+    let edge = matches
+        .next()
+        .unwrap_or_else(|| panic!("missing edge {from} -> {to}"));
+    assert!(
+        matches.next().is_none(),
+        "duplicate edges found for {from} -> {to}; add an edge-indexed observation helper"
+    );
+    edge
+}
+
+fn find_node<'a>(output: &'a Output, id: &str) -> &'a MmdsNode {
+    output
+        .nodes
+        .iter()
+        .find(|node| node.id == id)
+        .unwrap_or_else(|| panic!("missing node {id}"))
+}
+
+fn assert_visible_shape_preserved(obs: &PortObservation) {
+    assert_endpoint_available(&obs.path_source, obs, "path source");
+    assert_endpoint_available(&obs.path_target, obs, "path target");
+
+    if obs.svg_source.is_none() || obs.svg_target.is_none() {
+        assert!(
+            obs.svg_source.is_none() && obs.svg_target.is_none(),
+            "partial SVG endpoint observation for {} {} -> {}",
+            obs.fixture,
+            obs.from,
+            obs.to
+        );
+        assert!(
+            obs.svg_rejection_reason.is_some(),
+            "SVG endpoint observation unavailable for {} {} -> {}, but no reason was recorded",
+            obs.fixture,
+            obs.from,
+            obs.to
+        );
+    }
+
+    if obs.text_source.is_none() || obs.text_target.is_none() {
+        assert!(
+            obs.text_source.is_none() && obs.text_target.is_none(),
+            "partial text endpoint observation for {} {} -> {}; reason: {}",
+            obs.fixture,
+            obs.from,
+            obs.to,
+            obs.text_rejection_reason
+                .as_deref()
+                .unwrap_or("no text rejection reason recorded")
+        );
+        assert!(
+            obs.text_rejection_reason.is_some(),
+            "text endpoint observation unavailable for {} {} -> {}, but no reason was recorded",
+            obs.fixture,
+            obs.from,
+            obs.to
+        );
+    }
+}
+
+fn assert_nested_known_unknown(edge_label: &str, obs: &PortObservation) {
+    assert_eq!(obs.fixture, "subgraph_direction_nested_both.mmd");
+    assert_eq!(format!("{} -> {}", obs.from, obs.to), edge_label);
+    assert_endpoint_available(&obs.source_port, obs, "logical source port");
+    assert_endpoint_available(&obs.target_port, obs, "logical target port");
+    assert_endpoint_available(&obs.path_source, obs, "path source");
+    assert_endpoint_available(&obs.path_target, obs, "path target");
+    assert_visible_shape_preserved(obs);
+    assert!(
+        obs.text_source.is_some() && obs.text_target.is_some() && obs.text_path_family.is_some(),
+        "nested known-unknown {edge_label} should capture text endpoint/path-family evidence"
+    );
+    assert!(
+        obs.svg_rejection_reason.is_some(),
+        "nested known-unknown {edge_label} should record why SVG endpoint evidence is unavailable"
+    );
+}
+
+fn assert_fraction_near(actual: Option<f64>, expected: f64, label: &str) {
+    let actual = actual.unwrap_or_else(|| panic!("{label} should be present"));
+    assert!(
+        (actual - expected).abs() <= 1e-6,
+        "{label} should be near {expected}, got {actual}"
+    );
+}
+
+fn assert_endpoint_available(
+    endpoint: &EndpointObservation,
+    obs: &PortObservation,
+    endpoint_name: &str,
+) {
+    assert!(
+        endpoint.face.is_some(),
+        "{endpoint_name} face missing for {} {} -> {}",
+        obs.fixture,
+        obs.from,
+        obs.to
+    );
+    assert!(
+        endpoint.fraction.is_some(),
+        "{endpoint_name} fraction missing for {} {} -> {}",
+        obs.fixture,
+        obs.from,
+        obs.to
+    );
+    assert!(
+        endpoint.position.is_some(),
+        "{endpoint_name} position missing for {} {} -> {}",
+        obs.fixture,
+        obs.from,
+        obs.to
+    );
+}
+
+fn port_observation(port: &Port) -> EndpointObservation {
+    EndpointObservation {
+        face: Some(port.face.clone()),
+        fraction: Some(port.fraction),
+        position: Some((port.position.x, port.position.y)),
+    }
+}
+
+fn infer_endpoint_observation(point: (f64, f64), node: &MmdsNode) -> EndpointObservation {
+    let rect = node_rect(node);
+    let candidates = [
+        ("top", (point.1 - rect.top).abs()),
+        ("bottom", (point.1 - rect.bottom).abs()),
+        ("left", (point.0 - rect.left).abs()),
+        ("right", (point.0 - rect.right).abs()),
+    ];
+    let (face, _) = candidates
+        .into_iter()
+        .min_by(|(_, lhs), (_, rhs)| lhs.total_cmp(rhs))
+        .expect("face candidates should be non-empty");
+    let fraction = match face {
+        "top" | "bottom" => fraction(point.0, rect.left, rect.right),
+        "left" | "right" => fraction(point.1, rect.top, rect.bottom),
+        _ => unreachable!("known face"),
+    };
+
+    EndpointObservation {
+        face: Some(face.to_string()),
+        fraction: Some(fraction),
+        position: Some(point),
+    }
+}
+
+fn node_rect(node: &MmdsNode) -> NodeRect {
+    let half_width = node.size.width / 2.0;
+    let half_height = node.size.height / 2.0;
+    NodeRect {
+        left: node.position.x - half_width,
+        right: node.position.x + half_width,
+        top: node.position.y - half_height,
+        bottom: node.position.y + half_height,
+    }
+}
+
+fn fraction(value: f64, start: f64, end: f64) -> f64 {
+    let span = end - start;
+    if span.abs() <= f64::EPSILON {
+        0.5
+    } else {
+        ((value - start) / span).clamp(0.0, 1.0)
+    }
+}

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -8,8 +8,8 @@ use std::path::Path;
 
 use mmdflux::graph::GeometryLevel;
 use mmdflux::mmds::{
-    Edge as MmdsEdge, Output, Position as MmdsPosition, Rect as MmdsRect, SUPPORTED_PROFILES,
-    evaluate_profiles, hydrate_routed_geometry_from_output, parse_input,
+    Edge as MmdsEdge, Output, Port as MmdsPort, Position as MmdsPosition, Rect as MmdsRect,
+    SUPPORTED_PROFILES, evaluate_profiles, hydrate_routed_geometry_from_output, parse_input,
 };
 use mmdflux::simplification::PathSimplification;
 use mmdflux::{EngineAlgorithmId, OutputFormat, RenderConfig, TextColorMode};
@@ -1220,6 +1220,54 @@ fn mmds_routed_port_fractions_fan_in() {
 }
 
 #[test]
+fn mmds_routed_port_roundtrip_preserves_direction_override_boundary_ports_and_path() {
+    let input = flowchart_fixture("subgraph_direction_lr.mmd");
+    let direct_json = render_json_with_level(&input, GeometryLevel::Routed);
+    let direct: Output = serde_json::from_str(&direct_json).unwrap();
+    let roundtrip_json = render_mmds_input(
+        &direct_json,
+        OutputFormat::Mmds,
+        RenderConfig {
+            geometry_level: GeometryLevel::Routed,
+            ..RenderConfig::default()
+        },
+    );
+    let roundtrip: Output = serde_json::from_str(&roundtrip_json).unwrap();
+
+    let direct_edge = find_mmds_edge(&direct, "C", "End");
+    let roundtrip_edge = find_mmds_edge(&roundtrip, "C", "End");
+
+    assert_mmds_ports_equal(
+        direct_edge.source_port.as_ref(),
+        roundtrip_edge.source_port.as_ref(),
+        "C -> End source_port",
+    );
+    assert_mmds_ports_equal(
+        direct_edge.target_port.as_ref(),
+        roundtrip_edge.target_port.as_ref(),
+        "C -> End target_port",
+    );
+    assert_eq!(
+        direct_edge.path, roundtrip_edge.path,
+        "C -> End routed path should round-trip unchanged"
+    );
+}
+
+#[test]
+fn mmds_docs_and_schema_define_ports_as_logical_anchors() {
+    let docs = std::fs::read_to_string("docs/mmds.md").unwrap();
+    assert_contract_terms_near(&docs, "edge.path", &["visible", "geometry"]);
+    assert_contract_terms_near(&docs, "source_port", &["logical", "anchor"]);
+    assert_contract_terms_near(&docs, "target_port", &["logical", "anchor"]);
+    assert_contract_terms_near(&docs, "position", &["logical", "not guaranteed"]);
+
+    let schema = std::fs::read_to_string("docs/mmds.schema.json").unwrap();
+    assert_contract_terms_near(&schema, "\"path\"", &["visible", "path"]);
+    assert_contract_terms_near(&schema, "\"source_port\"", &["logical", "anchor"]);
+    assert_contract_terms_near(&schema, "\"target_port\"", &["logical", "anchor"]);
+}
+
+#[test]
 fn mmds_layout_excludes_port_metadata() {
     let json = render_json("graph TD\nA-->B");
     assert!(
@@ -1229,6 +1277,53 @@ fn mmds_layout_excludes_port_metadata() {
     assert!(
         !json.contains("target_port"),
         "layout JSON must not contain target_port"
+    );
+}
+
+fn assert_contract_terms_near(document: &str, needle: &str, terms: &[&str]) {
+    let document = document.to_lowercase();
+    let needle = needle.to_lowercase();
+    let terms: Vec<String> = terms.iter().map(|term| term.to_lowercase()).collect();
+
+    for (index, _) in document.match_indices(&needle) {
+        let end = (index + 1_000).min(document.len());
+        let window = &document[index..end];
+        if terms.iter().all(|term| window.contains(term)) {
+            return;
+        }
+    }
+
+    panic!("expected {needle:?} to appear near contract terms {terms:?}");
+}
+
+fn find_mmds_edge<'a>(output: &'a Output, source: &str, target: &str) -> &'a MmdsEdge {
+    output
+        .edges
+        .iter()
+        .find(|edge| edge.source == source && edge.target == target)
+        .unwrap_or_else(|| panic!("missing MMDS edge {source} -> {target}"))
+}
+
+fn assert_mmds_ports_equal(left: Option<&MmdsPort>, right: Option<&MmdsPort>, label: &str) {
+    let left = left.unwrap_or_else(|| panic!("{label} missing from direct output"));
+    let right = right.unwrap_or_else(|| panic!("{label} missing from roundtrip output"));
+
+    assert_eq!(left.face, right.face, "{label} face should round-trip");
+    assert_eq!(
+        left.fraction, right.fraction,
+        "{label} fraction should round-trip"
+    );
+    assert_eq!(
+        left.group_size, right.group_size,
+        "{label} group_size should round-trip"
+    );
+    assert_eq!(
+        left.position.x, right.position.x,
+        "{label} position.x should round-trip"
+    );
+    assert_eq!(
+        left.position.y, right.position.y,
+        "{label} position.y should round-trip"
     );
 }
 


### PR DESCRIPTION
## Summary
- route MMDS source_port and target_port face planning through the shared node-to-node direction policy
- add internal observation and canary coverage for subgraph direction override boundary edges
- document edge.path as authoritative visible geometry and ports as logical route-intent anchors

## Validation
- cog check
- cargo nextest run -E 'test(port_attachment_observation)'
- cargo nextest run --test mmds_json -E 'test(mmds_routed_port)'
- cargo xtask architecture check

Previously run on the same final tree before squashing:
- cargo nextest run -E 'test(mmds_logical_port)'
- cargo nextest run -E 'test(subgraph_direction)'
- git diff -- tests/snapshots/flowchart tests/svg-snapshots/flowchart