### PR TITLE
Add layout stability diagnostics and quality oracles

### DIFF
--- a/src/engines/graph/algorithms/layered/kernel/mod.rs
+++ b/src/engines/graph/algorithms/layered/kernel/mod.rs
@@ -9,6 +9,8 @@ pub mod graph;
 pub mod normalize;
 pub mod pipeline;
 pub mod support;
+#[cfg(test)]
+pub(crate) mod trace;
 pub mod types;
 
 pub(crate) mod acyclic;

--- a/src/engines/graph/algorithms/layered/kernel/pipeline.rs
+++ b/src/engines/graph/algorithms/layered/kernel/pipeline.rs
@@ -12,6 +12,8 @@ use super::support::{
     make_space_for_labeled_edges, position_self_edges, select_label_sides_direction_down,
     select_label_sides_first_last, switch_label_dummies, translate_layout_result,
 };
+#[cfg(test)]
+use super::trace::{self, LayeredPhaseTrace, TraceStage};
 use super::types::EdgeLabelInfo;
 use super::{
     DiGraph, EdgeLayout, LabelDummyPlacement, LabelSideStrategy, LayoutConfig, LayoutResult,
@@ -41,6 +43,34 @@ where
     layout_with_labels(graph, config, get_dimensions, &HashMap::new())
 }
 
+#[cfg(test)]
+pub(crate) fn layout_with_trace<N, F>(
+    graph: &DiGraph<N>,
+    config: &LayoutConfig,
+    get_dimensions: F,
+) -> (LayoutResult, LayeredPhaseTrace)
+where
+    F: Fn(&NodeId, &N) -> (f64, f64),
+{
+    layout_with_labels_and_trace(graph, config, get_dimensions, &HashMap::new())
+}
+
+#[cfg(test)]
+pub(crate) fn layout_with_labels_and_trace<N, F>(
+    graph: &DiGraph<N>,
+    config: &LayoutConfig,
+    get_dimensions: F,
+    edge_labels: &HashMap<usize, EdgeLabelInfo>,
+) -> (LayoutResult, LayeredPhaseTrace)
+where
+    F: Fn(&NodeId, &N) -> (f64, f64),
+{
+    trace::begin_capture();
+    let result = layout_with_labels(graph, config, get_dimensions, edge_labels);
+    let trace = trace::finish_capture();
+    (result, trace)
+}
+
 /// Layout computation with edge label support.
 ///
 /// This variant allows specifying label dimensions for edges, which will be
@@ -66,6 +96,8 @@ where
     if config.acyclic {
         acyclic::run_with_policy(&mut lg, config.acyclic_policy);
     }
+    #[cfg(test)]
+    trace::capture_stage(TraceStage::Acyclic, &lg);
 
     // Phase 1.5: Create space for edge label dummies.
     // Two strategies (both halve rank_sep to compensate for the doubled minlen model):
@@ -122,6 +154,8 @@ where
         nesting::assign_rank_minmax(&mut lg);
         debug_dump_pipeline(&lg, "after_rank_minmax");
     }
+    #[cfg(test)]
+    trace::capture_stage(TraceStage::Rank, &lg);
 
     // Phase 2.4: Detect rank-reversed edges that the acyclic DFS missed.
     //
@@ -173,6 +207,8 @@ where
         border::add_segments(&mut lg);
         debug_dump_pipeline(&lg, "after_border_segments");
     }
+    #[cfg(test)]
+    trace::capture_stage(TraceStage::Normalize, &lg);
 
     // Clear model_order when tie-breaking is disabled so that it has no effect
     // on barycenter sorting (None.cmp(&None) == Equal).
@@ -190,6 +226,8 @@ where
         },
     );
     debug_dump_pipeline(&lg, "after_order");
+    #[cfg(test)]
+    trace::capture_stage(TraceStage::Order, &lg);
 
     // Phase 3.6: Assign Above/Below sides to label dummies to reduce overlaps
     if config.label_side_selection {
@@ -232,6 +270,8 @@ where
 
     // Phase 4: Assign coordinates (now uses per-gap overrides via rank_sep_for_gap)
     position::run(&mut lg, &config);
+    #[cfg(test)]
+    trace::capture_stage(TraceStage::Position, &lg);
 
     // Phase 4.5: Compute self-edge loop paths
     let self_edge_layouts = position_self_edges(&lg, &config);
@@ -473,6 +513,8 @@ where
     translate_layout_result(&mut result, config.margin, config.margin, config.direction);
     // Adjust edge endpoints to node borders (dagre.js assignNodeIntersects).
     assign_node_intersects(&mut result);
+    #[cfg(test)]
+    trace::capture_stage(TraceStage::Route, &lg);
 
     debug_dump_layout_result(&result, lg.original_edge_count);
 

--- a/src/engines/graph/algorithms/layered/kernel/trace.rs
+++ b/src/engines/graph/algorithms/layered/kernel/trace.rs
@@ -1,0 +1,257 @@
+use std::cell::RefCell;
+
+use super::graph::LayoutGraph;
+use super::pipeline::layout_with_trace;
+use super::types::DummyType;
+use super::{DiGraph, LayoutConfig, NodeId};
+
+thread_local! {
+    static ACTIVE_TRACE: RefCell<Option<LayeredPhaseTrace>> = const { RefCell::new(None) };
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct LayeredPhaseTrace {
+    pub(crate) stages: Vec<TraceStageSnapshot>,
+}
+
+impl LayeredPhaseTrace {
+    pub(crate) fn push_stage(&mut self, stage: TraceStageSnapshot) {
+        self.stages.push(stage);
+    }
+
+    pub(crate) fn has_stage(&self, stage: TraceStage) -> bool {
+        self.stages.iter().any(|snapshot| snapshot.stage == stage)
+    }
+
+    pub(crate) fn stage_names(&self) -> Vec<TraceStage> {
+        self.stages.iter().map(|stage| stage.stage).collect()
+    }
+
+    pub(crate) fn generated_dummy_ids(&self) -> Vec<String> {
+        self.stages
+            .iter()
+            .flat_map(|stage| stage.dummies.iter().map(|dummy| dummy.generated_id.clone()))
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TraceStageSnapshot {
+    pub(crate) stage: TraceStage,
+    pub(crate) nodes: Vec<TraceNodeSnapshot>,
+    pub(crate) dummies: Vec<TraceDummySnapshot>,
+    pub(crate) reversed_edges: Vec<usize>,
+}
+
+impl TraceStageSnapshot {
+    pub(crate) fn empty(stage: TraceStage) -> Self {
+        Self {
+            stage,
+            nodes: Vec::new(),
+            dummies: Vec::new(),
+            reversed_edges: Vec::new(),
+        }
+    }
+
+    pub(crate) fn from_layout_graph(stage: TraceStage, graph: &LayoutGraph) -> Self {
+        let nodes = graph
+            .node_ids
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| !graph.is_dummy_index(*idx))
+            .map(|(idx, id)| TraceNodeSnapshot {
+                id: id.0.clone(),
+                rank: graph.ranks[idx],
+                order: graph.order[idx],
+                x: Some(graph.positions[idx].x),
+                y: Some(graph.positions[idx].y),
+            })
+            .collect();
+
+        let mut dummies = Vec::new();
+        for chain in &graph.dummy_chains {
+            for (chain_position, dummy_id) in chain.dummy_ids.iter().enumerate() {
+                let Some(dummy) = graph.dummy_nodes.get(dummy_id) else {
+                    continue;
+                };
+                let Some(&idx) = graph.node_index.get(dummy_id) else {
+                    continue;
+                };
+                let is_label_dummy = chain.label_dummy_index == Some(chain_position);
+                dummies.push(TraceDummySnapshot {
+                    generated_id: dummy_id.0.clone(),
+                    key: DummyTraceKey {
+                        edge_index: chain.edge_index,
+                        role: DummyTraceRole::from(dummy.dummy_type),
+                        chain_position,
+                        is_label_dummy,
+                    },
+                    rank: graph.ranks[idx],
+                    order: graph.order[idx],
+                });
+            }
+        }
+
+        Self {
+            stage,
+            nodes,
+            dummies,
+            reversed_edges: graph.reversed_edges.iter().copied().collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum TraceStage {
+    Acyclic,
+    Rank,
+    Normalize,
+    Order,
+    Position,
+    Route,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TraceNodeSnapshot {
+    pub(crate) id: String,
+    pub(crate) rank: i32,
+    pub(crate) order: usize,
+    pub(crate) x: Option<f64>,
+    pub(crate) y: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TraceDummySnapshot {
+    pub(crate) generated_id: String,
+    pub(crate) key: DummyTraceKey,
+    pub(crate) rank: i32,
+    pub(crate) order: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct DummyTraceKey {
+    pub(crate) edge_index: usize,
+    pub(crate) role: DummyTraceRole,
+    pub(crate) chain_position: usize,
+    pub(crate) is_label_dummy: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum DummyTraceRole {
+    Edge,
+    EdgeLabel,
+}
+
+impl From<DummyType> for DummyTraceRole {
+    fn from(value: DummyType) -> Self {
+        match value {
+            DummyType::Edge => Self::Edge,
+            DummyType::EdgeLabel => Self::EdgeLabel,
+        }
+    }
+}
+
+pub(crate) fn begin_capture() {
+    ACTIVE_TRACE.with(|trace| {
+        *trace.borrow_mut() = Some(LayeredPhaseTrace::default());
+    });
+}
+
+pub(crate) fn finish_capture() -> LayeredPhaseTrace {
+    ACTIVE_TRACE.with(|trace| trace.borrow_mut().take().unwrap_or_default())
+}
+
+pub(crate) fn capture_stage(stage: TraceStage, graph: &LayoutGraph) {
+    ACTIVE_TRACE.with(|trace| {
+        if let Some(active) = trace.borrow_mut().as_mut() {
+            active.push_stage(TraceStageSnapshot::from_layout_graph(stage, graph));
+        }
+    });
+}
+
+#[test]
+fn dummy_chain_key_ignores_generated_dummy_node_id() {
+    let before = TraceDummySnapshot {
+        generated_id: "_d4".to_string(),
+        key: DummyTraceKey {
+            edge_index: 7,
+            role: DummyTraceRole::Edge,
+            chain_position: 2,
+            is_label_dummy: false,
+        },
+        rank: 3,
+        order: 1,
+    };
+    let after = TraceDummySnapshot {
+        generated_id: "_d9".to_string(),
+        key: before.key.clone(),
+        rank: 3,
+        order: 1,
+    };
+
+    assert_eq!(before.key, after.key);
+    assert_ne!(before.generated_id, after.generated_id);
+}
+
+#[test]
+fn phase_trace_records_named_stages_in_order() {
+    let mut trace = LayeredPhaseTrace::default();
+    trace.push_stage(TraceStageSnapshot::empty(TraceStage::Acyclic));
+    trace.push_stage(TraceStageSnapshot::empty(TraceStage::Rank));
+    trace.push_stage(TraceStageSnapshot::empty(TraceStage::Normalize));
+
+    assert_eq!(
+        trace.stage_names(),
+        vec![TraceStage::Acyclic, TraceStage::Rank, TraceStage::Normalize]
+    );
+}
+
+#[test]
+fn stage_snapshot_carries_future_diff_payloads() {
+    let snapshot = TraceStageSnapshot {
+        stage: TraceStage::Order,
+        nodes: vec![TraceNodeSnapshot {
+            id: "A".to_string(),
+            rank: 1,
+            order: 0,
+            x: Some(10.0),
+            y: Some(20.0),
+        }],
+        dummies: vec![TraceDummySnapshot {
+            generated_id: "_ld2".to_string(),
+            key: DummyTraceKey {
+                edge_index: 4,
+                role: DummyTraceRole::EdgeLabel,
+                chain_position: 1,
+                is_label_dummy: true,
+            },
+            rank: 2,
+            order: 3,
+        }],
+        reversed_edges: vec![4],
+    };
+
+    assert_eq!(snapshot.stage, TraceStage::Order);
+    assert_eq!(snapshot.nodes.len(), 1);
+    assert_eq!(snapshot.dummies.len(), 1);
+    assert_eq!(snapshot.reversed_edges, vec![4]);
+    assert_eq!([TraceStage::Position, TraceStage::Route].len(), 2);
+}
+
+#[test]
+fn trace_capture_includes_core_layered_stages() {
+    let mut graph = DiGraph::<()>::new();
+    graph.add_node(NodeId::from("A"), ());
+    graph.add_node(NodeId::from("B"), ());
+    graph.add_edge(NodeId::from("A"), NodeId::from("B"));
+
+    let (_layout, trace) =
+        layout_with_trace(&graph, &LayoutConfig::default(), |_id, _node| (40.0, 20.0));
+
+    assert!(trace.has_stage(TraceStage::Acyclic));
+    assert!(trace.has_stage(TraceStage::Rank));
+    assert!(trace.has_stage(TraceStage::Normalize));
+    assert!(trace.has_stage(TraceStage::Order));
+    assert!(trace.has_stage(TraceStage::Position));
+    assert!(trace.has_stage(TraceStage::Route));
+}

--- a/src/graph/routing/label_lanes.rs
+++ b/src/graph/routing/label_lanes.rs
@@ -264,6 +264,12 @@ pub(super) fn assign_label_tracks(
     let descriptors = build_label_descriptors(diagram, geometry, paths, backward_flags, metrics);
     let compartments = group_label_compartments(descriptors);
     let mut outcomes: HashMap<usize, LabelTrackOutcome> = HashMap::new();
+    #[cfg(test)]
+    let mut trace_edges = Vec::new();
+    #[cfg(test)]
+    let mut trace_compartments = Vec::new();
+    #[cfg(test)]
+    let mut trace_subclusters = Vec::new();
 
     // Dense id counter assigned in iteration order. Each axis-conflict
     // sub-cluster within a compartment gets its own id so `label_step` is
@@ -271,6 +277,20 @@ pub(super) fn assign_label_tracks(
     // members together. Not stable across renders.
     let mut next_id: usize = 0;
     for compartment in compartments {
+        #[cfg(test)]
+        let trace_compartment_id = stable_label_lane_compartment_id(
+            compartment
+                .members
+                .first()
+                .and_then(|member| member.scope_parent.clone()),
+            &member_edge_ids(&compartment.members),
+        );
+        #[cfg(test)]
+        trace_compartments.push(label_lane_compartment_snapshot(
+            trace_compartment_id.clone(),
+            &compartment.members,
+        ));
+
         let full_compartment_size = compartment.members.len();
         for mut subcluster in split_into_axis_conflict_subclusters(compartment.members) {
             let compartment_id = next_id;
@@ -309,12 +329,49 @@ pub(super) fn assign_label_tracks(
             } else {
                 0.0
             };
+            #[cfg(test)]
+            let (trace_subcluster_id, trace_sort_positions) = {
+                let mut sweep_order = subcluster.iter().collect::<Vec<_>>();
+                sweep_order.sort_by(|a, b| {
+                    a.axis_min
+                        .partial_cmp(&b.axis_min)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then(a.edge_index.cmp(&b.edge_index))
+                });
+                let subcluster_id = stable_label_lane_subcluster_id(
+                    &trace_compartment_id,
+                    &member_edge_ids(&subcluster),
+                );
+                trace_subclusters.push(label_lane_subcluster_snapshot(
+                    subcluster_id.clone(),
+                    trace_compartment_id.clone(),
+                    &sweep_order,
+                ));
+                let sort_positions = sweep_order
+                    .iter()
+                    .enumerate()
+                    .map(|(sort_position, desc)| (desc.edge_index, sort_position))
+                    .collect::<HashMap<_, _>>();
+                (subcluster_id, sort_positions)
+            };
             for desc in &subcluster {
                 let track = tracks[&desc.edge_index];
                 let centered_track = track as f64 - track_center;
                 let label_offset = centered_track * label_step;
                 let path_offset = centered_track * path_step;
                 let (new_center, new_rect) = shift_label(desc, label_offset, direction);
+                #[cfg(test)]
+                trace_edges.push(crate::graph::routing::trace::LabelLaneEdgeSnapshot {
+                    edge_index: desc.edge_index,
+                    mmds_edge_id: mmds_edge_id(desc.edge_index),
+                    compartment_id: trace_compartment_id.clone(),
+                    subcluster_id: trace_subcluster_id.clone(),
+                    sort_position: trace_sort_positions[&desc.edge_index],
+                    track,
+                    track_center,
+                    label_step,
+                    label_rect: new_rect,
+                });
                 let new_path = paths
                     .get(&desc.edge_index)
                     .map(|p| shift_middle_segment(p, path_offset, direction))
@@ -337,6 +394,15 @@ pub(super) fn assign_label_tracks(
             }
         }
     }
+
+    #[cfg(test)]
+    crate::graph::routing::trace::capture_label_lanes(
+        crate::graph::routing::trace::LabelLaneTraceSnapshot {
+            edges: trace_edges,
+            compartments: trace_compartments,
+            subclusters: trace_subclusters,
+        },
+    );
 
     outcomes
 }
@@ -656,6 +722,113 @@ fn are_collinear(path: &[FPoint]) -> bool {
 }
 
 #[cfg(test)]
+fn mmds_edge_id(edge_index: usize) -> String {
+    format!("e{edge_index}")
+}
+
+#[cfg(test)]
+fn member_edge_ids(members: &[LabelDescriptor]) -> Vec<String> {
+    let mut edge_ids = members
+        .iter()
+        .map(|member| mmds_edge_id(member.edge_index))
+        .collect::<Vec<_>>();
+    edge_ids.sort();
+    edge_ids
+}
+
+#[cfg(test)]
+fn member_edge_indices(members: &[LabelDescriptor]) -> Vec<usize> {
+    let mut edge_indices = members
+        .iter()
+        .map(|member| member.edge_index)
+        .collect::<Vec<_>>();
+    edge_indices.sort_unstable();
+    edge_indices
+}
+
+#[cfg(test)]
+fn stable_label_lane_compartment_id(
+    scope_parent: Option<String>,
+    member_edge_ids: &[String],
+) -> String {
+    let scope = scope_parent.unwrap_or_else(|| "none".to_string());
+    format!(
+        "scope:{scope}|members:{}",
+        sorted_member_edge_ids(member_edge_ids).join(",")
+    )
+}
+
+#[cfg(test)]
+fn stable_label_lane_subcluster_id(compartment_id: &str, member_edge_ids: &[String]) -> String {
+    format!(
+        "{compartment_id}|cluster:{}",
+        sorted_member_edge_ids(member_edge_ids).join(",")
+    )
+}
+
+#[cfg(test)]
+fn sorted_member_edge_ids(member_edge_ids: &[String]) -> Vec<String> {
+    let mut member_edge_ids = member_edge_ids.to_vec();
+    member_edge_ids.sort();
+    member_edge_ids
+}
+
+#[cfg(test)]
+fn label_lane_compartment_snapshot(
+    id: String,
+    members: &[LabelDescriptor],
+) -> crate::graph::routing::trace::LabelLaneCompartmentSnapshot {
+    crate::graph::routing::trace::LabelLaneCompartmentSnapshot {
+        id,
+        member_edge_indices: member_edge_indices(members),
+        member_edge_ids: member_edge_ids(members),
+        scope_parent: members
+            .first()
+            .and_then(|member| member.scope_parent.clone()),
+        cross_min: members
+            .iter()
+            .map(|member| member.cross_min)
+            .fold(f64::INFINITY, f64::min),
+        cross_max: members
+            .iter()
+            .map(|member| member.cross_max)
+            .fold(f64::NEG_INFINITY, f64::max),
+    }
+}
+
+#[cfg(test)]
+fn label_lane_subcluster_snapshot(
+    id: String,
+    compartment_id: String,
+    sweep_order: &[&LabelDescriptor],
+) -> crate::graph::routing::trace::LabelLaneSubclusterSnapshot {
+    crate::graph::routing::trace::LabelLaneSubclusterSnapshot {
+        id,
+        compartment_id,
+        member_edge_indices: {
+            let mut indices = sweep_order
+                .iter()
+                .map(|member| member.edge_index)
+                .collect::<Vec<_>>();
+            indices.sort_unstable();
+            indices
+        },
+        member_edge_ids: {
+            let mut edge_ids = sweep_order
+                .iter()
+                .map(|member| mmds_edge_id(member.edge_index))
+                .collect::<Vec<_>>();
+            edge_ids.sort();
+            edge_ids
+        },
+        sweep_order: sweep_order
+            .iter()
+            .map(|member| mmds_edge_id(member.edge_index))
+            .collect(),
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -685,6 +858,132 @@ mod tests {
         assert_eq!(d.axis_max - d.axis_min, 40.0);
         assert_eq!(d.cross_max - d.cross_min, 20.0);
         assert_eq!(d.direction_sign, 1);
+    }
+
+    #[test]
+    fn stable_compartment_id_ignores_cross_band_extent_changes() {
+        let before = stable_label_lane_compartment_id(None, &["e1".to_string(), "e4".to_string()]);
+        let after = stable_label_lane_compartment_id(None, &["e1".to_string(), "e4".to_string()]);
+
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn stable_compartment_id_sorts_member_edge_ids() {
+        let before = stable_label_lane_compartment_id(None, &["e4".to_string(), "e1".to_string()]);
+        let after = stable_label_lane_compartment_id(None, &["e1".to_string(), "e4".to_string()]);
+
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn stable_subcluster_id_includes_parent_compartment_and_members() {
+        let compartment_id =
+            stable_label_lane_compartment_id(Some("outer".to_string()), &["e2".to_string()]);
+        let subcluster_id = stable_label_lane_subcluster_id(&compartment_id, &["e2".to_string()]);
+
+        assert!(subcluster_id.contains(&compartment_id));
+        assert!(subcluster_id.contains("e2"));
+    }
+
+    #[test]
+    fn label_lane_scope_snapshot_uses_lca_scope() {
+        let mut diagram = Graph::new(Direction::TopDown);
+        let mut source = crate::graph::Node::new("A");
+        source.parent = Some("LEFT".to_string());
+        let mut target = crate::graph::Node::new("B");
+        target.parent = Some("RIGHT".to_string());
+        diagram.add_node(source);
+        diagram.add_node(target);
+        diagram.subgraphs.insert(
+            "OUTER".to_string(),
+            crate::graph::Subgraph {
+                id: "OUTER".to_string(),
+                title: "OUTER".to_string(),
+                nodes: Vec::new(),
+                parent: None,
+                dir: None,
+                invisible: false,
+                concurrent_regions: Vec::new(),
+            },
+        );
+        diagram.subgraphs.insert(
+            "LEFT".to_string(),
+            crate::graph::Subgraph {
+                id: "LEFT".to_string(),
+                title: "LEFT".to_string(),
+                nodes: vec!["A".to_string()],
+                parent: Some("OUTER".to_string()),
+                dir: None,
+                invisible: false,
+                concurrent_regions: Vec::new(),
+            },
+        );
+        diagram.subgraphs.insert(
+            "RIGHT".to_string(),
+            crate::graph::Subgraph {
+                id: "RIGHT".to_string(),
+                title: "RIGHT".to_string(),
+                nodes: vec!["B".to_string()],
+                parent: Some("OUTER".to_string()),
+                dir: None,
+                invisible: false,
+                concurrent_regions: Vec::new(),
+            },
+        );
+        diagram.add_edge(crate::graph::Edge::new("A", "B").with_label("shared parent label"));
+
+        let geometry = GraphGeometry {
+            nodes: HashMap::from([
+                (
+                    "A".to_string(),
+                    crate::graph::geometry::PositionedNode {
+                        id: "A".to_string(),
+                        rect: FRect::new(0.0, 0.0, 40.0, 30.0),
+                        shape: crate::graph::Shape::Rectangle,
+                        label: "A".to_string(),
+                        parent: Some("LEFT".to_string()),
+                    },
+                ),
+                (
+                    "B".to_string(),
+                    crate::graph::geometry::PositionedNode {
+                        id: "B".to_string(),
+                        rect: FRect::new(100.0, 100.0, 40.0, 30.0),
+                        shape: crate::graph::Shape::Rectangle,
+                        label: "B".to_string(),
+                        parent: Some("RIGHT".to_string()),
+                    },
+                ),
+            ]),
+            edges: Vec::new(),
+            subgraphs: HashMap::new(),
+            self_edges: Vec::new(),
+            direction: Direction::TopDown,
+            node_directions: HashMap::new(),
+            bounds: FRect::new(0.0, 0.0, 100.0, 100.0),
+            reversed_edges: Vec::new(),
+            engine_hints: None,
+            grid_projection: None,
+            rerouted_edges: HashSet::new(),
+            enhanced_backward_routing: false,
+        };
+        let paths = HashMap::from([(0, vec![FPoint::new(0.0, 0.0), FPoint::new(100.0, 100.0)])]);
+        let descriptors = build_label_descriptors(
+            &diagram,
+            &geometry,
+            &paths,
+            &HashMap::new(),
+            &ProportionalTextMetrics::new(16.0, 15.0, 15.0),
+        );
+        let compartment_id = stable_label_lane_compartment_id(
+            descriptors[0].scope_parent.clone(),
+            &member_edge_ids(&descriptors),
+        );
+        let snapshot = label_lane_compartment_snapshot(compartment_id, &descriptors);
+
+        assert_eq!(descriptors[0].scope_parent.as_deref(), Some("OUTER"));
+        assert_eq!(snapshot.scope_parent.as_deref(), Some("OUTER"));
     }
 
     #[test]

--- a/src/graph/routing/mod.rs
+++ b/src/graph/routing/mod.rs
@@ -16,6 +16,8 @@ mod label_rewrap;
 mod labels;
 mod orthogonal;
 mod stage;
+#[cfg(test)]
+pub(crate) mod trace;
 
 pub use self::float_core::{
     build_orthogonal_path_float, hexagon_vertices, intersect_convex_polygon,
@@ -96,6 +98,50 @@ mod tests {
         };
 
         (diagram, geom)
+    }
+
+    #[test]
+    fn route_graph_geometry_trace_records_route_input_and_output() {
+        let (diagram, geometry) = simple_geometry();
+
+        trace::begin_capture();
+        let routed = route_graph_geometry(
+            &diagram,
+            &geometry,
+            EdgeRouting::PolylineRoute,
+            &default_proportional_text_metrics(),
+        );
+        let trace = trace::finish_capture();
+
+        assert!(trace.has_stage(trace::RoutingTraceStage::Input));
+        assert!(trace.has_stage(trace::RoutingTraceStage::Output));
+        assert_eq!(trace.input().unwrap().edges[0].index, 0);
+        assert_eq!(
+            trace.output().unwrap().edges[0].index,
+            routed.edges[0].index
+        );
+    }
+
+    #[test]
+    fn route_input_trace_includes_label_descriptor_dimensions() {
+        let (mut diagram, mut geometry) = simple_geometry();
+        diagram.edges[0].label = Some("validate payload".to_string());
+        geometry.edges[0].label_position = Some(FPoint::new(50.0, 50.0));
+
+        trace::begin_capture();
+        let _ = route_graph_geometry(
+            &diagram,
+            &geometry,
+            EdgeRouting::PolylineRoute,
+            &default_proportional_text_metrics(),
+        );
+        let trace = trace::finish_capture();
+
+        let input = trace.input().unwrap();
+        assert_eq!(input.labels.len(), 1);
+        assert_eq!(input.labels[0].edge_index, 0);
+        assert!(input.labels[0].width > 0.0);
+        assert!(input.labels[0].height > 0.0);
     }
 
     #[test]

--- a/src/graph/routing/stage.rs
+++ b/src/graph/routing/stage.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use super::float_core::compute_port_attachments_from_geometry;
 use super::labels::{arc_length_midpoint, compute_end_labels_for_edge};
 use super::orthogonal::{OrthogonalRoutingOptions, build_path_from_hints, route_edges_orthogonal};
+#[cfg(test)]
+use super::trace;
 use super::{backward_corridor, label_clamp, label_lanes, label_rewrap};
 use crate::graph::direction_policy::effective_edge_direction;
 use crate::graph::geometry::{
@@ -39,6 +41,8 @@ pub fn route_graph_geometry(
     metrics: &ProportionalTextMetrics,
 ) -> RoutedGraphGeometry {
     let port_attachments = compute_port_attachments_from_geometry(diagram, geometry);
+    #[cfg(test)]
+    trace::capture_route_input(diagram, geometry, edge_routing, &port_attachments, metrics);
 
     let edges: Vec<RoutedEdgeGeometry> = match edge_routing {
         EdgeRouting::OrthogonalRoute => {
@@ -316,7 +320,7 @@ pub fn route_graph_geometry(
 
     let bounds = recompute_routed_bounds(geometry, &edges, &self_edges);
 
-    RoutedGraphGeometry {
+    let routed = RoutedGraphGeometry {
         nodes: geometry.nodes.clone(),
         edges,
         subgraphs: geometry.subgraphs.clone(),
@@ -324,7 +328,10 @@ pub fn route_graph_geometry(
         direction: geometry.direction,
         bounds,
         unfit_label_overlaps,
-    }
+    };
+    #[cfg(test)]
+    trace::capture_route_output(&routed);
+    routed
 }
 
 pub(crate) fn recompute_routed_bounds(

--- a/src/graph/routing/trace.rs
+++ b/src/graph/routing/trace.rs
@@ -1,0 +1,550 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use super::EdgeRouting;
+use crate::graph::attachment::EdgePort;
+use crate::graph::geometry::{
+    EdgeLabelSide, GraphGeometry, RoutedEdgeGeometry, RoutedGraphGeometry,
+};
+use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::space::{FPoint, FRect};
+use crate::graph::{Direction, Graph, Shape};
+
+thread_local! {
+    static ACTIVE_TRACE: RefCell<Option<RoutingTrace>> = const { RefCell::new(None) };
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct RoutingTrace {
+    pub(crate) stages: Vec<RoutingTraceStageSnapshot>,
+}
+
+impl RoutingTrace {
+    pub(crate) fn push_stage(&mut self, stage: RoutingTraceStageSnapshot) {
+        self.stages.push(stage);
+    }
+
+    pub(crate) fn stage_names(&self) -> Vec<RoutingTraceStage> {
+        self.stages.iter().map(|stage| stage.stage).collect()
+    }
+
+    pub(crate) fn has_stage(&self, stage: RoutingTraceStage) -> bool {
+        self.stages.iter().any(|snapshot| snapshot.stage == stage)
+    }
+
+    pub(crate) fn input(&self) -> Option<&RouteInputSnapshot> {
+        self.stages.iter().find_map(|stage| stage.input.as_ref())
+    }
+
+    pub(crate) fn output(&self) -> Option<&RouteOutputSnapshot> {
+        self.stages.iter().find_map(|stage| stage.output.as_ref())
+    }
+
+    pub(crate) fn label_lanes(&self) -> Option<&LabelLaneTraceSnapshot> {
+        self.stages
+            .iter()
+            .find_map(|stage| stage.label_lanes.as_ref())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RoutingTraceStage {
+    Input,
+    LabelLanes,
+    Output,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RoutingTraceStageSnapshot {
+    pub(crate) stage: RoutingTraceStage,
+    pub(crate) input: Option<RouteInputSnapshot>,
+    pub(crate) label_lanes: Option<LabelLaneTraceSnapshot>,
+    pub(crate) output: Option<RouteOutputSnapshot>,
+}
+
+impl RoutingTraceStageSnapshot {
+    pub(crate) fn empty(stage: RoutingTraceStage) -> Self {
+        Self {
+            stage,
+            input: (stage == RoutingTraceStage::Input).then(RouteInputSnapshot::empty),
+            label_lanes: (stage == RoutingTraceStage::LabelLanes)
+                .then(LabelLaneTraceSnapshot::default),
+            output: (stage == RoutingTraceStage::Output).then(RouteOutputSnapshot::default),
+        }
+    }
+
+    pub(crate) fn label_lanes(label_lanes: LabelLaneTraceSnapshot) -> Self {
+        Self {
+            stage: RoutingTraceStage::LabelLanes,
+            input: None,
+            label_lanes: Some(label_lanes),
+            output: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteInputSnapshot {
+    pub(crate) edge_routing: EdgeRouting,
+    pub(crate) nodes: Vec<RouteNodeInput>,
+    pub(crate) edges: Vec<RouteEdgeInput>,
+    pub(crate) labels: Vec<RouteLabelInput>,
+}
+
+impl RouteInputSnapshot {
+    fn empty() -> Self {
+        Self {
+            edge_routing: EdgeRouting::PolylineRoute,
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            labels: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub(crate) struct RouteOutputSnapshot {
+    pub(crate) edges: Vec<RouteEdgeOutput>,
+    pub(crate) labels: Vec<RouteLabelOutput>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub(crate) struct LabelLaneTraceSnapshot {
+    pub(crate) edges: Vec<LabelLaneEdgeSnapshot>,
+    pub(crate) compartments: Vec<LabelLaneCompartmentSnapshot>,
+    pub(crate) subclusters: Vec<LabelLaneSubclusterSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LabelLaneEdgeSnapshot {
+    pub(crate) edge_index: usize,
+    pub(crate) mmds_edge_id: String,
+    pub(crate) compartment_id: String,
+    pub(crate) subcluster_id: String,
+    pub(crate) sort_position: usize,
+    pub(crate) track: i32,
+    pub(crate) track_center: f64,
+    pub(crate) label_step: f64,
+    pub(crate) label_rect: FRect,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LabelLaneCompartmentSnapshot {
+    pub(crate) id: String,
+    pub(crate) member_edge_indices: Vec<usize>,
+    pub(crate) member_edge_ids: Vec<String>,
+    pub(crate) scope_parent: Option<String>,
+    pub(crate) cross_min: f64,
+    pub(crate) cross_max: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LabelLaneSubclusterSnapshot {
+    pub(crate) id: String,
+    pub(crate) compartment_id: String,
+    pub(crate) member_edge_indices: Vec<usize>,
+    pub(crate) member_edge_ids: Vec<String>,
+    pub(crate) sweep_order: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteNodeInput {
+    pub(crate) id: String,
+    pub(crate) rect: FRect,
+    pub(crate) shape: Shape,
+    pub(crate) label: String,
+    pub(crate) parent: Option<String>,
+    pub(crate) direction: Direction,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteEdgeInput {
+    pub(crate) index: usize,
+    pub(crate) from: String,
+    pub(crate) to: String,
+    pub(crate) waypoints: Vec<FPoint>,
+    pub(crate) layout_path_hint: Option<Vec<FPoint>>,
+    pub(crate) label_position: Option<FPoint>,
+    pub(crate) label_side: Option<EdgeLabelSide>,
+    pub(crate) source_port: Option<RoutePortInput>,
+    pub(crate) target_port: Option<RoutePortInput>,
+    pub(crate) is_backward: bool,
+    pub(crate) preserve_orthogonal_topology: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteLabelInput {
+    pub(crate) edge_index: usize,
+    pub(crate) label_text: Option<String>,
+    pub(crate) width: f64,
+    pub(crate) height: f64,
+    pub(crate) axis_min: f64,
+    pub(crate) axis_max: f64,
+    pub(crate) cross_min: f64,
+    pub(crate) cross_max: f64,
+    pub(crate) side: Option<EdgeLabelSide>,
+    pub(crate) direction_sign: i32,
+    pub(crate) scope_parent: Option<String>,
+    pub(crate) midpoint: FPoint,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RoutePortInput {
+    pub(crate) face: String,
+    pub(crate) fraction: f64,
+    pub(crate) group_size: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteEdgeOutput {
+    pub(crate) index: usize,
+    pub(crate) path: Vec<FPoint>,
+    pub(crate) source_port: Option<RoutePortInput>,
+    pub(crate) target_port: Option<RoutePortInput>,
+    pub(crate) is_backward: bool,
+    pub(crate) preserve_orthogonal_topology: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteLabelOutput {
+    pub(crate) edge_index: usize,
+    pub(crate) center: FPoint,
+    pub(crate) rect: FRect,
+    pub(crate) side: EdgeLabelSide,
+    pub(crate) track: i32,
+    pub(crate) compartment_size: usize,
+}
+
+pub(crate) fn begin_capture() {
+    ACTIVE_TRACE.with(|trace| {
+        *trace.borrow_mut() = Some(RoutingTrace::default());
+    });
+}
+
+pub(crate) fn finish_capture() -> RoutingTrace {
+    ACTIVE_TRACE.with(|trace| trace.borrow_mut().take().unwrap_or_default())
+}
+
+pub(crate) fn capture_route_input(
+    diagram: &Graph,
+    geometry: &GraphGeometry,
+    edge_routing: EdgeRouting,
+    port_attachments: &HashMap<usize, (Option<EdgePort>, Option<EdgePort>)>,
+    metrics: &ProportionalTextMetrics,
+) {
+    ACTIVE_TRACE.with(|trace| {
+        let mut trace = trace.borrow_mut();
+        let Some(active) = trace.as_mut() else {
+            return;
+        };
+        active.push_stage(RoutingTraceStageSnapshot {
+            stage: RoutingTraceStage::Input,
+            input: Some(RouteInputSnapshot::from_geometry(
+                diagram,
+                geometry,
+                edge_routing,
+                port_attachments,
+                metrics,
+            )),
+            label_lanes: None,
+            output: None,
+        });
+    });
+}
+
+pub(crate) fn capture_route_output(routed: &RoutedGraphGeometry) {
+    ACTIVE_TRACE.with(|trace| {
+        let mut trace = trace.borrow_mut();
+        let Some(active) = trace.as_mut() else {
+            return;
+        };
+        active.push_stage(RoutingTraceStageSnapshot {
+            stage: RoutingTraceStage::Output,
+            input: None,
+            label_lanes: None,
+            output: Some(RouteOutputSnapshot::from_routed(routed)),
+        });
+    });
+}
+
+pub(crate) fn capture_label_lanes(snapshot: LabelLaneTraceSnapshot) {
+    ACTIVE_TRACE.with(|trace| {
+        let mut trace = trace.borrow_mut();
+        let Some(active) = trace.as_mut() else {
+            return;
+        };
+        active.push_stage(RoutingTraceStageSnapshot::label_lanes(snapshot));
+    });
+}
+
+impl RouteInputSnapshot {
+    fn from_geometry(
+        diagram: &Graph,
+        geometry: &GraphGeometry,
+        edge_routing: EdgeRouting,
+        port_attachments: &HashMap<usize, (Option<EdgePort>, Option<EdgePort>)>,
+        metrics: &ProportionalTextMetrics,
+    ) -> Self {
+        let mut nodes = geometry
+            .nodes
+            .values()
+            .map(|node| RouteNodeInput {
+                id: node.id.clone(),
+                rect: node.rect,
+                shape: node.shape,
+                label: node.label.clone(),
+                parent: node.parent.clone(),
+                direction: geometry
+                    .node_directions
+                    .get(&node.id)
+                    .copied()
+                    .unwrap_or(geometry.direction),
+            })
+            .collect::<Vec<_>>();
+        nodes.sort_by(|a, b| a.id.cmp(&b.id));
+
+        let edges = geometry
+            .edges
+            .iter()
+            .map(|edge| {
+                let (source_port, target_port) = port_attachments
+                    .get(&edge.index)
+                    .cloned()
+                    .unwrap_or((None, None));
+                RouteEdgeInput {
+                    index: edge.index,
+                    from: edge.from.clone(),
+                    to: edge.to.clone(),
+                    waypoints: edge.waypoints.clone(),
+                    layout_path_hint: edge.layout_path_hint.clone(),
+                    label_position: edge.label_position,
+                    label_side: edge.label_side,
+                    source_port: source_port.as_ref().map(RoutePortInput::from_edge_port),
+                    target_port: target_port.as_ref().map(RoutePortInput::from_edge_port),
+                    is_backward: geometry.reversed_edges.contains(&edge.index),
+                    preserve_orthogonal_topology: edge.preserve_orthogonal_topology,
+                }
+            })
+            .collect();
+
+        let labels = geometry
+            .edges
+            .iter()
+            .filter_map(|edge| {
+                let diagram_edge = diagram.edges.get(edge.index)?;
+                let label = diagram_edge.label.as_deref()?;
+                if label.is_empty() {
+                    return None;
+                }
+                let midpoint = edge.label_position?;
+                let (width, height) = match diagram_edge.wrapped_label_lines.as_deref() {
+                    Some(lines) => metrics.edge_label_dimensions_wrapped(lines),
+                    None => metrics.edge_label_dimensions(label),
+                };
+                let (axis_dim, cross_dim, axis_center, cross_center) = match geometry.direction {
+                    Direction::TopDown | Direction::BottomTop => {
+                        (height, width, midpoint.y, midpoint.x)
+                    }
+                    Direction::LeftRight | Direction::RightLeft => {
+                        (width, height, midpoint.x, midpoint.y)
+                    }
+                };
+                Some(RouteLabelInput {
+                    edge_index: edge.index,
+                    label_text: Some(label.to_string()),
+                    width,
+                    height,
+                    axis_min: axis_center - axis_dim / 2.0,
+                    axis_max: axis_center + axis_dim / 2.0,
+                    cross_min: cross_center - cross_dim / 2.0,
+                    cross_max: cross_center + cross_dim / 2.0,
+                    side: edge.label_side,
+                    direction_sign: if geometry.reversed_edges.contains(&edge.index) {
+                        -1
+                    } else {
+                        1
+                    },
+                    scope_parent: shared_direct_parent(geometry, &edge.from, &edge.to),
+                    midpoint,
+                })
+            })
+            .collect();
+
+        Self {
+            edge_routing,
+            nodes,
+            edges,
+            labels,
+        }
+    }
+}
+
+impl RouteOutputSnapshot {
+    fn from_routed(routed: &RoutedGraphGeometry) -> Self {
+        Self {
+            edges: routed
+                .edges
+                .iter()
+                .map(RouteEdgeOutput::from_routed_edge)
+                .collect(),
+            labels: routed
+                .edges
+                .iter()
+                .filter_map(|edge| {
+                    let label = edge.label_geometry.as_ref()?;
+                    Some(RouteLabelOutput {
+                        edge_index: edge.index,
+                        center: label.center,
+                        rect: label.rect,
+                        side: label.side,
+                        track: label.track,
+                        compartment_size: label.compartment_size,
+                    })
+                })
+                .collect(),
+        }
+    }
+}
+
+impl RouteEdgeOutput {
+    fn from_routed_edge(edge: &RoutedEdgeGeometry) -> Self {
+        Self {
+            index: edge.index,
+            path: edge.path.clone(),
+            source_port: edge
+                .source_port
+                .as_ref()
+                .map(RoutePortInput::from_edge_port),
+            target_port: edge
+                .target_port
+                .as_ref()
+                .map(RoutePortInput::from_edge_port),
+            is_backward: edge.is_backward,
+            preserve_orthogonal_topology: edge.preserve_orthogonal_topology,
+        }
+    }
+}
+
+impl RoutePortInput {
+    fn from_edge_port(port: &EdgePort) -> Self {
+        Self {
+            face: port.face.as_str().to_string(),
+            fraction: port.fraction,
+            group_size: port.group_size,
+        }
+    }
+}
+
+fn shared_direct_parent(geometry: &GraphGeometry, from: &str, to: &str) -> Option<String> {
+    let from_parent = geometry.nodes.get(from)?.parent.as_ref()?;
+    let to_parent = geometry.nodes.get(to)?.parent.as_ref()?;
+    (from_parent == to_parent).then(|| from_parent.clone())
+}
+
+#[test]
+fn route_trace_records_input_and_output_stages_in_order() {
+    let mut trace = RoutingTrace::default();
+    trace.push_stage(RoutingTraceStageSnapshot::empty(RoutingTraceStage::Input));
+    trace.push_stage(RoutingTraceStageSnapshot::empty(RoutingTraceStage::Output));
+
+    assert_eq!(
+        trace.stage_names(),
+        vec![RoutingTraceStage::Input, RoutingTraceStage::Output]
+    );
+    assert!(trace.input().is_some());
+    assert!(trace.output().is_some());
+}
+
+#[test]
+fn label_lane_trace_records_stage_and_snapshot() {
+    let mut trace = RoutingTrace::default();
+    trace.push_stage(RoutingTraceStageSnapshot::label_lanes(
+        LabelLaneTraceSnapshot {
+            edges: vec![LabelLaneEdgeSnapshot {
+                edge_index: 2,
+                mmds_edge_id: "e2".to_string(),
+                compartment_id: "scope:none|members:e2,e4".to_string(),
+                subcluster_id: "scope:none|members:e2,e4|cluster:e2,e4".to_string(),
+                sort_position: 1,
+                track: -1,
+                track_center: -0.5,
+                label_step: 32.0,
+                label_rect: FRect::new(10.0, 20.0, 40.0, 16.0),
+            }],
+            compartments: vec![LabelLaneCompartmentSnapshot {
+                id: "scope:none|members:e2,e4".to_string(),
+                member_edge_indices: vec![2, 4],
+                member_edge_ids: vec!["e2".to_string(), "e4".to_string()],
+                scope_parent: None,
+                cross_min: 10.0,
+                cross_max: 80.0,
+            }],
+            subclusters: vec![LabelLaneSubclusterSnapshot {
+                id: "scope:none|members:e2,e4|cluster:e2,e4".to_string(),
+                compartment_id: "scope:none|members:e2,e4".to_string(),
+                member_edge_indices: vec![2, 4],
+                member_edge_ids: vec!["e2".to_string(), "e4".to_string()],
+                sweep_order: vec!["e4".to_string(), "e2".to_string()],
+            }],
+        },
+    ));
+
+    assert_eq!(trace.stage_names(), vec![RoutingTraceStage::LabelLanes]);
+    let snapshot = trace.label_lanes().expect("label-lane snapshot");
+    assert_eq!(snapshot.edges[0].mmds_edge_id, "e2");
+    assert_eq!(snapshot.edges[0].track, -1);
+    assert_eq!(snapshot.compartments[0].member_edge_ids, vec!["e2", "e4"]);
+}
+
+#[test]
+fn route_input_snapshot_carries_label_and_port_facts() {
+    let snapshot = RouteInputSnapshot {
+        edge_routing: EdgeRouting::PolylineRoute,
+        nodes: vec![RouteNodeInput {
+            id: "A".to_string(),
+            rect: FRect::new(10.0, 20.0, 40.0, 30.0),
+            shape: Shape::Rectangle,
+            label: "A".to_string(),
+            parent: None,
+            direction: Direction::TopDown,
+        }],
+        edges: vec![RouteEdgeInput {
+            index: 0,
+            from: "A".to_string(),
+            to: "B".to_string(),
+            waypoints: vec![FPoint::new(10.0, 50.0)],
+            layout_path_hint: None,
+            label_position: Some(FPoint::new(10.0, 35.0)),
+            label_side: Some(EdgeLabelSide::Above),
+            source_port: Some(RoutePortInput {
+                face: "south".to_string(),
+                fraction: 0.5,
+                group_size: 1,
+            }),
+            target_port: None,
+            is_backward: false,
+            preserve_orthogonal_topology: false,
+        }],
+        labels: vec![RouteLabelInput {
+            edge_index: 0,
+            label_text: None,
+            width: 80.0,
+            height: 28.0,
+            axis_min: 21.0,
+            axis_max: 49.0,
+            cross_min: -30.0,
+            cross_max: 50.0,
+            side: Some(EdgeLabelSide::Above),
+            direction_sign: 1,
+            scope_parent: None,
+            midpoint: FPoint::new(10.0, 35.0),
+        }],
+    };
+
+    assert_eq!(snapshot.edge_routing, EdgeRouting::PolylineRoute);
+    assert_eq!(snapshot.labels[0].width, 80.0);
+    assert_eq!(
+        snapshot.edges[0].source_port.as_ref().unwrap().face,
+        "south"
+    );
+}

--- a/src/internal_tests/layout_stability/geometry_metrics.rs
+++ b/src/internal_tests/layout_stability/geometry_metrics.rs
@@ -1,0 +1,94 @@
+use super::mmds_metrics::COORD_EPS;
+use crate::graph::geometry::{FPoint, FRect};
+
+pub(crate) fn bend_count(path: &[FPoint]) -> usize {
+    path.windows(3)
+        .filter(|points| {
+            let first = segment_axis(points[0], points[1]);
+            let second = segment_axis(points[1], points[2]);
+            first != Axis::Point && second != Axis::Point && first != second
+        })
+        .count()
+}
+
+pub(crate) fn polyline_length(path: &[FPoint]) -> f64 {
+    path.windows(2)
+        .map(|points| {
+            let dx = points[1].x - points[0].x;
+            let dy = points[1].y - points[0].y;
+            dx.hypot(dy)
+        })
+        .sum()
+}
+
+pub(crate) fn route_envelope(path: &[FPoint]) -> Option<FRect> {
+    let first = path.first()?;
+    let mut min_x = first.x;
+    let mut max_x = first.x;
+    let mut min_y = first.y;
+    let mut max_y = first.y;
+
+    for point in path {
+        min_x = min_x.min(point.x);
+        max_x = max_x.max(point.x);
+        min_y = min_y.min(point.y);
+        max_y = max_y.max(point.y);
+    }
+
+    Some(FRect::new(min_x, min_y, max_x - min_x, max_y - min_y))
+}
+
+pub(crate) fn rects_overlap(a: FRect, b: FRect) -> bool {
+    a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
+}
+
+pub(crate) fn distance_point_to_path(point: FPoint, path: &[FPoint]) -> f64 {
+    match path {
+        [] => f64::INFINITY,
+        [only] => distance(point, *only),
+        _ => path
+            .windows(2)
+            .map(|segment| distance_point_to_segment(point, segment[0], segment[1]))
+            .fold(f64::INFINITY, f64::min),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Axis {
+    Horizontal,
+    Vertical,
+    Diagonal,
+    Point,
+}
+
+fn segment_axis(start: FPoint, end: FPoint) -> Axis {
+    let dx = end.x - start.x;
+    let dy = end.y - start.y;
+    if dx.abs() <= COORD_EPS && dy.abs() <= COORD_EPS {
+        Axis::Point
+    } else if dy.abs() <= COORD_EPS {
+        Axis::Horizontal
+    } else if dx.abs() <= COORD_EPS {
+        Axis::Vertical
+    } else {
+        Axis::Diagonal
+    }
+}
+
+fn distance_point_to_segment(point: FPoint, start: FPoint, end: FPoint) -> f64 {
+    let dx = end.x - start.x;
+    let dy = end.y - start.y;
+    let length_squared = dx * dx + dy * dy;
+    if length_squared <= COORD_EPS * COORD_EPS {
+        return distance(point, start);
+    }
+
+    let t =
+        (((point.x - start.x) * dx + (point.y - start.y) * dy) / length_squared).clamp(0.0, 1.0);
+    let projection = FPoint::new(start.x + t * dx, start.y + t * dy);
+    distance(point, projection)
+}
+
+fn distance(a: FPoint, b: FPoint) -> f64 {
+    (a.x - b.x).hypot(a.y - b.y)
+}

--- a/src/internal_tests/layout_stability/mmds_metrics.rs
+++ b/src/internal_tests/layout_stability/mmds_metrics.rs
@@ -1,0 +1,856 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{geometry_metrics, mutations};
+use crate::graph::geometry::{FPoint, FRect};
+use crate::mmds;
+
+pub(crate) const COORD_EPS: f64 = 0.01;
+pub(crate) const DISPLAY_EPS: f64 = 1.0;
+
+#[derive(Debug, Clone)]
+pub(crate) struct LayoutMmdsMetrics {
+    pub(crate) coord_eps: f64,
+    pub(crate) added_nodes: BTreeSet<String>,
+    pub(crate) removed_nodes: BTreeSet<String>,
+    pub(crate) inferred_renames: Vec<InferredRename>,
+    pub(crate) direct_impact_nodes: BTreeSet<String>,
+    pub(crate) unchanged_node_count: usize,
+    pub(crate) unchanged_node_displacements: BTreeMap<String, Displacement>,
+    pub(crate) node_size_changes: BTreeMap<String, SizeDelta>,
+    pub(crate) bounds_delta: BoundsDelta,
+    pub(crate) subgraph_membership_changes: Vec<SubgraphMembershipDelta>,
+    pub(crate) label_side_changes: Vec<LabelSideDelta>,
+    pub(crate) global_shift: GlobalShiftSummary,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RoutedMmdsMetrics {
+    pub(crate) added_edges: BTreeSet<String>,
+    pub(crate) removed_edges: BTreeSet<String>,
+    pub(crate) path_metrics: Vec<EdgePathMetric>,
+    pub(crate) label_rect_changes: Vec<LabelRectDelta>,
+    pub(crate) port_intent_changes: Vec<PortIntentDelta>,
+    pub(crate) endpoint_face_changes: Vec<EndpointFaceDelta>,
+    pub(crate) path_port_divergence: Vec<PathPortDivergence>,
+    pub(crate) routed_bounds_delta: BoundsDelta,
+}
+
+impl RoutedMmdsMetrics {
+    pub(crate) fn changed_path_geometry_count(&self) -> usize {
+        self.path_metrics
+            .iter()
+            .filter(|metric| metric.geometry_changed())
+            .count()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct QualityOracleMetrics {
+    pub(crate) route_length_total_delta: f64,
+    pub(crate) bend_count_total_delta: isize,
+    pub(crate) label_rect_overlaps: Vec<LabelRectOverlap>,
+    pub(crate) label_path_drift: Vec<LabelPathDrift>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct InferredRename {
+    pub(crate) before_id: String,
+    pub(crate) after_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Displacement {
+    pub(crate) dx: f64,
+    pub(crate) dy: f64,
+    pub(crate) distance: f64,
+    pub(crate) changed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct SizeDelta {
+    pub(crate) width_delta: f64,
+    pub(crate) height_delta: f64,
+    pub(crate) area_delta: f64,
+    pub(crate) changed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct BoundsDelta {
+    pub(crate) width_delta: f64,
+    pub(crate) height_delta: f64,
+    pub(crate) area_delta: f64,
+    pub(crate) changed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SubgraphMembershipDelta {
+    pub(crate) id: String,
+    pub(crate) before_children: Vec<String>,
+    pub(crate) after_children: Vec<String>,
+    pub(crate) before_parent: Option<String>,
+    pub(crate) after_parent: Option<String>,
+    pub(crate) before_direction: Option<String>,
+    pub(crate) after_direction: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LabelSideDelta {
+    pub(crate) edge_id: String,
+    pub(crate) before: Option<String>,
+    pub(crate) after: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct EdgePathMetric {
+    pub(crate) edge_id: String,
+    pub(crate) source: String,
+    pub(crate) target: String,
+    pub(crate) point_count_delta: isize,
+    pub(crate) bend_count_delta: isize,
+    pub(crate) length_delta: f64,
+    pub(crate) envelope_delta: BoundsDelta,
+}
+
+impl EdgePathMetric {
+    pub(crate) fn geometry_changed(&self) -> bool {
+        self.point_count_delta != 0
+            || self.bend_count_delta != 0
+            || self.length_delta.abs() > DISPLAY_EPS
+            || self.envelope_delta.changed
+    }
+
+    pub(crate) fn subject_mentions_node(&self, node_id: &str) -> bool {
+        self.source == node_id || self.target == node_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LabelRectDelta {
+    pub(crate) edge_id: String,
+    pub(crate) center_dx: f64,
+    pub(crate) center_dy: f64,
+    pub(crate) width_delta: f64,
+    pub(crate) height_delta: f64,
+    pub(crate) before_present: bool,
+    pub(crate) after_present: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PortIntentDelta {
+    pub(crate) edge_id: String,
+    pub(crate) endpoint: Endpoint,
+    pub(crate) before_face: Option<String>,
+    pub(crate) after_face: Option<String>,
+    pub(crate) before_fraction: Option<f64>,
+    pub(crate) after_fraction: Option<f64>,
+    pub(crate) before_group_size: Option<usize>,
+    pub(crate) after_group_size: Option<usize>,
+    pub(crate) source: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct EndpointFaceDelta {
+    pub(crate) edge_id: String,
+    pub(crate) endpoint: Endpoint,
+    pub(crate) before: DerivedEndpointFace,
+    pub(crate) after: DerivedEndpointFace,
+    pub(crate) source: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PathPortDivergence {
+    pub(crate) edge_id: String,
+    pub(crate) endpoint: Endpoint,
+    pub(crate) path_face: DerivedEndpointFace,
+    pub(crate) port_face: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LabelRectOverlap {
+    pub(crate) first_edge_id: String,
+    pub(crate) second_edge_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LabelPathDrift {
+    pub(crate) edge_id: String,
+    pub(crate) distance: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Endpoint {
+    Source,
+    Target,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DerivedEndpointFace {
+    Face(String),
+    Ambiguous,
+    Missing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct GlobalShiftSummary {
+    pub(crate) anchor_count: usize,
+    pub(crate) dx: f64,
+    pub(crate) dy: f64,
+    pub(crate) confidence: ShiftConfidence,
+    pub(crate) collapsed_movement: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShiftConfidence {
+    High,
+    Low,
+}
+
+pub(crate) fn compare_layout_mmds(
+    pair: &mutations::MutationPair,
+    before: &mmds::Output,
+    after: &mmds::Output,
+) -> LayoutMmdsMetrics {
+    let before_nodes = nodes_by_id(before);
+    let after_nodes = nodes_by_id(after);
+    let direct_impact_nodes = direct_impact_nodes(pair);
+    let added_nodes = difference(after_nodes.keys(), &before_nodes);
+    let removed_nodes = difference(before_nodes.keys(), &after_nodes);
+    let mut unchanged_node_displacements = BTreeMap::new();
+    let mut node_size_changes = BTreeMap::new();
+
+    for (id, before_node) in &before_nodes {
+        let Some(after_node) = after_nodes.get(id) else {
+            continue;
+        };
+        if direct_impact_nodes.contains(id) {
+            continue;
+        }
+
+        unchanged_node_displacements.insert((*id).clone(), position_delta(before_node, after_node));
+        let size = size_delta(before_node, after_node);
+        if size.changed {
+            node_size_changes.insert((*id).clone(), size);
+        }
+    }
+
+    let unchanged_node_count = unchanged_node_displacements.len();
+    let global_shift = global_shift_summary(&unchanged_node_displacements);
+
+    LayoutMmdsMetrics {
+        coord_eps: COORD_EPS,
+        added_nodes,
+        removed_nodes,
+        inferred_renames: Vec::new(),
+        direct_impact_nodes,
+        unchanged_node_count,
+        unchanged_node_displacements,
+        node_size_changes,
+        bounds_delta: bounds_delta(&before.metadata.bounds, &after.metadata.bounds),
+        subgraph_membership_changes: subgraph_membership_changes(before, after),
+        label_side_changes: label_side_changes(before, after),
+        global_shift,
+    }
+}
+
+pub(crate) fn compare_routed_mmds(
+    pair: &mutations::MutationPair,
+    before: &mmds::Output,
+    after: &mmds::Output,
+) -> RoutedMmdsMetrics {
+    let before_edges = edges_by_id(before);
+    let after_edges = edges_by_id(after);
+    let before_nodes = nodes_by_id(before);
+    let after_nodes = nodes_by_id(after);
+    let direct_nodes = direct_impact_nodes(pair);
+    let mut added_edges = edge_difference(after_edges.keys(), &before_edges);
+    let mut removed_edges = edge_difference(before_edges.keys(), &after_edges);
+    let mut path_metrics = Vec::new();
+    let mut label_rect_changes = Vec::new();
+    let mut port_intent_changes = Vec::new();
+    let mut endpoint_face_changes = Vec::new();
+    let mut path_port_divergences = Vec::new();
+
+    for (edge_id, before_edge) in &before_edges {
+        let Some(after_edge) = after_edges.get(edge_id) else {
+            continue;
+        };
+        if endpoint_identity_changed_across_direct_node(before_edge, after_edge, &direct_nodes) {
+            removed_edges.insert((*edge_id).clone());
+            added_edges.insert((*edge_id).clone());
+            continue;
+        }
+
+        path_metrics.push(edge_path_metric(edge_id, before_edge, after_edge));
+        if let Some(delta) = label_rect_delta(edge_id, before_edge, after_edge) {
+            label_rect_changes.push(delta);
+        }
+        port_intent_changes.extend(port_intent_deltas(edge_id, before_edge, after_edge));
+        endpoint_face_changes.extend(endpoint_face_deltas(
+            edge_id,
+            before_edge,
+            after_edge,
+            &before_nodes,
+            &after_nodes,
+        ));
+        path_port_divergences.extend(path_port_divergence(edge_id, after_edge, &after_nodes));
+    }
+
+    RoutedMmdsMetrics {
+        added_edges,
+        removed_edges,
+        path_metrics,
+        label_rect_changes,
+        port_intent_changes,
+        endpoint_face_changes,
+        path_port_divergence: path_port_divergences,
+        routed_bounds_delta: bounds_delta(&before.metadata.bounds, &after.metadata.bounds),
+    }
+}
+
+pub(crate) fn collect_quality_oracle_metrics(
+    pair: &mutations::MutationPair,
+    before: &mmds::Output,
+    after: &mmds::Output,
+) -> QualityOracleMetrics {
+    let routed = compare_routed_mmds(pair, before, after);
+
+    QualityOracleMetrics {
+        route_length_total_delta: routed
+            .path_metrics
+            .iter()
+            .map(|metric| metric.length_delta)
+            .sum(),
+        bend_count_total_delta: routed
+            .path_metrics
+            .iter()
+            .map(|metric| metric.bend_count_delta)
+            .sum(),
+        label_rect_overlaps: label_rect_overlaps(after),
+        label_path_drift: label_path_drift(after),
+    }
+}
+
+fn nodes_by_id(output: &mmds::Output) -> BTreeMap<String, &mmds::Node> {
+    output
+        .nodes
+        .iter()
+        .map(|node| (node.id.clone(), node))
+        .collect()
+}
+
+fn direct_impact_nodes(pair: &mutations::MutationPair) -> BTreeSet<String> {
+    pair.direct_nodes
+        .iter()
+        .map(|id| (*id).to_string())
+        .collect()
+}
+
+fn difference<'a>(
+    candidates: impl Iterator<Item = &'a String>,
+    other: &BTreeMap<String, &mmds::Node>,
+) -> BTreeSet<String> {
+    candidates
+        .filter(|id| !other.contains_key(*id))
+        .cloned()
+        .collect()
+}
+
+fn edge_difference<'a>(
+    candidates: impl Iterator<Item = &'a String>,
+    other: &BTreeMap<String, &mmds::Edge>,
+) -> BTreeSet<String> {
+    candidates
+        .filter(|id| !other.contains_key(*id))
+        .cloned()
+        .collect()
+}
+
+fn position_delta(before: &mmds::Node, after: &mmds::Node) -> Displacement {
+    let dx = after.position.x - before.position.x;
+    let dy = after.position.y - before.position.y;
+    let distance = dx.hypot(dy);
+
+    Displacement {
+        dx,
+        dy,
+        distance,
+        changed: distance > COORD_EPS,
+    }
+}
+
+fn size_delta(before: &mmds::Node, after: &mmds::Node) -> SizeDelta {
+    let width_delta = after.size.width - before.size.width;
+    let height_delta = after.size.height - before.size.height;
+    let before_area = before.size.width * before.size.height;
+    let after_area = after.size.width * after.size.height;
+    let area_delta = after_area - before_area;
+
+    SizeDelta {
+        width_delta,
+        height_delta,
+        area_delta,
+        changed: width_delta.abs() > COORD_EPS
+            || height_delta.abs() > COORD_EPS
+            || area_delta.abs() > COORD_EPS,
+    }
+}
+
+fn bounds_delta(before: &mmds::Bounds, after: &mmds::Bounds) -> BoundsDelta {
+    let width_delta = after.width - before.width;
+    let height_delta = after.height - before.height;
+    let area_delta = after.width * after.height - before.width * before.height;
+
+    BoundsDelta {
+        width_delta,
+        height_delta,
+        area_delta,
+        changed: width_delta.abs() > COORD_EPS
+            || height_delta.abs() > COORD_EPS
+            || area_delta.abs() > COORD_EPS,
+    }
+}
+
+fn subgraph_membership_changes(
+    before: &mmds::Output,
+    after: &mmds::Output,
+) -> Vec<SubgraphMembershipDelta> {
+    let before_subgraphs = subgraphs_by_id(before);
+    let after_subgraphs = subgraphs_by_id(after);
+    let ids = before_subgraphs
+        .keys()
+        .chain(after_subgraphs.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut changes = Vec::new();
+
+    for id in ids {
+        let before = before_subgraphs.get(&id);
+        let after = after_subgraphs.get(&id);
+        let before_children = before
+            .map(|subgraph| sorted_children(&subgraph.children))
+            .unwrap_or_default();
+        let after_children = after
+            .map(|subgraph| sorted_children(&subgraph.children))
+            .unwrap_or_default();
+        let before_parent = before.and_then(|subgraph| subgraph.parent.clone());
+        let after_parent = after.and_then(|subgraph| subgraph.parent.clone());
+        let before_direction = before.and_then(|subgraph| subgraph.direction.clone());
+        let after_direction = after.and_then(|subgraph| subgraph.direction.clone());
+
+        if before_children != after_children
+            || before_parent != after_parent
+            || before_direction != after_direction
+        {
+            changes.push(SubgraphMembershipDelta {
+                id,
+                before_children,
+                after_children,
+                before_parent,
+                after_parent,
+                before_direction,
+                after_direction,
+            });
+        }
+    }
+
+    changes
+}
+
+fn subgraphs_by_id(output: &mmds::Output) -> BTreeMap<String, &mmds::Subgraph> {
+    output
+        .subgraphs
+        .iter()
+        .map(|subgraph| (subgraph.id.clone(), subgraph))
+        .collect()
+}
+
+fn sorted_children(children: &[String]) -> Vec<String> {
+    let mut sorted = children.to_vec();
+    sorted.sort();
+    sorted
+}
+
+fn label_side_changes(before: &mmds::Output, after: &mmds::Output) -> Vec<LabelSideDelta> {
+    let before_edges = edges_by_id(before);
+    let after_edges = edges_by_id(after);
+    let mut changes = Vec::new();
+
+    for (id, before_edge) in before_edges {
+        let Some(after_edge) = after_edges.get(&id) else {
+            continue;
+        };
+        if before_edge.label_side != after_edge.label_side {
+            changes.push(LabelSideDelta {
+                edge_id: id,
+                before: before_edge.label_side.clone(),
+                after: after_edge.label_side.clone(),
+            });
+        }
+    }
+
+    changes
+}
+
+fn edges_by_id(output: &mmds::Output) -> BTreeMap<String, &mmds::Edge> {
+    output
+        .edges
+        .iter()
+        .map(|edge| (edge.id.clone(), edge))
+        .collect()
+}
+
+fn endpoint_identity_changed_across_direct_node(
+    before: &mmds::Edge,
+    after: &mmds::Edge,
+    direct_nodes: &BTreeSet<String>,
+) -> bool {
+    (before.source != after.source || before.target != after.target)
+        && (edge_mentions_direct_node(before, direct_nodes)
+            || edge_mentions_direct_node(after, direct_nodes))
+}
+
+fn edge_mentions_direct_node(edge: &mmds::Edge, direct_nodes: &BTreeSet<String>) -> bool {
+    direct_nodes.contains(&edge.source) || direct_nodes.contains(&edge.target)
+}
+
+fn edge_path_metric(edge_id: &str, before: &mmds::Edge, after: &mmds::Edge) -> EdgePathMetric {
+    let before_path = before.path.as_deref().unwrap_or(&[]);
+    let after_path = after.path.as_deref().unwrap_or(&[]);
+    let before_points = points_from_mmds_path(before_path);
+    let after_points = points_from_mmds_path(after_path);
+
+    EdgePathMetric {
+        edge_id: edge_id.to_string(),
+        source: before.source.clone(),
+        target: before.target.clone(),
+        point_count_delta: after_path.len() as isize - before_path.len() as isize,
+        bend_count_delta: geometry_metrics::bend_count(&after_points) as isize
+            - geometry_metrics::bend_count(&before_points) as isize,
+        length_delta: geometry_metrics::polyline_length(&after_points)
+            - geometry_metrics::polyline_length(&before_points),
+        envelope_delta: path_envelope_delta(&before_points, &after_points),
+    }
+}
+
+fn points_from_mmds_path(path: &[[f64; 2]]) -> Vec<FPoint> {
+    path.iter()
+        .map(|point| FPoint::new(point[0], point[1]))
+        .collect()
+}
+
+fn path_envelope_delta(before: &[FPoint], after: &[FPoint]) -> BoundsDelta {
+    let before = bounds_from_rect(geometry_metrics::route_envelope(before));
+    let after = bounds_from_rect(geometry_metrics::route_envelope(after));
+
+    bounds_delta(&before, &after)
+}
+
+fn bounds_from_rect(rect: Option<FRect>) -> mmds::Bounds {
+    match rect {
+        Some(rect) => mmds::Bounds {
+            width: rect.width,
+            height: rect.height,
+        },
+        None => mmds::Bounds {
+            width: 0.0,
+            height: 0.0,
+        },
+    }
+}
+
+fn label_rect_delta(
+    edge_id: &str,
+    before: &mmds::Edge,
+    after: &mmds::Edge,
+) -> Option<LabelRectDelta> {
+    if before.label_rect.is_none() && after.label_rect.is_none() {
+        return None;
+    }
+
+    let before_center = before.label_rect.as_ref().map(rect_center);
+    let after_center = after.label_rect.as_ref().map(rect_center);
+    let center_dx = match (before_center, after_center) {
+        (Some(before), Some(after)) => after.0 - before.0,
+        _ => 0.0,
+    };
+    let center_dy = match (before_center, after_center) {
+        (Some(before), Some(after)) => after.1 - before.1,
+        _ => 0.0,
+    };
+    let width_delta = match (&before.label_rect, &after.label_rect) {
+        (Some(before), Some(after)) => after.width - before.width,
+        _ => 0.0,
+    };
+    let height_delta = match (&before.label_rect, &after.label_rect) {
+        (Some(before), Some(after)) => after.height - before.height,
+        _ => 0.0,
+    };
+
+    Some(LabelRectDelta {
+        edge_id: edge_id.to_string(),
+        center_dx,
+        center_dy,
+        width_delta,
+        height_delta,
+        before_present: before.label_rect.is_some(),
+        after_present: after.label_rect.is_some(),
+    })
+}
+
+fn rect_center(rect: &mmds::Rect) -> (f64, f64) {
+    (rect.x + rect.width / 2.0, rect.y + rect.height / 2.0)
+}
+
+fn label_rect_overlaps(output: &mmds::Output) -> Vec<LabelRectOverlap> {
+    let rects = output
+        .edges
+        .iter()
+        .filter_map(|edge| {
+            edge.label_rect
+                .as_ref()
+                .map(|rect| (edge.id.as_str(), rect_from_mmds(rect)))
+        })
+        .collect::<Vec<_>>();
+    let mut overlaps = Vec::new();
+
+    for (index, (first_id, first)) in rects.iter().enumerate() {
+        for (second_id, second) in rects.iter().skip(index + 1) {
+            if geometry_metrics::rects_overlap(*first, *second) {
+                overlaps.push(LabelRectOverlap {
+                    first_edge_id: (*first_id).to_string(),
+                    second_edge_id: (*second_id).to_string(),
+                });
+            }
+        }
+    }
+
+    overlaps
+}
+
+fn label_path_drift(output: &mmds::Output) -> Vec<LabelPathDrift> {
+    output
+        .edges
+        .iter()
+        .filter_map(|edge| {
+            let rect = edge.label_rect.as_ref()?;
+            let path = edge.path.as_deref()?;
+            let center = rect_from_mmds(rect).center();
+            let points = points_from_mmds_path(path);
+
+            Some(LabelPathDrift {
+                edge_id: edge.id.clone(),
+                distance: geometry_metrics::distance_point_to_path(center, &points),
+            })
+        })
+        .collect()
+}
+
+fn rect_from_mmds(rect: &mmds::Rect) -> FRect {
+    FRect::new(rect.x, rect.y, rect.width, rect.height)
+}
+
+fn port_intent_deltas(
+    edge_id: &str,
+    before: &mmds::Edge,
+    after: &mmds::Edge,
+) -> Vec<PortIntentDelta> {
+    [
+        (
+            Endpoint::Source,
+            before.source_port.as_ref(),
+            after.source_port.as_ref(),
+        ),
+        (
+            Endpoint::Target,
+            before.target_port.as_ref(),
+            after.target_port.as_ref(),
+        ),
+    ]
+    .into_iter()
+    .filter_map(|(endpoint, before, after)| {
+        if same_port_intent(before, after) {
+            return None;
+        }
+        Some(PortIntentDelta {
+            edge_id: edge_id.to_string(),
+            endpoint,
+            before_face: before.map(|port| port.face.clone()),
+            after_face: after.map(|port| port.face.clone()),
+            before_fraction: before.map(|port| port.fraction),
+            after_fraction: after.map(|port| port.fraction),
+            before_group_size: before.map(|port| port.group_size),
+            after_group_size: after.map(|port| port.group_size),
+            source: "port",
+        })
+    })
+    .collect()
+}
+
+fn same_port_intent(before: Option<&mmds::Port>, after: Option<&mmds::Port>) -> bool {
+    match (before, after) {
+        (None, None) => true,
+        (Some(before), Some(after)) => {
+            before.face == after.face
+                && (before.fraction - after.fraction).abs() <= COORD_EPS
+                && before.group_size == after.group_size
+        }
+        _ => false,
+    }
+}
+
+fn endpoint_face_deltas(
+    edge_id: &str,
+    before_edge: &mmds::Edge,
+    after_edge: &mmds::Edge,
+    before_nodes: &BTreeMap<String, &mmds::Node>,
+    after_nodes: &BTreeMap<String, &mmds::Node>,
+) -> Vec<EndpointFaceDelta> {
+    let endpoints = [
+        (
+            Endpoint::Source,
+            endpoint_face(before_edge, before_nodes, Endpoint::Source),
+            endpoint_face(after_edge, after_nodes, Endpoint::Source),
+        ),
+        (
+            Endpoint::Target,
+            endpoint_face(before_edge, before_nodes, Endpoint::Target),
+            endpoint_face(after_edge, after_nodes, Endpoint::Target),
+        ),
+    ];
+
+    endpoints
+        .into_iter()
+        .filter_map(|(endpoint, before, after)| {
+            (before != after).then(|| EndpointFaceDelta {
+                edge_id: edge_id.to_string(),
+                endpoint,
+                before,
+                after,
+                source: "path",
+            })
+        })
+        .collect()
+}
+
+fn path_port_divergence(
+    edge_id: &str,
+    edge: &mmds::Edge,
+    nodes: &BTreeMap<String, &mmds::Node>,
+) -> Vec<PathPortDivergence> {
+    [
+        (
+            Endpoint::Source,
+            endpoint_face(edge, nodes, Endpoint::Source),
+            edge.source_port.as_ref().map(|port| port.face.clone()),
+        ),
+        (
+            Endpoint::Target,
+            endpoint_face(edge, nodes, Endpoint::Target),
+            edge.target_port.as_ref().map(|port| port.face.clone()),
+        ),
+    ]
+    .into_iter()
+    .filter_map(|(endpoint, path_face, port_face)| {
+        let diverged = match (&path_face, &port_face) {
+            (DerivedEndpointFace::Face(path), Some(port)) => path != port,
+            (DerivedEndpointFace::Ambiguous, Some(_)) => true,
+            _ => false,
+        };
+        diverged.then(|| PathPortDivergence {
+            edge_id: edge_id.to_string(),
+            endpoint,
+            path_face,
+            port_face,
+        })
+    })
+    .collect()
+}
+
+fn endpoint_face(
+    edge: &mmds::Edge,
+    nodes: &BTreeMap<String, &mmds::Node>,
+    endpoint: Endpoint,
+) -> DerivedEndpointFace {
+    let Some(path) = &edge.path else {
+        return DerivedEndpointFace::Missing;
+    };
+    let point = match endpoint {
+        Endpoint::Source => path.first(),
+        Endpoint::Target => path.last(),
+    };
+    let Some(point) = point else {
+        return DerivedEndpointFace::Missing;
+    };
+    let node_id = match endpoint {
+        Endpoint::Source => &edge.source,
+        Endpoint::Target => &edge.target,
+    };
+    let Some(node) = nodes.get(node_id) else {
+        return DerivedEndpointFace::Missing;
+    };
+
+    derive_face_for_point(*point, node)
+}
+
+fn derive_face_for_point(point: [f64; 2], node: &mmds::Node) -> DerivedEndpointFace {
+    let left = node.position.x - node.size.width / 2.0;
+    let right = node.position.x + node.size.width / 2.0;
+    let top = node.position.y - node.size.height / 2.0;
+    let bottom = node.position.y + node.size.height / 2.0;
+    let candidates = [
+        ("left", (point[0] - left).abs()),
+        ("right", (point[0] - right).abs()),
+        ("top", (point[1] - top).abs()),
+        ("bottom", (point[1] - bottom).abs()),
+    ]
+    .into_iter()
+    .filter(|(_, distance)| *distance <= COORD_EPS)
+    .map(|(face, _)| face)
+    .collect::<Vec<_>>();
+
+    match candidates.as_slice() {
+        [] => DerivedEndpointFace::Missing,
+        [face] => DerivedEndpointFace::Face((*face).to_string()),
+        _ => DerivedEndpointFace::Ambiguous,
+    }
+}
+
+fn global_shift_summary(displacements: &BTreeMap<String, Displacement>) -> GlobalShiftSummary {
+    let anchor_count = displacements.len();
+    if anchor_count < 2 {
+        return GlobalShiftSummary {
+            anchor_count,
+            dx: 0.0,
+            dy: 0.0,
+            confidence: ShiftConfidence::Low,
+            collapsed_movement: false,
+        };
+    }
+
+    let dx = median(displacements.values().map(|delta| delta.dx).collect());
+    let dy = median(displacements.values().map(|delta| delta.dy).collect());
+    let collapsed_movement = displacements.values().all(|delta| {
+        let residual_dx = delta.dx - dx;
+        let residual_dy = delta.dy - dy;
+        residual_dx.hypot(residual_dy) <= DISPLAY_EPS
+    });
+
+    GlobalShiftSummary {
+        anchor_count,
+        dx,
+        dy,
+        confidence: ShiftConfidence::High,
+        collapsed_movement,
+    }
+}
+
+fn median(mut values: Vec<f64>) -> f64 {
+    values.sort_by(f64::total_cmp);
+    let mid = values.len() / 2;
+
+    if values.len().is_multiple_of(2) {
+        (values[mid - 1] + values[mid]) / 2.0
+    } else {
+        values[mid]
+    }
+}

--- a/src/internal_tests/layout_stability/mod.rs
+++ b/src/internal_tests/layout_stability/mod.rs
@@ -1,0 +1,1931 @@
+mod geometry_metrics;
+mod mmds_metrics;
+mod mutations;
+mod phase_attribution;
+mod proportionality;
+mod render_metrics;
+mod render_surfaces;
+mod report;
+mod route_diagnostics;
+
+use mmds_metrics::Endpoint;
+use phase_attribution::PhaseName;
+use route_diagnostics::RouteDecisionClass;
+
+use crate::engines::graph::algorithms::layered::kernel::trace::{
+    DummyTraceKey, DummyTraceRole, LayeredPhaseTrace, TraceDummySnapshot, TraceNodeSnapshot,
+    TraceStage, TraceStageSnapshot,
+};
+
+#[test]
+fn input_magnitude_keeps_incompatible_axes_separate() {
+    let magnitude = proportionality::InputMagnitude {
+        label_dimension: Some(proportionality::LabelDimensionMagnitude {
+            changed_labels: 1,
+            max_axis_delta: 24.0,
+            total_axis_delta: 24.0,
+        }),
+        edge_insertion: Some(proportionality::EdgeInsertionMagnitude {
+            semantic_added_edge_ids: vec!["e7".to_string()],
+            route_input_added_edges: 3,
+        }),
+        node_insertion: None,
+        subgraph_change: None,
+    };
+
+    assert_eq!(
+        magnitude.non_zero_axes(),
+        vec![
+            proportionality::InputMagnitudeAxis::LabelDimensionUnits,
+            proportionality::InputMagnitudeAxis::EdgeInsertion,
+        ]
+    );
+    assert_eq!(magnitude.scalar_denominator(), None);
+}
+
+#[test]
+fn input_magnitude_basis_names_label_and_edge_cases_without_mixing_units() {
+    assert_eq!(
+        proportionality::InputMagnitudeBasis::for_pair_id("M14"),
+        proportionality::InputMagnitudeBasis::LabelDimensionUnits
+    );
+    assert_eq!(
+        proportionality::InputMagnitudeBasis::for_pair_id("M11"),
+        proportionality::InputMagnitudeBasis::EdgeInsertionContext
+    );
+    assert_eq!(
+        proportionality::InputMagnitudeBasis::for_pair_id("M15"),
+        proportionality::InputMagnitudeBasis::MultiAxis
+    );
+}
+
+#[test]
+fn input_magnitude_collects_m14_label_dimension_without_edge_context() {
+    let pair = mutations::pair_by_id("M14").expect("M14 pair");
+    let magnitude = proportionality::input_magnitude_for_pair(pair).expect("M14 input magnitude");
+    let label = magnitude
+        .label_dimension
+        .expect("label dimension magnitude");
+
+    assert_eq!(label.changed_labels, 1);
+    assert!(label.max_axis_delta > 0.0);
+    assert!(label.total_axis_delta >= label.max_axis_delta);
+    assert!(magnitude.edge_insertion.is_none());
+    assert_eq!(
+        proportionality::InputMagnitudeBasis::for_pair_id("M14"),
+        proportionality::InputMagnitudeBasis::LabelDimensionUnits
+    );
+}
+
+#[test]
+fn input_magnitude_collects_m11_edge_insertion_context_without_label_units() {
+    let pair = mutations::pair_by_id("M11").expect("M11 pair");
+    let magnitude = proportionality::input_magnitude_for_pair(pair).expect("M11 input magnitude");
+    let edge = magnitude.edge_insertion.expect("edge insertion magnitude");
+
+    assert_eq!(edge.semantic_added_edge_ids, vec!["e7".to_string()]);
+    assert!(edge.route_input_added_edges > 0);
+    assert!(magnitude.label_dimension.is_none());
+    assert_eq!(
+        proportionality::InputMagnitudeBasis::for_pair_id("M11"),
+        proportionality::InputMagnitudeBasis::EdgeInsertionContext
+    );
+}
+
+#[test]
+fn input_magnitude_collects_control_axes_without_classifying_them() {
+    for pair_id in ["M02", "M03", "M04"] {
+        let pair = mutations::pair_by_id(pair_id).expect("control pair");
+        let magnitude =
+            proportionality::input_magnitude_for_pair(pair).expect("control input magnitude");
+        assert!(
+            magnitude.edge_insertion.is_some() || magnitude.node_insertion.is_some(),
+            "{pair_id} should expose edge or node insertion context"
+        );
+    }
+
+    for pair_id in ["M05", "M07", "S02", "S03"] {
+        let pair = mutations::pair_by_id(pair_id).expect("guardrail pair");
+        let magnitude =
+            proportionality::input_magnitude_for_pair(pair).expect("guardrail input magnitude");
+        assert!(
+            magnitude.non_zero_axes().len() <= 1,
+            "{pair_id} should stay simple enough to be a guardrail"
+        );
+    }
+}
+
+#[test]
+fn route_output_magnitude_uses_absolute_length_to_avoid_cancellation() {
+    let paths = vec![
+        proportionality::PathOutputMagnitude {
+            edge_id: "e1".to_string(),
+            signed_route_len_delta: 12.0,
+            abs_route_len_delta: 12.0,
+            bend_count_delta: 1,
+            abs_bend_count_delta: 1,
+            port_face_changed: false,
+            endpoint_face_changed: false,
+            endpoint_moved: false,
+            decision_classes: vec![route_diagnostics::RouteDecisionClass::PathShape],
+        },
+        proportionality::PathOutputMagnitude {
+            edge_id: "e2".to_string(),
+            signed_route_len_delta: -10.0,
+            abs_route_len_delta: 10.0,
+            bend_count_delta: -1,
+            abs_bend_count_delta: 1,
+            port_face_changed: false,
+            endpoint_face_changed: false,
+            endpoint_moved: true,
+            decision_classes: vec![route_diagnostics::RouteDecisionClass::BendTopology],
+        },
+    ];
+
+    let summary = proportionality::RouteOutputMagnitudeSummary::from_paths(paths);
+
+    assert_eq!(summary.changed_path_count, 2);
+    assert_eq!(summary.signed_route_len_delta_sum, 2.0);
+    assert_eq!(summary.sum_abs_route_len_delta, 22.0);
+    assert_eq!(summary.max_abs_route_len_delta, 12.0);
+    assert_eq!(summary.abs_bend_count_delta_sum, 2);
+    assert_eq!(summary.layout_amplified_path_count, 1);
+}
+
+#[test]
+fn route_output_magnitude_empty_summary_is_zeroed() {
+    let summary = proportionality::RouteOutputMagnitudeSummary::from_paths(Vec::new());
+
+    assert_eq!(summary.changed_path_count, 0);
+    assert_eq!(summary.signed_route_len_delta_sum, 0.0);
+    assert_eq!(summary.sum_abs_route_len_delta, 0.0);
+    assert_eq!(summary.median_abs_route_len_delta, 0.0);
+    assert_eq!(summary.p75_abs_route_len_delta, 0.0);
+    assert_eq!(summary.max_abs_route_len_delta, 0.0);
+    assert_eq!(summary.abs_bend_count_delta_sum, 0);
+    assert_eq!(summary.port_face_change_count, 0);
+    assert_eq!(summary.endpoint_face_change_count, 0);
+    assert_eq!(summary.layout_amplified_path_count, 0);
+}
+
+#[test]
+fn route_output_magnitude_collects_m14_changed_paths_and_additive_classes() {
+    let pair = mutations::pair_by_id("M14").expect("M14 pair");
+    let output =
+        proportionality::route_output_magnitude_for_pair(pair).expect("M14 output magnitude");
+
+    assert_eq!(output.summary.changed_path_count, 15);
+    assert_eq!(output.paths.len(), 15);
+    assert!(output.summary.sum_abs_route_len_delta > 0.0);
+    assert!(
+        output.summary.sum_abs_route_len_delta >= output.summary.signed_route_len_delta_sum.abs()
+    );
+    assert_eq!(
+        output.decision_edge_count(route_diagnostics::RouteDecisionClass::PathShape),
+        15
+    );
+}
+
+#[test]
+fn route_output_magnitude_collects_m11_without_label_lane_class() {
+    let pair = mutations::pair_by_id("M11").expect("M11 pair");
+    let output =
+        proportionality::route_output_magnitude_for_pair(pair).expect("M11 output magnitude");
+
+    assert_eq!(output.summary.changed_path_count, 7);
+    assert!(output.summary.port_face_change_count > 0);
+    assert_eq!(
+        output.decision_edge_count(route_diagnostics::RouteDecisionClass::LabelLane),
+        0
+    );
+}
+
+#[test]
+fn proportionality_summary_reports_ratio_without_classification() {
+    let input = proportionality::InputMagnitude {
+        label_dimension: Some(proportionality::LabelDimensionMagnitude {
+            changed_labels: 1,
+            max_axis_delta: 20.0,
+            total_axis_delta: 20.0,
+        }),
+        edge_insertion: None,
+        node_insertion: None,
+        subgraph_change: None,
+    };
+    let output =
+        proportionality::RouteOutputMagnitudeSummary::from_abs_lengths(vec![10.0, 20.0, 30.0]);
+
+    let summary = proportionality::ProportionalitySummary::from_parts(
+        "M14",
+        proportionality::InputMagnitudeBasis::LabelDimensionUnits,
+        input,
+        output,
+    )
+    .expect("summary");
+
+    assert_eq!(summary.pair_id, "M14");
+    assert_eq!(
+        summary.basis,
+        proportionality::InputMagnitudeBasis::LabelDimensionUnits
+    );
+    assert_eq!(
+        summary
+            .input
+            .label_dimension
+            .as_ref()
+            .expect("label magnitude")
+            .total_axis_delta,
+        20.0
+    );
+    assert_eq!(summary.output.changed_path_count, 3);
+    assert_eq!(summary.aggregate_ratio, Some(3.0));
+    assert_eq!(summary.max_path_ratio, Some(1.5));
+    assert_eq!(summary.classification, None);
+}
+
+#[test]
+fn calibration_profile_is_explicit_before_classification() {
+    let calibration = proportionality::CalibrationProfile::seeded();
+
+    assert_eq!(calibration.label_ratio_proportionate_max, 2.0);
+    assert_eq!(
+        calibration.source,
+        proportionality::CalibrationSource::Seeded
+    );
+    assert!(
+        calibration.control_pair_ids.is_empty(),
+        "control data is added by a later task"
+    );
+    assert_eq!(calibration.label_ratio_disproportionate_min, 3.0);
+    assert_eq!(calibration.event_control_p75_abs_route_len_delta, None);
+    let control_derived = proportionality::CalibrationSource::ControlDerived;
+    assert_ne!(control_derived, calibration.source);
+}
+
+#[test]
+fn proportionality_class_vocabulary_is_not_applied_without_classification() {
+    let classes = [
+        proportionality::ProportionalityClass::Proportionate,
+        proportionality::ProportionalityClass::Disproportionate,
+        proportionality::ProportionalityClass::Mixed,
+    ];
+
+    assert_eq!(classes.len(), 3);
+}
+
+#[test]
+fn control_calibration_status_reports_inconsistent_controls() {
+    let consistent = proportionality::control_calibration_status(&[
+        proportionality::ControlCalibrationPoint {
+            pair_id: "M02",
+            p75_abs_route_len_delta: 20.0,
+        },
+        proportionality::ControlCalibrationPoint {
+            pair_id: "M04",
+            p75_abs_route_len_delta: 40.0,
+        },
+    ]);
+    assert_eq!(
+        consistent,
+        proportionality::ControlCalibrationStatus::Consistent
+    );
+
+    let inconsistent = proportionality::control_calibration_status(&[
+        proportionality::ControlCalibrationPoint {
+            pair_id: "M02",
+            p75_abs_route_len_delta: 10.0,
+        },
+        proportionality::ControlCalibrationPoint {
+            pair_id: "M04",
+            p75_abs_route_len_delta: 100.0,
+        },
+    ]);
+
+    match inconsistent {
+        proportionality::ControlCalibrationStatus::Inconsistent { reason } => {
+            assert!(reason.contains("M02"));
+            assert!(reason.contains("M04"));
+        }
+        proportionality::ControlCalibrationStatus::Consistent => {
+            panic!("spread controls should not calibrate cleanly")
+        }
+    }
+}
+
+#[test]
+fn proportionality_classification_uses_calibration_profile() {
+    let calibration = proportionality::CalibrationProfile::seeded();
+
+    assert_eq!(
+        proportionality::classify_label_ratio(1.5, 1.8, &calibration),
+        proportionality::ProportionalityClass::Proportionate
+    );
+    assert_eq!(
+        proportionality::classify_label_ratio(2.5, 1.4, &calibration),
+        proportionality::ProportionalityClass::Mixed
+    );
+    assert_eq!(
+        proportionality::classify_label_ratio(3.5, 3.0, &calibration),
+        proportionality::ProportionalityClass::Disproportionate
+    );
+}
+
+#[test]
+fn route_proportionality_report_classifies_or_data_defers_m11() {
+    let report =
+        proportionality::run_route_proportionality_report().expect("route proportionality report");
+
+    let m14 = report.summary_for("M14").expect("M14 summary");
+    assert_eq!(
+        m14.classification,
+        Some(proportionality::ProportionalityClass::Disproportionate)
+    );
+    assert_eq!(m14.classification_reason, None);
+
+    let m11 = report.summary_for("M11").expect("M11 summary");
+    assert_eq!(
+        m11.basis,
+        proportionality::InputMagnitudeBasis::EdgeInsertionContext
+    );
+
+    match m11.classification {
+        Some(classification) => {
+            assert!(matches!(
+                classification,
+                proportionality::ProportionalityClass::Proportionate
+                    | proportionality::ProportionalityClass::Mixed
+                    | proportionality::ProportionalityClass::Disproportionate
+            ));
+            assert_eq!(m11.classification_reason, None);
+        }
+        None => {
+            let reason = m11
+                .classification_reason
+                .as_deref()
+                .expect("data-driven deferral reason");
+            assert_ne!(
+                reason,
+                "pure-edge-insertion controls are insufficient for honest M11 classification"
+            );
+            assert!(
+                reason.contains("pure-edge")
+                    || reason.contains("cluster")
+                    || reason.contains("sub-band"),
+                "{reason}"
+            );
+        }
+    }
+}
+
+#[test]
+fn route_proportionality_report_uses_explicit_event_control_families() {
+    assert_eq!(
+        proportionality::node_plus_edge_control_pair_ids(),
+        ["M02", "M03"]
+    );
+    assert_eq!(
+        proportionality::pure_edge_control_pair_ids(),
+        ["M04", "M19", "M20", "M21"]
+    );
+
+    let report =
+        proportionality::run_route_proportionality_report().expect("route proportionality report");
+
+    for id in ["M02", "M03", "M04", "M19", "M20", "M21", "M14", "M11"] {
+        assert!(report.summary_for(id).is_some(), "{id} missing from report");
+    }
+
+    assert!(!proportionality::pure_edge_control_pair_ids().contains(&"M11"));
+    assert!(!proportionality::node_plus_edge_control_pair_ids().contains(&"M04"));
+}
+
+#[test]
+fn pure_edge_cluster_summary_reports_consistent_and_split_spreads() {
+    let consistent = proportionality::pure_edge_cluster_status(&[
+        proportionality::ControlCalibrationPoint {
+            pair_id: "M04",
+            p75_abs_route_len_delta: 10.0,
+        },
+        proportionality::ControlCalibrationPoint {
+            pair_id: "M19",
+            p75_abs_route_len_delta: 20.0,
+        },
+        proportionality::ControlCalibrationPoint {
+            pair_id: "M20",
+            p75_abs_route_len_delta: 30.0,
+        },
+    ]);
+    assert_eq!(
+        consistent,
+        proportionality::PureEdgeClusterStatus::OneCluster
+    );
+
+    let split = proportionality::pure_edge_cluster_status(&[
+        proportionality::ControlCalibrationPoint {
+            pair_id: "M04",
+            p75_abs_route_len_delta: 10.0,
+        },
+        proportionality::ControlCalibrationPoint {
+            pair_id: "M21",
+            p75_abs_route_len_delta: 80.0,
+        },
+    ]);
+    assert!(matches!(
+        split,
+        proportionality::PureEdgeClusterStatus::Split { .. }
+    ));
+}
+
+#[test]
+fn route_proportionality_report_exposes_pure_edge_cluster_summary() {
+    let report =
+        proportionality::run_route_proportionality_report().expect("route proportionality report");
+    let cluster = report
+        .pure_edge_cluster
+        .as_ref()
+        .expect("pure-edge cluster");
+
+    assert_eq!(cluster.control_pair_ids, vec!["M04", "M19", "M20", "M21"]);
+    assert!(cluster.p75_min > 0.0);
+    assert!(cluster.p75_max >= cluster.p75_min);
+    assert!(cluster.spread_ratio.unwrap_or_default() >= 1.0);
+}
+
+#[test]
+fn plan_0166_guardrails_preserve_prior_calibration_outputs() {
+    let report =
+        proportionality::run_route_proportionality_report().expect("route proportionality report");
+
+    let m14 = report.summary_for("M14").expect("M14 summary");
+    assert_eq!(
+        m14.classification,
+        Some(proportionality::ProportionalityClass::Disproportionate)
+    );
+    assert!((m14.aggregate_ratio.expect("M14 aggregate ratio") - 5.4764).abs() < 0.25);
+    assert_eq!(m14.additive_path_shape_count, Some(15));
+    assert_eq!(m14.label_geometry_overlap_count, Some(6));
+
+    for (id, expected_p75) in [("M02", 78.13), ("M03", 78.81), ("M04", 13.37)] {
+        let summary = report.summary_for(id).expect("control summary");
+        assert!(
+            (summary.output.p75_abs_route_len_delta - expected_p75).abs() < 1.0,
+            "{id} p75 changed: {}",
+            summary.output.p75_abs_route_len_delta
+        );
+    }
+
+    for id in ["M05", "M07", "S02", "S03"] {
+        let pair = mutations::pair_by_id(id).expect("guardrail pair");
+        let pair_report = report::run_pair(pair).expect("guardrail report");
+        assert_eq!(pair_report.routed.changed_path_geometry_count(), 0, "{id}");
+    }
+}
+
+#[test]
+fn tier_a_surface_includes_plan_0166_pure_edge_controls() {
+    let expected_ids = [
+        "M01", "M02", "M03", "M04", "M05", "M06", "M07", "M08", "M09", "M10", "M11", "M12", "M14",
+        "M15", "M05-ID", "M19", "M20", "M21", "S01", "S02", "S03", "S04",
+    ];
+
+    let corpus = mutations::tier_a_pairs();
+    assert_eq!(corpus.len(), expected_ids.len());
+    for id in expected_ids {
+        assert!(corpus.iter().any(|pair| pair.id == id), "missing {id}");
+    }
+}
+
+#[test]
+fn route_proportionality_guardrails_preserve_prior_diagnostics() {
+    let reports = report::run_corpus(mutations::tier_a_pairs()).expect("tier a reports");
+
+    for pair_id in ["M05", "M07", "S02", "S03"] {
+        let report = reports
+            .iter()
+            .find(|report| report.pair_id == pair_id)
+            .expect("guardrail report");
+        assert_eq!(
+            report.routed.changed_path_geometry_count(),
+            0,
+            "{pair_id} should remain a zero-path-churn guardrail"
+        );
+    }
+
+    let m14 = route_diagnostics::run_pair_route_diagnostics(
+        mutations::pair_by_id("M14").expect("M14 pair"),
+    )
+    .expect("M14 route diagnostics");
+    assert_eq!(
+        m14.route_decisions.primary_histogram()[&route_diagnostics::RouteDecisionClass::LabelLane],
+        6
+    );
+    assert_eq!(
+        m14.route_decisions
+            .edge_ids_for_class(route_diagnostics::RouteDecisionClass::PathShape)
+            .len(),
+        15
+    );
+    assert_eq!(
+        m14.path_shape_correlation
+            .as_ref()
+            .expect("M14 path-shape correlation")
+            .overlap_count,
+        6
+    );
+
+    let m11 = route_diagnostics::run_pair_route_diagnostics(
+        mutations::pair_by_id("M11").expect("M11 pair"),
+    )
+    .expect("M11 route diagnostics");
+    assert_eq!(
+        m11.route_decisions
+            .edge_ids_for_class(route_diagnostics::RouteDecisionClass::LabelLane)
+            .len(),
+        0
+    );
+
+    let proportionality =
+        proportionality::run_route_proportionality_report().expect("route proportionality report");
+    assert!(proportionality.summary_for("M14").is_some());
+    assert!(proportionality.summary_for("M11").is_some());
+}
+
+#[test]
+#[ignore]
+fn print_route_proportionality_diagnostics() {
+    let report =
+        proportionality::run_route_proportionality_report().expect("route proportionality report");
+    println!("{}", report.summary());
+}
+
+#[test]
+fn user_node_order_change_sets_first_divergence_to_order() {
+    let before = synthetic_trace_with_user_node("A", 1, 0, 10.0, 20.0);
+    let after = synthetic_trace_with_user_node("A", 1, 2, 10.0, 20.0);
+
+    let attribution = phase_attribution::compare_phase_traces(&before, &after);
+
+    assert_eq!(attribution.first_divergence(), Some(PhaseName::Order));
+    assert_eq!(attribution.order.changed_nodes, vec!["A"]);
+    assert!(attribution.rank.changed_nodes.is_empty());
+}
+
+#[test]
+fn user_node_rank_change_precedes_order_and_position() {
+    let before = synthetic_trace_with_user_node("A", 1, 0, 10.0, 20.0);
+    let after = synthetic_trace_with_user_node("A", 2, 3, 40.0, 80.0);
+
+    let attribution = phase_attribution::compare_phase_traces(&before, &after);
+
+    assert_eq!(attribution.first_divergence(), Some(PhaseName::Rank));
+    assert_eq!(attribution.rank.changed_nodes, vec!["A"]);
+    assert_eq!(attribution.order.changed_nodes, vec!["A"]);
+    assert_eq!(attribution.position.changed_nodes, vec!["A"]);
+}
+
+#[test]
+fn generated_dummy_id_change_does_not_count_as_normalize_churn() {
+    let before = synthetic_trace_with_dummy("_d1", edge_dummy_key(3, 0), 1, 0);
+    let after = synthetic_trace_with_dummy("_d8", edge_dummy_key(3, 0), 1, 0);
+
+    let attribution = phase_attribution::compare_phase_traces(&before, &after);
+
+    assert!(attribution.normalize.changed_dummy_chains.is_empty());
+    assert_ne!(before.generated_dummy_ids(), after.generated_dummy_ids());
+}
+
+#[test]
+fn label_dummy_rank_change_counts_as_normalize_churn() {
+    let key = label_dummy_key(14, 1);
+    let before = synthetic_trace_with_dummy("_ld1", key.clone(), 2, 0);
+    let after = synthetic_trace_with_dummy("_ld9", key, 3, 0);
+
+    let attribution = phase_attribution::compare_phase_traces(&before, &after);
+
+    assert_eq!(attribution.first_divergence(), Some(PhaseName::Normalize));
+    assert_eq!(attribution.normalize.changed_dummy_chains.len(), 1);
+}
+
+#[test]
+fn changed_path_with_stable_endpoints_is_route_phase_churn() {
+    let path_metric = changed_path_metric("e1", "A", "B");
+    let attribution = attribution_with_no_user_node_movement();
+
+    let route_delta = phase_attribution::attribute_route_metric(&path_metric, &attribution);
+
+    assert_eq!(route_delta.phase, PhaseName::Route);
+    assert!(!route_delta.endpoint_layout_changed);
+}
+
+#[test]
+fn changed_path_with_moved_endpoint_is_layout_amplified_route_churn() {
+    let path_metric = changed_path_metric("e1", "A", "B");
+    let attribution = attribution_with_position_change("A");
+
+    let route_delta = phase_attribution::attribute_route_metric(&path_metric, &attribution);
+
+    assert_eq!(route_delta.phase, PhaseName::Route);
+    assert!(route_delta.endpoint_layout_changed);
+}
+
+#[test]
+fn m06_report_includes_phase_attribution() {
+    let report = report::run_pair(mutations::pair_by_id("M06").unwrap()).unwrap();
+    let summary = report.summary();
+
+    assert!(summary.contains("first_divergence="));
+    assert!(summary.contains("phase_components="));
+    assert!(summary.contains("paths_changed=1"));
+}
+
+#[test]
+fn m14_and_m11_reports_include_route_attribution() {
+    for id in ["M14", "M11"] {
+        let report = report::run_pair(mutations::pair_by_id(id).unwrap()).unwrap();
+        let summary = report.summary();
+
+        assert!(summary.contains("first_divergence="), "{id}: {summary}");
+        assert!(summary.contains("Route"), "{id}: {summary}");
+    }
+}
+
+#[test]
+fn primary_phase_attribution_canaries_are_decomposed() {
+    for id in ["M14", "M11", "M02", "M03", "M04", "M06"] {
+        let report = report::run_pair(mutations::pair_by_id(id).unwrap()).unwrap();
+        let attribution = report.phase_attribution();
+
+        assert!(
+            attribution.first_divergence().is_some(),
+            "{id} should have a first divergence: {}",
+            report.summary()
+        );
+        assert!(
+            !attribution.phase_components_for_test().is_empty(),
+            "{id} should report phase components: {}",
+            report.summary()
+        );
+    }
+}
+
+#[test]
+fn calibration_guardrails_stay_calibrated_with_phase_attribution() {
+    let m05 = report::run_pair(mutations::pair_by_id("M05").unwrap()).unwrap();
+    let m07 = report::run_pair(mutations::pair_by_id("M07").unwrap()).unwrap();
+    let s02 = report::run_pair(mutations::pair_by_id("S02").unwrap()).unwrap();
+    let s03 = report::run_pair(mutations::pair_by_id("S03").unwrap()).unwrap();
+
+    assert_eq!(m05.routed.changed_path_geometry_count(), 0);
+    assert!(
+        m05.churn_explanation()
+            .is_label_only_without_route_geometry()
+    );
+    assert!(
+        m07.churn_explanation()
+            .is_style_only_without_route_geometry()
+    );
+    assert_eq!(s02.routed.changed_path_geometry_count(), 0);
+    assert!(
+        s03.churn_explanation()
+            .is_style_only_without_route_geometry()
+    );
+}
+
+#[test]
+fn route_signature_report_counts_unique_outputs() {
+    let report = route_diagnostics::determinism_report_from_signatures(vec![
+        "same".to_string(),
+        "same".to_string(),
+        "different".to_string(),
+    ]);
+
+    assert_eq!(report.run_count, 3);
+    assert_eq!(report.unique_signature_count, 2);
+    assert!(!report.is_deterministic());
+}
+
+#[test]
+fn primary_canary_determinism_diagnostic_runs_requested_iterations() {
+    for id in ["M14", "M11"] {
+        let pair = mutations::pair_by_id(id).unwrap();
+        let report = route_diagnostics::measure_pair_determinism(pair, 10).unwrap();
+
+        assert_eq!(report.run_count, 10, "{id}: {report:?}");
+        assert!(report.unique_signature_count >= 1, "{id}: {report:?}");
+    }
+}
+
+#[test]
+fn routing_determinism_summary_mentions_primary_canaries() {
+    let summary = route_diagnostics::determinism_summary_for_pair_ids(&["M14", "M11"], 3).unwrap();
+
+    assert!(summary.contains("M14"), "{summary}");
+    assert!(summary.contains("M11"), "{summary}");
+    assert!(summary.contains("route_signature_variants="), "{summary}");
+    assert!(summary.contains("route_deterministic="), "{summary}");
+}
+
+#[test]
+#[ignore]
+fn print_routing_stability_diagnostics() {
+    let summary = route_diagnostics::determinism_summary_for_pair_ids(&["M14", "M11"], 10).unwrap();
+    println!("{summary}");
+}
+
+#[test]
+#[ignore]
+fn print_route_input_and_decision_diagnostics() {
+    for id in ["M14", "M11"] {
+        let pair = mutations::pair_by_id(id).unwrap();
+        let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+        println!("{}", diagnostic.summary());
+    }
+}
+
+#[test]
+#[ignore]
+fn print_label_lane_decomposition_diagnostics() {
+    let pair = mutations::pair_by_id("M14").unwrap();
+    let rendered = render_surfaces::render_pair(pair).unwrap();
+    let before = rendered.before.route_trace.label_lanes().unwrap();
+    let after = rendered.after.route_trace.label_lanes().unwrap();
+    let raw_diff = route_diagnostics::diff_label_lane_snapshots(before, after);
+    let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+
+    println!("raw_label_lane_diff={raw_diff:?}");
+    println!(
+        "route_decision_edges={:?}",
+        diagnostic.route_decisions.by_edge
+    );
+    println!("{}", diagnostic.summary());
+}
+
+#[test]
+fn m14_route_trace_includes_label_lane_snapshot() {
+    let pair = mutations::pair_by_id("M14").unwrap();
+    let rendered = render_surfaces::render_pair(pair).unwrap();
+
+    let snapshot = rendered
+        .after
+        .route_trace
+        .label_lanes()
+        .expect("M14 should capture label-lane stage");
+
+    assert!(!snapshot.edges.is_empty(), "{snapshot:?}");
+    assert!(!snapshot.compartments.is_empty(), "{snapshot:?}");
+    assert!(!snapshot.subclusters.is_empty(), "{snapshot:?}");
+    assert!(
+        snapshot
+            .edges
+            .iter()
+            .all(|edge| edge.mmds_edge_id == format!("e{}", edge.edge_index)),
+        "{snapshot:?}"
+    );
+}
+
+#[test]
+fn route_input_diff_detects_label_dimension_change() {
+    let before = route_diagnostics::synthetic_route_input_with_label(0, 40.0, 20.0);
+    let after = route_diagnostics::synthetic_route_input_with_label(0, 80.0, 20.0);
+
+    let diff = route_diagnostics::diff_route_inputs(&before, &after);
+
+    assert_eq!(diff.changed_labels.len(), 1);
+    assert_eq!(diff.changed_labels[0].edge_index, 0);
+    assert_eq!(diff.changed_labels[0].width_delta, 40.0);
+    assert_eq!(diff.changed_labels[0].height_delta, 0.0);
+    assert!(diff.changed_labels[0].is_decision_relevant());
+}
+
+#[test]
+fn route_input_diff_detects_port_intent_change() {
+    let before = route_diagnostics::synthetic_route_input_with_source_port(0, "south", 0.25);
+    let after = route_diagnostics::synthetic_route_input_with_source_port(0, "south", 0.75);
+
+    let diff = route_diagnostics::diff_route_inputs(&before, &after);
+
+    assert_eq!(diff.changed_ports.len(), 1);
+    assert_eq!(diff.changed_ports[0].edge_index, 0);
+    assert_eq!(diff.changed_ports[0].before_fraction, Some(0.25));
+    assert_eq!(diff.changed_ports[0].after_fraction, Some(0.75));
+    assert!(diff.changed_ports[0].is_decision_relevant());
+}
+
+#[test]
+fn route_input_diff_separates_incidental_label_text_from_decision_inputs() {
+    let before =
+        route_diagnostics::synthetic_route_input_with_label_text(0, "old label", 80.0, 20.0);
+    let after =
+        route_diagnostics::synthetic_route_input_with_label_text(0, "new label", 80.0, 20.0);
+
+    let diff = route_diagnostics::diff_route_inputs(&before, &after);
+
+    assert_eq!(diff.incidental_label_changes.len(), 1);
+    assert_eq!(diff.decision_input_change_count(), 0);
+}
+
+#[test]
+fn route_input_diff_ignores_identical_inputs() {
+    let before = route_diagnostics::synthetic_route_input_with_label(0, 40.0, 20.0);
+    let after = before.clone();
+
+    let diff = route_diagnostics::diff_route_inputs(&before, &after);
+
+    assert!(!diff.has_changes(), "{diff:?}");
+}
+
+#[test]
+fn label_lane_diff_classifies_compartment_before_track() {
+    let before = route_diagnostics::synthetic_label_lane_snapshot("e1")
+        .with_compartment("c-old")
+        .with_track(0);
+    let after = route_diagnostics::synthetic_label_lane_snapshot("e1")
+        .with_compartment("c-new")
+        .with_track(1);
+
+    let diff = route_diagnostics::diff_label_lane_snapshots(&before, &after);
+
+    assert_eq!(
+        diff.edge_deltas["e1"].class,
+        route_diagnostics::LabelLaneDeltaClass::CompartmentMembership
+    );
+}
+
+#[test]
+fn label_lane_diff_classifies_label_step_only_after_stable_track() {
+    let before = route_diagnostics::synthetic_label_lane_snapshot("e1").with_label_step(32.0);
+    let after = route_diagnostics::synthetic_label_lane_snapshot("e1").with_label_step(40.0);
+
+    let diff = route_diagnostics::diff_label_lane_snapshots(&before, &after);
+
+    assert_eq!(
+        diff.edge_deltas["e1"].class,
+        route_diagnostics::LabelLaneDeltaClass::LabelStepOnly
+    );
+}
+
+#[test]
+fn m14_label_lane_decomposition_reports_geometry_only_changes() {
+    let pair = mutations::pair_by_id("M14").unwrap();
+    let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+    let decomposition = diagnostic
+        .label_lane_decomposition
+        .as_ref()
+        .expect("M14 label-lane decomposition");
+
+    assert_eq!(decomposition.total_edges(), 6, "{decomposition:?}");
+    assert!(
+        decomposition
+            .edge_deltas
+            .keys()
+            .all(|edge_id| edge_id.starts_with('e')),
+        "{decomposition:?}"
+    );
+    assert_eq!(decomposition.histogram_total(), 6, "{decomposition:?}");
+    assert_eq!(
+        decomposition.histogram()[&route_diagnostics::LabelLaneDeltaClass::LabelGeometryOnly],
+        6,
+        "{decomposition:?}"
+    );
+    assert_eq!(decomposition.structural_total(), 0, "{decomposition:?}");
+}
+
+#[test]
+fn m14_route_input_diff_reports_label_input_change() {
+    let pair = mutations::pair_by_id("M14").unwrap();
+    let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+
+    assert!(
+        !diagnostic.route_input_diff.changed_labels.is_empty(),
+        "{diagnostic:?}"
+    );
+    assert_eq!(
+        diagnostic.phase_attribution.first_divergence(),
+        Some(PhaseName::Route)
+    );
+}
+
+#[test]
+fn m11_route_input_diff_reports_added_route_edge_context() {
+    let pair = mutations::pair_by_id("M11").unwrap();
+    let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+
+    assert!(
+        !diagnostic.route_input_diff.added_edges.is_empty(),
+        "{diagnostic:?}"
+    );
+    assert_eq!(
+        diagnostic.phase_attribution.first_divergence(),
+        Some(PhaseName::Route)
+    );
+}
+
+#[test]
+fn m11_label_lane_decomposition_is_not_applicable() {
+    let pair = mutations::pair_by_id("M11").unwrap();
+    let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+
+    assert_eq!(
+        diagnostic.label_lane_non_applicability_reason.as_deref(),
+        Some("M11 has no LabelLane route decision edges")
+    );
+}
+
+#[test]
+fn plan_0164_guardrails_preserve_0162_and_0163_calibration() {
+    for id in ["M14", "M11"] {
+        let pair = mutations::pair_by_id(id).unwrap();
+        let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+        assert_eq!(
+            diagnostic.phase_attribution.first_divergence(),
+            Some(PhaseName::Route)
+        );
+    }
+
+    for id in ["M02", "M03", "M04"] {
+        let report = report::run_pair(mutations::pair_by_id(id).unwrap()).unwrap();
+        assert!(
+            !report
+                .phase_attribution()
+                .route
+                .layout_amplified_paths
+                .is_empty()
+        );
+    }
+
+    for id in ["M05", "M07", "S02", "S03"] {
+        let report = report::run_pair(mutations::pair_by_id(id).unwrap()).unwrap();
+        assert_eq!(report.routed.changed_path_geometry_count(), 0);
+    }
+}
+
+#[test]
+fn route_input_summary_does_not_claim_all_inputs_are_identical() {
+    let pair = mutations::pair_by_id("M14").unwrap();
+    let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+    let summary = diagnostic.summary();
+
+    assert!(summary.contains("route_input_diffs="), "{summary}");
+    assert!(summary.contains("decision_input_changes="), "{summary}");
+    assert!(
+        !summary.contains("upstream_layout_is_identical"),
+        "{summary}"
+    );
+}
+
+#[test]
+fn port_change_classifies_before_bend_or_length() {
+    let input = route_diagnostics::synthetic_route_decision_input()
+        .with_changed_port("e0", Endpoint::Source, "south", "east")
+        .with_bend_delta("e0", 2)
+        .with_length_delta("e0", 25.0);
+
+    let decisions = route_diagnostics::classify_route_decisions(input);
+
+    assert_eq!(
+        decisions.by_edge["e0"].primary_class,
+        RouteDecisionClass::Port
+    );
+    assert!(
+        decisions.by_edge["e0"]
+            .classes
+            .contains(&RouteDecisionClass::BendTopology)
+    );
+}
+
+#[test]
+fn label_track_change_classifies_as_label_lane() {
+    let input =
+        route_diagnostics::synthetic_route_decision_input().with_label_track_delta("e0", 0, 1);
+
+    let decisions = route_diagnostics::classify_route_decisions(input);
+
+    assert_eq!(
+        decisions.by_edge["e0"].primary_class,
+        RouteDecisionClass::LabelLane
+    );
+}
+
+#[test]
+fn length_only_change_classifies_as_length_only() {
+    let input = route_diagnostics::synthetic_route_decision_input().with_length_delta("e0", 12.5);
+
+    let decisions = route_diagnostics::classify_route_decisions(input);
+
+    assert_eq!(
+        decisions.by_edge["e0"].primary_class,
+        RouteDecisionClass::LengthOnly
+    );
+}
+
+#[test]
+fn route_decision_edge_sets_use_additive_classes() {
+    let input = route_diagnostics::synthetic_route_decision_input()
+        .with_label_track_delta("e0", 0, 1)
+        .with_path_shape_changed("e0");
+
+    let decisions = route_diagnostics::classify_route_decisions(input);
+
+    assert!(
+        decisions
+            .edge_ids_for_class(RouteDecisionClass::LabelLane)
+            .contains("e0")
+    );
+    assert!(
+        decisions
+            .edge_ids_for_class(RouteDecisionClass::PathShape)
+            .contains("e0")
+    );
+}
+
+#[test]
+fn path_shape_correlation_thresholds_are_count_based() {
+    assert_eq!(
+        route_diagnostics::classify_path_shape_correlation(5),
+        route_diagnostics::PathShapeCorrelationOutcome::MostlyOverlapsLabelGeometry
+    );
+    assert_eq!(
+        route_diagnostics::classify_path_shape_correlation(1),
+        route_diagnostics::PathShapeCorrelationOutcome::MostlyDisjointFromLabelGeometry
+    );
+    assert_eq!(
+        route_diagnostics::classify_path_shape_correlation(3),
+        route_diagnostics::PathShapeCorrelationOutcome::Mixed
+    );
+}
+
+#[test]
+fn m14_path_shape_correlation_reports_counts_and_outcome() {
+    let pair = mutations::pair_by_id("M14").unwrap();
+    let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+    let correlation = diagnostic
+        .path_shape_correlation
+        .as_ref()
+        .expect("M14 path-shape correlation");
+
+    assert_eq!(correlation.label_geometry_count, 6, "{correlation:?}");
+    assert_eq!(correlation.path_shape_count, 15, "{correlation:?}");
+    assert!(correlation.overlap_count <= 6, "{correlation:?}");
+    assert_eq!(
+        correlation.outcome,
+        route_diagnostics::PathShapeCorrelationOutcome::MostlyOverlapsLabelGeometry,
+        "{correlation:?}"
+    );
+}
+
+#[test]
+fn m14_and_m11_route_decision_histograms_cover_changed_paths() {
+    for id in ["M14", "M11"] {
+        let pair = mutations::pair_by_id(id).unwrap();
+        let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+
+        let changed = diagnostic.phase_attribution.route.changed_paths.len();
+        let histogram_total = diagnostic.route_decisions.primary_histogram_total();
+
+        assert_eq!(histogram_total, changed, "{id}: {diagnostic:?}");
+        assert!(changed > 0, "{id}: {diagnostic:?}");
+    }
+}
+
+#[test]
+fn route_decision_summary_mentions_histogram_classes() {
+    let pair = mutations::pair_by_id("M14").unwrap();
+    let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+    let summary = diagnostic.summary();
+
+    assert!(summary.contains("route_decisions="), "{summary}");
+    assert!(summary.contains("decision_input_changes="), "{summary}");
+    assert!(
+        summary.contains("Port")
+            || summary.contains("LabelLane")
+            || summary.contains("BendTopology")
+            || summary.contains("PathShape")
+            || summary.contains("LengthOnly"),
+        "{summary}"
+    );
+}
+
+#[test]
+fn primary_route_canaries_keep_route_first_attribution_with_route_diagnostics() {
+    for id in ["M14", "M11"] {
+        let pair = mutations::pair_by_id(id).unwrap();
+        let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair).unwrap();
+
+        assert_eq!(
+            diagnostic.phase_attribution.first_divergence(),
+            Some(PhaseName::Route),
+            "{id}: {}",
+            diagnostic.summary()
+        );
+        assert!(
+            diagnostic
+                .phase_attribution
+                .route
+                .layout_amplified_paths
+                .is_empty(),
+            "{id}: {}",
+            diagnostic.summary()
+        );
+    }
+}
+
+#[test]
+fn secondary_localized_canaries_keep_layout_amplified_classification() {
+    for id in ["M02", "M03", "M04"] {
+        let report = report::run_pair(mutations::pair_by_id(id).unwrap()).unwrap();
+
+        assert!(
+            !report
+                .phase_attribution()
+                .route
+                .layout_amplified_paths
+                .is_empty(),
+            "{id}: {}",
+            report.summary()
+        );
+    }
+}
+
+#[test]
+fn calibration_guardrails_keep_zero_path_churn_where_expected() {
+    for id in ["M05", "M07", "S02", "S03"] {
+        let report = report::run_pair(mutations::pair_by_id(id).unwrap()).unwrap();
+
+        assert_eq!(
+            report.routed.changed_path_geometry_count(),
+            0,
+            "{id}: {}",
+            report.summary()
+        );
+    }
+}
+
+fn synthetic_trace_with_user_node(
+    id: &str,
+    rank: i32,
+    order: usize,
+    x: f64,
+    y: f64,
+) -> LayeredPhaseTrace {
+    let node = TraceNodeSnapshot {
+        id: id.to_string(),
+        rank,
+        order,
+        x: Some(x),
+        y: Some(y),
+    };
+    let mut trace = LayeredPhaseTrace::default();
+    trace.push_stage(TraceStageSnapshot {
+        stage: TraceStage::Rank,
+        nodes: vec![node.clone()],
+        dummies: Vec::new(),
+        reversed_edges: Vec::new(),
+    });
+    trace.push_stage(TraceStageSnapshot {
+        stage: TraceStage::Order,
+        nodes: vec![node.clone()],
+        dummies: Vec::new(),
+        reversed_edges: Vec::new(),
+    });
+    trace.push_stage(TraceStageSnapshot {
+        stage: TraceStage::Position,
+        nodes: vec![node],
+        dummies: Vec::new(),
+        reversed_edges: Vec::new(),
+    });
+    trace
+}
+
+fn synthetic_trace_with_dummy(
+    generated_id: &str,
+    key: DummyTraceKey,
+    rank: i32,
+    order: usize,
+) -> LayeredPhaseTrace {
+    let mut trace = LayeredPhaseTrace::default();
+    trace.push_stage(TraceStageSnapshot {
+        stage: TraceStage::Normalize,
+        nodes: Vec::new(),
+        dummies: vec![TraceDummySnapshot {
+            generated_id: generated_id.to_string(),
+            key,
+            rank,
+            order,
+        }],
+        reversed_edges: Vec::new(),
+    });
+    trace
+}
+
+fn edge_dummy_key(edge_index: usize, chain_position: usize) -> DummyTraceKey {
+    DummyTraceKey {
+        edge_index,
+        role: DummyTraceRole::Edge,
+        chain_position,
+        is_label_dummy: false,
+    }
+}
+
+fn label_dummy_key(edge_index: usize, chain_position: usize) -> DummyTraceKey {
+    DummyTraceKey {
+        edge_index,
+        role: DummyTraceRole::EdgeLabel,
+        chain_position,
+        is_label_dummy: true,
+    }
+}
+
+fn changed_path_metric(edge_id: &str, source: &str, target: &str) -> mmds_metrics::EdgePathMetric {
+    mmds_metrics::EdgePathMetric {
+        edge_id: edge_id.to_string(),
+        source: source.to_string(),
+        target: target.to_string(),
+        point_count_delta: 0,
+        bend_count_delta: 0,
+        length_delta: mmds_metrics::DISPLAY_EPS + 1.0,
+        envelope_delta: mmds_metrics::BoundsDelta {
+            width_delta: 0.0,
+            height_delta: 0.0,
+            area_delta: 0.0,
+            changed: false,
+        },
+    }
+}
+
+fn attribution_with_no_user_node_movement() -> phase_attribution::PhaseAttribution {
+    phase_attribution::PhaseAttribution::default()
+}
+
+fn attribution_with_position_change(node_id: &str) -> phase_attribution::PhaseAttribution {
+    phase_attribution::PhaseAttribution {
+        position: phase_attribution::NodePhaseDelta {
+            changed_nodes: vec![node_id.to_string()],
+        },
+        ..phase_attribution::PhaseAttribution::default()
+    }
+}
+
+#[test]
+fn mutation_corpus_exposes_seed_pairs_and_identity_policy() {
+    let corpus = mutations::tier_a_pairs();
+
+    assert!(corpus.iter().any(|pair| pair.id == "M01"));
+    assert!(corpus.iter().any(|pair| pair.id == "M06"));
+    assert!(corpus.iter().any(|pair| pair.id == "M10"));
+    assert!(corpus.iter().any(|pair| pair.id == "M14"));
+    assert!(corpus.iter().any(|pair| pair.id == "M15"));
+    assert!(corpus.iter().any(|pair| pair.id == "M05-ID"));
+    assert!(corpus.iter().any(|pair| pair.id == "S01"));
+
+    let m01 = corpus.iter().find(|pair| pair.id == "M01").unwrap();
+    assert!(
+        m01.expected_changes
+            .contains(&mutations::SemanticChangeKind::EdgeSplit)
+    );
+
+    let m05 = corpus.iter().find(|pair| pair.id == "M05").unwrap();
+    assert!(
+        m05.expected_changes
+            .contains(&mutations::SemanticChangeKind::NodeLabelChanged)
+    );
+    assert_eq!(
+        m05.identity_policy,
+        mutations::IdentityPolicy::IdsAreCanonical
+    );
+
+    let m05_id = corpus.iter().find(|pair| pair.id == "M05-ID").unwrap();
+    assert!(
+        m05_id
+            .expected_changes
+            .contains(&mutations::SemanticChangeKind::NodeRemoved)
+    );
+    assert!(
+        m05_id
+            .expected_changes
+            .contains(&mutations::SemanticChangeKind::NodeAdded)
+    );
+}
+
+#[test]
+fn class_canaries_are_defined_with_the_corpus() {
+    let canaries = mutations::class_canaries();
+
+    assert!(canaries.iter().any(|pair| pair.id == "M16"));
+    assert!(canaries.iter().any(|pair| pair.id == "M17"));
+    assert!(
+        canaries
+            .iter()
+            .all(|pair| pair.family == mutations::DiagramFamily::Class)
+    );
+}
+
+#[test]
+fn sequence_canary_is_excluded_from_graph_family_metrics() {
+    let canary = mutations::sequence_exclusion_canary();
+
+    assert_eq!(canary.id, "S-SEQ");
+    assert_eq!(canary.family, mutations::DiagramFamily::TimelineExcluded);
+    assert!(!canary.include_in_graph_stability_metrics);
+}
+
+#[test]
+fn mutation_corpus_tier_a_pairs_cover_task_1_1_expected_surface() {
+    let corpus = mutations::tier_a_pairs();
+    let expected_ids = [
+        "M01", "M02", "M03", "M04", "M05", "M06", "M07", "M08", "M09", "M10", "M11", "M12", "M14",
+        "M15", "M05-ID", "M19", "M20", "M21", "S01", "S02", "S03", "S04",
+    ];
+
+    assert_eq!(corpus.len(), expected_ids.len());
+    for id in expected_ids {
+        assert!(corpus.iter().any(|pair| pair.id == id), "missing {id}");
+        assert_eq!(mutations::pair_by_id(id).map(|pair| pair.id), Some(id));
+    }
+}
+
+#[test]
+fn pure_edge_control_ids_reserve_prior_tier_b_slots_and_are_explicit() {
+    let tier_a = mutations::tier_a_pairs();
+    let tier_a_ids = tier_a.iter().map(|pair| pair.id).collect::<Vec<_>>();
+
+    assert!(!tier_a_ids.contains(&"M13"));
+    assert!(mutations::pair_by_id("M13").is_none());
+    assert!(!tier_a_ids.contains(&"M18"));
+    assert!(mutations::pair_by_id("M18").is_none());
+
+    assert_eq!(
+        proportionality::pure_edge_control_pair_ids(),
+        ["M04", "M19", "M20", "M21"]
+    );
+
+    for id in ["M19", "M20", "M21"] {
+        let pair = mutations::pair_by_id(id).expect("pure-edge control pair");
+        assert_eq!(pair.tier, mutations::CorpusTier::TierA);
+        assert_eq!(pair.family, mutations::DiagramFamily::Flowchart);
+        assert_eq!(
+            pair.expected_changes,
+            &[mutations::SemanticChangeKind::EdgeAdded]
+        );
+        assert!(pair.direct_nodes.is_empty());
+        assert_eq!(pair.direct_edges.len(), 1);
+        assert!(pair.include_in_graph_stability_metrics);
+        assert_eq!(
+            proportionality::InputMagnitudeBasis::for_pair_id(id),
+            proportionality::InputMagnitudeBasis::EdgeInsertionContext
+        );
+    }
+
+    let edge_added_tier_a_ids = tier_a
+        .iter()
+        .filter(|pair| {
+            pair.expected_changes
+                .contains(&mutations::SemanticChangeKind::EdgeAdded)
+        })
+        .map(|pair| pair.id)
+        .collect::<Vec<_>>();
+
+    assert!(edge_added_tier_a_ids.contains(&"M11"));
+    assert!(!proportionality::pure_edge_control_pair_ids().contains(&"M11"));
+    assert_ne!(
+        proportionality::pure_edge_control_pair_ids().to_vec(),
+        edge_added_tier_a_ids
+    );
+}
+
+#[test]
+fn pure_edge_input_magnitude_controls_collect_edge_context_without_other_axes() {
+    for id in proportionality::pure_edge_control_pair_ids() {
+        let pair = mutations::pair_by_id(id).expect("pure-edge control pair");
+        let input =
+            proportionality::input_magnitude_for_pair(pair).expect("pure-edge input magnitude");
+        let edge = input.edge_insertion.expect("edge insertion magnitude");
+
+        assert_eq!(
+            edge.semantic_added_edge_ids,
+            pair.direct_edges
+                .iter()
+                .map(|edge| edge.to_string())
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            edge.route_input_added_edges > 0,
+            "{id} should add route-input edge context"
+        );
+        assert!(
+            input.label_dimension.is_none(),
+            "{id} should not be a label mutation"
+        );
+        assert!(input.node_insertion.is_none(), "{id} should not add nodes");
+        assert!(
+            input.subgraph_change.is_none(),
+            "{id} should not change subgraph semantics"
+        );
+
+        let output = proportionality::route_output_magnitude_for_pair(pair)
+            .expect("pure-edge output magnitude");
+        assert!(
+            output.summary.changed_path_count > 0,
+            "{id} should produce observable routed output magnitude"
+        );
+    }
+}
+
+#[test]
+fn mutation_corpus_class_canaries_are_disjoint_from_tier_a_pairs() {
+    let corpus = mutations::tier_a_pairs();
+    let canaries = mutations::class_canaries();
+
+    assert!(
+        canaries
+            .iter()
+            .all(|canary| !corpus.iter().any(|pair| pair.id == canary.id))
+    );
+}
+
+#[test]
+fn mutation_corpus_m05_id_direct_nodes_include_removed_and_added_ids() {
+    let m05_id = mutations::pair_by_id("M05-ID").unwrap();
+
+    assert_eq!(m05_id.direct_nodes, &["Lint", "Audit"]);
+}
+
+#[test]
+fn render_surfaces_include_text_svg_layout_and_routed_mmds() {
+    let pair = mutations::pair_by_id("M06").expect("M06 pair should exist");
+    let rendered = render_surfaces::render_pair(pair).expect("pair should render");
+
+    assert!(!rendered.before.text.is_empty());
+    assert!(!rendered.after.text.is_empty());
+    assert!(rendered.before.svg.contains("<svg"));
+    assert!(rendered.after.svg.contains("<svg"));
+    assert_eq!(rendered.before.layout_mmds.geometry_level, "layout");
+    assert_eq!(rendered.before.routed_mmds.geometry_level, "routed");
+    assert_eq!(rendered.after.layout_mmds.geometry_level, "layout");
+    assert_eq!(rendered.after.routed_mmds.geometry_level, "routed");
+}
+
+#[test]
+fn render_surfaces_allow_lossless_routed_mmds_for_style_canaries() {
+    let pair = mutations::pair_by_id("S03").expect("S03 pair should exist");
+    let rendered = render_surfaces::render_pair(pair).expect("pair should render");
+    let (_, lossless) =
+        render_surfaces::render_lossless_routed_mmds(&rendered.after.source).unwrap();
+
+    assert_eq!(rendered.after.routed_mmds.geometry_level, "routed");
+    assert_eq!(lossless.geometry_level, "routed");
+}
+
+#[test]
+fn render_surfaces_error_reports_pair_and_source_context() {
+    let pair = mutations::MutationPair {
+        id: "MISSING",
+        family: mutations::DiagramFamily::Flowchart,
+        tier: mutations::CorpusTier::TierA,
+        base: mutations::MutationInput::Fixture {
+            family: "flowchart",
+            name: "missing-fixture.mmd",
+        },
+        mutated: mutations::MutationInput::Inline("graph TD\n    A --> B\n"),
+        expected_changes: &[],
+        direct_nodes: &[],
+        direct_edges: &[],
+        include_in_graph_stability_metrics: true,
+        identity_policy: mutations::IdentityPolicy::IdsAreCanonical,
+    };
+    let message = render_surfaces::render_pair(&pair).unwrap_err().to_string();
+
+    assert!(message.contains("MISSING"));
+    assert!(message.contains("before"));
+    assert!(message.contains("missing-fixture.mmd"));
+}
+
+#[test]
+fn layout_metrics_ignore_direct_impact_nodes_and_use_coord_tolerance() {
+    let pair = mutations::pair_by_id("S01").expect("S01 pair should exist");
+    let rendered = render_surfaces::render_pair(pair).unwrap();
+    let report = mmds_metrics::compare_layout_mmds(
+        pair,
+        &rendered.before.layout_mmds,
+        &rendered.after.layout_mmds,
+    );
+
+    assert_eq!(report.coord_eps, 0.01);
+    assert!(report.direct_impact_nodes.iter().any(|id| *id == "X"));
+    assert!(!report.unchanged_node_displacements.contains_key("X"));
+    assert!(report.unchanged_node_count > 0);
+}
+
+#[test]
+fn layout_metrics_treat_id_edits_as_remove_add_not_rename() {
+    let pair = mutations::pair_by_id("M05-ID").expect("M05 ID canary should exist");
+    let rendered = render_surfaces::render_pair(pair).unwrap();
+    let report = mmds_metrics::compare_layout_mmds(
+        pair,
+        &rendered.before.layout_mmds,
+        &rendered.after.layout_mmds,
+    );
+
+    assert!(report.removed_nodes.contains("Lint"));
+    assert!(report.added_nodes.contains("Audit"));
+    assert!(report.inferred_renames.is_empty());
+}
+
+#[test]
+fn layout_metrics_do_not_collapse_global_shift_when_anchor_set_is_too_small() {
+    let pair = mutations::pair_by_id("S01").expect("S01 pair should exist");
+    let rendered = render_surfaces::render_pair(pair).unwrap();
+    let report = mmds_metrics::compare_layout_mmds(
+        pair,
+        &rendered.before.layout_mmds,
+        &rendered.after.layout_mmds,
+    );
+
+    if report.global_shift.anchor_count < 2 {
+        assert_eq!(
+            report.global_shift.confidence,
+            mmds_metrics::ShiftConfidence::Low
+        );
+        assert!(!report.global_shift.collapsed_movement);
+    }
+}
+
+#[test]
+fn routed_metrics_report_label_rect_for_label_mutation() {
+    let pair = mutations::pair_by_id("M06").expect("M06 pair should exist");
+    let rendered = render_surfaces::render_pair(pair).unwrap();
+    let report = mmds_metrics::compare_routed_mmds(
+        pair,
+        &rendered.before.routed_mmds,
+        &rendered.after.routed_mmds,
+    );
+
+    assert!(
+        report
+            .label_rect_changes
+            .iter()
+            .any(|change| change.edge_id == "e0")
+    );
+    assert!(
+        report
+            .path_metrics
+            .iter()
+            .any(|metric| metric.edge_id == "e0")
+    );
+}
+
+#[test]
+fn routed_metrics_keep_visible_endpoint_and_port_intent_separate() {
+    let pair = mutations::pair_by_id("M10").expect("M10 pair should exist");
+    let rendered = render_surfaces::render_pair(pair).unwrap();
+    let report = mmds_metrics::compare_routed_mmds(
+        pair,
+        &rendered.before.routed_mmds,
+        &rendered.after.routed_mmds,
+    );
+
+    assert!(
+        report
+            .endpoint_face_changes
+            .iter()
+            .all(|change| change.source == "path")
+    );
+    assert!(
+        report
+            .port_intent_changes
+            .iter()
+            .all(|change| change.source == "port")
+    );
+}
+
+#[test]
+fn routed_metrics_treat_id_rename_incident_edges_as_removed_added() {
+    let pair = mutations::pair_by_id("M05-ID").expect("M05 ID canary should exist");
+    let rendered = render_surfaces::render_pair(pair).unwrap();
+    let report = mmds_metrics::compare_routed_mmds(
+        pair,
+        &rendered.before.routed_mmds,
+        &rendered.after.routed_mmds,
+    );
+
+    assert!(!report.removed_edges.is_empty());
+    assert!(!report.added_edges.is_empty());
+    assert!(
+        report
+            .path_metrics
+            .iter()
+            .all(|metric| !metric.subject_mentions_node("Lint"))
+    );
+}
+
+#[test]
+fn style_only_canaries_compare_paths_without_geometry_changes() {
+    let m07 = report::run_pair(mutations::pair_by_id("M07").unwrap()).unwrap();
+    let s03 = report::run_pair(mutations::pair_by_id("S03").unwrap()).unwrap();
+
+    assert_eq!(m07.routed.path_metrics.len(), 4);
+    assert_eq!(s03.routed.path_metrics.len(), 2);
+    assert_eq!(m07.routed.changed_path_geometry_count(), 0);
+    assert_eq!(s03.routed.changed_path_geometry_count(), 0);
+}
+
+#[test]
+fn style_only_canaries_explain_style_without_route_geometry_churn() {
+    for id in ["M07", "S03"] {
+        let report = report::run_pair(mutations::pair_by_id(id).unwrap()).unwrap();
+        let explanation = report.churn_explanation();
+
+        assert!(
+            explanation
+                .components
+                .contains(&report::ChurnComponent::Style)
+        );
+        assert!(
+            !explanation
+                .components
+                .contains(&report::ChurnComponent::RouteGeometry)
+        );
+        assert_eq!(report.routed.changed_path_geometry_count(), 0);
+    }
+}
+
+#[test]
+fn m05_label_only_churn_is_attributed_to_label_and_bounds_not_route_geometry() {
+    let report = report::run_pair(mutations::pair_by_id("M05").unwrap()).unwrap();
+    let explanation = report.churn_explanation();
+
+    assert_eq!(report.routed.path_metrics.len(), 6);
+    assert_eq!(report.routed.changed_path_geometry_count(), 0);
+    assert!(
+        explanation
+            .components
+            .contains(&report::ChurnComponent::LabelRect)
+    );
+    assert!(
+        explanation
+            .components
+            .contains(&report::ChurnComponent::Bounds)
+    );
+    assert!(
+        !explanation
+            .components
+            .contains(&report::ChurnComponent::RouteGeometry)
+    );
+}
+
+#[test]
+fn m14_label_cascade_reports_route_and_port_contributors() {
+    let report = report::run_pair(mutations::pair_by_id("M14").unwrap()).unwrap();
+    let explanation = report.churn_explanation();
+
+    assert!(report.routed.changed_path_geometry_count() > 0);
+    assert!(report.quality.route_length_total_delta.abs() > 1.0);
+    assert_ne!(report.quality.bend_count_total_delta, 0);
+    assert!(!report.routed.path_port_divergence.is_empty());
+    assert!(
+        explanation
+            .components
+            .contains(&report::ChurnComponent::RouteGeometry)
+    );
+    assert!(
+        explanation
+            .components
+            .contains(&report::ChurnComponent::PortDivergence)
+    );
+    assert!(
+        explanation
+            .components
+            .contains(&report::ChurnComponent::LabelRect)
+    );
+}
+
+#[test]
+fn mixed_churn_exposes_all_detected_components() {
+    let report = report::run_pair(mutations::pair_by_id("M14").unwrap()).unwrap();
+    let explanation = report.churn_explanation();
+
+    assert_eq!(report.render_churn, render_metrics::RenderChurnClass::Mixed);
+    assert!(explanation.components.len() > 1);
+    assert_eq!(
+        explanation.components,
+        explanation.components_sorted_for_test()
+    );
+}
+
+#[test]
+fn report_summary_distinguishes_compared_paths_from_changed_paths() {
+    let report = report::run_pair(mutations::pair_by_id("M07").unwrap()).unwrap();
+    let summary = report.summary();
+
+    assert!(summary.contains("paths_compared=4"));
+    assert!(summary.contains("paths_changed=0"));
+    assert!(summary.contains("components=[Style]"));
+}
+
+#[test]
+fn h1_h2_canaries_have_calibrated_explanations() {
+    let m07 = report::run_pair(mutations::pair_by_id("M07").unwrap()).unwrap();
+    let s03 = report::run_pair(mutations::pair_by_id("S03").unwrap()).unwrap();
+    let m05 = report::run_pair(mutations::pair_by_id("M05").unwrap()).unwrap();
+    let m14 = report::run_pair(mutations::pair_by_id("M14").unwrap()).unwrap();
+
+    assert_eq!(m07.routed.changed_path_geometry_count(), 0);
+    assert_eq!(s03.routed.changed_path_geometry_count(), 0);
+    assert_eq!(m05.routed.changed_path_geometry_count(), 0);
+    assert!(m14.routed.changed_path_geometry_count() > 0);
+
+    assert!(
+        m07.churn_explanation()
+            .is_style_only_without_route_geometry()
+    );
+    assert!(
+        s03.churn_explanation()
+            .is_style_only_without_route_geometry()
+    );
+    assert!(
+        m05.churn_explanation()
+            .is_label_only_without_route_geometry()
+    );
+    assert!(m14.churn_explanation().has_route_geometry_cascade());
+}
+
+#[test]
+fn geometry_metrics_count_bends_and_route_length() {
+    let path = vec![
+        point(0.0, 0.0),
+        point(10.0, 0.0),
+        point(10.0, 5.0),
+        point(20.0, 5.0),
+    ];
+
+    assert_eq!(geometry_metrics::bend_count(&path), 2);
+    assert_eq!(geometry_metrics::polyline_length(&path), 25.0);
+}
+
+#[test]
+fn geometry_metrics_detect_label_overlap_and_drift() {
+    let a = rect(0.0, 0.0, 10.0, 10.0);
+    let b = rect(5.0, 5.0, 10.0, 10.0);
+    let path = vec![point(0.0, 0.0), point(20.0, 0.0)];
+
+    assert!(geometry_metrics::rects_overlap(a, b));
+    assert_eq!(
+        geometry_metrics::distance_point_to_path(point(10.0, 5.0), &path),
+        5.0
+    );
+}
+
+fn point(x: f64, y: f64) -> crate::graph::geometry::FPoint {
+    crate::graph::geometry::FPoint::new(x, y)
+}
+
+fn rect(x: f64, y: f64, width: f64, height: f64) -> crate::graph::geometry::FRect {
+    crate::graph::geometry::FRect::new(x, y, width, height)
+}
+
+#[test]
+fn render_churn_classifier_prioritizes_route_topology_over_bounds_only() {
+    let summary = render_metrics::RenderMetricDelta {
+        svg_viewbox_changed: true,
+        path_topology_changed: true,
+        ..Default::default()
+    };
+
+    assert_eq!(
+        render_metrics::classify_render_churn(&summary),
+        render_metrics::RenderChurnClass::RouteTopologyChanged,
+    );
+}
+
+#[test]
+fn render_churn_classifier_marks_text_quantization_when_only_text_size_changes() {
+    let summary = render_metrics::RenderMetricDelta {
+        text_dimensions_changed: true,
+        ..Default::default()
+    };
+
+    assert_eq!(
+        render_metrics::classify_render_churn(&summary),
+        render_metrics::RenderChurnClass::TextGridQuantizationOrGlyphChurn,
+    );
+}
+
+#[test]
+fn render_churn_classifier_marks_mixed_for_multiple_real_changes() {
+    let summary = render_metrics::RenderMetricDelta {
+        path_topology_changed: true,
+        label_rect_changed: true,
+        ..Default::default()
+    };
+
+    assert_eq!(
+        render_metrics::classify_render_churn(&summary),
+        render_metrics::RenderChurnClass::Mixed,
+    );
+}
+
+#[test]
+fn render_churn_collectors_extract_text_and_svg_surface_metrics() {
+    let text = "A\nwide line\n";
+    let svg = r#"<svg viewBox="0 0 120 40"><path d="M0 0L1 1"/><path d="M1 1L2 2"/></svg>"#;
+
+    let text_metrics = render_metrics::collect_text_metrics(text);
+    let svg_metrics = render_metrics::collect_svg_metrics(svg);
+
+    assert_eq!(text_metrics.line_count, 2);
+    assert_eq!(text_metrics.max_line_width, 9);
+    assert_eq!(svg_metrics.viewbox_width, Some(120.0));
+    assert_eq!(svg_metrics.viewbox_height, Some(40.0));
+    assert_eq!(svg_metrics.path_count, 2);
+}
+
+#[test]
+fn tier_a_corpus_produces_deterministic_reports() {
+    let reports = report::run_corpus(mutations::tier_a_pairs()).expect("corpus should run");
+    let class_reports =
+        report::run_corpus(mutations::class_canaries()).expect("class canaries should run");
+
+    assert!(
+        reports.len() >= 19,
+        "Tier A should include M01-M12, M14-M15, M05-ID, and S01-S04"
+    );
+    assert_eq!(
+        class_reports.len(),
+        2,
+        "M16/M17 class canaries are disjoint from Tier A"
+    );
+    assert!(reports.iter().any(|report| report.pair_id == "M10"));
+    assert!(class_reports.iter().any(|report| report.pair_id == "M16"));
+    assert!(class_reports.iter().any(|report| report.pair_id == "M17"));
+    assert!(reports.iter().all(|report| !report.summary().is_empty()));
+    assert!(
+        class_reports
+            .iter()
+            .all(|report| !report.summary().is_empty())
+    );
+
+    let first = report::format_reports(&reports);
+    let second = report::format_reports(&reports);
+    assert_eq!(first, second);
+}
+
+#[test]
+fn corpus_reports_have_positive_signal_for_known_mutations() {
+    let reports = report::run_corpus(mutations::tier_a_pairs()).expect("corpus should run");
+
+    let m06 = reports
+        .iter()
+        .find(|report| report.pair_id == "M06")
+        .unwrap();
+    assert!(
+        !m06.routed.label_rect_changes.is_empty(),
+        "M06 should exercise label geometry"
+    );
+
+    let m10 = reports
+        .iter()
+        .find(|report| report.pair_id == "M10")
+        .unwrap();
+    assert!(
+        !m10.routed.endpoint_face_changes.is_empty() || m10.routed.routed_bounds_delta.changed,
+        "M10 should produce routed endpoint or bounds signal"
+    );
+
+    let m15 = reports
+        .iter()
+        .find(|report| report.pair_id == "M15")
+        .unwrap();
+    assert!(
+        !m15.quality.label_path_drift.is_empty() || !m15.quality.label_rect_overlaps.is_empty(),
+        "M15 should exercise label drift or overlap oracle signal"
+    );
+}
+
+#[test]
+fn class_canaries_are_supported_or_explicitly_tier_b() {
+    let canaries = mutations::class_canaries();
+
+    assert!(canaries.iter().any(|pair| pair.id == "M16"));
+    assert!(canaries.iter().any(|pair| pair.id == "M17"));
+    assert!(
+        canaries
+            .iter()
+            .all(|pair| pair.family == mutations::DiagramFamily::Class)
+    );
+}
+
+#[test]
+fn sequence_canary_never_enters_graph_stability_reports() {
+    let reports = report::run_corpus(mutations::tier_a_pairs()).expect("corpus should run");
+
+    assert!(reports.iter().all(|report| report.pair_id != "S-SEQ"));
+}
+
+#[test]
+fn sequence_canary_is_rejected_by_report_guardrails() {
+    let result = report::run_pair(mutations::sequence_exclusion_canary());
+
+    assert!(matches!(
+        result,
+        Err(report::ReportError::ExcludedFamily { .. })
+    ));
+}

--- a/src/internal_tests/layout_stability/mutations.rs
+++ b/src/internal_tests/layout_stability/mutations.rs
@@ -1,0 +1,475 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CorpusTier {
+    TierA,
+    TierB,
+    Synthetic,
+    Excluded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiagramFamily {
+    Flowchart,
+    Class,
+    TimelineExcluded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IdentityPolicy {
+    /// Current MVP policy. Future semantic-diff work may add an inferred
+    /// rename diagnostic mode, but node/subgraph IDs remain canonical here.
+    IdsAreCanonical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SemanticChangeKind {
+    NodeAdded,
+    NodeRemoved,
+    EdgeAdded,
+    EdgeRemoved,
+    /// Hand-authored high-level event for M01. Metric collectors still treat
+    /// canonical edge identity changes as removed/added unless a later diff
+    /// layer proves a stable edge correspondence.
+    EdgeSplit,
+    NodeLabelChanged,
+    EdgeLabelChanged,
+    EdgeStyleChanged,
+    SubgraphAdded,
+    SubgraphMembershipChanged,
+    SubgraphDirectionChanged,
+    CycleResolved,
+    ClassNodeAdded,
+    ClassEdgeAdded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MutationInput {
+    Fixture {
+        family: &'static str,
+        name: &'static str,
+    },
+    Inline(&'static str),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MutationPair {
+    pub(crate) id: &'static str,
+    pub(crate) family: DiagramFamily,
+    pub(crate) tier: CorpusTier,
+    pub(crate) base: MutationInput,
+    pub(crate) mutated: MutationInput,
+    pub(crate) expected_changes: &'static [SemanticChangeKind],
+    pub(crate) direct_nodes: &'static [&'static str],
+    pub(crate) direct_edges: &'static [&'static str],
+    pub(crate) include_in_graph_stability_metrics: bool,
+    pub(crate) identity_policy: IdentityPolicy,
+}
+
+const TIER_A_PAIRS: &[MutationPair] = &[
+    MutationPair {
+        id: "M01",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("chain.mmd"),
+        mutated: MutationInput::Inline(
+            "graph TD\n    A[Step 1] --> B[Step 2] --> X[Inserted] --> C[Step 3] --> D[Step 4]\n",
+        ),
+        expected_changes: &[
+            SemanticChangeKind::NodeAdded,
+            SemanticChangeKind::EdgeAdded,
+            SemanticChangeKind::EdgeRemoved,
+            SemanticChangeKind::EdgeSplit,
+        ],
+        direct_nodes: &["X"],
+        direct_edges: &["e1", "e2"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M02",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("fan_out.mmd"),
+        mutated: MutationInput::Inline(
+            "graph TD\n    A[Source] --> B[Target A]\n    A --> C[Target B]\n    A --> D[Target C]\n    A --> E[Target D]\n",
+        ),
+        expected_changes: &[SemanticChangeKind::NodeAdded, SemanticChangeKind::EdgeAdded],
+        direct_nodes: &["E"],
+        direct_edges: &["e3"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M03",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("fan_in.mmd"),
+        mutated: MutationInput::Inline(
+            "graph TD\n    A[Source A] --> D[Target]\n    B[Source B] --> D\n    C[Source C] --> D\n    E[Source D] --> D\n",
+        ),
+        expected_changes: &[SemanticChangeKind::NodeAdded, SemanticChangeKind::EdgeAdded],
+        direct_nodes: &["E"],
+        direct_edges: &["e3"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M04",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("chain.mmd"),
+        mutated: MutationInput::Inline(
+            "graph TD\n    A[Step 1] --> B[Step 2] --> C[Step 3] --> D[Step 4]\n    A --> D\n",
+        ),
+        expected_changes: &[SemanticChangeKind::EdgeAdded],
+        direct_nodes: &[],
+        direct_edges: &["e3"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M05",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("ci_pipeline.mmd"),
+        mutated: MutationInput::Inline(
+            "graph LR\n    Push[Git Push] --> Build[Build]\n    Build --> Test[Run Tests]\n    Test --> Lint[Static Analysis]\n    Lint --> Deploy{Deploy?}\n    Deploy -->|staging| Staging[Staging Env]\n    Deploy -->|production| Prod[Production]\n",
+        ),
+        expected_changes: &[SemanticChangeKind::NodeLabelChanged],
+        direct_nodes: &["Lint"],
+        direct_edges: &["e2", "e3"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M06",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: MutationInput::Inline("graph TD\n    B[Step 2] --> C[Step 3]\n"),
+        mutated: MutationInput::Inline("graph TD\n    B[Step 2] -->|validate| C[Step 3]\n"),
+        expected_changes: &[SemanticChangeKind::EdgeLabelChanged],
+        direct_nodes: &[],
+        direct_edges: &["e0"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M07",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("edge_styles.mmd"),
+        mutated: MutationInput::Inline(
+            "graph TD\n    A[Solid] -.-> B[Normal]\n    C[Dotted] -.-> D[Arrow]\n    E[Thick] ==> F[Arrow]\n    G[Open] --- H[Line]\n",
+        ),
+        expected_changes: &[SemanticChangeKind::EdgeStyleChanged],
+        direct_nodes: &[],
+        direct_edges: &["e0"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M08",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("ci_pipeline.mmd"),
+        mutated: MutationInput::Inline(
+            "graph LR\n    Push[Git Push] --> Build[Build]\n    subgraph checks [Checks]\n        Build --> Test[Run Tests]\n        Test --> Lint[Lint Check]\n    end\n    Lint --> Deploy{Deploy?}\n    Deploy -->|staging| Staging[Staging Env]\n    Deploy -->|production| Prod[Production]\n",
+        ),
+        expected_changes: &[
+            SemanticChangeKind::SubgraphAdded,
+            SemanticChangeKind::SubgraphMembershipChanged,
+        ],
+        direct_nodes: &["Build", "Test", "Lint"],
+        direct_edges: &["e0", "e1", "e2", "e3"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M09",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("system-architecture.mmd"),
+        mutated: MutationInput::Inline(
+            "graph LR\n  subgraph clients [Client Layer]\n    A([Web App])\n    C([Mobile App])\n  end\n  subgraph services [Service Layer]\n    B[API Gateway]\n    A --> B\n    C --> B\n    B --> D[Auth Service]\n    B --> E[User Service]\n    B --> F[Order Service]\n  end\n  subgraph data [Data Layer]\n    D --> G[(Auth DB)]\n    E --> H[(User DB)]\n    F --> I[(Order DB)]\n    F --> J([Message Queue])\n  end\n",
+        ),
+        expected_changes: &[SemanticChangeKind::SubgraphMembershipChanged],
+        direct_nodes: &["B"],
+        direct_edges: &["e0", "e1", "e2", "e3", "e4"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M10",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("subgraph_direction_lr.mmd"),
+        mutated: MutationInput::Inline(
+            "graph TD\n    Start --> A\n    subgraph sg1[Horizontal Flow]\n        direction TB\n        A[Step 1] --> B[Step 2] --> C[Step 3]\n    end\n    C --> End\n",
+        ),
+        expected_changes: &[SemanticChangeKind::SubgraphDirectionChanged],
+        direct_nodes: &["A", "B", "C"],
+        direct_edges: &["e1", "e2", "e3"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M11",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("subgraph_direction_cross_boundary.mmd"),
+        mutated: MutationInput::Inline(
+            "graph TD\n    subgraph sg1[Horizontal Section]\n        direction LR\n        A --> B\n    end\n    C --> E\n    E --> A\n    C --> A\n    B --> F\n    F --> D\n    B --> D\n    A --> D\n",
+        ),
+        expected_changes: &[SemanticChangeKind::EdgeAdded],
+        direct_nodes: &[],
+        direct_edges: &["e7"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M12",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("simple_cycle.mmd"),
+        mutated: MutationInput::Inline("graph TD\n    A[Start] --> B[Process]\n    B --> C[End]\n"),
+        expected_changes: &[
+            SemanticChangeKind::EdgeRemoved,
+            SemanticChangeKind::CycleResolved,
+        ],
+        direct_nodes: &[],
+        direct_edges: &["e2"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M14",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("inline_label_flowchart.mmd"),
+        mutated: MutationInput::Inline(
+            "flowchart TD\n  start((Start)) --> ingest[Ingest Request]\n  ingest --> parse[Parse Payload]\n  parse --> validate{Valid?}\n\n  validate -- no --> reject[Reject]\n  reject -.-> notify[Notify User]\n  reject --> metrics[Emit Metrics]\n\n  validate -- yes --> route{Route Type}\n  route -- sync --> sync[Sync Pipeline]\n  route -- async --> queue[Enqueue Job]\n\n  queue --> worker[Worker Pool]\n  worker --> process[Process Job]\n  process --> success{Success?}\n\n  success -- retry later --> retry[Retry]\n  retry ==> queue\n\n  success -- yes --> persist[Persist Result]\n  sync --> persist\n  persist --> metrics\n\n  parse --> cache[Lookup Cache]\n  cache -- hit --> fastpath[Serve Cached]\n  fastpath --> metrics\n  cache -- miss --> validate\n\n  ingest --> audit[Audit Log]\n  audit --> metrics\n\n  process -- warn --> alert[Page On-call]\n  alert -.-> metrics\n\n  metrics --> End((Done))\n",
+        ),
+        expected_changes: &[SemanticChangeKind::EdgeLabelChanged],
+        direct_nodes: &[],
+        direct_edges: &["e11"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M15",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("nested_subgraph_parallel_labels.mmd"),
+        mutated: MutationInput::Inline(
+            "graph TD\n    subgraph outer [Outer region]\n        subgraph inner_a [A region]\n            A1 --> A2\n        end\n        subgraph inner_b [B region]\n            B1 --> B2\n        end\n    end\n    A1 -->|cross edge one| B1\n    A2 -->|cross edge two| B2\n    A1 -->|cross edge three| B2\n",
+        ),
+        expected_changes: &[
+            SemanticChangeKind::EdgeLabelChanged,
+            SemanticChangeKind::EdgeAdded,
+        ],
+        direct_nodes: &[],
+        direct_edges: &["e4"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M19",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("fan_out.mmd"),
+        mutated: MutationInput::Inline(
+            "graph TD\n    A[Source] --> B[Target A]\n    A --> C[Target B]\n    A --> D[Target C]\n    B --> D\n",
+        ),
+        expected_changes: &[SemanticChangeKind::EdgeAdded],
+        direct_nodes: &[],
+        direct_edges: &["e3"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M20",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: MutationInput::Inline(
+            "graph TD\n    A --> B\n    A --> C\n    B --> D\n    C --> D\n    B --> E\n    C --> E\n    D --> F\n    E --> F\n",
+        ),
+        mutated: MutationInput::Inline(
+            "graph TD\n    A --> B\n    A --> C\n    B --> D\n    C --> D\n    B --> E\n    C --> E\n    D --> F\n    E --> F\n    A --> F\n",
+        ),
+        expected_changes: &[SemanticChangeKind::EdgeAdded],
+        direct_nodes: &[],
+        direct_edges: &["e8"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M21",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: MutationInput::Inline(
+            "graph TD\n    subgraph left [Left]\n        A --> B\n        A --> C\n    end\n    subgraph right [Right]\n        D --> E\n        D --> F\n    end\n    B --> D\n    C --> E\n    E --> G\n    F --> G\n",
+        ),
+        mutated: MutationInput::Inline(
+            "graph TD\n    subgraph left [Left]\n        A --> B\n        A --> C\n    end\n    subgraph right [Right]\n        D --> E\n        D --> F\n    end\n    B --> D\n    C --> E\n    E --> G\n    F --> G\n    C --> F\n",
+        ),
+        expected_changes: &[SemanticChangeKind::EdgeAdded],
+        direct_nodes: &[],
+        direct_edges: &["e8"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M05-ID",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::TierA,
+        base: flowchart_fixture("ci_pipeline.mmd"),
+        mutated: MutationInput::Inline(
+            "graph LR\n    Push[Git Push] --> Build[Build]\n    Build --> Test[Run Tests]\n    Test --> Audit[Lint Check]\n    Audit --> Deploy{Deploy?}\n    Deploy -->|staging| Staging[Staging Env]\n    Deploy -->|production| Prod[Production]\n",
+        ),
+        expected_changes: &[
+            SemanticChangeKind::NodeRemoved,
+            SemanticChangeKind::NodeAdded,
+        ],
+        direct_nodes: &["Lint", "Audit"],
+        direct_edges: &["e2", "e3"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "S01",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::Synthetic,
+        base: MutationInput::Inline("graph TD\n    A --> C\n    B --> C\n"),
+        mutated: MutationInput::Inline("graph TD\n    A --> C\n    X --> C\n    B --> C\n"),
+        expected_changes: &[SemanticChangeKind::NodeAdded, SemanticChangeKind::EdgeAdded],
+        direct_nodes: &["X"],
+        direct_edges: &["e1"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "S02",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::Synthetic,
+        base: MutationInput::Inline("graph TD\n    A -->|x| B\n"),
+        mutated: MutationInput::Inline("graph TD\n    A -->|a deliberately long label| B\n"),
+        expected_changes: &[SemanticChangeKind::EdgeLabelChanged],
+        direct_nodes: &[],
+        direct_edges: &["e0"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "S03",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::Synthetic,
+        base: MutationInput::Inline("graph LR\n    A --> B\n    B --> C\n"),
+        mutated: MutationInput::Inline("graph LR\n    A --> B\n    B -.-> C\n"),
+        expected_changes: &[SemanticChangeKind::EdgeStyleChanged],
+        direct_nodes: &[],
+        direct_edges: &["e1"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "S04",
+        family: DiagramFamily::Flowchart,
+        tier: CorpusTier::Synthetic,
+        base: MutationInput::Inline(
+            "graph TD\n    subgraph sg[Group]\n        A --> B\n    end\n    C --> A\n",
+        ),
+        mutated: MutationInput::Inline(
+            "graph TD\n    subgraph sg[Group]\n        A --> B\n        C --> A\n    end\n",
+        ),
+        expected_changes: &[SemanticChangeKind::SubgraphMembershipChanged],
+        direct_nodes: &["C"],
+        direct_edges: &["e1"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+];
+
+const CLASS_CANARIES: &[MutationPair] = &[
+    MutationPair {
+        id: "M16",
+        family: DiagramFamily::Class,
+        tier: CorpusTier::TierB,
+        base: class_fixture("inheritance_chain.mmd"),
+        mutated: MutationInput::Inline(
+            "classDiagram\n    class Vehicle\n    class Car\n    class Truck\n    class ElectricCar\n    class ElectricTruck\n    Vehicle <|-- Car\n    Vehicle <|-- Truck\n    Car <|-- ElectricCar\n    Truck <|-- ElectricTruck\n",
+        ),
+        expected_changes: &[
+            SemanticChangeKind::ClassNodeAdded,
+            SemanticChangeKind::ClassEdgeAdded,
+        ],
+        direct_nodes: &["ElectricTruck"],
+        direct_edges: &["e3"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+    MutationPair {
+        id: "M17",
+        family: DiagramFamily::Class,
+        tier: CorpusTier::TierB,
+        base: class_fixture("cardinality_labels.mmd"),
+        mutated: MutationInput::Inline(
+            "classDiagram\nUser \"1\" --> \"many\" Session:owns actively\nOrder \"0..1\" --> \"*\" Item:contains\n",
+        ),
+        expected_changes: &[SemanticChangeKind::EdgeLabelChanged],
+        direct_nodes: &[],
+        direct_edges: &["e0"],
+        include_in_graph_stability_metrics: true,
+        identity_policy: IdentityPolicy::IdsAreCanonical,
+    },
+];
+
+const SEQUENCE_EXCLUSION_CANARY: MutationPair = MutationPair {
+    id: "S-SEQ",
+    family: DiagramFamily::TimelineExcluded,
+    tier: CorpusTier::Excluded,
+    base: MutationInput::Fixture {
+        family: "sequence",
+        name: "simple.mmd",
+    },
+    mutated: MutationInput::Inline(
+        "sequenceDiagram\n    participant A\n    participant B\n    A->>B: Hello\n    B->>A: Hi\n    A->>B: Follow up\n",
+    ),
+    expected_changes: &[],
+    direct_nodes: &[],
+    direct_edges: &[],
+    include_in_graph_stability_metrics: false,
+    identity_policy: IdentityPolicy::IdsAreCanonical,
+};
+
+pub(crate) fn tier_a_pairs() -> &'static [MutationPair] {
+    TIER_A_PAIRS
+}
+
+pub(crate) fn class_canaries() -> &'static [MutationPair] {
+    CLASS_CANARIES
+}
+
+pub(crate) fn sequence_exclusion_canary() -> &'static MutationPair {
+    &SEQUENCE_EXCLUSION_CANARY
+}
+
+pub(crate) fn pair_by_id(id: &str) -> Option<&'static MutationPair> {
+    TIER_A_PAIRS
+        .iter()
+        .chain(CLASS_CANARIES)
+        .chain([&SEQUENCE_EXCLUSION_CANARY])
+        .find(|pair| pair.id == id)
+}
+
+const fn flowchart_fixture(name: &'static str) -> MutationInput {
+    MutationInput::Fixture {
+        family: "flowchart",
+        name,
+    }
+}
+
+const fn class_fixture(name: &'static str) -> MutationInput {
+    MutationInput::Fixture {
+        family: "class",
+        name,
+    }
+}

--- a/src/internal_tests/layout_stability/phase_attribution.rs
+++ b/src/internal_tests/layout_stability/phase_attribution.rs
@@ -1,0 +1,303 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::mmds_metrics::{COORD_EPS, EdgePathMetric, RoutedMmdsMetrics};
+use crate::engines::graph::algorithms::layered::kernel::trace::{
+    DummyTraceKey, LayeredPhaseTrace, TraceDummySnapshot, TraceNodeSnapshot, TraceStage,
+    TraceStageSnapshot,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum PhaseName {
+    Acyclic,
+    Rank,
+    Normalize,
+    Order,
+    Position,
+    Route,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct PhaseAttribution {
+    pub(crate) rank: NodePhaseDelta,
+    pub(crate) normalize: NormalizePhaseDelta,
+    pub(crate) order: NodePhaseDelta,
+    pub(crate) position: NodePhaseDelta,
+    pub(crate) route: RoutePhaseDelta,
+}
+
+impl PhaseAttribution {
+    pub(crate) fn first_divergence(&self) -> Option<PhaseName> {
+        if !self.rank.changed_nodes.is_empty() {
+            return Some(PhaseName::Rank);
+        }
+        if self.normalize.has_changes() {
+            return Some(PhaseName::Normalize);
+        }
+        if !self.order.changed_nodes.is_empty() {
+            return Some(PhaseName::Order);
+        }
+        if !self.position.changed_nodes.is_empty() {
+            return Some(PhaseName::Position);
+        }
+        if self.route.has_changes() {
+            return Some(PhaseName::Route);
+        }
+        None
+    }
+
+    pub(crate) fn phase_components(&self) -> Vec<PhaseName> {
+        let mut components = Vec::new();
+        if !self.rank.changed_nodes.is_empty() {
+            components.push(PhaseName::Rank);
+        }
+        if self.normalize.has_changes() {
+            components.push(PhaseName::Normalize);
+        }
+        if !self.order.changed_nodes.is_empty() {
+            components.push(PhaseName::Order);
+        }
+        if !self.position.changed_nodes.is_empty() {
+            components.push(PhaseName::Position);
+        }
+        if self.route.has_changes() {
+            components.push(PhaseName::Route);
+        }
+        components
+    }
+
+    pub(crate) fn phase_components_for_test(&self) -> Vec<PhaseName> {
+        self.phase_components()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct NodePhaseDelta {
+    pub(crate) changed_nodes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct NormalizePhaseDelta {
+    pub(crate) added_dummy_chains: Vec<DummyTraceKey>,
+    pub(crate) removed_dummy_chains: Vec<DummyTraceKey>,
+    pub(crate) changed_dummy_chains: Vec<DummyTraceKey>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct RoutePhaseDelta {
+    pub(crate) changed_paths: Vec<String>,
+    pub(crate) route_only_paths: Vec<String>,
+    pub(crate) layout_amplified_paths: Vec<String>,
+    pub(crate) port_divergence_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RouteMetricAttribution {
+    pub(crate) phase: PhaseName,
+    pub(crate) endpoint_layout_changed: bool,
+}
+
+impl NormalizePhaseDelta {
+    fn has_changes(&self) -> bool {
+        !self.added_dummy_chains.is_empty()
+            || !self.removed_dummy_chains.is_empty()
+            || !self.changed_dummy_chains.is_empty()
+    }
+}
+
+impl RoutePhaseDelta {
+    fn has_changes(&self) -> bool {
+        !self.changed_paths.is_empty() || self.port_divergence_count > 0
+    }
+}
+
+pub(crate) fn compare_phase_traces(
+    before: &LayeredPhaseTrace,
+    after: &LayeredPhaseTrace,
+) -> PhaseAttribution {
+    PhaseAttribution {
+        rank: compare_node_phase(before, after, TraceStage::Rank, node_rank_changed),
+        normalize: compare_normalize_phase(before, after),
+        order: compare_node_phase(before, after, TraceStage::Order, node_order_changed),
+        position: compare_node_phase(before, after, TraceStage::Position, node_position_changed),
+        route: RoutePhaseDelta::default(),
+    }
+}
+
+pub(crate) fn attribute_route_metric(
+    metric: &EdgePathMetric,
+    attribution: &PhaseAttribution,
+) -> RouteMetricAttribution {
+    let moved_nodes = layout_changed_nodes(attribution);
+    RouteMetricAttribution {
+        phase: PhaseName::Route,
+        endpoint_layout_changed: moved_nodes
+            .iter()
+            .any(|node_id| metric.subject_mentions_node(node_id)),
+    }
+}
+
+pub(crate) fn attribute_routed_metrics(
+    attribution: &mut PhaseAttribution,
+    routed: &RoutedMmdsMetrics,
+) {
+    let mut changed_paths = Vec::new();
+    let mut route_only_paths = Vec::new();
+    let mut layout_amplified_paths = Vec::new();
+
+    for metric in routed
+        .path_metrics
+        .iter()
+        .filter(|metric| metric.geometry_changed())
+    {
+        changed_paths.push(metric.edge_id.clone());
+        let route_attribution = attribute_route_metric(metric, attribution);
+        if route_attribution.endpoint_layout_changed {
+            layout_amplified_paths.push(metric.edge_id.clone());
+        } else {
+            route_only_paths.push(metric.edge_id.clone());
+        }
+    }
+
+    changed_paths.sort();
+    route_only_paths.sort();
+    layout_amplified_paths.sort();
+
+    attribution.route = RoutePhaseDelta {
+        changed_paths,
+        route_only_paths,
+        layout_amplified_paths,
+        port_divergence_count: routed.path_port_divergence.len(),
+    };
+}
+
+fn compare_node_phase(
+    before: &LayeredPhaseTrace,
+    after: &LayeredPhaseTrace,
+    stage: TraceStage,
+    changed: fn(&TraceNodeSnapshot, &TraceNodeSnapshot) -> bool,
+) -> NodePhaseDelta {
+    let Some(before_stage) = stage_snapshot(before, stage) else {
+        return NodePhaseDelta::default();
+    };
+    let Some(after_stage) = stage_snapshot(after, stage) else {
+        return NodePhaseDelta::default();
+    };
+
+    let before_nodes = nodes_by_id(before_stage);
+    let after_nodes = nodes_by_id(after_stage);
+    let mut changed_nodes = before_nodes
+        .iter()
+        .filter_map(|(id, before_node)| {
+            let after_node = after_nodes.get(id)?;
+            changed(before_node, after_node).then(|| id.clone())
+        })
+        .collect::<Vec<_>>();
+    changed_nodes.sort();
+
+    NodePhaseDelta { changed_nodes }
+}
+
+fn stage_snapshot(trace: &LayeredPhaseTrace, stage: TraceStage) -> Option<&TraceStageSnapshot> {
+    trace.stages.iter().find(|snapshot| snapshot.stage == stage)
+}
+
+fn nodes_by_id(stage: &TraceStageSnapshot) -> BTreeMap<String, &TraceNodeSnapshot> {
+    stage
+        .nodes
+        .iter()
+        .map(|node| (node.id.clone(), node))
+        .collect()
+}
+
+fn layout_changed_nodes(attribution: &PhaseAttribution) -> BTreeSet<&str> {
+    attribution
+        .rank
+        .changed_nodes
+        .iter()
+        .chain(attribution.order.changed_nodes.iter())
+        .chain(attribution.position.changed_nodes.iter())
+        .map(String::as_str)
+        .collect()
+}
+
+fn compare_normalize_phase(
+    before: &LayeredPhaseTrace,
+    after: &LayeredPhaseTrace,
+) -> NormalizePhaseDelta {
+    let Some(before_stage) = stage_snapshot(before, TraceStage::Normalize) else {
+        return NormalizePhaseDelta::default();
+    };
+    let Some(after_stage) = stage_snapshot(after, TraceStage::Normalize) else {
+        return NormalizePhaseDelta::default();
+    };
+
+    let before_dummies = dummies_by_key(before_stage);
+    let after_dummies = dummies_by_key(after_stage);
+
+    let mut added_dummy_chains = after_dummies
+        .keys()
+        .filter(|key| !before_dummies.contains_key(*key))
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut removed_dummy_chains = before_dummies
+        .keys()
+        .filter(|key| !after_dummies.contains_key(*key))
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut changed_dummy_chains = before_dummies
+        .iter()
+        .filter_map(|(key, before_dummy)| {
+            let after_dummy = after_dummies.get(key)?;
+            dummy_changed(before_dummy, after_dummy).then(|| key.clone())
+        })
+        .collect::<Vec<_>>();
+
+    added_dummy_chains.sort();
+    removed_dummy_chains.sort();
+    changed_dummy_chains.sort();
+
+    NormalizePhaseDelta {
+        added_dummy_chains,
+        removed_dummy_chains,
+        changed_dummy_chains,
+    }
+}
+
+fn dummies_by_key(stage: &TraceStageSnapshot) -> BTreeMap<DummyTraceKey, &TraceDummySnapshot> {
+    stage
+        .dummies
+        .iter()
+        .map(|dummy| (dummy.key.clone(), dummy))
+        .collect()
+}
+
+fn dummy_changed(before: &TraceDummySnapshot, after: &TraceDummySnapshot) -> bool {
+    before.rank != after.rank || before.order != after.order
+}
+
+fn node_rank_changed(before: &TraceNodeSnapshot, after: &TraceNodeSnapshot) -> bool {
+    before.rank != after.rank
+}
+
+fn node_order_changed(before: &TraceNodeSnapshot, after: &TraceNodeSnapshot) -> bool {
+    before.order != after.order
+}
+
+fn node_position_changed(before: &TraceNodeSnapshot, after: &TraceNodeSnapshot) -> bool {
+    coordinate_changed(before.x, after.x) || coordinate_changed(before.y, after.y)
+}
+
+fn coordinate_changed(before: Option<f64>, after: Option<f64>) -> bool {
+    match (before, after) {
+        (Some(before), Some(after)) => (before - after).abs() > COORD_EPS,
+        _ => before != after,
+    }
+}
+
+#[test]
+fn phase_names_include_future_attribution_boundaries() {
+    assert_eq!(
+        [PhaseName::Acyclic, PhaseName::Normalize, PhaseName::Route].len(),
+        3
+    );
+}

--- a/src/internal_tests/layout_stability/proportionality.rs
+++ b/src/internal_tests/layout_stability/proportionality.rs
@@ -1,0 +1,933 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{mutations, render_surfaces, report, route_diagnostics};
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct InputMagnitude {
+    pub(crate) label_dimension: Option<LabelDimensionMagnitude>,
+    pub(crate) edge_insertion: Option<EdgeInsertionMagnitude>,
+    pub(crate) node_insertion: Option<NodeInsertionMagnitude>,
+    pub(crate) subgraph_change: Option<SubgraphChangeMagnitude>,
+}
+
+impl InputMagnitude {
+    pub(crate) fn non_zero_axes(&self) -> Vec<InputMagnitudeAxis> {
+        let mut axes = Vec::new();
+        if self
+            .label_dimension
+            .as_ref()
+            .is_some_and(LabelDimensionMagnitude::is_non_zero)
+        {
+            axes.push(InputMagnitudeAxis::LabelDimensionUnits);
+        }
+        if self
+            .edge_insertion
+            .as_ref()
+            .is_some_and(EdgeInsertionMagnitude::is_non_zero)
+        {
+            axes.push(InputMagnitudeAxis::EdgeInsertion);
+        }
+        if self
+            .node_insertion
+            .as_ref()
+            .is_some_and(NodeInsertionMagnitude::is_non_zero)
+        {
+            axes.push(InputMagnitudeAxis::NodeInsertionArea);
+        }
+        if self
+            .subgraph_change
+            .as_ref()
+            .is_some_and(SubgraphChangeMagnitude::is_non_zero)
+        {
+            axes.push(InputMagnitudeAxis::SubgraphChange);
+        }
+        axes
+    }
+
+    pub(crate) fn scalar_denominator(&self) -> Option<f64> {
+        match self.non_zero_axes().as_slice() {
+            [InputMagnitudeAxis::LabelDimensionUnits] => self
+                .label_dimension
+                .as_ref()
+                .map(|magnitude| magnitude.total_axis_delta),
+            [InputMagnitudeAxis::NodeInsertionArea] => self
+                .node_insertion
+                .as_ref()
+                .map(|magnitude| magnitude.bbox_area_added),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LabelDimensionMagnitude {
+    pub(crate) changed_labels: usize,
+    pub(crate) max_axis_delta: f64,
+    pub(crate) total_axis_delta: f64,
+}
+
+impl LabelDimensionMagnitude {
+    fn is_non_zero(&self) -> bool {
+        self.changed_labels > 0
+            || self.max_axis_delta.abs() > f64::EPSILON
+            || self.total_axis_delta.abs() > f64::EPSILON
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EdgeInsertionMagnitude {
+    pub(crate) semantic_added_edge_ids: Vec<String>,
+    pub(crate) route_input_added_edges: usize,
+}
+
+impl EdgeInsertionMagnitude {
+    fn is_non_zero(&self) -> bool {
+        !self.semantic_added_edge_ids.is_empty() || self.route_input_added_edges > 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct NodeInsertionMagnitude {
+    pub(crate) added_node_ids: Vec<String>,
+    pub(crate) bbox_area_added: f64,
+}
+
+impl NodeInsertionMagnitude {
+    fn is_non_zero(&self) -> bool {
+        !self.added_node_ids.is_empty() || self.bbox_area_added.abs() > f64::EPSILON
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SubgraphChangeMagnitude {
+    pub(crate) membership_delta_count: usize,
+    pub(crate) direction_changed: bool,
+    pub(crate) scope_parent_id: Option<String>,
+}
+
+impl SubgraphChangeMagnitude {
+    fn is_non_zero(&self) -> bool {
+        self.membership_delta_count > 0 || self.direction_changed
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputMagnitudeAxis {
+    LabelDimensionUnits,
+    EdgeInsertion,
+    NodeInsertionArea,
+    SubgraphChange,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputMagnitudeBasis {
+    LabelDimensionUnits,
+    EdgeInsertionContext,
+    NodeInsertionArea,
+    SubgraphChange,
+    MultiAxis,
+    None,
+}
+
+impl InputMagnitudeBasis {
+    pub(crate) fn for_pair_id(pair_id: &str) -> Self {
+        match pair_id {
+            "M06" | "M14" | "S02" => Self::LabelDimensionUnits,
+            "M02" | "M03" | "M04" | "M11" | "M19" | "M20" | "M21" | "S01" => {
+                Self::EdgeInsertionContext
+            }
+            "M05-ID" => Self::NodeInsertionArea,
+            "M08" | "M09" | "M10" | "S04" => Self::SubgraphChange,
+            "M15" => Self::MultiAxis,
+            _ => Self::None,
+        }
+    }
+}
+
+pub(crate) fn pure_edge_control_pair_ids() -> [&'static str; 4] {
+    ["M04", "M19", "M20", "M21"]
+}
+
+pub(crate) fn node_plus_edge_control_pair_ids() -> [&'static str; 2] {
+    ["M02", "M03"]
+}
+
+pub(crate) fn input_magnitude_for_pair(
+    pair: &'static mutations::MutationPair,
+) -> Result<InputMagnitude, String> {
+    let rendered = render_surfaces::render_pair(pair)
+        .map_err(|error| format!("{} input magnitude render failed: {error}", pair.id))?;
+    let route_diagnostic = route_diagnostics::run_pair_route_diagnostics(pair)?;
+
+    Ok(InputMagnitude {
+        label_dimension: label_dimension_magnitude(&route_diagnostic.route_input_diff),
+        edge_insertion: edge_insertion_magnitude(pair, &route_diagnostic.route_input_diff),
+        node_insertion: node_insertion_magnitude(pair, &rendered),
+        subgraph_change: subgraph_change_magnitude(pair, &rendered),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PathOutputMagnitude {
+    pub(crate) edge_id: String,
+    pub(crate) signed_route_len_delta: f64,
+    pub(crate) abs_route_len_delta: f64,
+    pub(crate) bend_count_delta: isize,
+    pub(crate) abs_bend_count_delta: usize,
+    pub(crate) port_face_changed: bool,
+    pub(crate) endpoint_face_changed: bool,
+    pub(crate) endpoint_moved: bool,
+    pub(crate) decision_classes: Vec<route_diagnostics::RouteDecisionClass>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteOutputMagnitudeSummary {
+    pub(crate) changed_path_count: usize,
+    pub(crate) signed_route_len_delta_sum: f64,
+    pub(crate) sum_abs_route_len_delta: f64,
+    pub(crate) median_abs_route_len_delta: f64,
+    pub(crate) p75_abs_route_len_delta: f64,
+    pub(crate) max_abs_route_len_delta: f64,
+    pub(crate) abs_bend_count_delta_sum: usize,
+    pub(crate) port_face_change_count: usize,
+    pub(crate) endpoint_face_change_count: usize,
+    pub(crate) layout_amplified_path_count: usize,
+}
+
+impl RouteOutputMagnitudeSummary {
+    pub(crate) fn from_abs_lengths(lengths: Vec<f64>) -> Self {
+        Self::from_paths(
+            lengths
+                .into_iter()
+                .enumerate()
+                .map(|(index, length)| PathOutputMagnitude {
+                    edge_id: format!("path-{index}"),
+                    signed_route_len_delta: length,
+                    abs_route_len_delta: length.abs(),
+                    bend_count_delta: 0,
+                    abs_bend_count_delta: 0,
+                    port_face_changed: false,
+                    endpoint_face_changed: false,
+                    endpoint_moved: false,
+                    decision_classes: Vec::new(),
+                })
+                .collect(),
+        )
+    }
+
+    pub(crate) fn from_paths(paths: Vec<PathOutputMagnitude>) -> Self {
+        if paths.is_empty() {
+            return Self {
+                changed_path_count: 0,
+                signed_route_len_delta_sum: 0.0,
+                sum_abs_route_len_delta: 0.0,
+                median_abs_route_len_delta: 0.0,
+                p75_abs_route_len_delta: 0.0,
+                max_abs_route_len_delta: 0.0,
+                abs_bend_count_delta_sum: 0,
+                port_face_change_count: 0,
+                endpoint_face_change_count: 0,
+                layout_amplified_path_count: 0,
+            };
+        }
+
+        let mut abs_lengths = paths
+            .iter()
+            .map(|path| path.abs_route_len_delta)
+            .collect::<Vec<_>>();
+        abs_lengths.sort_by(f64::total_cmp);
+
+        Self {
+            changed_path_count: paths.len(),
+            signed_route_len_delta_sum: paths.iter().map(|path| path.signed_route_len_delta).sum(),
+            sum_abs_route_len_delta: abs_lengths.iter().sum(),
+            median_abs_route_len_delta: nearest_rank(&abs_lengths, 0.5),
+            p75_abs_route_len_delta: nearest_rank(&abs_lengths, 0.75),
+            max_abs_route_len_delta: *abs_lengths.last().unwrap_or(&0.0),
+            abs_bend_count_delta_sum: paths.iter().map(|path| path.abs_bend_count_delta).sum(),
+            port_face_change_count: paths.iter().filter(|path| path.port_face_changed).count(),
+            endpoint_face_change_count: paths
+                .iter()
+                .filter(|path| path.endpoint_face_changed)
+                .count(),
+            layout_amplified_path_count: paths.iter().filter(|path| path.endpoint_moved).count(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProportionalityClass {
+    Proportionate,
+    Disproportionate,
+    Mixed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CalibrationSource {
+    Seeded,
+    ControlDerived,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CalibrationProfile {
+    pub(crate) label_ratio_proportionate_max: f64,
+    pub(crate) label_ratio_disproportionate_min: f64,
+    pub(crate) event_control_p75_abs_route_len_delta: Option<f64>,
+    pub(crate) source: CalibrationSource,
+    pub(crate) control_pair_ids: Vec<&'static str>,
+}
+
+impl CalibrationProfile {
+    pub(crate) fn seeded() -> Self {
+        Self {
+            label_ratio_proportionate_max: 2.0,
+            label_ratio_disproportionate_min: 3.0,
+            event_control_p75_abs_route_len_delta: None,
+            source: CalibrationSource::Seeded,
+            control_pair_ids: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ProportionalitySummary {
+    pub(crate) pair_id: &'static str,
+    pub(crate) basis: InputMagnitudeBasis,
+    pub(crate) input: InputMagnitude,
+    pub(crate) output: RouteOutputMagnitudeSummary,
+    pub(crate) aggregate_ratio: Option<f64>,
+    pub(crate) max_path_ratio: Option<f64>,
+    pub(crate) classification: Option<ProportionalityClass>,
+}
+
+impl ProportionalitySummary {
+    pub(crate) fn from_parts(
+        pair_id: &'static str,
+        basis: InputMagnitudeBasis,
+        input: InputMagnitude,
+        output: RouteOutputMagnitudeSummary,
+    ) -> Result<Self, String> {
+        let (aggregate_ratio, max_path_ratio) = match basis {
+            InputMagnitudeBasis::LabelDimensionUnits => {
+                let denominator = input.scalar_denominator().ok_or_else(|| {
+                    format!("{pair_id} label dimension summary needs a non-zero denominator")
+                })?;
+                if denominator.abs() <= f64::EPSILON {
+                    return Err(format!(
+                        "{pair_id} label dimension summary needs a non-zero denominator"
+                    ));
+                }
+                (
+                    Some(output.sum_abs_route_len_delta / denominator),
+                    Some(output.max_abs_route_len_delta / denominator),
+                )
+            }
+            _ => (None, None),
+        };
+
+        Ok(Self {
+            pair_id,
+            basis,
+            input,
+            output,
+            aggregate_ratio,
+            max_path_ratio,
+            classification: None,
+        })
+    }
+}
+
+pub(crate) fn classify_label_ratio(
+    aggregate_ratio: f64,
+    max_path_ratio: f64,
+    calibration: &CalibrationProfile,
+) -> ProportionalityClass {
+    if aggregate_ratio <= calibration.label_ratio_proportionate_max
+        && max_path_ratio <= calibration.label_ratio_proportionate_max
+    {
+        ProportionalityClass::Proportionate
+    } else if aggregate_ratio >= calibration.label_ratio_disproportionate_min
+        || max_path_ratio >= calibration.label_ratio_disproportionate_min
+    {
+        ProportionalityClass::Disproportionate
+    } else {
+        ProportionalityClass::Mixed
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ControlCalibrationPoint {
+    pub(crate) pair_id: &'static str,
+    pub(crate) p75_abs_route_len_delta: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PureEdgeClusterSummary {
+    pub(crate) control_pair_ids: Vec<&'static str>,
+    pub(crate) p75_min: f64,
+    pub(crate) p75_max: f64,
+    pub(crate) spread_ratio: Option<f64>,
+    pub(crate) status: PureEdgeClusterStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PureEdgeClusterStatus {
+    OneCluster,
+    Split { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ControlCalibrationStatus {
+    Consistent,
+    Inconsistent { reason: String },
+}
+
+pub(crate) fn control_calibration_status(
+    controls: &[ControlCalibrationPoint],
+) -> ControlCalibrationStatus {
+    let Some((min, max, _spread_ratio)) = p75_spread(controls) else {
+        return ControlCalibrationStatus::Consistent;
+    };
+    let non_zero = non_zero_p75_controls(controls);
+    if non_zero.len() < 2 {
+        return ControlCalibrationStatus::Consistent;
+    }
+
+    if max / min <= 4.0 {
+        ControlCalibrationStatus::Consistent
+    } else {
+        let pair_ids = non_zero
+            .iter()
+            .map(|control| control.pair_id)
+            .collect::<Vec<_>>()
+            .join(", ");
+        ControlCalibrationStatus::Inconsistent {
+            reason: format!(
+                "control p75 spread is too wide for one event threshold ({pair_ids}: {min:.2}..{max:.2})"
+            ),
+        }
+    }
+}
+
+pub(crate) fn pure_edge_cluster_status(
+    controls: &[ControlCalibrationPoint],
+) -> PureEdgeClusterStatus {
+    let Some((min, max, _spread_ratio)) = p75_spread(controls) else {
+        return PureEdgeClusterStatus::OneCluster;
+    };
+
+    if max / min <= 4.0 {
+        PureEdgeClusterStatus::OneCluster
+    } else {
+        let pair_ids = controls
+            .iter()
+            .filter(|control| control.p75_abs_route_len_delta > f64::EPSILON)
+            .map(|control| control.pair_id)
+            .collect::<Vec<_>>()
+            .join(", ");
+        PureEdgeClusterStatus::Split {
+            reason: format!(
+                "pure-edge control p75 spread is too wide for one cluster ({pair_ids}: {min:.2}..{max:.2})"
+            ),
+        }
+    }
+}
+
+fn pure_edge_cluster_summary(
+    controls: &[ControlCalibrationPoint],
+) -> Option<PureEdgeClusterSummary> {
+    if controls.is_empty() {
+        return None;
+    }
+
+    let (p75_min, p75_max, spread_ratio) = p75_spread(controls).unwrap_or((0.0, 0.0, None));
+
+    Some(PureEdgeClusterSummary {
+        control_pair_ids: controls.iter().map(|control| control.pair_id).collect(),
+        p75_min,
+        p75_max,
+        spread_ratio,
+        status: pure_edge_cluster_status(controls),
+    })
+}
+
+fn p75_spread(controls: &[ControlCalibrationPoint]) -> Option<(f64, f64, Option<f64>)> {
+    let non_zero = non_zero_p75_controls(controls);
+    if non_zero.is_empty() {
+        return None;
+    }
+
+    let min = non_zero
+        .iter()
+        .map(|control| control.p75_abs_route_len_delta)
+        .min_by(f64::total_cmp)
+        .unwrap_or(0.0);
+    let max = non_zero
+        .iter()
+        .map(|control| control.p75_abs_route_len_delta)
+        .max_by(f64::total_cmp)
+        .unwrap_or(0.0);
+    let spread_ratio = (min > f64::EPSILON).then_some(max / min);
+
+    Some((min, max, spread_ratio))
+}
+
+fn non_zero_p75_controls(controls: &[ControlCalibrationPoint]) -> Vec<&ControlCalibrationPoint> {
+    controls
+        .iter()
+        .filter(|control| control.p75_abs_route_len_delta > f64::EPSILON)
+        .collect()
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteProportionalityReport {
+    pub(crate) calibration: CalibrationProfile,
+    pub(crate) control_calibration_status: ControlCalibrationStatus,
+    pub(crate) pure_edge_cluster: Option<PureEdgeClusterSummary>,
+    pub(crate) summaries: Vec<CanaryProportionalitySummary>,
+}
+
+impl RouteProportionalityReport {
+    pub(crate) fn summary_for(&self, pair_id: &str) -> Option<&CanaryProportionalitySummary> {
+        self.summaries
+            .iter()
+            .find(|summary| summary.pair_id == pair_id)
+    }
+
+    pub(crate) fn summary(&self) -> String {
+        let control_status = match &self.control_calibration_status {
+            ControlCalibrationStatus::Consistent => "consistent".to_string(),
+            ControlCalibrationStatus::Inconsistent { reason } => {
+                format!("inconsistent ({reason})")
+            }
+        };
+        let mut lines = vec![format!(
+            "calibration_source={:?}; label_ratio_proportionate_max={:.2}; label_ratio_disproportionate_min={:.2}; event_control_p75_abs_route_len_delta={:?}; control_calibration_status={control_status}",
+            self.calibration.source,
+            self.calibration.label_ratio_proportionate_max,
+            self.calibration.label_ratio_disproportionate_min,
+            self.calibration.event_control_p75_abs_route_len_delta,
+        )];
+
+        for summary in &self.summaries {
+            lines.push(format!(
+                "{}: basis={:?}; changed_paths={}; sum_abs_route_len_delta={:.2}; p75_abs_route_len_delta={:.2}; max_abs_route_len_delta={:.2}; aggregate_ratio={:?}; max_path_ratio={:?}; classification={:?}; classification_reason={:?}; additive_path_shape_count={:?}; label_geometry_overlap_count={:?}",
+                summary.pair_id,
+                summary.basis,
+                summary.output.changed_path_count,
+                summary.output.sum_abs_route_len_delta,
+                summary.output.p75_abs_route_len_delta,
+                summary.output.max_abs_route_len_delta,
+                summary.aggregate_ratio,
+                summary.max_path_ratio,
+                summary.classification,
+                summary.classification_reason,
+                summary.additive_path_shape_count,
+                summary.label_geometry_overlap_count,
+            ));
+        }
+
+        lines.join("\n")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CanaryProportionalitySummary {
+    pub(crate) pair_id: &'static str,
+    pub(crate) basis: InputMagnitudeBasis,
+    pub(crate) input: InputMagnitude,
+    pub(crate) output: RouteOutputMagnitudeSummary,
+    pub(crate) aggregate_ratio: Option<f64>,
+    pub(crate) max_path_ratio: Option<f64>,
+    pub(crate) classification: Option<ProportionalityClass>,
+    pub(crate) classification_reason: Option<String>,
+    pub(crate) additive_path_shape_count: Option<usize>,
+    pub(crate) label_geometry_overlap_count: Option<usize>,
+}
+
+pub(crate) fn run_route_proportionality_report() -> Result<RouteProportionalityReport, String> {
+    let primary_pair_ids = ["M14", "M11"];
+    let mut control_points = Vec::new();
+    let mut pure_edge_points = Vec::new();
+    let mut summaries = Vec::new();
+
+    for pair_id in node_plus_edge_control_pair_ids() {
+        let pair =
+            mutations::pair_by_id(pair_id).ok_or_else(|| format!("unknown pair id {pair_id}"))?;
+        let output = route_output_magnitude_for_pair(pair)?;
+        control_points.push(ControlCalibrationPoint {
+            pair_id,
+            p75_abs_route_len_delta: output.summary.p75_abs_route_len_delta,
+        });
+        summaries.push(summary_for_pair(
+            pair,
+            output,
+            &CalibrationProfile::seeded(),
+            None,
+        )?);
+    }
+
+    for pair_id in pure_edge_control_pair_ids() {
+        let pair =
+            mutations::pair_by_id(pair_id).ok_or_else(|| format!("unknown pair id {pair_id}"))?;
+        let output = route_output_magnitude_for_pair(pair)?;
+        let control_point = ControlCalibrationPoint {
+            pair_id,
+            p75_abs_route_len_delta: output.summary.p75_abs_route_len_delta,
+        };
+        control_points.push(control_point.clone());
+        pure_edge_points.push(control_point);
+        summaries.push(summary_for_pair(
+            pair,
+            output,
+            &CalibrationProfile::seeded(),
+            None,
+        )?);
+    }
+
+    let control_calibration_status = control_calibration_status(&control_points);
+    let pure_edge_cluster = pure_edge_cluster_summary(&pure_edge_points);
+    let calibration = CalibrationProfile::seeded();
+
+    for pair_id in primary_pair_ids {
+        let pair =
+            mutations::pair_by_id(pair_id).ok_or_else(|| format!("unknown pair id {pair_id}"))?;
+        let output = route_output_magnitude_for_pair(pair)?;
+        summaries.push(summary_for_pair(
+            pair,
+            output,
+            &calibration,
+            pure_edge_cluster.as_ref(),
+        )?);
+    }
+
+    summaries.sort_by_key(|summary| summary.pair_id);
+
+    Ok(RouteProportionalityReport {
+        calibration,
+        control_calibration_status,
+        pure_edge_cluster,
+        summaries,
+    })
+}
+
+fn summary_for_pair(
+    pair: &'static mutations::MutationPair,
+    output: RouteOutputMagnitude,
+    calibration: &CalibrationProfile,
+    pure_edge_cluster: Option<&PureEdgeClusterSummary>,
+) -> Result<CanaryProportionalitySummary, String> {
+    let basis = InputMagnitudeBasis::for_pair_id(pair.id);
+    let input = input_magnitude_for_pair(pair)?;
+    let proportionality =
+        ProportionalitySummary::from_parts(pair.id, basis, input.clone(), output.summary.clone())?;
+    let diagnostic = route_diagnostics::run_pair_route_diagnostics(pair)?;
+    let additive_path_shape_count =
+        output.decision_edge_count(route_diagnostics::RouteDecisionClass::PathShape);
+    let (classification, classification_reason) =
+        classify_summary(&proportionality, calibration, pure_edge_cluster);
+
+    Ok(CanaryProportionalitySummary {
+        pair_id: pair.id,
+        basis,
+        input,
+        output: output.summary,
+        aggregate_ratio: proportionality.aggregate_ratio,
+        max_path_ratio: proportionality.max_path_ratio,
+        classification,
+        classification_reason,
+        additive_path_shape_count: Some(additive_path_shape_count),
+        label_geometry_overlap_count: diagnostic
+            .path_shape_correlation
+            .as_ref()
+            .map(|correlation| correlation.overlap_count),
+    })
+}
+
+fn classify_summary(
+    summary: &ProportionalitySummary,
+    calibration: &CalibrationProfile,
+    pure_edge_cluster: Option<&PureEdgeClusterSummary>,
+) -> (Option<ProportionalityClass>, Option<String>) {
+    match summary.basis {
+        InputMagnitudeBasis::LabelDimensionUnits => (
+            Some(classify_label_ratio(
+                summary.aggregate_ratio.unwrap_or_default(),
+                summary.max_path_ratio.unwrap_or_default(),
+                calibration,
+            )),
+            None,
+        ),
+        InputMagnitudeBasis::EdgeInsertionContext if summary.pair_id == "M11" => {
+            classify_edge_insertion_context(summary, pure_edge_cluster)
+        }
+        _ => (None, None),
+    }
+}
+
+fn classify_edge_insertion_context(
+    summary: &ProportionalitySummary,
+    pure_edge_cluster: Option<&PureEdgeClusterSummary>,
+) -> (Option<ProportionalityClass>, Option<String>) {
+    let Some(cluster) = pure_edge_cluster else {
+        return (
+            None,
+            Some("pure-edge cluster unavailable for M11 classification".to_string()),
+        );
+    };
+
+    match &cluster.status {
+        PureEdgeClusterStatus::OneCluster => {
+            let p75 = summary.output.p75_abs_route_len_delta;
+            if p75 <= cluster.p75_max {
+                (Some(ProportionalityClass::Proportionate), None)
+            } else if p75 > cluster.p75_max * 4.0 {
+                (Some(ProportionalityClass::Disproportionate), None)
+            } else {
+                (Some(ProportionalityClass::Mixed), None)
+            }
+        }
+        PureEdgeClusterStatus::Split { reason } => (
+            None,
+            Some(format!(
+                "pure-edge cluster split; sub-band classification needs at least two matching controls ({reason})"
+            )),
+        ),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteOutputMagnitude {
+    pub(crate) paths: Vec<PathOutputMagnitude>,
+    pub(crate) summary: RouteOutputMagnitudeSummary,
+}
+
+impl RouteOutputMagnitude {
+    pub(crate) fn decision_edge_count(
+        &self,
+        class: route_diagnostics::RouteDecisionClass,
+    ) -> usize {
+        self.paths
+            .iter()
+            .filter(|path| path.decision_classes.contains(&class))
+            .count()
+    }
+}
+
+pub(crate) fn route_output_magnitude_for_pair(
+    pair: &'static mutations::MutationPair,
+) -> Result<RouteOutputMagnitude, String> {
+    let report = report::run_pair(pair).map_err(|error| error.to_string())?;
+    let route_diagnostic = route_diagnostics::run_pair_route_diagnostics(pair)?;
+    let port_face_changes = report
+        .routed
+        .port_intent_changes
+        .iter()
+        .map(|delta| delta.edge_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let endpoint_face_changes = report
+        .routed
+        .endpoint_face_changes
+        .iter()
+        .map(|delta| delta.edge_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let layout_amplified_paths = report
+        .phase_attribution()
+        .route
+        .layout_amplified_paths
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+
+    let mut paths = report
+        .routed
+        .path_metrics
+        .iter()
+        .filter(|metric| metric.geometry_changed())
+        .map(|metric| PathOutputMagnitude {
+            edge_id: metric.edge_id.clone(),
+            signed_route_len_delta: metric.length_delta,
+            abs_route_len_delta: metric.length_delta.abs(),
+            bend_count_delta: metric.bend_count_delta,
+            abs_bend_count_delta: metric.bend_count_delta.unsigned_abs(),
+            port_face_changed: port_face_changes.contains(metric.edge_id.as_str()),
+            endpoint_face_changed: endpoint_face_changes.contains(metric.edge_id.as_str()),
+            endpoint_moved: layout_amplified_paths.contains(metric.edge_id.as_str()),
+            decision_classes: route_diagnostic
+                .route_decisions
+                .by_edge
+                .get(&metric.edge_id)
+                .map(|decision| decision.classes.clone())
+                .unwrap_or_default(),
+        })
+        .collect::<Vec<_>>();
+    paths.sort_by(|a, b| a.edge_id.cmp(&b.edge_id));
+    let summary = RouteOutputMagnitudeSummary::from_paths(paths.clone());
+
+    Ok(RouteOutputMagnitude { paths, summary })
+}
+
+fn nearest_rank(sorted_values: &[f64], percentile: f64) -> f64 {
+    if sorted_values.is_empty() {
+        return 0.0;
+    }
+    let rank = (percentile.clamp(0.0, 1.0) * sorted_values.len() as f64).ceil() as usize;
+    let index = rank.saturating_sub(1).min(sorted_values.len() - 1);
+    sorted_values[index]
+}
+
+fn label_dimension_magnitude(
+    route_input_diff: &route_diagnostics::RouteInputDiff,
+) -> Option<LabelDimensionMagnitude> {
+    let mut max_axis_delta = 0.0_f64;
+    let mut total_axis_delta = 0.0_f64;
+    for delta in &route_input_diff.changed_labels {
+        let axis_delta = delta.width_delta.abs().max(delta.height_delta.abs());
+        max_axis_delta = max_axis_delta.max(axis_delta);
+        total_axis_delta += axis_delta;
+    }
+
+    (!route_input_diff.changed_labels.is_empty()).then_some(LabelDimensionMagnitude {
+        changed_labels: route_input_diff.changed_labels.len(),
+        max_axis_delta,
+        total_axis_delta,
+    })
+}
+
+fn edge_insertion_magnitude(
+    pair: &mutations::MutationPair,
+    route_input_diff: &route_diagnostics::RouteInputDiff,
+) -> Option<EdgeInsertionMagnitude> {
+    let mut semantic_added_edge_ids = if pair
+        .expected_changes
+        .contains(&mutations::SemanticChangeKind::EdgeAdded)
+    {
+        pair.direct_edges
+            .iter()
+            .map(|id| (*id).to_string())
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    semantic_added_edge_ids.sort();
+
+    let magnitude = EdgeInsertionMagnitude {
+        semantic_added_edge_ids,
+        route_input_added_edges: route_input_diff.added_edges.len(),
+    };
+
+    magnitude.is_non_zero().then_some(magnitude)
+}
+
+fn node_insertion_magnitude(
+    pair: &mutations::MutationPair,
+    rendered: &render_surfaces::RenderedPair,
+) -> Option<NodeInsertionMagnitude> {
+    if !pair
+        .expected_changes
+        .contains(&mutations::SemanticChangeKind::NodeAdded)
+    {
+        return None;
+    }
+
+    let before_node_ids = rendered
+        .before
+        .layout_mmds
+        .nodes
+        .iter()
+        .map(|node| node.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut added_node_ids = Vec::new();
+    let mut bbox_area_added = 0.0;
+
+    for node in &rendered.after.layout_mmds.nodes {
+        if before_node_ids.contains(node.id.as_str()) {
+            continue;
+        }
+        added_node_ids.push(node.id.clone());
+        bbox_area_added += node.size.width * node.size.height;
+    }
+    added_node_ids.sort();
+
+    let magnitude = NodeInsertionMagnitude {
+        added_node_ids,
+        bbox_area_added,
+    };
+
+    magnitude.is_non_zero().then_some(magnitude)
+}
+
+fn subgraph_change_magnitude(
+    pair: &mutations::MutationPair,
+    rendered: &render_surfaces::RenderedPair,
+) -> Option<SubgraphChangeMagnitude> {
+    if !pair.expected_changes.iter().any(|change| {
+        matches!(
+            change,
+            mutations::SemanticChangeKind::SubgraphAdded
+                | mutations::SemanticChangeKind::SubgraphMembershipChanged
+                | mutations::SemanticChangeKind::SubgraphDirectionChanged
+        )
+    }) {
+        return None;
+    }
+
+    let before = rendered
+        .before
+        .layout_mmds
+        .subgraphs
+        .iter()
+        .map(|subgraph| (subgraph.id.as_str(), subgraph))
+        .collect::<BTreeMap<_, _>>();
+    let after = rendered
+        .after
+        .layout_mmds
+        .subgraphs
+        .iter()
+        .map(|subgraph| (subgraph.id.as_str(), subgraph))
+        .collect::<BTreeMap<_, _>>();
+    let ids = before
+        .keys()
+        .chain(after.keys())
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut membership_delta_count = 0;
+    let mut direction_changed = false;
+    let mut scope_parent_id = None;
+
+    for id in ids {
+        let before_subgraph = before.get(id).copied();
+        let after_subgraph = after.get(id).copied();
+        let before_children = before_subgraph
+            .map(|subgraph| sorted_strings(&subgraph.children))
+            .unwrap_or_default();
+        let after_children = after_subgraph
+            .map(|subgraph| sorted_strings(&subgraph.children))
+            .unwrap_or_default();
+        if before_children != after_children {
+            membership_delta_count += before_children.len().abs_diff(after_children.len()).max(1);
+        }
+        let before_direction = before_subgraph.and_then(|subgraph| subgraph.direction.as_ref());
+        let after_direction = after_subgraph.and_then(|subgraph| subgraph.direction.as_ref());
+        direction_changed |= before_direction != after_direction;
+        if scope_parent_id.is_none() {
+            scope_parent_id = after_subgraph
+                .and_then(|subgraph| subgraph.parent.clone())
+                .or_else(|| before_subgraph.and_then(|subgraph| subgraph.parent.clone()));
+        }
+    }
+
+    let magnitude = SubgraphChangeMagnitude {
+        membership_delta_count,
+        direction_changed,
+        scope_parent_id,
+    };
+
+    magnitude.is_non_zero().then_some(magnitude)
+}
+
+fn sorted_strings(values: &[String]) -> Vec<String> {
+    let mut sorted = values.to_vec();
+    sorted.sort();
+    sorted
+}

--- a/src/internal_tests/layout_stability/render_metrics.rs
+++ b/src/internal_tests/layout_stability/render_metrics.rs
@@ -1,0 +1,126 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RenderChurnClass {
+    NoMeaningfulChange,
+    BoundsOnly,
+    StyleOnly,
+    RouteTopologyChanged,
+    LabelRectChanged,
+    EndpointFaceChanged,
+    TextGridQuantizationOrGlyphChurn,
+    Mixed,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct RenderMetricDelta {
+    pub(crate) svg_viewbox_changed: bool,
+    pub(crate) svg_path_count_changed: bool,
+    pub(crate) path_topology_changed: bool,
+    pub(crate) label_rect_changed: bool,
+    pub(crate) endpoint_face_changed: bool,
+    /// Style-only canaries should use default/lossless routed MMDS when this
+    /// boolean comes from route churn, not the diagnostic `None` surface.
+    pub(crate) style_only_changed: bool,
+    pub(crate) text_dimensions_changed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TextSurfaceMetrics {
+    pub(crate) line_count: usize,
+    pub(crate) max_line_width: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct SvgSurfaceMetrics {
+    pub(crate) viewbox_width: Option<f64>,
+    pub(crate) viewbox_height: Option<f64>,
+    pub(crate) path_count: usize,
+}
+
+pub(crate) fn classify_render_churn(delta: &RenderMetricDelta) -> RenderChurnClass {
+    let route_changed = delta.path_topology_changed || delta.svg_path_count_changed;
+    let real_change_count = [
+        route_changed,
+        delta.label_rect_changed,
+        delta.endpoint_face_changed,
+        delta.style_only_changed,
+        delta.text_dimensions_changed,
+    ]
+    .into_iter()
+    .filter(|changed| *changed)
+    .count();
+
+    if real_change_count > 1 {
+        return RenderChurnClass::Mixed;
+    }
+    if route_changed {
+        return RenderChurnClass::RouteTopologyChanged;
+    }
+    if delta.label_rect_changed {
+        return RenderChurnClass::LabelRectChanged;
+    }
+    if delta.endpoint_face_changed {
+        return RenderChurnClass::EndpointFaceChanged;
+    }
+    if delta.style_only_changed {
+        return RenderChurnClass::StyleOnly;
+    }
+    if delta.text_dimensions_changed {
+        return RenderChurnClass::TextGridQuantizationOrGlyphChurn;
+    }
+    if delta.svg_viewbox_changed {
+        return RenderChurnClass::BoundsOnly;
+    }
+
+    RenderChurnClass::NoMeaningfulChange
+}
+
+pub(crate) fn collect_text_metrics(text: &str) -> TextSurfaceMetrics {
+    let mut line_count = 0;
+    let mut max_line_width = 0;
+    for line in text.lines() {
+        line_count += 1;
+        max_line_width = max_line_width.max(line.chars().count());
+    }
+
+    TextSurfaceMetrics {
+        line_count,
+        max_line_width,
+    }
+}
+
+pub(crate) fn collect_svg_metrics(svg: &str) -> SvgSurfaceMetrics {
+    let (viewbox_width, viewbox_height) = parse_viewbox_dimensions(svg).unwrap_or((None, None));
+
+    SvgSurfaceMetrics {
+        viewbox_width,
+        viewbox_height,
+        path_count: svg.matches("<path").count(),
+    }
+}
+
+fn parse_viewbox_dimensions(svg: &str) -> Option<(Option<f64>, Option<f64>)> {
+    let value = attribute_value(svg, "viewBox")?;
+    let parts = value
+        .split_ascii_whitespace()
+        .filter_map(|part| part.parse::<f64>().ok())
+        .collect::<Vec<_>>();
+    if parts.len() == 4 {
+        Some((Some(parts[2]), Some(parts[3])))
+    } else {
+        Some((None, None))
+    }
+}
+
+fn attribute_value<'a>(input: &'a str, name: &str) -> Option<&'a str> {
+    let start = input.find(name)?;
+    let after_name = &input[start + name.len()..];
+    let equals = after_name.find('=')?;
+    let after_equals = after_name[equals + 1..].trim_start();
+    let quote = after_equals.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let value_start = quote.len_utf8();
+    let value_end = after_equals[value_start..].find(quote)?;
+    Some(&after_equals[value_start..value_start + value_end])
+}

--- a/src/internal_tests/layout_stability/render_surfaces.rs
+++ b/src/internal_tests/layout_stability/render_surfaces.rs
@@ -1,0 +1,229 @@
+use std::path::{Path, PathBuf};
+use std::{fmt, fs};
+
+use super::mutations;
+use crate::engines::graph::algorithms::layered::kernel::trace::{self, LayeredPhaseTrace};
+use crate::graph::GeometryLevel;
+use crate::graph::routing::trace::{self as route_trace, RoutingTrace};
+use crate::simplification::PathSimplification;
+use crate::{OutputFormat, RenderConfig, mmds, render_diagram};
+
+#[derive(Debug)]
+pub(crate) struct RenderedDiagram {
+    pub(crate) source: String,
+    pub(crate) text: String,
+    pub(crate) svg: String,
+    pub(crate) layout_mmds: mmds::Output,
+    pub(crate) routed_mmds: mmds::Output,
+    pub(crate) phase_trace: LayeredPhaseTrace,
+    pub(crate) route_trace: RoutingTrace,
+}
+
+#[derive(Debug)]
+pub(crate) struct RenderedPair {
+    pub(crate) before: RenderedDiagram,
+    pub(crate) after: RenderedDiagram,
+}
+
+#[derive(Debug)]
+pub(crate) enum RenderSurfaceError {
+    Source {
+        pair_id: &'static str,
+        side: &'static str,
+        path: PathBuf,
+        message: String,
+    },
+    Render {
+        pair_id: &'static str,
+        side: &'static str,
+        surface: &'static str,
+        message: String,
+    },
+    MmdsParse {
+        pair_id: &'static str,
+        side: &'static str,
+        geometry_level: GeometryLevel,
+        message: String,
+    },
+}
+
+impl fmt::Display for RenderSurfaceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RenderSurfaceError::Source {
+                pair_id,
+                side,
+                path,
+                message,
+            } => write!(
+                f,
+                "failed to resolve {side} source for {pair_id} from {}: {message}",
+                path.display()
+            ),
+            RenderSurfaceError::Render {
+                pair_id,
+                side,
+                surface,
+                message,
+            } => write!(
+                f,
+                "failed to render {surface} surface for {pair_id} {side}: {message}"
+            ),
+            RenderSurfaceError::MmdsParse {
+                pair_id,
+                side,
+                geometry_level,
+                message,
+            } => write!(
+                f,
+                "failed to parse {geometry_level} MMDS for {pair_id} {side}: {message}"
+            ),
+        }
+    }
+}
+
+pub(crate) fn render_pair(
+    pair: &mutations::MutationPair,
+) -> Result<RenderedPair, RenderSurfaceError> {
+    let before_source = resolve_input(pair.id, "before", pair.base)?;
+    let after_source = resolve_input(pair.id, "after", pair.mutated)?;
+
+    Ok(RenderedPair {
+        before: render_input_with_context(pair.id, "before", &before_source)?,
+        after: render_input_with_context(pair.id, "after", &after_source)?,
+    })
+}
+
+pub(crate) fn render_lossless_routed_mmds(
+    source: &str,
+) -> Result<(String, mmds::Output), RenderSurfaceError> {
+    render_mmds_with_simplification(
+        "<direct>",
+        "input",
+        source,
+        GeometryLevel::Routed,
+        PathSimplification::Lossless,
+    )
+}
+
+fn render_input_with_context(
+    pair_id: &'static str,
+    side: &'static str,
+    source: &str,
+) -> Result<RenderedDiagram, RenderSurfaceError> {
+    let text = render_surface(
+        pair_id,
+        side,
+        "text",
+        source,
+        OutputFormat::Text,
+        &default_config(),
+    )?;
+    let svg = render_surface(
+        pair_id,
+        side,
+        "svg",
+        source,
+        OutputFormat::Svg,
+        &default_config(),
+    )?;
+    let (_, layout_mmds) = render_mmds_with_simplification(
+        pair_id,
+        side,
+        source,
+        GeometryLevel::Layout,
+        PathSimplification::None,
+    )?;
+    trace::begin_capture();
+    route_trace::begin_capture();
+    let routed_result = render_mmds_with_simplification(
+        pair_id,
+        side,
+        source,
+        GeometryLevel::Routed,
+        PathSimplification::None,
+    );
+    let phase_trace = trace::finish_capture();
+    let route_trace = route_trace::finish_capture();
+    let (_, routed_mmds) = routed_result?;
+
+    Ok(RenderedDiagram {
+        source: source.to_string(),
+        text,
+        svg,
+        layout_mmds,
+        routed_mmds,
+        phase_trace,
+        route_trace,
+    })
+}
+
+fn render_mmds_with_simplification(
+    pair_id: &'static str,
+    side: &'static str,
+    source: &str,
+    geometry_level: GeometryLevel,
+    path_simplification: PathSimplification,
+) -> Result<(String, mmds::Output), RenderSurfaceError> {
+    let config = RenderConfig {
+        geometry_level,
+        path_simplification,
+        ..RenderConfig::default()
+    };
+    let json = render_surface(pair_id, side, "mmds", source, OutputFormat::Mmds, &config)?;
+    let output = mmds::parse_input(&json).map_err(|error| RenderSurfaceError::MmdsParse {
+        pair_id,
+        side,
+        geometry_level,
+        message: error.to_string(),
+    })?;
+
+    Ok((json, output))
+}
+
+fn render_surface(
+    pair_id: &'static str,
+    side: &'static str,
+    surface: &'static str,
+    source: &str,
+    format: OutputFormat,
+    config: &RenderConfig,
+) -> Result<String, RenderSurfaceError> {
+    render_diagram(source, format, config).map_err(|error| RenderSurfaceError::Render {
+        pair_id,
+        side,
+        surface,
+        message: error.to_string(),
+    })
+}
+
+fn resolve_input(
+    pair_id: &'static str,
+    side: &'static str,
+    input: mutations::MutationInput,
+) -> Result<String, RenderSurfaceError> {
+    match input {
+        mutations::MutationInput::Inline(source) => Ok(source.to_string()),
+        mutations::MutationInput::Fixture { family, name } => {
+            let path = fixture_path(family, name);
+            fs::read_to_string(&path).map_err(|error| RenderSurfaceError::Source {
+                pair_id,
+                side,
+                path,
+                message: error.to_string(),
+            })
+        }
+    }
+}
+
+fn fixture_path(family: &str, name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(family)
+        .join(name)
+}
+
+fn default_config() -> RenderConfig {
+    RenderConfig::default()
+}

--- a/src/internal_tests/layout_stability/report.rs
+++ b/src/internal_tests/layout_stability/report.rs
@@ -1,0 +1,319 @@
+use std::collections::BTreeSet;
+use std::fmt;
+
+use super::mmds_metrics::{self, LayoutMmdsMetrics, QualityOracleMetrics, RoutedMmdsMetrics};
+use super::mutations::{DiagramFamily, MutationPair, SemanticChangeKind};
+use super::phase_attribution::{self, PhaseAttribution};
+use super::render_metrics::{self, RenderChurnClass, RenderMetricDelta};
+use super::render_surfaces;
+
+#[derive(Debug)]
+pub(crate) struct MutationStabilityReport {
+    pub(crate) pair_id: &'static str,
+    pub(crate) expected_changes: Vec<SemanticChangeKind>,
+    pub(crate) layout: LayoutMmdsMetrics,
+    pub(crate) routed: RoutedMmdsMetrics,
+    pub(crate) quality: QualityOracleMetrics,
+    pub(crate) phase_attribution: PhaseAttribution,
+    pub(crate) render_churn: RenderChurnClass,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChurnExplanation {
+    pub(crate) components: Vec<ChurnComponent>,
+}
+
+impl ChurnExplanation {
+    pub(crate) fn components_sorted_for_test(&self) -> Vec<ChurnComponent> {
+        let mut components = self.components.clone();
+        components.sort();
+        components.dedup();
+        components
+    }
+
+    pub(crate) fn is_style_only_without_route_geometry(&self) -> bool {
+        self.components == [ChurnComponent::Style]
+    }
+
+    pub(crate) fn is_label_only_without_route_geometry(&self) -> bool {
+        self.has_component(ChurnComponent::LabelRect)
+            && !self.has_component(ChurnComponent::RouteGeometry)
+            && !self.has_component(ChurnComponent::PortDivergence)
+            && !self.has_component(ChurnComponent::Style)
+    }
+
+    pub(crate) fn has_route_geometry_cascade(&self) -> bool {
+        self.has_component(ChurnComponent::LabelRect)
+            && self.has_component(ChurnComponent::RouteGeometry)
+            && self.has_component(ChurnComponent::PortDivergence)
+    }
+
+    fn has_component(&self, component: ChurnComponent) -> bool {
+        self.components.contains(&component)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum ChurnComponent {
+    Style,
+    LabelRect,
+    Bounds,
+    RouteGeometry,
+    PortDivergence,
+}
+
+impl MutationStabilityReport {
+    pub(crate) fn phase_attribution(&self) -> &PhaseAttribution {
+        &self.phase_attribution
+    }
+
+    pub(crate) fn churn_explanation(&self) -> ChurnExplanation {
+        let mut components = Vec::new();
+        if self.render_churn == RenderChurnClass::StyleOnly {
+            components.push(ChurnComponent::Style);
+        }
+        if !self.routed.label_rect_changes.is_empty() {
+            components.push(ChurnComponent::LabelRect);
+        }
+        if self.layout.bounds_delta.changed || self.routed.routed_bounds_delta.changed {
+            components.push(ChurnComponent::Bounds);
+        }
+        if self.routed.changed_path_geometry_count() > 0 {
+            components.push(ChurnComponent::RouteGeometry);
+        }
+        if !self.routed.path_port_divergence.is_empty() {
+            components.push(ChurnComponent::PortDivergence);
+        }
+        components.sort();
+        components.dedup();
+
+        ChurnExplanation { components }
+    }
+
+    pub(crate) fn summary(&self) -> String {
+        let explanation = self.churn_explanation();
+        let first_divergence = self.phase_attribution.first_divergence();
+        let phase_components = self.phase_attribution.phase_components();
+        format!(
+            "{}: changes={:?}; layout_nodes +{}/-{}; sizes={}; layout_bounds={}; routed_bounds={}; subgraphs={}; label_sides={}; routed_edges +{}/-{}; paths_compared={}; paths_changed={}; labels={}; port_divergence={}; route_len_delta={:.2}; bend_delta={}; components={:?}; churn={:?}; first_divergence={:?}; phase_components={:?}; route_only_paths={}; layout_amplified_paths={}",
+            self.pair_id,
+            self.expected_changes,
+            self.layout.added_nodes.len(),
+            self.layout.removed_nodes.len(),
+            self.layout.node_size_changes.len(),
+            self.layout.bounds_delta.changed,
+            self.routed.routed_bounds_delta.changed,
+            self.layout.subgraph_membership_changes.len(),
+            self.layout.label_side_changes.len(),
+            self.routed.added_edges.len(),
+            self.routed.removed_edges.len(),
+            self.routed.path_metrics.len(),
+            self.routed.changed_path_geometry_count(),
+            self.routed.label_rect_changes.len(),
+            self.routed.path_port_divergence.len(),
+            self.quality.route_length_total_delta,
+            self.quality.bend_count_total_delta,
+            explanation.components,
+            self.render_churn,
+            first_divergence,
+            phase_components,
+            self.phase_attribution.route.route_only_paths.len(),
+            self.phase_attribution.route.layout_amplified_paths.len()
+        )
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ReportError {
+    Render {
+        pair_id: &'static str,
+        message: String,
+    },
+    DirectImpact {
+        pair_id: &'static str,
+        subject_kind: &'static str,
+        subject_id: String,
+    },
+    ExcludedFamily {
+        pair_id: &'static str,
+        family: DiagramFamily,
+    },
+}
+
+impl fmt::Display for ReportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ReportError::Render { pair_id, message } => {
+                write!(f, "failed to render report for {pair_id}: {message}")
+            }
+            ReportError::DirectImpact {
+                pair_id,
+                subject_kind,
+                subject_id,
+            } => write!(
+                f,
+                "direct-impact {subject_kind} {subject_id:?} for {pair_id} was not found in before or after MMDS"
+            ),
+            ReportError::ExcludedFamily { pair_id, family } => {
+                write!(
+                    f,
+                    "{pair_id} is excluded from graph-family reports: {family:?}"
+                )
+            }
+        }
+    }
+}
+
+pub(crate) fn run_pair(
+    pair: &'static MutationPair,
+) -> Result<MutationStabilityReport, ReportError> {
+    if pair.family == DiagramFamily::TimelineExcluded || !pair.include_in_graph_stability_metrics {
+        return Err(ReportError::ExcludedFamily {
+            pair_id: pair.id,
+            family: pair.family,
+        });
+    }
+
+    let rendered = render_surfaces::render_pair(pair).map_err(|error| ReportError::Render {
+        pair_id: pair.id,
+        message: error.to_string(),
+    })?;
+    validate_direct_impacts(pair, &rendered)?;
+
+    let layout = mmds_metrics::compare_layout_mmds(
+        pair,
+        &rendered.before.layout_mmds,
+        &rendered.after.layout_mmds,
+    );
+    let routed = mmds_metrics::compare_routed_mmds(
+        pair,
+        &rendered.before.routed_mmds,
+        &rendered.after.routed_mmds,
+    );
+    let quality = mmds_metrics::collect_quality_oracle_metrics(
+        pair,
+        &rendered.before.routed_mmds,
+        &rendered.after.routed_mmds,
+    );
+    let mut phase_attribution = phase_attribution::compare_phase_traces(
+        &rendered.before.phase_trace,
+        &rendered.after.phase_trace,
+    );
+    phase_attribution::attribute_routed_metrics(&mut phase_attribution, &routed);
+    let render_delta = render_delta(&rendered, &routed);
+    let render_churn = render_metrics::classify_render_churn(&render_delta);
+
+    Ok(MutationStabilityReport {
+        pair_id: pair.id,
+        expected_changes: pair.expected_changes.to_vec(),
+        layout,
+        routed,
+        quality,
+        phase_attribution,
+        render_churn,
+    })
+}
+
+pub(crate) fn run_corpus(
+    pairs: &'static [MutationPair],
+) -> Result<Vec<MutationStabilityReport>, ReportError> {
+    let mut reports = pairs
+        .iter()
+        .map(run_pair)
+        .collect::<Result<Vec<_>, ReportError>>()?;
+    reports.sort_by_key(|report| report.pair_id);
+    Ok(reports)
+}
+
+pub(crate) fn format_reports(reports: &[MutationStabilityReport]) -> String {
+    let mut summaries = reports
+        .iter()
+        .map(MutationStabilityReport::summary)
+        .collect::<Vec<_>>();
+    summaries.sort();
+    summaries.join("\n")
+}
+
+fn validate_direct_impacts(
+    pair: &MutationPair,
+    rendered: &render_surfaces::RenderedPair,
+) -> Result<(), ReportError> {
+    let node_ids = rendered
+        .before
+        .layout_mmds
+        .nodes
+        .iter()
+        .chain(&rendered.after.layout_mmds.nodes)
+        .map(|node| node.id.as_str())
+        .collect::<BTreeSet<_>>();
+    let edge_ids = rendered
+        .before
+        .routed_mmds
+        .edges
+        .iter()
+        .chain(&rendered.after.routed_mmds.edges)
+        .map(|edge| edge.id.as_str())
+        .collect::<BTreeSet<_>>();
+
+    for id in pair.direct_nodes {
+        if !node_ids.contains(id) {
+            return Err(ReportError::DirectImpact {
+                pair_id: pair.id,
+                subject_kind: "node",
+                subject_id: (*id).to_string(),
+            });
+        }
+    }
+    for id in pair.direct_edges {
+        if !edge_ids.contains(id) {
+            return Err(ReportError::DirectImpact {
+                pair_id: pair.id,
+                subject_kind: "edge",
+                subject_id: (*id).to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn render_delta(
+    rendered: &render_surfaces::RenderedPair,
+    routed: &RoutedMmdsMetrics,
+) -> RenderMetricDelta {
+    let before_text = render_metrics::collect_text_metrics(&rendered.before.text);
+    let after_text = render_metrics::collect_text_metrics(&rendered.after.text);
+    let before_svg = render_metrics::collect_svg_metrics(&rendered.before.svg);
+    let after_svg = render_metrics::collect_svg_metrics(&rendered.after.svg);
+
+    RenderMetricDelta {
+        svg_viewbox_changed: before_svg.viewbox_width != after_svg.viewbox_width
+            || before_svg.viewbox_height != after_svg.viewbox_height,
+        svg_path_count_changed: before_svg.path_count != after_svg.path_count,
+        path_topology_changed: routed
+            .path_metrics
+            .iter()
+            .any(|metric| metric.point_count_delta != 0 || metric.bend_count_delta != 0),
+        label_rect_changed: !routed.label_rect_changes.is_empty(),
+        endpoint_face_changed: !routed.endpoint_face_changes.is_empty(),
+        style_only_changed: rendered
+            .after
+            .routed_mmds
+            .edges
+            .iter()
+            .zip(&rendered.before.routed_mmds.edges)
+            .any(|(after, before)| {
+                after.stroke != before.stroke
+                    || after.arrow_start != before.arrow_start
+                    || after.arrow_end != before.arrow_end
+            }),
+        text_dimensions_changed: before_text != after_text,
+    }
+}
+
+#[test]
+#[ignore]
+fn print_tier_a_stability_report() {
+    let reports = run_corpus(super::mutations::tier_a_pairs()).unwrap();
+    println!("{}", format_reports(&reports));
+}

--- a/src/internal_tests/layout_stability/route_diagnostics.rs
+++ b/src/internal_tests/layout_stability/route_diagnostics.rs
@@ -1,0 +1,911 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{mmds_metrics, mutations, phase_attribution, render_surfaces, report};
+use crate::graph::geometry::EdgeLabelSide;
+use crate::graph::routing::EdgeRouting;
+use crate::graph::routing::trace::{
+    LabelLaneEdgeSnapshot, LabelLaneTraceSnapshot, RouteEdgeInput, RouteInputSnapshot,
+    RouteLabelInput, RouteNodeInput, RoutePortInput,
+};
+use crate::graph::space::{FPoint, FRect};
+use crate::graph::{Direction, Shape};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RouteDeterminismReport {
+    pub(crate) run_count: usize,
+    pub(crate) unique_signature_count: usize,
+    pub(crate) signatures: Vec<String>,
+}
+
+impl RouteDeterminismReport {
+    pub(crate) fn is_deterministic(&self) -> bool {
+        self.run_count > 0 && self.unique_signature_count == 1
+    }
+}
+
+pub(crate) fn determinism_report_from_signatures(
+    signatures: Vec<String>,
+) -> RouteDeterminismReport {
+    let unique_signature_count = signatures.iter().collect::<BTreeSet<_>>().len();
+    RouteDeterminismReport {
+        run_count: signatures.len(),
+        unique_signature_count,
+        signatures,
+    }
+}
+
+pub(crate) fn measure_pair_determinism(
+    pair: &mutations::MutationPair,
+    iterations: usize,
+) -> Result<RouteDeterminismReport, render_surfaces::RenderSurfaceError> {
+    let mut signatures = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let rendered = render_surfaces::render_pair(pair)?;
+        signatures.push(routed_mmds_signature(&rendered.after.routed_mmds));
+    }
+    Ok(determinism_report_from_signatures(signatures))
+}
+
+pub(crate) fn determinism_summary_for_pair_ids(
+    pair_ids: &[&str],
+    iterations: usize,
+) -> Result<String, String> {
+    let mut lines = Vec::with_capacity(pair_ids.len());
+    for pair_id in pair_ids {
+        let pair =
+            mutations::pair_by_id(pair_id).ok_or_else(|| format!("unknown pair id {pair_id}"))?;
+        let report =
+            measure_pair_determinism(pair, iterations).map_err(|error| error.to_string())?;
+        lines.push(format!(
+            "{pair_id}: route_deterministic={}; route_signature_variants={}/{}",
+            report.is_deterministic(),
+            report.unique_signature_count,
+            report.run_count
+        ));
+    }
+    Ok(lines.join("\n"))
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteInputDiff {
+    pub(crate) added_edges: Vec<RouteEdgeInputDelta>,
+    pub(crate) removed_edges: Vec<RouteEdgeInputDelta>,
+    pub(crate) changed_labels: Vec<RouteLabelInputDelta>,
+    pub(crate) changed_ports: Vec<RoutePortInputDelta>,
+    pub(crate) changed_edges: Vec<RouteEdgeInputDelta>,
+    pub(crate) changed_nodes: Vec<RouteNodeInputDelta>,
+    pub(crate) incidental_label_changes: Vec<RouteIncidentalLabelDelta>,
+}
+
+impl RouteInputDiff {
+    pub(crate) fn has_changes(&self) -> bool {
+        !self.added_edges.is_empty()
+            || !self.removed_edges.is_empty()
+            || !self.changed_labels.is_empty()
+            || !self.changed_ports.is_empty()
+            || !self.changed_edges.is_empty()
+            || !self.changed_nodes.is_empty()
+            || !self.incidental_label_changes.is_empty()
+    }
+
+    pub(crate) fn decision_input_change_count(&self) -> usize {
+        self.added_edges.len()
+            + self.removed_edges.len()
+            + self.changed_labels.len()
+            + self.changed_ports.len()
+            + self.changed_edges.len()
+            + self.changed_nodes.len()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RouteInputChangeKind {
+    DecisionRelevant,
+    Incidental,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteLabelInputDelta {
+    pub(crate) edge_index: usize,
+    pub(crate) width_delta: f64,
+    pub(crate) height_delta: f64,
+    pub(crate) kind: RouteInputChangeKind,
+}
+
+impl RouteLabelInputDelta {
+    pub(crate) fn is_decision_relevant(&self) -> bool {
+        self.kind == RouteInputChangeKind::DecisionRelevant
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RoutePortInputDelta {
+    pub(crate) edge_index: usize,
+    pub(crate) before_fraction: Option<f64>,
+    pub(crate) after_fraction: Option<f64>,
+    pub(crate) kind: RouteInputChangeKind,
+}
+
+impl RoutePortInputDelta {
+    pub(crate) fn is_decision_relevant(&self) -> bool {
+        self.kind == RouteInputChangeKind::DecisionRelevant
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteEdgeInputDelta {
+    pub(crate) edge_index: usize,
+    pub(crate) kind: RouteInputChangeKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteNodeInputDelta {
+    pub(crate) node_id: String,
+    pub(crate) kind: RouteInputChangeKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RouteIncidentalLabelDelta {
+    pub(crate) edge_index: usize,
+    pub(crate) kind: RouteInputChangeKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum LabelLaneDeltaClass {
+    CompartmentMembership,
+    SubclusterMembership,
+    SortOrder,
+    Track,
+    TrackCenterOnly,
+    LabelStepOnly,
+    LabelGeometryOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LabelLaneEdgeDelta {
+    pub(crate) class: LabelLaneDeltaClass,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct LabelLaneSnapshotDiff {
+    pub(crate) edge_deltas: BTreeMap<String, LabelLaneEdgeDelta>,
+}
+
+impl LabelLaneSnapshotDiff {
+    pub(crate) fn total_edges(&self) -> usize {
+        self.edge_deltas.len()
+    }
+
+    pub(crate) fn histogram(&self) -> BTreeMap<LabelLaneDeltaClass, usize> {
+        let mut histogram = BTreeMap::new();
+        for delta in self.edge_deltas.values() {
+            *histogram.entry(delta.class).or_insert(0) += 1;
+        }
+        histogram
+    }
+
+    pub(crate) fn histogram_total(&self) -> usize {
+        self.histogram().values().sum()
+    }
+
+    pub(crate) fn structural_total(&self) -> usize {
+        self.edge_deltas
+            .values()
+            .filter(|delta| delta.class != LabelLaneDeltaClass::LabelGeometryOnly)
+            .count()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PathShapeCorrelationOutcome {
+    MostlyOverlapsLabelGeometry,
+    MostlyDisjointFromLabelGeometry,
+    Mixed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PathShapeCorrelation {
+    pub(crate) label_geometry_count: usize,
+    pub(crate) path_shape_count: usize,
+    pub(crate) overlap_count: usize,
+    pub(crate) outcome: PathShapeCorrelationOutcome,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RoutePairDiagnostic {
+    pub(crate) pair_id: &'static str,
+    pub(crate) route_input_diff: RouteInputDiff,
+    pub(crate) phase_attribution: phase_attribution::PhaseAttribution,
+    pub(crate) route_decisions: RouteDecisionBreakdown,
+    pub(crate) label_lane_decomposition: Option<LabelLaneSnapshotDiff>,
+    pub(crate) path_shape_correlation: Option<PathShapeCorrelation>,
+    pub(crate) label_lane_non_applicability_reason: Option<String>,
+}
+
+impl RoutePairDiagnostic {
+    pub(crate) fn summary(&self) -> String {
+        format!(
+            "{}: route_input_diffs={}; decision_input_changes={}; added_edges={}; changed_labels={}; incidental_label_changes={}; route_decisions={:?}; label_lane_decomposition={:?}; path_shape_correlation={:?}; label_lane_non_applicability={:?}; route_input_correlation={}; first_divergence={:?}",
+            self.pair_id,
+            self.route_input_diff.total_change_count(),
+            self.route_input_diff.decision_input_change_count(),
+            self.route_input_diff.added_edges.len(),
+            self.route_input_diff.changed_labels.len(),
+            self.route_input_diff.incidental_label_changes.len(),
+            self.route_decisions.primary_histogram(),
+            self.label_lane_decomposition
+                .as_ref()
+                .map(LabelLaneSnapshotDiff::histogram)
+                .unwrap_or_default(),
+            self.path_shape_correlation,
+            self.label_lane_non_applicability_reason,
+            self.route_decisions
+                .correlate_with_route_inputs(&self.route_input_diff),
+            self.phase_attribution.first_divergence()
+        )
+    }
+}
+
+pub(crate) fn run_pair_route_diagnostics(
+    pair: &'static mutations::MutationPair,
+) -> Result<RoutePairDiagnostic, String> {
+    let rendered = render_surfaces::render_pair(pair).map_err(|error| error.to_string())?;
+    let before = rendered
+        .before
+        .route_trace
+        .input()
+        .ok_or_else(|| format!("{} before route input trace missing", pair.id))?;
+    let after = rendered
+        .after
+        .route_trace
+        .input()
+        .ok_or_else(|| format!("{} after route input trace missing", pair.id))?;
+    let report = report::run_pair(pair).map_err(|error| error.to_string())?;
+    let route_decisions =
+        classify_route_decisions(route_decision_input_from_metrics(&report.routed));
+    let label_geometry_edge_ids = label_geometry_change_edge_ids(&report.routed);
+    let label_lane_edge_ids = route_decisions.edge_ids_for_class(RouteDecisionClass::LabelLane);
+    let label_lane_non_applicability_reason = label_lane_edge_ids
+        .is_empty()
+        .then(|| format!("{} has no LabelLane route decision edges", pair.id));
+    let label_lane_decomposition = (!label_lane_edge_ids.is_empty())
+        .then(|| {
+            rendered
+                .before
+                .route_trace
+                .label_lanes()
+                .zip(rendered.after.route_trace.label_lanes())
+                .map(|(before, after)| {
+                    decompose_label_lane_changes(
+                        diff_label_lane_snapshots(before, after),
+                        &route_decisions,
+                        &label_geometry_edge_ids,
+                    )
+                })
+        })
+        .flatten();
+    let path_shape_correlation = label_lane_decomposition.as_ref().map(|decomposition| {
+        correlate_path_shape_with_label_geometry(decomposition, &route_decisions)
+    });
+
+    Ok(RoutePairDiagnostic {
+        pair_id: pair.id,
+        route_input_diff: diff_route_inputs(before, after),
+        route_decisions,
+        label_lane_decomposition,
+        path_shape_correlation,
+        label_lane_non_applicability_reason,
+        phase_attribution: report.phase_attribution().clone(),
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum RouteDecisionClass {
+    Port,
+    EndpointFace,
+    LabelLane,
+    BendTopology,
+    PathShape,
+    LengthOnly,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RouteDecisionInput {
+    by_edge: BTreeMap<String, RouteDecisionFacts>,
+}
+
+impl RouteDecisionInput {
+    pub(crate) fn with_changed_port(
+        mut self,
+        edge_id: &str,
+        endpoint: super::mmds_metrics::Endpoint,
+        before_face: &str,
+        after_face: &str,
+    ) -> Self {
+        self.facts_mut(edge_id)
+            .port_changes
+            .push(RoutePortDecisionDelta {
+                endpoint,
+                before_face: before_face.to_string(),
+                after_face: after_face.to_string(),
+            });
+        self
+    }
+
+    pub(crate) fn with_bend_delta(mut self, edge_id: &str, bend_delta: isize) -> Self {
+        self.facts_mut(edge_id).bend_delta = bend_delta;
+        self
+    }
+
+    pub(crate) fn with_length_delta(mut self, edge_id: &str, length_delta: f64) -> Self {
+        self.facts_mut(edge_id).length_delta = length_delta;
+        self
+    }
+
+    pub(crate) fn with_label_track_delta(
+        mut self,
+        edge_id: &str,
+        before_track: i32,
+        after_track: i32,
+    ) -> Self {
+        self.facts_mut(edge_id).label_track_delta = Some((before_track, after_track));
+        self
+    }
+
+    pub(crate) fn with_path_shape_changed(mut self, edge_id: &str) -> Self {
+        self.facts_mut(edge_id).path_shape_changed = true;
+        self
+    }
+
+    fn facts_mut(&mut self, edge_id: &str) -> &mut RouteDecisionFacts {
+        self.by_edge.entry(edge_id.to_string()).or_default()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct RouteDecisionFacts {
+    port_changes: Vec<RoutePortDecisionDelta>,
+    endpoint_face_changed: bool,
+    label_track_delta: Option<(i32, i32)>,
+    label_lane_changed: bool,
+    bend_delta: isize,
+    point_count_delta: isize,
+    path_shape_changed: bool,
+    length_delta: f64,
+}
+
+#[derive(Debug, Clone)]
+struct RoutePortDecisionDelta {
+    endpoint: super::mmds_metrics::Endpoint,
+    before_face: String,
+    after_face: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RouteDecisionBreakdown {
+    pub(crate) by_edge: BTreeMap<String, RoutePathDecision>,
+}
+
+impl RouteDecisionBreakdown {
+    pub(crate) fn primary_histogram(&self) -> BTreeMap<RouteDecisionClass, usize> {
+        let mut histogram = BTreeMap::new();
+        for decision in self.by_edge.values() {
+            *histogram.entry(decision.primary_class).or_insert(0) += 1;
+        }
+        histogram
+    }
+
+    pub(crate) fn primary_histogram_total(&self) -> usize {
+        self.primary_histogram().values().sum()
+    }
+
+    pub(crate) fn edge_ids_for_class(&self, class: RouteDecisionClass) -> BTreeSet<String> {
+        self.by_edge
+            .iter()
+            .filter(|(_edge_id, decision)| decision.classes.contains(&class))
+            .map(|(edge_id, _decision)| edge_id.clone())
+            .collect()
+    }
+
+    pub(crate) fn correlate_with_route_inputs(&self, input_diff: &RouteInputDiff) -> String {
+        if input_diff.decision_input_change_count() == 0 {
+            "no_decision_input_change".to_string()
+        } else {
+            format!(
+                "decision_input_changes={}",
+                input_diff.decision_input_change_count()
+            )
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RoutePathDecision {
+    pub(crate) primary_class: RouteDecisionClass,
+    pub(crate) classes: Vec<RouteDecisionClass>,
+}
+
+pub(crate) fn synthetic_route_decision_input() -> RouteDecisionInput {
+    RouteDecisionInput::default()
+}
+
+pub(crate) fn classify_route_decisions(input: RouteDecisionInput) -> RouteDecisionBreakdown {
+    let mut by_edge = BTreeMap::new();
+    for (edge_id, facts) in input.by_edge {
+        let classes = decision_classes(&facts);
+        let Some(primary_class) = classes.first().copied() else {
+            continue;
+        };
+        by_edge.insert(
+            edge_id,
+            RoutePathDecision {
+                primary_class,
+                classes,
+            },
+        );
+    }
+    RouteDecisionBreakdown { by_edge }
+}
+
+pub(crate) fn classify_path_shape_correlation(overlap_count: usize) -> PathShapeCorrelationOutcome {
+    if overlap_count >= 5 {
+        PathShapeCorrelationOutcome::MostlyOverlapsLabelGeometry
+    } else if overlap_count <= 1 {
+        PathShapeCorrelationOutcome::MostlyDisjointFromLabelGeometry
+    } else {
+        PathShapeCorrelationOutcome::Mixed
+    }
+}
+
+fn route_decision_input_from_metrics(
+    metrics: &mmds_metrics::RoutedMmdsMetrics,
+) -> RouteDecisionInput {
+    let changed_edge_ids = metrics
+        .path_metrics
+        .iter()
+        .filter(|metric| metric.geometry_changed())
+        .map(|metric| metric.edge_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut input = RouteDecisionInput::default();
+
+    for metric in metrics
+        .path_metrics
+        .iter()
+        .filter(|metric| metric.geometry_changed())
+    {
+        let facts = input.facts_mut(&metric.edge_id);
+        facts.bend_delta = metric.bend_count_delta;
+        facts.point_count_delta = metric.point_count_delta;
+        facts.path_shape_changed = metric.envelope_delta.changed;
+        facts.length_delta = metric.length_delta;
+    }
+
+    for delta in &metrics.port_intent_changes {
+        if !changed_edge_ids.contains(delta.edge_id.as_str()) {
+            continue;
+        }
+        input
+            .facts_mut(&delta.edge_id)
+            .port_changes
+            .push(RoutePortDecisionDelta {
+                endpoint: delta.endpoint,
+                before_face: delta
+                    .before_face
+                    .clone()
+                    .unwrap_or_else(|| "none".to_string()),
+                after_face: delta
+                    .after_face
+                    .clone()
+                    .unwrap_or_else(|| "none".to_string()),
+            });
+    }
+
+    for delta in &metrics.endpoint_face_changes {
+        if changed_edge_ids.contains(delta.edge_id.as_str()) {
+            input.facts_mut(&delta.edge_id).endpoint_face_changed = true;
+        }
+    }
+
+    for delta in &metrics.label_rect_changes {
+        if changed_edge_ids.contains(delta.edge_id.as_str()) {
+            input.facts_mut(&delta.edge_id).label_lane_changed = true;
+        }
+    }
+
+    input
+}
+
+pub(crate) fn diff_route_inputs(
+    before: &RouteInputSnapshot,
+    after: &RouteInputSnapshot,
+) -> RouteInputDiff {
+    let mut added_edges = after
+        .edges
+        .iter()
+        .filter(|after_edge| {
+            !before
+                .edges
+                .iter()
+                .any(|before_edge| same_edge_identity(before_edge, after_edge))
+        })
+        .map(|edge| RouteEdgeInputDelta {
+            edge_index: edge.index,
+            kind: RouteInputChangeKind::DecisionRelevant,
+        })
+        .collect::<Vec<_>>();
+    added_edges.sort_by_key(|edge| edge.edge_index);
+
+    let mut removed_edges = before
+        .edges
+        .iter()
+        .filter(|before_edge| {
+            !after
+                .edges
+                .iter()
+                .any(|after_edge| same_edge_identity(before_edge, after_edge))
+        })
+        .map(|edge| RouteEdgeInputDelta {
+            edge_index: edge.index,
+            kind: RouteInputChangeKind::DecisionRelevant,
+        })
+        .collect::<Vec<_>>();
+    removed_edges.sort_by_key(|edge| edge.edge_index);
+
+    let mut changed_labels = Vec::new();
+    let mut incidental_label_changes = Vec::new();
+    for before_label in &before.labels {
+        let Some(after_label) = after
+            .labels
+            .iter()
+            .find(|label| label.edge_index == before_label.edge_index)
+        else {
+            continue;
+        };
+        let width_delta = after_label.width - before_label.width;
+        let height_delta = after_label.height - before_label.height;
+        if changed_float(width_delta) || changed_float(height_delta) {
+            changed_labels.push(RouteLabelInputDelta {
+                edge_index: before_label.edge_index,
+                width_delta,
+                height_delta,
+                kind: RouteInputChangeKind::DecisionRelevant,
+            });
+        } else if before_label.label_text != after_label.label_text {
+            incidental_label_changes.push(RouteIncidentalLabelDelta {
+                edge_index: before_label.edge_index,
+                kind: RouteInputChangeKind::Incidental,
+            });
+        }
+    }
+
+    let mut changed_ports = Vec::new();
+    for before_edge in &before.edges {
+        let Some(after_edge) = after
+            .edges
+            .iter()
+            .find(|edge| edge.index == before_edge.index)
+        else {
+            continue;
+        };
+        if before_edge.source_port != after_edge.source_port {
+            changed_ports.push(RoutePortInputDelta {
+                edge_index: before_edge.index,
+                before_fraction: before_edge.source_port.as_ref().map(|port| port.fraction),
+                after_fraction: after_edge.source_port.as_ref().map(|port| port.fraction),
+                kind: RouteInputChangeKind::DecisionRelevant,
+            });
+        }
+    }
+
+    RouteInputDiff {
+        added_edges,
+        removed_edges,
+        changed_labels,
+        changed_ports,
+        changed_edges: Vec::new(),
+        changed_nodes: Vec::new(),
+        incidental_label_changes,
+    }
+}
+
+pub(crate) fn diff_label_lane_snapshots(
+    before: &LabelLaneTraceSnapshot,
+    after: &LabelLaneTraceSnapshot,
+) -> LabelLaneSnapshotDiff {
+    let before_by_edge = before
+        .edges
+        .iter()
+        .map(|edge| (edge.mmds_edge_id.as_str(), edge))
+        .collect::<BTreeMap<_, _>>();
+    let after_by_edge = after
+        .edges
+        .iter()
+        .map(|edge| (edge.mmds_edge_id.as_str(), edge))
+        .collect::<BTreeMap<_, _>>();
+    let mut edge_deltas = BTreeMap::new();
+
+    for (edge_id, before_edge) in before_by_edge {
+        let Some(after_edge) = after_by_edge.get(edge_id) else {
+            continue;
+        };
+        let Some(class) = label_lane_delta_class(before_edge, after_edge) else {
+            continue;
+        };
+        edge_deltas.insert(edge_id.to_string(), LabelLaneEdgeDelta { class });
+    }
+
+    LabelLaneSnapshotDiff { edge_deltas }
+}
+
+fn decompose_label_lane_changes(
+    diff: LabelLaneSnapshotDiff,
+    route_decisions: &RouteDecisionBreakdown,
+    label_geometry_edge_ids: &BTreeSet<String>,
+) -> LabelLaneSnapshotDiff {
+    let mut edge_deltas = BTreeMap::new();
+
+    for (edge_id, decision) in &route_decisions.by_edge {
+        if !decision.classes.contains(&RouteDecisionClass::LabelLane) {
+            continue;
+        }
+        if let Some(delta) = diff.edge_deltas.get(edge_id) {
+            edge_deltas.insert(edge_id.clone(), delta.clone());
+        } else if label_geometry_edge_ids.contains(edge_id) {
+            edge_deltas.insert(
+                edge_id.clone(),
+                LabelLaneEdgeDelta {
+                    class: LabelLaneDeltaClass::LabelGeometryOnly,
+                },
+            );
+        }
+    }
+
+    LabelLaneSnapshotDiff { edge_deltas }
+}
+
+fn label_geometry_change_edge_ids(metrics: &mmds_metrics::RoutedMmdsMetrics) -> BTreeSet<String> {
+    metrics
+        .label_rect_changes
+        .iter()
+        .map(|delta| delta.edge_id.clone())
+        .collect()
+}
+
+fn correlate_path_shape_with_label_geometry(
+    decomposition: &LabelLaneSnapshotDiff,
+    route_decisions: &RouteDecisionBreakdown,
+) -> PathShapeCorrelation {
+    let label_geometry_edge_ids = decomposition
+        .edge_deltas
+        .iter()
+        .filter(|(_edge_id, delta)| delta.class == LabelLaneDeltaClass::LabelGeometryOnly)
+        .map(|(edge_id, _delta)| edge_id.clone())
+        .collect::<BTreeSet<_>>();
+    let path_shape_edge_ids = route_decisions.edge_ids_for_class(RouteDecisionClass::PathShape);
+    let overlap_count = label_geometry_edge_ids
+        .intersection(&path_shape_edge_ids)
+        .count();
+
+    PathShapeCorrelation {
+        label_geometry_count: label_geometry_edge_ids.len(),
+        path_shape_count: path_shape_edge_ids.len(),
+        overlap_count,
+        outcome: classify_path_shape_correlation(overlap_count),
+    }
+}
+
+impl RouteInputDiff {
+    fn total_change_count(&self) -> usize {
+        self.added_edges.len()
+            + self.removed_edges.len()
+            + self.changed_labels.len()
+            + self.changed_ports.len()
+            + self.changed_edges.len()
+            + self.changed_nodes.len()
+            + self.incidental_label_changes.len()
+    }
+}
+
+pub(crate) fn synthetic_route_input_with_label(
+    edge_index: usize,
+    width: f64,
+    height: f64,
+) -> RouteInputSnapshot {
+    synthetic_route_input(edge_index, None, width, height, None)
+}
+
+pub(crate) fn synthetic_route_input_with_label_text(
+    edge_index: usize,
+    label_text: &str,
+    width: f64,
+    height: f64,
+) -> RouteInputSnapshot {
+    synthetic_route_input(edge_index, Some(label_text), width, height, None)
+}
+
+pub(crate) fn synthetic_route_input_with_source_port(
+    edge_index: usize,
+    face: &str,
+    fraction: f64,
+) -> RouteInputSnapshot {
+    synthetic_route_input(
+        edge_index,
+        None,
+        80.0,
+        20.0,
+        Some(RoutePortInput {
+            face: face.to_string(),
+            fraction,
+            group_size: 1,
+        }),
+    )
+}
+
+pub(crate) fn synthetic_label_lane_snapshot(edge_id: &str) -> LabelLaneTraceSnapshot {
+    LabelLaneTraceSnapshot {
+        edges: vec![LabelLaneEdgeSnapshot {
+            edge_index: edge_index_from_mmds_id(edge_id),
+            mmds_edge_id: edge_id.to_string(),
+            compartment_id: format!("scope:none|members:{edge_id}"),
+            subcluster_id: format!("scope:none|members:{edge_id}|cluster:{edge_id}"),
+            sort_position: 0,
+            track: 0,
+            track_center: 0.0,
+            label_step: 32.0,
+            label_rect: FRect::new(10.0, 20.0, 40.0, 16.0),
+        }],
+        compartments: Vec::new(),
+        subclusters: Vec::new(),
+    }
+}
+
+impl LabelLaneTraceSnapshot {
+    pub(crate) fn with_compartment(mut self, compartment_id: &str) -> Self {
+        self.edges[0].compartment_id = compartment_id.to_string();
+        self
+    }
+
+    pub(crate) fn with_track(mut self, track: i32) -> Self {
+        self.edges[0].track = track;
+        self
+    }
+
+    pub(crate) fn with_label_step(mut self, label_step: f64) -> Self {
+        self.edges[0].label_step = label_step;
+        self
+    }
+}
+
+fn routed_mmds_signature(output: &crate::mmds::Output) -> String {
+    serde_json::to_string(output).expect("MMDS output should serialize")
+}
+
+fn synthetic_route_input(
+    edge_index: usize,
+    label_text: Option<&str>,
+    width: f64,
+    height: f64,
+    source_port: Option<RoutePortInput>,
+) -> RouteInputSnapshot {
+    RouteInputSnapshot {
+        edge_routing: EdgeRouting::PolylineRoute,
+        nodes: vec![RouteNodeInput {
+            id: "A".to_string(),
+            rect: FRect::new(10.0, 20.0, 40.0, 30.0),
+            shape: Shape::Rectangle,
+            label: "A".to_string(),
+            parent: None,
+            direction: Direction::TopDown,
+        }],
+        edges: vec![RouteEdgeInput {
+            index: edge_index,
+            from: "A".to_string(),
+            to: "B".to_string(),
+            waypoints: Vec::new(),
+            layout_path_hint: None,
+            label_position: Some(FPoint::new(10.0, 35.0)),
+            label_side: Some(EdgeLabelSide::Above),
+            source_port,
+            target_port: None,
+            is_backward: false,
+            preserve_orthogonal_topology: false,
+        }],
+        labels: vec![RouteLabelInput {
+            edge_index,
+            label_text: label_text.map(str::to_string),
+            width,
+            height,
+            axis_min: 35.0 - height / 2.0,
+            axis_max: 35.0 + height / 2.0,
+            cross_min: 10.0 - width / 2.0,
+            cross_max: 10.0 + width / 2.0,
+            side: Some(EdgeLabelSide::Above),
+            direction_sign: 1,
+            scope_parent: None,
+            midpoint: FPoint::new(10.0, 35.0),
+        }],
+    }
+}
+
+fn changed_float(value: f64) -> bool {
+    value.abs() > super::mmds_metrics::COORD_EPS
+}
+
+fn label_lane_delta_class(
+    before: &LabelLaneEdgeSnapshot,
+    after: &LabelLaneEdgeSnapshot,
+) -> Option<LabelLaneDeltaClass> {
+    if before.compartment_id != after.compartment_id {
+        return Some(LabelLaneDeltaClass::CompartmentMembership);
+    }
+    if before.subcluster_id != after.subcluster_id {
+        return Some(LabelLaneDeltaClass::SubclusterMembership);
+    }
+    if before.sort_position != after.sort_position {
+        return Some(LabelLaneDeltaClass::SortOrder);
+    }
+    if before.track != after.track {
+        return Some(LabelLaneDeltaClass::Track);
+    }
+    if changed_float(after.track_center - before.track_center) {
+        return Some(LabelLaneDeltaClass::TrackCenterOnly);
+    }
+    if changed_float(after.label_step - before.label_step) {
+        return Some(LabelLaneDeltaClass::LabelStepOnly);
+    }
+    if changed_rect(&before.label_rect, &after.label_rect) {
+        return Some(LabelLaneDeltaClass::LabelGeometryOnly);
+    }
+    None
+}
+
+fn changed_rect(before: &FRect, after: &FRect) -> bool {
+    changed_float(after.x - before.x)
+        || changed_float(after.y - before.y)
+        || changed_float(after.width - before.width)
+        || changed_float(after.height - before.height)
+}
+
+fn edge_index_from_mmds_id(edge_id: &str) -> usize {
+    edge_id
+        .strip_prefix('e')
+        .and_then(|suffix| suffix.parse().ok())
+        .unwrap_or_default()
+}
+
+fn same_edge_identity(before: &RouteEdgeInput, after: &RouteEdgeInput) -> bool {
+    before.index == after.index && before.from == after.from && before.to == after.to
+}
+
+fn decision_classes(facts: &RouteDecisionFacts) -> Vec<RouteDecisionClass> {
+    let mut classes = Vec::new();
+    if facts.port_changes.iter().any(|delta| {
+        delta.before_face != delta.after_face
+            || matches!(
+                delta.endpoint,
+                super::mmds_metrics::Endpoint::Source | super::mmds_metrics::Endpoint::Target
+            )
+    }) {
+        classes.push(RouteDecisionClass::Port);
+    }
+    if facts.endpoint_face_changed {
+        classes.push(RouteDecisionClass::EndpointFace);
+    }
+    if facts
+        .label_track_delta
+        .is_some_and(|(before, after)| before != after)
+        || facts.label_lane_changed
+    {
+        classes.push(RouteDecisionClass::LabelLane);
+    }
+    if facts.bend_delta != 0 {
+        classes.push(RouteDecisionClass::BendTopology);
+    }
+    if facts.point_count_delta != 0 || facts.path_shape_changed {
+        classes.push(RouteDecisionClass::PathShape);
+    }
+    if facts.length_delta.abs() > super::mmds_metrics::DISPLAY_EPS {
+        classes.push(RouteDecisionClass::LengthOnly);
+    }
+    classes
+}

--- a/src/internal_tests/mod.rs
+++ b/src/internal_tests/mod.rs
@@ -5,6 +5,7 @@ mod graph_routing_pipeline;
 mod grid_routing_regression;
 mod label_node_overlap;
 mod layered_adapter_pipeline;
+mod layout_stability;
 mod mmds_output_serialization;
 mod mmds_roundtrip;
 mod port_attachment_observation;


### PR DESCRIPTION
## Summary

- Add the Tier A mutation stability corpus and render surfaces for layout/routed MMDS, SVG, and text stability checks.
- Add internal quality oracle collectors for MMDS metrics, routed geometry, render churn, phase attribution, routing input/output diagnostics, label-lane decomposition, and route proportionality.
- Expand pure-edge calibration controls with M19/M20/M21 and classify M11 as `Mixed`, leaving M14 as the only disproportionate Tier A route-proportionality signal.

## Why

This PR packages the investigation foundation from Plans 0160-0166. The main conclusion is that no broad Tier A layout-stability blocker was found, and the harness now gives us durable checks before moving into semantic MMDS diff work.

The code intentionally stays internal/test-only for now. These checks are valuable as stability oracles today, and several pieces could later move toward production tracing, change tracking, or semantic diff features once the user-facing contracts are designed.

## Review and merge notes

- This PR has been squashed to one conventional `test:` commit for durable history.
- Please merge this PR with a merge commit when accepted to preserve the PR boundary.
- No public API, CLI flags, MMDS schema changes, TypeScript package work, runtime config, stabilization layer, previous-layout state, or route caching are intended here.
- The trace surfaces are `#[cfg(test)]` and the primary harness lives under `src/internal_tests/layout_stability/`.

## Validation

- `cargo nextest run -E 'test(route_proportionality) | test(layout_stability)'`
- `just check`
- Rewritten one-commit tree was verified identical to the original 33-commit branch tree before force-push.
