### PR TITLE
feat: support tracing diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,13 +168,41 @@ cargo nextest run -E 'test(dagre_parity)'  # Compare layout against dagre.js fix
 ./scripts/refresh-parity-fixtures.sh   # Regenerate from dagre.js
 ```
 
-### Debug Environment Variables
+### Tracing Controls
 
-- `MMDFLUX_DEBUG_LAYOUT=<file>` - Write layout JSON
-- `MMDFLUX_DEBUG_PIPELINE=<file>` - Write pipeline stages (JSONL)
-- `MMDFLUX_DEBUG_BORDER_NODES=1` - Print border node trace
-- `MMDFLUX_DEBUG_ORDER=1` - Order debug tracing
-- `MMDFLUX_DEBUG_BK_TRACE=1` - Brandes-Köpf coordinate assignment trace
+Library code emits `tracing` events but does not install subscribers. The CLI
+and `xtask` own subscriber setup.
+
+- `--log <FILTER>` - Enable CLI tracing with a `tracing_subscriber::EnvFilter`
+  directive
+- `MMDFLUX_LOG=<FILTER>` - Enable CLI tracing when `--log` is absent
+- `RUST_LOG=<FILTER>` - Fallback tracing filter for CLI and `xtask`
+- `--log-format <compact|pretty|json>` - Select tracing format (`compact` by default)
+- `--log-file <path>` - Write tracing output to a file instead of stderr
+- `MMDFLUX_XTASK_LOG=<FILTER>` - Enable `xtask` tracing when its `--log` is absent
+
+Common target filters:
+
+- `MMDFLUX_LOG=mmdflux::runtime=debug` - Render facade timing and outcome
+- `MMDFLUX_LOG=mmdflux::engines::graph::algorithms::layered::kernel=trace` - All layered-kernel diagnostics
+- `MMDFLUX_LOG=mmdflux::engines::graph::algorithms::layered::kernel::order=trace` - Order diagnostics
+- `MMDFLUX_LOG=mmdflux::engines::graph::algorithms::layered::kernel::bk=trace` - Brandes-Köpf diagnostics
+- `MMDFLUX_LOG=mmdflux::engines::graph::algorithms::layered::kernel::border=trace` - Border/subgraph diagnostics
+- `MMDFLUX_LOG=mmdflux::engines::graph::algorithms::layered::kernel::parent_dummy_chains=trace` - Dummy-parent diagnostics
+- `MMDFLUX_LOG=mmdflux::graph::grid::routing=trace` - Route-segment diagnostics
+
+### Retained Debug Dumpers
+
+These env vars produce deterministic files or parity text and are intentionally
+not replaced by subscriber formatting:
+
+- `MMDFLUX_DEBUG_LAYOUT=1|<file>` - Write one compact layout JSON document
+- `MMDFLUX_DEBUG_PIPELINE=1|<file>` - Write pipeline stages as JSONL; file mode appends
+- `MMDFLUX_DEBUG_BORDER_NODES=1` - Print border-node parity trace to stderr
+- `MMDFLUX_DEBUG_SVG_THEME_AUTO=<file>` - Write/truncate the SVG auto-theme probe transcript
+
+Behavior-changing debug switches are separate from tracing. Do not add new
+behavior modifiers as tracing controls.
 
 ### Debug Scripts
 
@@ -183,4 +211,4 @@ cargo nextest run -E 'test(dagre_parity)'  # Compare layout against dagre.js fix
 - `scripts/dump-dagre-borders.js` - Extract dagre border nodes
 - `scripts/dump-dagre-order.js` - Dump node order per rank
 
-See `docs/DEBUG.md` for comprehensive documentation.
+See `docs/development/mermaid-parity.md` for comprehensive parity and debug documentation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1360,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44cd706ff0d503ee32b2071166510ca27e281228de10cd3aa8d35ff94560f81"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1391,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -1422,6 +1453,7 @@ version = "2.2.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "ctor",
  "jsonschema",
  "libc",
  "pest",
@@ -1431,6 +1463,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
  "windows-sys 0.52.0",
 ]
 
@@ -3513,16 +3547,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "thread_local",
  "time",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4101,6 +4153,8 @@ dependencies = [
  "serde",
  "serde_json",
  "toml 0.8.23",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ pest_derive = "2.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+tracing = { version = "0.1.44", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.3.23", optional = true, default-features = false, features = ["std", "fmt", "ansi", "env-filter", "json"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = [
@@ -38,7 +40,7 @@ windows-sys = { version = "0.52", features = [
 # Keep CLI behavior by default while allowing library/WASM users to opt out.
 default = ["cli"]
 # CLI-only dependency surface.
-cli = ["dep:clap", "dep:libc", "dep:windows-sys"]
+cli = ["dep:clap", "dep:libc", "dep:tracing-subscriber", "dep:windows-sys"]
 engine-elk = []
 
 [[bin]]
@@ -49,6 +51,8 @@ required-features = ["cli"]
 
 [dev-dependencies]
 assert_cmd = "2"
+ctor = "0.12.0"
 jsonschema = "0.41"
 predicates = "3"
 regex = "1.12.2"
+tracing-subscriber = { version = "0.3.23", default-features = false, features = ["std", "fmt", "ansi", "env-filter"] }

--- a/docs/development/mermaid-parity.md
+++ b/docs/development/mermaid-parity.md
@@ -133,15 +133,56 @@ cargo run -- fixture.mmd --format mmds | jq -f scripts/mmds-to-dagre-input.jq
 | `DAGRE_ROOT`   | `deps/dagre`   | Path to dagre v0.8.5 repo |
 | `MERMAID_ROOT` | `deps/mermaid` | Path to mermaid repo      |
 
-### Debug Output
+### Trace Streams
 
-| Variable                        | Description                              |
-| ------------------------------- | ---------------------------------------- |
-| `MMDFLUX_DEBUG_LAYOUT=<file>`   | Write layout JSON to file                |
-| `MMDFLUX_DEBUG_PIPELINE=<file>` | Write pipeline stages to JSONL           |
-| `MMDFLUX_DEBUG_BORDER_NODES=1`  | Print border node trace                  |
-| `MMDFLUX_DEBUG_ORDER=1`         | Enable order debug tracing               |
-| `MMDFLUX_DEBUG_BK_TRACE=1`      | Trace Brandes-Köpf coordinate assignment |
+`mmdflux` emits `tracing` events from the library, while the CLI owns subscriber
+configuration. Render output stays on stdout; tracing output goes to stderr by
+default or to `--log-file`.
+
+| Control | Description |
+| ------- | ----------- |
+| `--log <FILTER>` | Enable CLI tracing with a `tracing_subscriber::EnvFilter` directive |
+| `MMDFLUX_LOG=<FILTER>` | Enable CLI tracing when `--log` is absent |
+| `RUST_LOG=<FILTER>` | Fallback tracing filter for CLI and `xtask` |
+| `--log-format <compact|pretty|json>` | Select tracing output format (`compact` by default) |
+| `--log-file <path>` | Write tracing output to a file instead of stderr |
+| `MMDFLUX_XTASK_LOG=<FILTER>` | Enable `xtask` tracing when its `--log` is absent |
+
+Useful target filters:
+
+| Filter | Use |
+| ------ | --- |
+| `mmdflux::runtime=debug` | Render facade timing and outcome |
+| `mmdflux::engines::graph::algorithms::layered::kernel=trace` | All layered-kernel diagnostics |
+| `mmdflux::engines::graph::algorithms::layered::kernel::order=trace` | Order phase diagnostics |
+| `mmdflux::engines::graph::algorithms::layered::kernel::bk=trace` | Brandes-Köpf coordinate assignment diagnostics |
+| `mmdflux::engines::graph::algorithms::layered::kernel::border=trace` | Border and subgraph-bound diagnostics |
+| `mmdflux::engines::graph::algorithms::layered::kernel::parent_dummy_chains=trace` | Parent dummy-chain diagnostics |
+| `mmdflux::graph::grid::routing=trace` | Route candidate and segment diagnostics |
+
+Example:
+
+```bash
+MMDFLUX_LOG=mmdflux::engines::graph::algorithms::layered::kernel::order=trace \
+  cargo run -- tests/fixtures/flowchart/external_node_subgraph.mmd >/tmp/render.txt
+```
+
+### Retained Deterministic Dumpers
+
+These debug env vars are deterministic file or parity producers. They remain
+explicit file/stderr contracts and are not replaced by tracing subscriber JSON.
+
+| Variable | Description |
+| -------- | ----------- |
+| `MMDFLUX_DEBUG_LAYOUT=1` | Write one compact layout JSON document to stderr |
+| `MMDFLUX_DEBUG_LAYOUT=<file>` | Truncate and write one compact layout JSON document to file |
+| `MMDFLUX_DEBUG_PIPELINE=1` | Write pipeline stages as JSONL to stderr |
+| `MMDFLUX_DEBUG_PIPELINE=<file>` | Append pipeline JSONL to file |
+| `MMDFLUX_DEBUG_BORDER_NODES=1` | Print border-node parity trace to stderr for fixture generation |
+| `MMDFLUX_DEBUG_SVG_THEME_AUTO=<file>` | Truncate and write the SVG auto-theme probe transcript |
+
+Behavior-changing debug switches are not logging controls and are intentionally
+not part of tracing documentation.
 
 ## Troubleshooting
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -78,3 +78,31 @@ just run diagram.mmd   # Run the CLI
 ```
 
 See the [Justfile](../../Justfile) for the full list.
+
+## Diagnostics and tracing
+
+The CLI supports opt-in `tracing` output for development diagnostics:
+
+```bash
+mmdflux --log mmdflux::runtime=debug diagram.mmd >/tmp/render.txt
+mmdflux --log mmdflux::graph::grid::routing=trace --log-format json diagram.mmd
+mmdflux --log mmdflux::engines::graph::algorithms::layered::kernel::order=trace --log-file /tmp/mmdflux.log diagram.mmd
+```
+
+`--log` takes precedence over `MMDFLUX_LOG`; `MMDFLUX_LOG` takes precedence over
+`RUST_LOG`. Tracing output goes to stderr unless `--log-file` is provided, so
+rendered text, SVG, and MMDS output remain safe to pipe from stdout.
+
+`xtask` accepts the same global tracing flags before the subcommand and uses
+`MMDFLUX_XTASK_LOG` before falling back to `RUST_LOG`:
+
+```bash
+cargo xtask --log xtask=debug architecture check
+MMDFLUX_XTASK_LOG=xtask=debug cargo xtask readme-assets check
+```
+
+Parity fixture dumpers such as `MMDFLUX_DEBUG_PIPELINE`,
+`MMDFLUX_DEBUG_LAYOUT`, and `MMDFLUX_DEBUG_BORDER_NODES` remain separate
+deterministic file/stderr contracts. Use trace filters for interactive
+diagnostics and the `MMDFLUX_DEBUG_*` dumpers only for their documented parity
+or probe artifacts.

--- a/docs/development/wasm.md
+++ b/docs/development/wasm.md
@@ -78,6 +78,19 @@ Notes:
 - Legacy keys such as `edgeRouting`, `edgeStyle`, `svgEdgeCurve`, and
   `svgEdgeCurveRadius` are rejected.
 
+## Tracing and Diagnostics
+
+The wasm adapter depends on the root `mmdflux` crate with
+`default-features = false`, and it does not install a tracing subscriber or
+export an `init_logging()` function. Subscriber setup is owned by native
+entrypoints such as the CLI, `xtask`, and test harnesses.
+
+Keep `tracing-subscriber`, wasm-specific subscriber setup, and log-interop
+features out of the default wasm dependency path unless a browser consumer has
+a concrete need for them. For parity dumpers and trace-stream diagnostics, use
+the native CLI workflows documented in
+[mermaid-parity.md](./mermaid-parity.md).
+
 Example:
 
 ```json

--- a/src/engines/graph/algorithms/layered/kernel/bk.rs
+++ b/src/engines/graph/algorithms/layered/kernel/bk.rs
@@ -474,6 +474,10 @@ fn find_other_inner_segment_node(graph: &LayoutGraph, node: NodeIndex) -> Option
         .find(|&u| is_dummy_like(graph, u))
 }
 
+fn bk_trace_enabled() -> bool {
+    tracing::enabled!(tracing::Level::TRACE)
+}
+
 /// Find all Type-2 conflicts in the graph.
 ///
 /// A Type-2 conflict occurs between inner segments of different long edges
@@ -485,7 +489,7 @@ pub fn find_type2_conflicts(graph: &LayoutGraph) -> ConflictSet {
         return conflicts;
     }
 
-    if super::debug::conflicts_enabled() {
+    if bk_trace_enabled() {
         debug_dump_layer_matrix(graph, &layers);
     }
 
@@ -574,9 +578,7 @@ pub(crate) fn is_dummy_like(graph: &LayoutGraph, node: NodeIndex) -> bool {
 }
 
 fn debug_dump_layer_matrix(graph: &LayoutGraph, layers: &[Vec<Option<NodeIndex>>]) {
-    eprintln!("[layer_matrix] start");
     for (rank, layer) in layers.iter().enumerate() {
-        eprintln!("[layer_matrix] rank {}", rank);
         for (pos, slot) in layer.iter().enumerate() {
             let Some(node) = *slot else {
                 continue;
@@ -586,22 +588,33 @@ fn debug_dump_layer_matrix(graph: &LayoutGraph, layers: &[Vec<Option<NodeIndex>>
             let is_border = is_border_node(graph, node);
             let is_dummy_like = is_dummy_like(graph, node);
             let predecessors = get_predecessors(graph, node);
-            let pred_entries: Vec<String> = predecessors
-                .iter()
-                .map(|&p| format!("{}(order={})", graph.node_ids[p].0, graph.order[p]))
-                .collect();
-            eprintln!(
-                "[layer_matrix]   pos {} node={} order={} border={} dummy_like={} predecessors=[{}]",
-                pos,
-                node_id,
-                order,
-                is_border,
-                is_dummy_like,
-                pred_entries.join(", ")
-            );
+            if predecessors.is_empty() {
+                tracing::trace!(
+                    event = "layer_matrix",
+                    rank,
+                    position = pos,
+                    node_id = %node_id,
+                    order,
+                    is_border,
+                    is_dummy_like,
+                );
+            } else {
+                for predecessor in predecessors {
+                    tracing::trace!(
+                        event = "layer_matrix",
+                        rank,
+                        position = pos,
+                        node_id = %node_id,
+                        order,
+                        is_border,
+                        is_dummy_like,
+                        predecessor = %graph.node_ids[predecessor].0,
+                        predecessor_order = graph.order[predecessor],
+                    );
+                }
+            }
         }
     }
-    eprintln!("[layer_matrix] end");
 }
 
 /// Find all conflicts (Type-1 and Type-2) in the graph.
@@ -609,7 +622,7 @@ pub fn find_all_conflicts(graph: &LayoutGraph) -> ConflictSet {
     let type1 = find_type1_conflicts(graph);
     let type2 = find_type2_conflicts(graph);
 
-    if super::debug::conflicts_enabled() {
+    if bk_trace_enabled() {
         debug_log_conflicts(graph, &type1, &type2);
     }
 
@@ -633,9 +646,14 @@ fn debug_log_conflicts(graph: &LayoutGraph, type1: &ConflictSet, type2: &Conflic
         let (la, pa) = node_layer[a];
         let (lb, pb) = node_layer[b];
         let layer = la.max(lb);
-        eprintln!(
-            "[conflicts] {} layer {} pos {}({}) vs pos {}({})",
-            conflict_type, layer, pa, &graph.node_ids[a], pb, &graph.node_ids[b]
+        tracing::trace!(
+            event = "conflict",
+            conflict_type,
+            layer,
+            a_node = %graph.node_ids[a].0,
+            a_position = pa,
+            b_node = %graph.node_ids[b].0,
+            b_position = pb,
         );
     };
 
@@ -680,7 +698,7 @@ pub fn vertical_alignment(
     let base_layers = get_layers_with_order(graph);
     let adjusted_layers = adjusted_layers_with_order(&base_layers, direction);
     let downward = direction.is_downward();
-    vertical_alignment_with_layering(graph, &adjusted_layers, conflicts, downward)
+    vertical_alignment_with_layering(graph, &adjusted_layers, conflicts, downward, direction)
 }
 
 fn vertical_alignment_with_layering(
@@ -688,6 +706,7 @@ fn vertical_alignment_with_layering(
     layers: &[Vec<Option<NodeIndex>>],
     conflicts: &ConflictSet,
     downward: bool,
+    direction: AlignmentDirection,
 ) -> BlockAlignment {
     let all_nodes: Vec<NodeIndex> = (0..graph.node_ids.len()).collect();
     let mut alignment = BlockAlignment::new(&all_nodes);
@@ -696,7 +715,7 @@ fn vertical_alignment_with_layering(
         return alignment;
     }
 
-    let bk_trace = super::debug::bk_trace_enabled();
+    let trace_enabled = bk_trace_enabled();
 
     let mut pos: HashMap<NodeIndex, isize> = HashMap::new();
     for layer in layers {
@@ -728,8 +747,7 @@ fn vertical_alignment_with_layering(
             let start = mp.floor() as usize;
             let end = mp.ceil() as usize;
 
-            for i in start..=end {
-                let m = neighbors[i];
+            for &m in &neighbors[start..=end] {
                 if alignment.align.get(&v) != Some(&v) {
                     continue;
                 }
@@ -738,16 +756,20 @@ fn vertical_alignment_with_layering(
                 let order_ok = prev_idx < m_pos;
                 let conflict_free = !has_conflict(conflicts, v, m);
 
-                if bk_trace && graph.border_type.contains_key(&v) {
+                if trace_enabled && graph.border_type.contains_key(&v) {
                     let v_name = &graph.node_ids[v].0;
-                    let neighbor_names: Vec<&str> = neighbors
-                        .iter()
-                        .map(|n| graph.node_ids[*n].0.as_str())
-                        .collect();
                     let m_name = &graph.node_ids[m].0;
-                    eprintln!(
-                        "[BK] border node={} neighbors={:?} prev_idx={} conflict_free={} order_ok={} median_candidate={}",
-                        v_name, neighbor_names, prev_idx, conflict_free, order_ok, m_name
+                    let root_name = &graph.node_ids[alignment.get_root(m)].0;
+                    tracing::trace!(
+                        event = "vertical_alignment",
+                        direction = ?direction,
+                        node_id = %v_name,
+                        neighbor = %m_name,
+                        prev_idx,
+                        conflict_free,
+                        order_ok,
+                        median_candidate = %m_name,
+                        root = %root_name,
                     );
                 }
 
@@ -758,16 +780,6 @@ fn vertical_alignment_with_layering(
                     alignment.root.insert(v, m_root);
                     alignment.align.insert(v, m_root);
                     prev_idx = m_pos;
-
-                    if bk_trace && graph.border_type.contains_key(&v) {
-                        let v_name = &graph.node_ids[v].0;
-                        let m_name = &graph.node_ids[m].0;
-                        let m_root_name = &graph.node_ids[alignment.get_root(m)].0;
-                        eprintln!(
-                            "[BK]   -> ALIGNED {}  to {} (root={})",
-                            v_name, m_name, m_root_name
-                        );
-                    }
                 }
             }
         }
@@ -1110,8 +1122,13 @@ fn compute_all_alignments(
         let adjusted_layers = adjusted_layers_with_order(&base_layers, direction);
         let compact_layers = compact_layers(&adjusted_layers);
         let downward = direction.is_downward();
-        let alignment =
-            vertical_alignment_with_layering(graph, &adjusted_layers, conflicts, downward);
+        let alignment = vertical_alignment_with_layering(
+            graph,
+            &adjusted_layers,
+            conflicts,
+            downward,
+            direction,
+        );
         let mut compaction = horizontal_compaction_with_direction(
             graph,
             &alignment,
@@ -1277,7 +1294,7 @@ pub fn position_x(graph: &LayoutGraph, config: &BKConfig) -> HashMap<NodeIndex, 
     if graph.node_ids.is_empty() {
         return HashMap::new();
     }
-    let bk_trace = super::debug::bk_trace_enabled();
+    let trace_enabled = bk_trace_enabled();
 
     // Step 1: Find all conflicts
     let conflicts = find_all_conflicts(graph);
@@ -1285,18 +1302,23 @@ pub fn position_x(graph: &LayoutGraph, config: &BKConfig) -> HashMap<NodeIndex, 
 
     // Step 2: Compute all 4 alignments
     let mut results = compute_all_alignments(graph, &conflicts, config);
-    if bk_trace {
+    if trace_enabled {
         for dir in AlignmentDirection::all() {
             if let Some(result) = results.get(&dir) {
                 let (center_min, center_max) = find_center_bounds(result);
                 let (bounds_min, bounds_max) = find_bounds(graph, result, config.direction);
                 let width = calculate_width(graph, result, config.direction);
                 let finite = result.x.values().filter(|x| x.is_finite()).count();
-                eprintln!(
-                    "[BK] {:?}: nodes={} finite={} center=[{center_min}, {center_max}] bounds=[{bounds_min}, {bounds_max}] width={width}",
-                    dir,
-                    result.x.len(),
-                    finite,
+                tracing::trace!(
+                    event = "alignment_result",
+                    direction = ?dir,
+                    node_count = result.x.len(),
+                    finite_count = finite,
+                    center_min,
+                    center_max,
+                    bounds_min,
+                    bounds_max,
+                    width,
                 );
             }
         }
@@ -1313,21 +1335,18 @@ pub fn position_x(graph: &LayoutGraph, config: &BKConfig) -> HashMap<NodeIndex, 
 }
 
 fn debug_dump_border_blocks(graph: &LayoutGraph, conflicts: &ConflictSet) {
-    if !super::debug::border_blocks_enabled() {
+    if !bk_trace_enabled() {
         return;
     }
 
     let mut compounds: Vec<usize> = graph.compound_nodes.iter().copied().collect();
     compounds.sort_by_key(|&idx| graph.node_ids[idx].0.clone());
 
-    eprintln!("[border_blocks] block roots");
     for dir in AlignmentDirection::all() {
         let alignment = vertical_alignment(graph, conflicts, dir);
-        eprintln!("[border_blocks] {:?}", dir);
 
         for compound_idx in &compounds {
             let name = &graph.node_ids[*compound_idx].0;
-            eprintln!("[border_blocks]   {}", name);
 
             let mut nodes: Vec<NodeIndex> = Vec::new();
             if let Some(left) = graph.border_left.get(compound_idx) {
@@ -1349,9 +1368,14 @@ fn debug_dump_border_blocks(graph: &LayoutGraph, conflicts: &ConflictSet) {
             for idx in nodes {
                 let root = alignment.get_root(idx);
                 let root_id = &graph.node_ids[root].0;
-                eprintln!(
-                    "[border_blocks]     {} rank={} order={} root={}",
-                    graph.node_ids[idx].0, graph.ranks[idx], graph.order[idx], root_id
+                tracing::trace!(
+                    event = "border_block",
+                    direction = ?dir,
+                    compound = %name,
+                    node_id = %graph.node_ids[idx].0,
+                    rank = graph.ranks[idx],
+                    order = graph.order[idx],
+                    root = %root_id,
                 );
             }
         }

--- a/src/engines/graph/algorithms/layered/kernel/border.rs
+++ b/src/engines/graph/algorithms/layered/kernel/border.rs
@@ -134,8 +134,6 @@ pub fn add_segments(lg: &mut LayoutGraph) {
 pub fn remove_nodes(lg: &mut LayoutGraph) -> HashMap<String, Rect> {
     debug_border_nodes(lg);
 
-    let debug_bounds = debug::subgraph_bounds_enabled();
-
     let mut bounds = HashMap::new();
 
     let compound_indices: Vec<usize> = lg.compound_nodes.iter().copied().collect();
@@ -183,20 +181,21 @@ pub fn remove_nodes(lg: &mut LayoutGraph) -> HashMap<String, Rect> {
             y_max = y_max.max(pos.y);
         }
 
-        // Bounds come from border nodes only, matching dagre.js removeBorderNodes
-        // (layout.js:309-330) which uses borderLeft/Right/Top/Bottom exclusively.
-        if debug_bounds {
-            let name = &lg.node_ids[compound_idx].0;
-            eprintln!(
-                "[subgraph_bounds] {} border=({:.2},{:.2})-({:.2},{:.2})",
-                name, x_min, y_min, x_max, y_max
-            );
-        }
-
         let width = (x_max - x_min).max(0.0);
         let height = (y_max - y_min).max(0.0);
 
         let name = lg.node_ids[compound_idx].0.clone();
+        tracing::trace!(
+            event = "subgraph_bounds",
+            compound = %name,
+            x_min,
+            y_min,
+            x_max,
+            y_max,
+            width,
+            height,
+        );
+
         bounds.insert(
             name,
             Rect {

--- a/src/engines/graph/algorithms/layered/kernel/debug.rs
+++ b/src/engines/graph/algorithms/layered/kernel/debug.rs
@@ -18,30 +18,6 @@ pub(crate) fn border_nodes_enabled() -> bool {
     env_flag("MMDFLUX_DEBUG_BORDER_NODES")
 }
 
-pub(crate) fn subgraph_bounds_enabled() -> bool {
-    env_flag("MMDFLUX_DEBUG_SUBGRAPH_BOUNDS")
-}
-
-pub(crate) fn dummy_parents_enabled() -> bool {
-    env_flag("MMDFLUX_DEBUG_DUMMY_PARENTS")
-}
-
-pub(crate) fn order_enabled() -> bool {
-    env_flag("MMDFLUX_DEBUG_ORDER")
-}
-
-pub(crate) fn conflicts_enabled() -> bool {
-    env_flag("MMDFLUX_DEBUG_CONFLICTS")
-}
-
-pub(crate) fn bk_trace_enabled() -> bool {
-    env_flag("MMDFLUX_DEBUG_BK_TRACE")
-}
-
-pub(crate) fn border_blocks_enabled() -> bool {
-    env_flag("MMDFLUX_DEBUG_BORDER_BLOCKS")
-}
-
 fn debug_pipeline_target() -> Option<String> {
     std::env::var("MMDFLUX_DEBUG_PIPELINE").ok()
 }

--- a/src/engines/graph/algorithms/layered/kernel/order.rs
+++ b/src/engines/graph/algorithms/layered/kernel/order.rs
@@ -615,29 +615,32 @@ fn add_subgraph_constraints(graph: &LayoutGraph, cg: &mut ConstraintGraph, sorte
     }
 }
 
-/// Check if order debug tracing is enabled via MMDFLUX_DEBUG_ORDER=1.
-fn debug_order() -> bool {
-    super::debug::order_enabled()
+fn order_trace_enabled() -> bool {
+    tracing::enabled!(tracing::Level::TRACE)
 }
 
 /// Dump per-rank node names and order values.
-fn debug_dump_order(graph: &LayoutGraph, label: &str) {
-    if !debug_order() {
+fn trace_rank_order(graph: &LayoutGraph, stage: &str) {
+    if !order_trace_enabled() {
         return;
     }
-    let layers = rank::by_rank(graph);
-    eprintln!("[order] {label}");
+
+    let layers = rank::by_rank_filtered(graph, |node| graph.is_position_node(node));
     for (rank, layer) in layers.iter().enumerate() {
         let mut nodes: Vec<(usize, &str)> = layer
             .iter()
             .map(|&idx| (graph.order[idx], graph.node_ids[idx].0.as_str()))
             .collect();
         nodes.sort_by_key(|&(ord, _)| ord);
-        let names: Vec<String> = nodes
-            .iter()
-            .map(|(ord, name)| format!("{name}={ord}"))
-            .collect();
-        eprintln!("[order]   rank {rank}: [{}]", names.join(", "));
+        for (order, node_id) in nodes {
+            tracing::trace!(
+                event = "rank_order",
+                stage,
+                rank,
+                node_id = %node_id,
+                order,
+            );
+        }
     }
 }
 
@@ -828,7 +831,7 @@ pub fn run_with_options(graph: &mut LayoutGraph, options: &OrderingOptions) {
 
     // DFS-based initial ordering
     init_order(graph, &layers, &backward_dummies);
-    debug_dump_order(graph, "after init_order");
+    trace_rank_order(graph, "after init_order");
 
     // Rebuild layers sorted by the new DFS order
     let layers = layers_sorted_by_order(&layers, graph);
@@ -845,6 +848,7 @@ pub fn run_with_options(graph: &mut LayoutGraph, options: &OrderingOptions) {
     let mut i: usize = 0;
     let mut last_best: usize = 0;
     let use_compound_sweeps = options.always_compound_ordering || !graph.compound_nodes.is_empty();
+    let trace_enabled = order_trace_enabled();
 
     while last_best < 4 {
         let bias_right = (i % 4) >= 2;
@@ -867,20 +871,25 @@ pub fn run_with_options(graph: &mut LayoutGraph, options: &OrderingOptions) {
 
         let cc = count_all_crossings(graph, &layers, &edges);
 
-        if debug_order() {
-            let dir = if i.is_multiple_of(2) { "up" } else { "down" };
-            eprintln!(
-                "[order] iter {i}: sweep_{dir}, bias_right={bias_right}, cc={cc}, best_cc={best_cc}"
+        if trace_enabled {
+            let sweep = if i.is_multiple_of(2) { "up" } else { "down" };
+            tracing::trace!(
+                event = "sweep",
+                iteration = i,
+                sweep,
+                bias_right,
+                crossings = cc,
+                best_crossings = best_cc,
             );
-            debug_dump_order(graph, &format!("after iter {i}"));
+            trace_rank_order(graph, &format!("after iter {i}"));
         }
 
         if cc < best_cc {
             last_best = 0;
             best_cc = cc;
             best_order = graph.order.clone();
-            if debug_order() {
-                eprintln!("[order] iter {i}: NEW BEST cc={cc}");
+            if trace_enabled {
+                tracing::trace!(event = "new_best", iteration = i, crossings = cc,);
             }
         }
         // NOTE: dagre 0.8.5 (used by Mermaid) does NOT replace the best order
@@ -901,17 +910,21 @@ pub fn run_with_options(graph: &mut LayoutGraph, options: &OrderingOptions) {
 
     // Post-pass: greedy switch refinement (two-sided, never increases crossings)
     if options.greedy_switch {
-        if debug_order() {
+        if trace_enabled {
             let before = count_all_crossings(graph, &layers, &edges);
             greedy_switch(graph, &layers, &edges, &backward_dummies);
             let after = count_all_crossings(graph, &layers, &edges);
-            eprintln!("[order] greedy_switch: {before} -> {after} crossings");
+            tracing::trace!(
+                event = "greedy_switch",
+                before_crossings = before,
+                after_crossings = after,
+            );
         } else {
             greedy_switch(graph, &layers, &edges, &backward_dummies);
         }
     }
 
-    debug_dump_order(graph, "final");
+    trace_rank_order(graph, "final");
 }
 
 /// Compound graph sweep: hierarchical ordering via sort_subgraph at each rank.

--- a/src/engines/graph/algorithms/layered/kernel/parent_dummy_chains.rs
+++ b/src/engines/graph/algorithms/layered/kernel/parent_dummy_chains.rs
@@ -4,7 +4,6 @@
 //! during normalization are associated with the correct compound ancestors,
 //! which affects ordering and border placement.
 
-use super::debug;
 use super::graph::LayoutGraph;
 
 #[derive(Clone, Copy, Debug)]
@@ -18,7 +17,7 @@ pub(crate) fn run(graph: &mut LayoutGraph) {
         return;
     }
 
-    let debug = debug::dummy_parents_enabled();
+    let trace_enabled = tracing::enabled!(tracing::Level::TRACE);
     let postorder = compute_postorder(graph);
 
     for chain in &graph.dummy_chains {
@@ -31,7 +30,7 @@ pub(crate) fn run(graph: &mut LayoutGraph) {
             continue;
         }
 
-        if debug {
+        if trace_enabled {
             let src_id = &graph.node_ids[src].0;
             let tgt_id = &graph.node_ids[tgt].0;
             let lca_label = lca
@@ -44,9 +43,13 @@ pub(crate) fn run(graph: &mut LayoutGraph) {
                         .unwrap_or_else(|| "None".to_string())
                 })
                 .collect();
-            eprintln!(
-                "[dummy_parents] edge {} src={} tgt={} lca={} path={:?}",
-                chain.edge_index, src_id, tgt_id, lca_label, path_ids
+            tracing::trace!(
+                event = "dummy_chain",
+                edge_index = chain.edge_index,
+                source_node = %src_id,
+                target_node = %tgt_id,
+                lca = %lca_label,
+                path = ?path_ids,
             );
         }
 
@@ -87,14 +90,17 @@ pub(crate) fn run(graph: &mut LayoutGraph) {
             }
 
             graph.parents[dummy_idx] = path_v;
-            if debug {
+            if trace_enabled {
                 let dummy_name = &graph.node_ids[dummy_idx].0;
                 let parent_label = path_v
                     .map(|pv| graph.node_ids[pv].0.clone())
                     .unwrap_or_else(|| "None".to_string());
-                eprintln!(
-                    "[dummy_parents]   dummy {} rank {} -> {}",
-                    dummy_name, dummy_rank, parent_label
+                tracing::trace!(
+                    event = "dummy_parent",
+                    edge_index = chain.edge_index,
+                    dummy = %dummy_name,
+                    rank = dummy_rank,
+                    parent = %parent_label,
                 );
             }
         }

--- a/src/engines/graph/algorithms/layered/kernel/rank.rs
+++ b/src/engines/graph/algorithms/layered/kernel/rank.rs
@@ -73,6 +73,7 @@ pub fn remove_empty_ranks(graph: &mut LayoutGraph) {
 }
 
 /// Get nodes grouped by rank.
+#[cfg(test)]
 pub fn by_rank(graph: &LayoutGraph) -> Vec<Vec<usize>> {
     let max_rank = graph.ranks.iter().max().copied().unwrap_or(0) as usize;
     let mut layers: Vec<Vec<usize>> = vec![Vec::new(); max_rank + 1];

--- a/src/graph/grid/routing/draw_path.rs
+++ b/src/graph/grid/routing/draw_path.rs
@@ -276,10 +276,20 @@ pub(super) fn route_edge_from_draw_path(
         return Err(TextPathRejection::SegmentCollision);
     }
 
-    if std::env::var("MMDFLUX_DEBUG_ROUTE_SEGMENTS").is_ok_and(|value| value == "1") {
-        eprintln!(
-            "[route-routed] {} -> {}: points={points:?} waypoints={waypoints:?} start={:?} end={:?} segments={:?}",
-            edge.from, edge.to, routed.start, routed.end, routed.segments
+    if tracing::enabled!(tracing::Level::TRACE) {
+        tracing::trace!(
+            event = "draw_path",
+            source_node = %edge.from,
+            target_node = %edge.to,
+            direction = ?direction,
+            point_count = points.len(),
+            waypoint_count = waypoints.len(),
+            segment_count = routed.segments.len(),
+            start = ?routed.start,
+            end = ?routed.end,
+            points = ?points,
+            waypoints = ?waypoints,
+            segments = ?routed.segments,
         );
     }
 

--- a/src/graph/grid/routing/path_selection.rs
+++ b/src/graph/grid/routing/path_selection.rs
@@ -266,10 +266,14 @@ fn debug_draw_path_rejection(
     rejection: TextPathRejection,
     draw_path: &[(usize, usize)],
 ) {
-    if std::env::var("MMDFLUX_DEBUG_ROUTE_SEGMENTS").is_ok_and(|value| value == "1") {
-        eprintln!(
-            "[route-routed-reject] {} -> {}: reason={rejection:?} points={draw_path:?}",
-            edge.from, edge.to
+    if tracing::enabled!(tracing::Level::TRACE) {
+        tracing::trace!(
+            event = "draw_path_rejected",
+            source_node = %edge.from,
+            target_node = %edge.to,
+            rejection_reason = ?rejection,
+            point_count = draw_path.len(),
+            points = ?draw_path,
         );
     }
 }

--- a/src/graph/grid/routing/route_variants.rs
+++ b/src/graph/grid/routing/route_variants.rs
@@ -16,6 +16,10 @@ use super::types::{
 };
 use crate::graph::{Arrow, Direction, Edge};
 
+fn route_segments_trace_enabled() -> bool {
+    tracing::enabled!(tracing::Level::TRACE)
+}
+
 /// Route an edge using waypoints from normalization.
 pub(super) fn route_edge_with_waypoints(
     edge: &Edge,
@@ -34,13 +38,6 @@ pub(super) fn route_edge_with_waypoints(
 
     let src_attach_point = clamp_to_boundary(src_attach_raw, &ep.from_bounds);
     let src_attach = (src_attach_point.x, src_attach_point.y);
-
-    if std::env::var("MMDFLUX_DEBUG_ROUTE_SEGMENTS").is_ok_and(|v| v == "1") {
-        eprintln!(
-            "[route] {} -> {}: waypoints={:?}",
-            edge.from, edge.to, waypoints
-        );
-    }
 
     let is_backward = is_backward_edge(&ep.from_bounds, &ep.to_bounds, direction);
     let (default_src_face, default_tgt_face) = edge_faces(direction, is_backward);
@@ -76,6 +73,20 @@ pub(super) fn route_edge_with_waypoints(
     };
     let mut start = offset_for_face(src_attach, src_face);
     let end = offset_for_face(tgt_attach, tgt_face);
+    let trace_enabled = route_segments_trace_enabled();
+    if trace_enabled {
+        tracing::trace!(
+            event = "route_candidate",
+            source_node = %edge.from,
+            target_node = %edge.to,
+            direction = ?direction,
+            is_backward,
+            src_face = ?src_face,
+            target_face = ?tgt_face,
+            waypoint_count = waypoints.len(),
+            waypoints = ?waypoints,
+        );
+    }
 
     if let Some(&(wp_x, wp_y)) = waypoints.first() {
         let should_skip_offset = match src_face {
@@ -159,10 +170,20 @@ pub(super) fn route_edge_with_waypoints(
     ensure_terminal_face_support(&mut segments, start, end, tgt_face);
     let entry_direction = entry_direction_from_face(tgt_face);
 
-    if std::env::var("MMDFLUX_DEBUG_ROUTE_SEGMENTS").is_ok_and(|v| v == "1") {
-        eprintln!(
-            "[route] {} -> {}: start={:?} end={:?} segments={:?}",
-            edge.from, edge.to, start, end, segments
+    if trace_enabled {
+        tracing::trace!(
+            event = "route_segments",
+            source_node = %edge.from,
+            target_node = %edge.to,
+            direction = ?direction,
+            is_backward,
+            src_face = ?src_face,
+            target_face = ?tgt_face,
+            waypoint_count = waypoints.len(),
+            segment_count = segments.len(),
+            start = ?start,
+            end = ?end,
+            segments = ?segments,
         );
     }
 

--- a/src/internal_tests/graph_routing_pipeline.rs
+++ b/src/internal_tests/graph_routing_pipeline.rs
@@ -88,6 +88,26 @@ fn layout_fixture_svg(name: &str) -> (crate::graph::Graph, GraphGeometry) {
     layout_test_svg(&input)
 }
 
+fn rust_log_requests_mmdflux_trace() -> bool {
+    std::env::var("RUST_LOG").is_ok_and(|value| {
+        value.split(',').any(|directive| {
+            let directive = directive.trim();
+            directive == "mmdflux=trace"
+                || directive == "mmdflux::runtime=trace"
+                || directive == "mmdflux::runtime=debug"
+        })
+    })
+}
+
+fn assert_render_trace_enabled_when_requested() {
+    if rust_log_requests_mmdflux_trace() {
+        assert!(
+            tracing::enabled!(target: "mmdflux::runtime", tracing::Level::DEBUG),
+            "RUST_LOG requests mmdflux render tracing, but no test subscriber enabled it"
+        );
+    }
+}
+
 const ROUTE_EPS: f64 = 0.000_001;
 
 fn approx_eq(a: f64, b: f64) -> bool {
@@ -3010,6 +3030,15 @@ fn fan_in_overflow_policy_spec_defines_spill_distribution_order() {
 
 #[test]
 fn fan_in_backward_channel_conflict_resolution_is_deterministic_and_documented() {
+    assert_render_trace_enabled_when_requested();
+    let rendered = crate::runtime::render_diagram(
+        "graph TD\nA-->B",
+        crate::format::OutputFormat::Text,
+        &crate::runtime::config::RenderConfig::default(),
+    )
+    .expect("render trace smoke should render");
+    assert!(rendered.contains("A"));
+
     let fixture = "fan_in_backward_channel_conflict.mmd";
     let (diagram, geom) = layout_fixture_svg(fixture);
     let first = route_graph_geometry(
@@ -3119,19 +3148,23 @@ fn fan_in_backward_channel_conflict_resolution_is_deterministic_and_documented()
     );
 
     let incoming_to_b: Vec<_> = first.edges.iter().filter(|edge| edge.to == "B").collect();
-    if std::env::var("MMDFLUX_DEBUG_FAN_IN").is_ok_and(|v| v == "1") {
-        for edge in &incoming_to_b {
-            let end = edge
-                .path
-                .last()
-                .copied()
-                .expect("inbound edge should have endpoint");
-            let end_face = point_on_target_face(target_rect, end);
-            eprintln!(
-                "edge {}->{} index={} backward={} end={:?} face={}",
-                edge.from, edge.to, edge.index, edge.is_backward, end, end_face
-            );
-        }
+    for edge in &incoming_to_b {
+        let end = edge
+            .path
+            .last()
+            .copied()
+            .expect("inbound edge should have endpoint");
+        let end_face = point_on_target_face(target_rect, end);
+        tracing::trace!(
+            target: "mmdflux::tests::graph_routing_pipeline",
+            event = "fan_in_edge",
+            source_node = %edge.from,
+            target_node = %edge.to,
+            edge_index = edge.index,
+            is_backward = edge.is_backward,
+            ?end,
+            end_face = ?end_face,
+        );
     }
     assert_eq!(
         incoming_to_b.len(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,4 +212,7 @@ pub use runtime::validate_diagram;
 
 // Residual crate-local tests stay narrowly scoped to cross-pipeline coverage.
 #[cfg(test)]
+mod test_tracing;
+
+#[cfg(test)]
 mod internal_tests;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,9 @@ mod svg_theme_auto;
 mod terminal_appearance;
 
 use std::ffi::OsStr;
-use std::io::{self, IsTerminal, Read};
+use std::io::{self, IsTerminal, Read, Write};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::{env, fmt, fs};
 
 use clap::{Parser, ValueEnum};
@@ -291,6 +292,18 @@ struct Cli {
     /// Ignored for text/ASCII.
     #[arg(long, value_enum)]
     path_simplification: Option<PathSimplificationArg>,
+
+    /// Enable tracing output with an EnvFilter directive.
+    #[arg(long, value_name = "FILTER")]
+    log: Option<String>,
+
+    /// Tracing output format.
+    #[arg(long, value_enum, default_value_t = LogFormatArg::Compact)]
+    log_format: LogFormatArg,
+
+    /// Write tracing output to a file instead of stderr.
+    #[arg(long, value_name = "PATH")]
+    log_file: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, ValueEnum, Debug)]
@@ -390,6 +403,13 @@ impl From<SvgThemeModeArg> for SvgThemeMode {
     }
 }
 
+#[derive(Clone, Copy, ValueEnum, Debug)]
+enum LogFormatArg {
+    Compact,
+    Pretty,
+    Json,
+}
+
 fn resolve_curve_from_cli(raw: Option<&str>) -> Result<Option<Curve>, String> {
     raw.map(Curve::parse).transpose().map_err(|err| {
         if err.message.contains("expected one of") {
@@ -462,8 +482,97 @@ fn svg_theme_from_cli(cli: &Cli) -> Option<SvgThemeConfig> {
     svg_theme_from_cli_with_appearance(cli, detect_terminal_appearance(), detect_os_appearance())
 }
 
+fn resolve_log_filter(cli: &Cli) -> Option<String> {
+    if let Some(filter) = cli.log.as_deref().filter(|value| !value.trim().is_empty()) {
+        return Some(filter.to_string());
+    }
+
+    env::var("MMDFLUX_LOG")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            env::var("RUST_LOG")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+}
+
+fn init_tracing(cli: &Cli) -> io::Result<()> {
+    let Some(filter) = resolve_log_filter(cli) else {
+        return Ok(());
+    };
+
+    let env_filter = tracing_subscriber::EnvFilter::try_new(&filter).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid log filter: {error}"),
+        )
+    })?;
+
+    match &cli.log_file {
+        Some(path) => {
+            let writer = SharedLogWriter::new(fs::File::create(path)?);
+            init_tracing_with_writer(env_filter, cli.log_format, move || writer.clone())
+        }
+        None => init_tracing_with_writer(env_filter, cli.log_format, io::stderr),
+    }
+}
+
+fn init_tracing_with_writer<W>(
+    env_filter: tracing_subscriber::EnvFilter,
+    log_format: LogFormatArg,
+    make_writer: W,
+) -> io::Result<()>
+where
+    W: for<'writer> tracing_subscriber::fmt::MakeWriter<'writer> + Send + Sync + 'static,
+{
+    let builder = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(make_writer)
+        .with_ansi(false)
+        .with_target(true);
+
+    let result = match log_format {
+        LogFormatArg::Compact => builder.compact().try_init(),
+        LogFormatArg::Pretty => builder.pretty().try_init(),
+        LogFormatArg::Json => builder.json().try_init(),
+    };
+
+    result.map_err(|error| io::Error::other(format!("failed to initialize tracing: {error}")))
+}
+
+#[derive(Clone)]
+struct SharedLogWriter {
+    file: Arc<Mutex<fs::File>>,
+}
+
+impl SharedLogWriter {
+    fn new(file: fs::File) -> Self {
+        Self {
+            file: Arc::new(Mutex::new(file)),
+        }
+    }
+}
+
+impl Write for SharedLogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.file
+            .lock()
+            .map_err(|_| io::Error::other("log file lock poisoned"))?
+            .write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file
+            .lock()
+            .map_err(|_| io::Error::other("log file lock poisoned"))?
+            .flush()
+    }
+}
+
 fn main() -> io::Result<()> {
     let cli = Cli::parse();
+    init_tracing(&cli)?;
 
     let input = match &cli.input {
         Some(path) => fs::read_to_string(path)?,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -44,7 +44,21 @@ pub fn render_diagram(
     format: OutputFormat,
     config: &RenderConfig,
 ) -> Result<String, RenderError> {
-    if matches!(detect_input_frontend(input), Some(InputFrontend::Mmds)) {
+    let frontend = detect_input_frontend(input);
+    let render_span = tracing::debug_span!(
+        "render_diagram",
+        format = %format,
+        input_bytes = input.len(),
+        frontend = tracing::field::Empty,
+        diagram_type = tracing::field::Empty,
+        geometry_level = %config.geometry_level,
+    );
+    let _render_span_guard = render_span.enter();
+
+    if matches!(frontend, Some(InputFrontend::Mmds)) {
+        render_span.record("frontend", "mmds");
+        render_span.record("diagram_type", "mmds");
+        tracing::debug!(event = "render", "render_diagram");
         let svg_theme = if matches!(format, OutputFormat::Svg) {
             resolve_configured_svg_theme(config)?
         } else {
@@ -64,9 +78,12 @@ pub fn render_diagram(
 
     let registry = default_registry();
 
+    render_span.record("frontend", "mermaid");
     let diagram_id = registry.detect(input).ok_or_else(|| RenderError {
         message: "unknown diagram type".to_string(),
     })?;
+    render_span.record("diagram_type", diagram_id);
+    tracing::debug!(event = "render", "render_diagram");
 
     // Check format support and engine policy before creating an instance.
     if !registry.supports_format(diagram_id, format) {
@@ -225,9 +242,32 @@ pub(in crate::runtime) fn svg_theme_spec_from_config(config: &SvgThemeConfig) ->
 
 #[cfg(test)]
 mod tests {
-    use super::{RenderConfig, effective_render_config, validate_diagram};
+    use std::sync::{Arc, Mutex};
+
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::layer::Context;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::registry::LookupSpan;
+
+    use super::{RenderConfig, effective_render_config, render_diagram, validate_diagram};
     use crate::format::OutputFormat;
     use crate::runtime::config::SvgThemeConfig;
+
+    #[test]
+    fn render_diagram_emits_render_trace_context() {
+        let input = "graph TD\nA-->B";
+        let collected = collect_trace_events_with_scoped_subscriber(|| {
+            let _ = render_diagram(input, OutputFormat::Text, &RenderConfig::default())
+                .expect("render");
+        });
+
+        assert!(collected.contains_target("mmdflux::runtime"));
+        assert!(collected.contains_field("format", "text"));
+        assert!(collected.contains_field("input_bytes", &input.len().to_string()));
+        assert!(collected.contains_field("frontend", "mermaid"));
+        assert!(collected.contains_field("diagram_type", "flowchart"));
+        assert!(collected.contains_field("geometry_level", "layout"));
+    }
 
     #[test]
     fn validate_diagram_skips_warning_for_frontmatter_theme_hint() {
@@ -292,5 +332,137 @@ mod tests {
                 .and_then(|theme| theme.name.as_deref()),
             Some("dark")
         );
+    }
+
+    fn collect_trace_events_with_scoped_subscriber(f: impl FnOnce()) -> CollectedTraceEvents {
+        let records = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(TraceCollector {
+            records: Arc::clone(&records),
+        });
+
+        tracing::subscriber::with_default(subscriber, f);
+
+        CollectedTraceEvents {
+            records: records.lock().expect("records lock").clone(),
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct CollectedTraceEvents {
+        records: Vec<TraceRecord>,
+    }
+
+    impl CollectedTraceEvents {
+        fn contains_target(&self, target: &str) -> bool {
+            self.records.iter().any(|record| record.target == target)
+        }
+
+        fn contains_field(&self, name: &str, value: &str) -> bool {
+            self.records.iter().any(|record| {
+                record
+                    .fields
+                    .iter()
+                    .any(|(field_name, field_value)| field_name == name && field_value == value)
+            })
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct TraceRecord {
+        target: String,
+        fields: Vec<(String, String)>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct TraceCollector {
+        records: Arc<Mutex<Vec<TraceRecord>>>,
+    }
+
+    impl<S> tracing_subscriber::Layer<S> for TraceCollector
+    where
+        S: tracing::Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(
+            &self,
+            attrs: &tracing::span::Attributes<'_>,
+            _id: &tracing::span::Id,
+            _ctx: Context<'_, S>,
+        ) {
+            let mut visitor = FieldVisitor::default();
+            attrs.record(&mut visitor);
+            self.records
+                .lock()
+                .expect("records lock")
+                .push(TraceRecord {
+                    target: attrs.metadata().target().to_string(),
+                    fields: visitor.fields,
+                });
+        }
+
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = FieldVisitor::default();
+            event.record(&mut visitor);
+            self.records
+                .lock()
+                .expect("records lock")
+                .push(TraceRecord {
+                    target: event.metadata().target().to_string(),
+                    fields: visitor.fields,
+                });
+        }
+
+        fn on_record(
+            &self,
+            id: &tracing::span::Id,
+            values: &tracing::span::Record<'_>,
+            ctx: Context<'_, S>,
+        ) {
+            let Some(span) = ctx.span(id) else {
+                return;
+            };
+
+            let mut visitor = FieldVisitor::default();
+            values.record(&mut visitor);
+            self.records
+                .lock()
+                .expect("records lock")
+                .push(TraceRecord {
+                    target: span.metadata().target().to_string(),
+                    fields: visitor.fields,
+                });
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct FieldVisitor {
+        fields: Vec<(String, String)>,
+    }
+
+    impl FieldVisitor {
+        fn push(&mut self, field: &Field, value: String) {
+            self.fields.push((field.name().to_string(), value));
+        }
+    }
+
+    impl Visit for FieldVisitor {
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            self.push(field, value.to_string());
+        }
+
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.push(field, value.to_string());
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.push(field, value.to_string());
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.push(field, value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.push(field, format!("{value:?}"));
+        }
     }
 }

--- a/src/test_tracing.rs
+++ b/src/test_tracing.rs
@@ -1,0 +1,25 @@
+//! Test-only tracing subscriber initialization for crate-local tests.
+
+use std::sync::OnceLock;
+
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{EnvFilter, fmt};
+
+static INIT: OnceLock<()> = OnceLock::new();
+
+#[ctor::ctor]
+fn init_tracing_for_tests() {
+    INIT.get_or_init(|| {
+        // The ctor runs once at process startup, so per-test RUST_LOG changes
+        // cannot reconfigure this subscriber. Scoped with_default subscribers
+        // are also thread-local and remain separate from this global default.
+        let filter = std::env::var_os("RUST_LOG")
+            .map(|_| EnvFilter::from_default_env())
+            .unwrap_or_else(|| EnvFilter::new("off"));
+
+        let _ = tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt::layer().with_test_writer())
+            .try_init();
+    });
+}

--- a/tests/class_instance.rs
+++ b/tests/class_instance.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::fs;
 use std::path::Path;
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,10 +1,22 @@
 //! CLI integration tests for mmdflux binary.
 
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::{fs, process};
 
 use assert_cmd::Command;
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
+
+const RENDER_TRACE_FILTER: &str = "mmdflux::runtime=debug";
+const LAYERED_KERNEL_TRACE_FILTER: &str = concat!(
+    "mmdflux::engines::graph::algorithms::layered::kernel::border=trace,",
+    "mmdflux::engines::graph::algorithms::layered::kernel::parent_dummy_chains=trace",
+);
+const ORDER_TRACE_FILTER: &str =
+    "mmdflux::engines::graph::algorithms::layered::kernel::order=trace";
+const BK_TRACE_FILTER: &str = "mmdflux::engines::graph::algorithms::layered::kernel::bk=trace";
+const ROUTE_SEGMENT_TRACE_FILTER: &str = "mmdflux::graph::grid::routing=trace";
 
 fn mmdflux() -> Command {
     cargo_bin_cmd!("mmdflux")
@@ -31,6 +43,49 @@ fn strip_ansi(input: &str) -> String {
     stripped
 }
 
+fn output_stdout(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+fn output_stderr(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+fn assert_command_success(output: &std::process::Output) {
+    assert!(
+        output.status.success(),
+        "command failed: status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        output_stdout(output),
+        output_stderr(output)
+    );
+}
+
+fn assert_render_trace_present(log: &str) {
+    assert!(
+        log.contains("mmdflux::runtime")
+            || (log.contains("render_diagram") && log.contains("input_bytes")),
+        "expected render trace context in log output:\n{log}"
+    );
+}
+
+fn assert_render_trace_absent(log: &str) {
+    assert!(
+        !log.contains("mmdflux::runtime")
+            && !log.contains("render_diagram")
+            && !log.contains("input_bytes"),
+        "did not expect render trace context in output:\n{log}"
+    );
+}
+
+fn temp_log_path(name: &str) -> std::path::PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("mmdflux-{name}-{}-{nanos}.log", process::id()))
+}
+
 // =============================================================================
 // Debug Flag Tests
 // =============================================================================
@@ -43,6 +98,417 @@ fn cli_debug_shows_detected_diagram_type() {
         .assert()
         .success()
         .stderr(predicate::str::contains("Detected diagram type: flowchart"));
+}
+
+// =============================================================================
+// Tracing Log Tests
+// =============================================================================
+
+#[test]
+fn cli_log_filter_enables_trace_output() {
+    let output = mmdflux()
+        .args(["--log", RENDER_TRACE_FILTER])
+        .env_remove("MMDFLUX_LOG")
+        .env_remove("RUST_LOG")
+        .write_stdin("graph TD\nA-->B")
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&output);
+    let stdout = output_stdout(&output);
+    let stderr = output_stderr(&output);
+    assert!(
+        stdout.contains('A'),
+        "render stdout should be preserved: {stdout}"
+    );
+    assert_render_trace_absent(&stdout);
+    assert_render_trace_present(&stderr);
+}
+
+#[test]
+fn cli_log_format_accepts_compact_pretty_and_json() {
+    for format in ["compact", "pretty", "json"] {
+        let output = mmdflux()
+            .args(["--log", RENDER_TRACE_FILTER, "--log-format", format])
+            .env_remove("MMDFLUX_LOG")
+            .env_remove("RUST_LOG")
+            .write_stdin("graph TD\nA-->B")
+            .output()
+            .expect("command should run");
+
+        assert_command_success(&output);
+        let stderr = output_stderr(&output);
+        assert_render_trace_present(&stderr);
+        if format == "json" {
+            assert!(
+                stderr.contains("\"target\":\"mmdflux::runtime\""),
+                "json trace output should include the render target:\n{stderr}"
+            );
+        }
+    }
+}
+
+#[test]
+fn cli_log_file_writes_trace_output_to_file_not_stdout() {
+    let log_path = temp_log_path("trace");
+    let output = mmdflux()
+        .args([
+            "--log",
+            RENDER_TRACE_FILTER,
+            "--log-file",
+            log_path.to_str().expect("temp path should be utf-8"),
+        ])
+        .env_remove("MMDFLUX_LOG")
+        .env_remove("RUST_LOG")
+        .write_stdin("graph TD\nA-->B")
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&output);
+    let stdout = output_stdout(&output);
+    let stderr = output_stderr(&output);
+    assert_render_trace_absent(&stdout);
+    assert_render_trace_absent(&stderr);
+
+    let file_log = fs::read_to_string(&log_path).expect("log file should be written");
+    assert_render_trace_present(&file_log);
+    let _ = fs::remove_file(log_path);
+}
+
+#[test]
+fn cli_log_invalid_filter_exits_nonzero() {
+    mmdflux()
+        .args(["--log", "["])
+        .env_remove("MMDFLUX_LOG")
+        .env_remove("RUST_LOG")
+        .write_stdin("graph TD\nA-->B")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid log filter"));
+}
+
+#[test]
+fn cli_log_filter_precedence_prefers_flag_then_mmdflux_log_then_rust_log() {
+    let flag_output = mmdflux()
+        .args(["--log", RENDER_TRACE_FILTER])
+        .env("MMDFLUX_LOG", "off")
+        .env("RUST_LOG", "off")
+        .write_stdin("graph TD\nA-->B")
+        .output()
+        .expect("command should run");
+    assert_command_success(&flag_output);
+    assert_render_trace_present(&output_stderr(&flag_output));
+
+    let mmdflux_log_output = mmdflux()
+        .env("MMDFLUX_LOG", RENDER_TRACE_FILTER)
+        .env("RUST_LOG", "off")
+        .write_stdin("graph TD\nA-->B")
+        .output()
+        .expect("command should run");
+    assert_command_success(&mmdflux_log_output);
+    assert_render_trace_present(&output_stderr(&mmdflux_log_output));
+
+    let rust_log_output = mmdflux()
+        .env_remove("MMDFLUX_LOG")
+        .env("RUST_LOG", RENDER_TRACE_FILTER)
+        .write_stdin("graph TD\nA-->B")
+        .output()
+        .expect("command should run");
+    assert_command_success(&rust_log_output);
+    assert_render_trace_present(&output_stderr(&rust_log_output));
+
+    let mmdflux_log_beats_rust_log_output = mmdflux()
+        .env("MMDFLUX_LOG", "off")
+        .env("RUST_LOG", RENDER_TRACE_FILTER)
+        .write_stdin("graph TD\nA-->B")
+        .output()
+        .expect("command should run");
+    assert_command_success(&mmdflux_log_beats_rust_log_output);
+    assert_render_trace_absent(&output_stderr(&mmdflux_log_beats_rust_log_output));
+}
+
+#[test]
+fn cli_log_debug_flag_still_only_prints_detected_diagram_type() {
+    let output = mmdflux()
+        .arg("--debug")
+        .env_remove("MMDFLUX_LOG")
+        .env_remove("RUST_LOG")
+        .write_stdin("graph TD\nA-->B")
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&output);
+    let stderr = output_stderr(&output);
+    assert!(stderr.contains("Detected diagram type: flowchart"));
+    assert_render_trace_absent(&stderr);
+}
+
+#[test]
+fn cli_log_quiet_suppresses_warnings_but_not_requested_trace_output() {
+    let input = "%%{init: {}}%%\ngraph TD\nA --> B\n";
+    let output = mmdflux()
+        .args(["--quiet", "--log", RENDER_TRACE_FILTER])
+        .env_remove("MMDFLUX_LOG")
+        .env_remove("RUST_LOG")
+        .write_stdin(input)
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&output);
+    let stderr = output_stderr(&output);
+    assert_render_trace_present(&stderr);
+    assert!(
+        !stderr.contains("Strict parsing would reject"),
+        "--quiet should suppress validation warnings even when traces are enabled:\n{stderr}"
+    );
+}
+
+#[test]
+fn cli_log_filter_enables_layered_kernel_trace_events() {
+    let output = mmdflux()
+        .args(["--log", LAYERED_KERNEL_TRACE_FILTER])
+        .env_remove("MMDFLUX_LOG")
+        .env_remove("RUST_LOG")
+        .write_stdin(include_str!(
+            "fixtures/flowchart/external_node_subgraph.mmd"
+        ))
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&output);
+    let stderr = strip_ansi(&output_stderr(&output));
+    assert!(
+        stderr.contains("mmdflux::engines::graph::algorithms::layered::kernel::border")
+            && stderr.contains("event=\"subgraph_bounds\""),
+        "expected subgraph bounds trace event:\n{stderr}"
+    );
+    assert!(
+        stderr
+            .contains("mmdflux::engines::graph::algorithms::layered::kernel::parent_dummy_chains")
+            && stderr.contains("event=\"dummy_chain\"")
+            && stderr.contains("event=\"dummy_parent\""),
+        "expected dummy parent trace events:\n{stderr}"
+    );
+}
+
+#[test]
+fn cli_log_filter_enables_order_trace_events() {
+    let output = mmdflux()
+        .args(["--log", ORDER_TRACE_FILTER])
+        .env_remove("MMDFLUX_LOG")
+        .env_remove("RUST_LOG")
+        .write_stdin(include_str!(
+            "fixtures/flowchart/external_node_subgraph.mmd"
+        ))
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&output);
+    let stderr = strip_ansi(&output_stderr(&output));
+    for event in [
+        "event=\"rank_order\"",
+        "event=\"sweep\"",
+        "event=\"new_best\"",
+        "event=\"greedy_switch\"",
+    ] {
+        assert!(
+            stderr.contains(event),
+            "expected order trace {event}:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn cli_log_filter_enables_bk_trace_events() {
+    let compound_output = mmdflux()
+        .args(["--log", BK_TRACE_FILTER])
+        .env_remove("MMDFLUX_LOG")
+        .env_remove("RUST_LOG")
+        .write_stdin(include_str!(
+            "fixtures/flowchart/external_node_subgraph.mmd"
+        ))
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&compound_output);
+    let compound_stderr = strip_ansi(&output_stderr(&compound_output));
+    for event in [
+        "event=\"layer_matrix\"",
+        "event=\"vertical_alignment\"",
+        "event=\"alignment_result\"",
+        "event=\"border_block\"",
+    ] {
+        assert!(
+            compound_stderr.contains(event),
+            "expected BK trace {event}:\n{compound_stderr}"
+        );
+    }
+
+    let conflict_output = mmdflux()
+        .args(["--log", BK_TRACE_FILTER])
+        .env_remove("MMDFLUX_LOG")
+        .env_remove("RUST_LOG")
+        .write_stdin(include_str!(
+            "fixtures/flowchart/architecture_graph_lr_terminal_contracts.mmd"
+        ))
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&conflict_output);
+    let conflict_stderr = strip_ansi(&output_stderr(&conflict_output));
+    assert!(
+        conflict_stderr.contains("event=\"conflict\""),
+        "expected BK conflict trace event:\n{conflict_stderr}"
+    );
+}
+
+#[test]
+fn cli_log_filter_enables_route_segment_trace_events() {
+    let output = mmdflux()
+        .args(["--log", ROUTE_SEGMENT_TRACE_FILTER])
+        .env_remove("MMDFLUX_LOG")
+        .env_remove("RUST_LOG")
+        .write_stdin(include_str!(
+            "fixtures/flowchart/architecture_graph_lr_terminal_contracts.mmd"
+        ))
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&output);
+    let stderr = strip_ansi(&output_stderr(&output));
+    for expected in [
+        "event=\"route_candidate\"",
+        "event=\"route_segments\"",
+        "event=\"draw_path\"",
+        "event=\"draw_path_rejected\"",
+        "segment_count",
+        "point_count",
+        "rejection_reason",
+    ] {
+        assert!(
+            stderr.contains(expected),
+            "expected route segment trace {expected}:\n{stderr}"
+        );
+    }
+}
+
+#[test]
+fn debug_pipeline_env_writes_jsonl_to_stderr_and_appends_file() {
+    let input = include_str!("fixtures/flowchart/external_node_subgraph.mmd");
+    let stderr_output = mmdflux()
+        .env("MMDFLUX_DEBUG_PIPELINE", "1")
+        .write_stdin(input)
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&stderr_output);
+    let stderr = output_stderr(&stderr_output);
+    let mut lines = stderr.lines();
+    let first_line = lines.next().expect("pipeline stderr should contain JSONL");
+    let parsed: serde_json::Value =
+        serde_json::from_str(first_line).expect("pipeline line should be JSON");
+    assert_eq!(parsed["stage"], "after_rank");
+    assert_eq!(parsed["id"], "Cloud");
+    assert!(stderr.contains(r#""stage":"after_border_segments""#));
+
+    let path = temp_log_path("debug-pipeline");
+    fs::write(&path, "sentinel\n").expect("seed pipeline file");
+    for _ in 0..2 {
+        let output = mmdflux()
+            .env("MMDFLUX_DEBUG_PIPELINE", &path)
+            .write_stdin(input)
+            .output()
+            .expect("command should run");
+        assert_command_success(&output);
+    }
+
+    let contents = fs::read_to_string(&path).expect("pipeline file should be written");
+    assert!(
+        contents.starts_with("sentinel\n"),
+        "pipeline file should append instead of truncating:\n{contents}"
+    );
+    assert!(
+        contents.matches(r#""stage":"after_rank""#).count() >= 2,
+        "pipeline file should append JSONL for each run:\n{contents}"
+    );
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn debug_layout_env_writes_compact_json_to_stderr_and_truncates_file() {
+    let input = include_str!("fixtures/flowchart/external_node_subgraph.mmd");
+    let stderr_output = mmdflux()
+        .env("MMDFLUX_DEBUG_LAYOUT", "1")
+        .write_stdin(input)
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&stderr_output);
+    let stderr = output_stderr(&stderr_output);
+    assert_eq!(
+        stderr.lines().count(),
+        1,
+        "layout stderr should be one compact JSON document:\n{stderr}"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(stderr.trim()).expect("layout stderr should parse");
+    assert!(parsed["nodes"].is_array());
+    assert!(parsed["edges"].is_array());
+    assert!(parsed["subgraph_bounds"].is_array());
+    assert!(parsed["graph"].is_object());
+
+    let path = temp_log_path("debug-layout");
+    fs::write(&path, "stale").expect("seed layout file");
+    let output = mmdflux()
+        .env("MMDFLUX_DEBUG_LAYOUT", &path)
+        .write_stdin(input)
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&output);
+    let contents = fs::read_to_string(&path).expect("layout file should be written");
+    assert!(
+        !contents.contains("stale"),
+        "layout file should truncate previous contents:\n{contents}"
+    );
+    let parsed: serde_json::Value =
+        serde_json::from_str(contents.trim()).expect("layout file should parse");
+    assert!(parsed["nodes"].is_array());
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn debug_svg_theme_auto_env_truncates_probe_transcript() {
+    let path = temp_log_path("svg-theme-auto");
+    fs::write(&path, "stale").expect("seed svg auto-theme trace file");
+
+    let output = mmdflux()
+        .args(["--format", "svg", "--svg-theme-auto"])
+        .env("MMDFLUX_DEBUG_SVG_THEME_AUTO", &path)
+        .write_stdin("graph TD\nA-->B")
+        .output()
+        .expect("command should run");
+
+    assert_command_success(&output);
+    let stdout = output_stdout(&output);
+    assert!(
+        stdout.starts_with("<svg"),
+        "svg output should still render: {stdout}"
+    );
+    let contents = fs::read_to_string(&path).expect("svg auto-theme trace file should be written");
+    assert!(
+        contents.starts_with("# MMDFLUX SVG auto-theme trace"),
+        "trace file should start with the current header:\n{contents}"
+    );
+    assert!(
+        !contents.contains("stale"),
+        "trace file should truncate previous contents:\n{contents}"
+    );
+    assert!(
+        contents.contains("probe_mode"),
+        "trace should record probe mode:\n{contents}"
+    );
+    let _ = fs::remove_file(path);
 }
 
 // =============================================================================

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,24 @@
+//! Common integration-test setup.
+
+use std::sync::OnceLock;
+
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::{EnvFilter, fmt};
+
+static INIT: OnceLock<()> = OnceLock::new();
+
+#[ctor::ctor]
+fn init_tracing_for_tests() {
+    INIT.get_or_init(|| {
+        // The ctor reads RUST_LOG once when the test process starts. Tests that
+        // need scoped subscribers should still use with_default explicitly.
+        let filter = std::env::var_os("RUST_LOG")
+            .map(|_| EnvFilter::from_default_env())
+            .unwrap_or_else(|| EnvFilter::new("off"));
+
+        let _ = tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt::layer().with_test_writer())
+            .try_init();
+    });
+}

--- a/tests/compliance_class.rs
+++ b/tests/compliance_class.rs
@@ -4,6 +4,8 @@
 //! Generate snapshots: `GENERATE_CLASS_TEXT_SNAPSHOTS=1 cargo test --test compliance_class`
 //! Generate SVG:       `GENERATE_CLASS_SVG_SNAPSHOTS=1 cargo test --test compliance_class`
 
+mod common;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/tests/compliance_flowchart.rs
+++ b/tests/compliance_flowchart.rs
@@ -2,6 +2,8 @@
 //!
 //! Detailed flowchart parser invariants live owner-local in `src/mermaid/flowchart.rs`.
 
+mod common;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/tests/compliance_sequence.rs
+++ b/tests/compliance_sequence.rs
@@ -3,6 +3,8 @@
 //! Locks sequence rendering output with deterministic text snapshots.
 //! Generate snapshots: `GENERATE_SEQUENCE_TEXT_SNAPSHOTS=1 cargo test --test compliance_sequence`
 
+mod common;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/tests/compliance_state.rs
+++ b/tests/compliance_state.rs
@@ -4,6 +4,8 @@
 //! Generate snapshots: `GENERATE_STATE_TEXT_SNAPSHOTS=1 cargo nextest run --test compliance_state -E 'test(state_text_snapshots)'`
 //! Generate SVG:       `GENERATE_STATE_SVG_SNAPSHOTS=1 cargo nextest run --test compliance_state -E 'test(state_svg_snapshots)'`
 
+mod common;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/tests/elk_integration.rs
+++ b/tests/elk_integration.rs
@@ -5,6 +5,8 @@
 
 #![cfg(feature = "engine-elk")]
 
+mod common;
+
 use mmdflux::{EngineAlgorithmId, OutputFormat, RenderConfig, RenderError};
 
 /// Helper: render via the FlowchartInstance with a specific engine.

--- a/tests/engine_registry.rs
+++ b/tests/engine_registry.rs
@@ -1,5 +1,7 @@
 //! Engine registry tests: typed engine IDs, parsing, availability, and registry lookup.
 
+mod common;
+
 use mmdflux::format::{CornerStyle, Curve, EdgePreset, RoutingStyle};
 use mmdflux::{AlgorithmId, EngineAlgorithmId, EngineId, OutputFormat, RenderConfig, RenderError};
 

--- a/tests/flowchart_instance.rs
+++ b/tests/flowchart_instance.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use mmdflux::builtins::default_registry;
 use mmdflux::format::EdgePreset;
 use mmdflux::graph::GeometryLevel;

--- a/tests/greedy_switch_quality.rs
+++ b/tests/greedy_switch_quality.rs
@@ -1,6 +1,8 @@
 //! Quality measurement for greedy switch validation.
 //! Records crossing-related quality metrics across all flowchart fixtures.
 
+mod common;
+
 use std::fs;
 use std::path::Path;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::fs;
 use std::path::Path;
 

--- a/tests/integration_full.rs
+++ b/tests/integration_full.rs
@@ -3,12 +3,34 @@
 //! These tests validate that registry detection, parsing, and rendering work
 //! together across diagram types and output formats.
 
+mod common;
+
 use std::fs;
 use std::path::Path;
 
 use mmdflux::builtins::default_registry;
 use mmdflux::mmds::generate_mermaid_from_str;
 use mmdflux::{OutputFormat, RenderConfig, render_diagram};
+
+fn rust_log_requests_mmdflux_trace() -> bool {
+    std::env::var("RUST_LOG").is_ok_and(|value| {
+        value.split(',').any(|directive| {
+            let directive = directive.trim();
+            directive == "mmdflux=trace"
+                || directive == "mmdflux::runtime=trace"
+                || directive == "mmdflux::runtime=debug"
+        })
+    })
+}
+
+fn assert_render_trace_enabled_when_requested() {
+    if rust_log_requests_mmdflux_trace() {
+        assert!(
+            tracing::enabled!(target: "mmdflux::runtime", tracing::Level::DEBUG),
+            "RUST_LOG requests mmdflux render tracing, but no test subscriber enabled it"
+        );
+    }
+}
 
 fn render_with_registry(input: &str, format: OutputFormat) -> String {
     render_diagram(input, format, &RenderConfig::default()).expect("should render")
@@ -97,6 +119,14 @@ fn registry_detects_all_diagram_types() {
         registry.detect("sequenceDiagram\nA->>B: hi"),
         Some("sequence")
     );
+}
+
+#[test]
+fn simple_render_trace_is_enabled_when_rust_log_requests_mmdflux_trace() {
+    assert_render_trace_enabled_when_requested();
+
+    let output = render_with_registry("graph TD\nA-->B", OutputFormat::Text);
+    assert!(output.contains("A"));
 }
 
 #[test]

--- a/tests/mmds_conformance.rs
+++ b/tests/mmds_conformance.rs
@@ -9,6 +9,8 @@
 //! - **Layout**: MMDS geometry export equivalence (node positions, edge topology)
 //! - **Visual**: rendered text output equivalence
 
+mod common;
+
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -4,6 +4,8 @@
 //! - Default output is `geometry_level: "layout"` with no edge geometry.
 //! - Routed output is explicit opt-in with edge paths and bounds.
 
+mod common;
+
 use std::path::Path;
 
 use mmdflux::graph::GeometryLevel;

--- a/tests/registry_regression.rs
+++ b/tests/registry_regression.rs
@@ -1,5 +1,7 @@
 //! Parity checks between the direct render API and registry instance API.
 
+mod common;
+
 use mmdflux::builtins::default_registry;
 use mmdflux::{EngineAlgorithmId, OutputFormat, RenderConfig, render_diagram};
 

--- a/tests/render_format.rs
+++ b/tests/render_format.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use mmdflux::mmds::supports_format;
 use mmdflux::{EngineAlgorithmId, OutputFormat, RenderConfig};
 #[test]

--- a/tests/runtime_facade.rs
+++ b/tests/runtime_facade.rs
@@ -4,6 +4,8 @@
 //! and that graph-family rendering is dispatched through the shared runtime
 //! facade rather than duplicated in each diagram instance.
 
+mod common;
+
 use mmdflux::builtins::default_registry;
 use mmdflux::registry::DiagramFamily;
 use mmdflux::{OutputFormat, RenderConfig};

--- a/tests/runtime_graph_dispatch.rs
+++ b/tests/runtime_graph_dispatch.rs
@@ -3,6 +3,8 @@
 //! Verifies that graph-family diagrams stay reachable through the supported
 //! public registry/payload/runtime workflow.
 
+mod common;
+
 use std::path::Path;
 
 use mmdflux::OutputFormat;

--- a/tests/sequence_instance.rs
+++ b/tests/sequence_instance.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use mmdflux::builtins::default_registry;
 use mmdflux::payload::Diagram;
 use mmdflux::registry::DiagramInstance;

--- a/tests/svg_render.rs
+++ b/tests/svg_render.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::fs;
 use std::path::Path;
 

--- a/tests/svg_snapshots.rs
+++ b/tests/svg_snapshots.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/tests/wasm_cli_contract.rs
+++ b/tests/wasm_cli_contract.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::collections::HashMap;
 use std::process::Command;
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -21,3 +21,5 @@ ra_ap_vfs = "=0.0.328"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", default-features = false, features = ["std", "fmt", "ansi", "env-filter", "json"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,11 +2,15 @@ mod architecture;
 mod lint;
 mod readme_assets;
 
+use std::fs;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 
 const REPO_ROOT_ENV: &str = "MMDFLUX_REPO_ROOT";
+const XTASK_LOG_ENV: &str = "MMDFLUX_XTASK_LOG";
 
 fn main() {
     if let Err(err) = try_main() {
@@ -16,21 +20,216 @@ fn main() {
 }
 
 fn try_main() -> Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    let Some(command) = args.first().map(String::as_str) else {
+    let parsed = parse_xtask_args(std::env::args().skip(1))?;
+    init_tracing_for_options(&parsed.log)?;
+
+    let Some(command) = parsed.command_args.first().map(String::as_str) else {
         print_help();
         return Ok(());
     };
 
+    tracing::debug!(target: "xtask", command, "dispatch xtask command");
+
     match command {
-        "architecture" => run_architecture_command(&args),
-        "lint" => run_lint_command(&args),
-        "readme-assets" => run_readme_assets_command(&args),
+        "architecture" => run_architecture_command(&parsed.command_args),
+        "lint" => run_lint_command(&parsed.command_args),
+        "readme-assets" => run_readme_assets_command(&parsed.command_args),
         "help" | "--help" | "-h" => {
             print_help();
             Ok(())
         }
         other => anyhow::bail!("unknown xtask subcommand `{other}`"),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedXtaskArgs {
+    log: XtaskLogOptions,
+    command_args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct XtaskLogOptions {
+    filter: Option<String>,
+    format: XtaskLogFormat,
+    file: Option<PathBuf>,
+}
+
+impl Default for XtaskLogOptions {
+    fn default() -> Self {
+        Self {
+            filter: None,
+            format: XtaskLogFormat::Compact,
+            file: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum XtaskLogFormat {
+    Compact,
+    Pretty,
+    Json,
+}
+
+impl XtaskLogFormat {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "compact" => Ok(Self::Compact),
+            "pretty" => Ok(Self::Pretty),
+            "json" => Ok(Self::Json),
+            other => bail!("unknown xtask log format `{other}`"),
+        }
+    }
+}
+
+fn parse_xtask_args<I, S>(args: I) -> Result<ParsedXtaskArgs>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut args = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_string())
+        .peekable();
+    let mut log = XtaskLogOptions::default();
+    let mut command_args = Vec::new();
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--log" => {
+                log.filter = Some(next_global_arg(&mut args, "--log")?);
+            }
+            "--log-format" => {
+                let value = next_global_arg(&mut args, "--log-format")?;
+                log.format = XtaskLogFormat::parse(&value)?;
+            }
+            "--log-file" => {
+                log.file = Some(PathBuf::from(next_global_arg(&mut args, "--log-file")?));
+            }
+            _ if arg.starts_with("--log=") => {
+                log.filter = Some(
+                    arg.strip_prefix("--log=")
+                        .expect("prefix checked")
+                        .to_string(),
+                );
+            }
+            _ if arg.starts_with("--log-format=") => {
+                let value = arg.strip_prefix("--log-format=").expect("prefix checked");
+                log.format = XtaskLogFormat::parse(value)?;
+            }
+            _ if arg.starts_with("--log-file=") => {
+                let value = arg.strip_prefix("--log-file=").expect("prefix checked");
+                log.file = Some(PathBuf::from(value));
+            }
+            _ => {
+                command_args.push(arg);
+                command_args.extend(args);
+                break;
+            }
+        }
+    }
+
+    Ok(ParsedXtaskArgs { log, command_args })
+}
+
+fn next_global_arg<I>(args: &mut I, flag: &str) -> Result<String>
+where
+    I: Iterator<Item = String>,
+{
+    args.next()
+        .ok_or_else(|| anyhow::anyhow!("missing value for `{flag}`"))
+}
+
+fn resolve_xtask_log_filter(options: &XtaskLogOptions) -> Option<String> {
+    resolve_xtask_log_filter_with(options, |name| std::env::var(name).ok())
+}
+
+fn resolve_xtask_log_filter_with<F>(options: &XtaskLogOptions, mut get_env: F) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    if let Some(filter) = options
+        .filter
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Some(filter.to_string());
+    }
+
+    get_env(XTASK_LOG_ENV)
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| get_env("RUST_LOG").filter(|value| !value.trim().is_empty()))
+}
+
+fn init_tracing_for_options(options: &XtaskLogOptions) -> Result<()> {
+    let Some(filter) = resolve_xtask_log_filter(options) else {
+        return Ok(());
+    };
+
+    let env_filter = tracing_subscriber::EnvFilter::try_new(&filter)
+        .with_context(|| format!("invalid log filter: {filter}"))?;
+
+    match &options.file {
+        Some(path) => {
+            let writer = SharedLogWriter::new(fs::File::create(path).with_context(|| {
+                format!("failed to create xtask log file `{}`", path.display())
+            })?);
+            init_tracing_with_writer(env_filter, options.format, move || writer.clone())
+        }
+        None => init_tracing_with_writer(env_filter, options.format, io::stderr),
+    }
+}
+
+fn init_tracing_with_writer<W>(
+    env_filter: tracing_subscriber::EnvFilter,
+    log_format: XtaskLogFormat,
+    make_writer: W,
+) -> Result<()>
+where
+    W: for<'writer> tracing_subscriber::fmt::MakeWriter<'writer> + Send + Sync + 'static,
+{
+    let builder = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(make_writer)
+        .with_ansi(false)
+        .with_target(true);
+
+    let result = match log_format {
+        XtaskLogFormat::Compact => builder.compact().try_init(),
+        XtaskLogFormat::Pretty => builder.pretty().try_init(),
+        XtaskLogFormat::Json => builder.json().try_init(),
+    };
+
+    result.map_err(|err| anyhow::anyhow!("failed to initialize xtask tracing: {err}"))
+}
+
+#[derive(Clone)]
+struct SharedLogWriter {
+    file: Arc<Mutex<fs::File>>,
+}
+
+impl SharedLogWriter {
+    fn new(file: fs::File) -> Self {
+        Self {
+            file: Arc::new(Mutex::new(file)),
+        }
+    }
+}
+
+impl Write for SharedLogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.file
+            .lock()
+            .map_err(|_| io::Error::other("xtask log file lock poisoned"))?
+            .write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.file
+            .lock()
+            .map_err(|_| io::Error::other("xtask log file lock poisoned"))?
+            .flush()
     }
 }
 
@@ -119,5 +318,80 @@ fn find_workspace_root(start: &Path) -> Option<PathBuf> {
         if !dir.pop() {
             return None;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn tracing_global_log_flag_is_removed_before_subcommand_parse() {
+        let parsed = parse_xtask_args(["--log", "xtask=debug", "architecture", "check"]).unwrap();
+
+        assert_eq!(parsed.log.filter.as_deref(), Some("xtask=debug"));
+        assert_eq!(parsed.log.format, XtaskLogFormat::Compact);
+        assert_eq!(parsed.log.file, None);
+        assert_eq!(parsed.command_args, ["architecture", "check"]);
+    }
+
+    #[test]
+    fn tracing_global_log_format_and_file_parse_before_subcommand() {
+        let parsed = parse_xtask_args([
+            "--log-format",
+            "json",
+            "--log-file",
+            "target/xtask.log",
+            "architecture",
+            "check",
+        ])
+        .unwrap();
+
+        assert_eq!(parsed.log.filter, None);
+        assert_eq!(parsed.log.format, XtaskLogFormat::Json);
+        assert_eq!(parsed.log.file, Some(PathBuf::from("target/xtask.log")));
+        assert_eq!(parsed.command_args, ["architecture", "check"]);
+    }
+
+    #[test]
+    fn tracing_invalid_log_filter_is_rejected_before_subcommand_execution() {
+        let parsed = parse_xtask_args(["--log", "[", "architecture", "check"]).unwrap();
+        let error = init_tracing_for_options(&parsed.log).unwrap_err();
+
+        assert!(error.to_string().contains("invalid log filter"));
+    }
+
+    #[test]
+    fn tracing_log_filter_precedence_prefers_flag_then_xtask_env_then_rust_log() {
+        let parsed = parse_xtask_args(["--log", "xtask=debug", "architecture"]).unwrap();
+        let flag = resolve_xtask_log_filter_with(&parsed.log, |_| None);
+        assert_eq!(flag.as_deref(), Some("xtask=debug"));
+
+        let parsed = parse_xtask_args(["architecture"]).unwrap();
+        let xtask_env = resolve_xtask_log_filter_with(&parsed.log, |name| match name {
+            "MMDFLUX_XTASK_LOG" => Some("xtask=trace".to_string()),
+            "RUST_LOG" => Some("off".to_string()),
+            _ => None,
+        });
+        assert_eq!(xtask_env.as_deref(), Some("xtask=trace"));
+
+        let rust_env = resolve_xtask_log_filter_with(&parsed.log, |name| match name {
+            "RUST_LOG" => Some("xtask=debug".to_string()),
+            _ => None,
+        });
+        assert_eq!(rust_env.as_deref(), Some("xtask=debug"));
+    }
+
+    #[test]
+    fn tracing_mmdflux_log_is_not_consumed_by_xtask_logging() {
+        let parsed = parse_xtask_args(["architecture"]).unwrap();
+        let filter = resolve_xtask_log_filter_with(&parsed.log, |name| match name {
+            "MMDFLUX_LOG" => Some("mmdflux::runtime::render=debug".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(filter, None);
     }
 }

--- a/xtask/src/readme_assets.rs
+++ b/xtask/src/readme_assets.rs
@@ -380,14 +380,7 @@ fn run_mmdflux_capture<I>(options: &ResolvedOptions, label: &str, args: I) -> Re
 where
     I: IntoIterator<Item = OsString>,
 {
-    let mut command = if let Some(bin) = &options.mmdflux_bin {
-        Command::new(bin)
-    } else {
-        let mut command = Command::new("cargo");
-        command.current_dir(&options.repo_root);
-        command.args(["run", "--quiet", "--bin", "mmdflux", "--"]);
-        command
-    };
+    let mut command = mmdflux_command_for_capture(options);
     command.args(args);
 
     let output = command
@@ -403,6 +396,17 @@ where
     }
 
     Ok(output.stdout)
+}
+
+fn mmdflux_command_for_capture(options: &ResolvedOptions) -> Command {
+    if let Some(bin) = &options.mmdflux_bin {
+        Command::new(bin)
+    } else {
+        let mut command = Command::new("cargo");
+        command.current_dir(&options.repo_root);
+        command.args(["run", "--quiet", "--bin", "mmdflux", "--"]);
+        command
+    }
 }
 
 fn should_update_readme(mode: ReadmeUpdate, name: &str) -> bool {
@@ -592,6 +596,8 @@ fn display_path(repo_root: &Path, path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsStr;
+
     use super::*;
 
     #[test]
@@ -644,5 +650,25 @@ old
     #[test]
     fn fenced_block_trims_extra_trailing_newlines() {
         assert_eq!(fenced_block("text", "a\n\n"), "```text\na\n```");
+    }
+
+    #[test]
+    fn tracing_mmdflux_log_is_left_for_readme_assets_child() {
+        let options = ResolvedOptions {
+            repo_root: PathBuf::from("/tmp/mmdflux"),
+            source: PathBuf::from("/tmp/mmdflux/input.mmd"),
+            out_dir: PathBuf::from("/tmp/mmdflux/out"),
+            name: "fixture".to_string(),
+            mmdflux_bin: Some(PathBuf::from("/bin/echo")),
+            readme: ReadmeUpdate::No,
+            check: true,
+        };
+
+        let command = mmdflux_command_for_capture(&options);
+        let removes_mmdflux_log = command
+            .get_envs()
+            .any(|(key, value)| key == OsStr::new("MMDFLUX_LOG") && value.is_none());
+
+        assert!(!removes_mmdflux_log);
     }
 }


### PR DESCRIPTION
## Summary

- add application-owned tracing subscriber setup for the CLI and xtask while keeping library code on the `tracing` facade only
- migrate ad hoc boolean diagnostic output to structured trace events with stable targets and fields
- preserve deterministic debug dumpers and document the new tracing filters, including full layered-kernel module targets
- add test coverage for CLI log filters, JSON/file output, test harness tracing, readme-assets env inheritance, and retained dumper contracts

## Validation

- `just check`

## Notes

This branch has been rebased onto `main` and squashed to one commit.