### PR TITLE
fix: preserve utf-8 flowchart labels

### DIFF
--- a/src/diagrams/flowchart/compiler.rs
+++ b/src/diagrams/flowchart/compiler.rs
@@ -400,54 +400,56 @@ pub(crate) fn normalize_br_tags(text: &str) -> String {
     let bytes = text.as_bytes();
     let len = bytes.len();
     let mut result = String::with_capacity(len);
-    let mut i = 0;
+    let mut cursor = 0;
 
-    while i < len {
-        if bytes[i] == b'<' {
-            // Try to match <br>, <br/>, <br />, etc.
-            let start = i;
-            i += 1;
-            // Skip optional whitespace after <
-            while i < len && bytes[i] == b' ' {
-                i += 1;
-            }
-            // Match 'b'/'B'
-            if i < len && bytes[i].eq_ignore_ascii_case(&b'b') {
-                i += 1;
-                // Match 'r'/'R'
-                if i < len && bytes[i].eq_ignore_ascii_case(&b'r') {
-                    i += 1;
-                    // Skip optional whitespace
-                    while i < len && bytes[i] == b' ' {
-                        i += 1;
-                    }
-                    // Skip optional '/'
-                    if i < len && bytes[i] == b'/' {
-                        i += 1;
-                    }
-                    // Skip optional whitespace
-                    while i < len && bytes[i] == b' ' {
-                        i += 1;
-                    }
-                    // Match '>'
-                    if i < len && bytes[i] == b'>' {
-                        i += 1;
-                        result.push('\n');
-                        continue;
-                    }
-                }
-            }
-            // Not a <br> tag — emit the characters we skipped
-            for &b in &bytes[start..i] {
-                result.push(b as char);
-            }
+    while let Some(offset) = text[cursor..].find('<') {
+        let start = cursor + offset;
+        result.push_str(&text[cursor..start]);
+
+        if let Some(end) = match_br_tag(bytes, start) {
+            result.push('\n');
+            cursor = end;
         } else {
-            result.push(bytes[i] as char);
-            i += 1;
+            result.push('<');
+            cursor = start + 1;
         }
     }
 
+    result.push_str(&text[cursor..]);
     result
+}
+
+fn match_br_tag(bytes: &[u8], start: usize) -> Option<usize> {
+    let len = bytes.len();
+    let mut i = start + 1;
+
+    // Skip optional whitespace after <
+    while i < len && bytes[i] == b' ' {
+        i += 1;
+    }
+
+    // Match 'b'/'B' and 'r'/'R'
+    if i >= len || !bytes[i].eq_ignore_ascii_case(&b'b') {
+        return None;
+    }
+    i += 1;
+    if i >= len || !bytes[i].eq_ignore_ascii_case(&b'r') {
+        return None;
+    }
+    i += 1;
+
+    // Skip optional whitespace and optional '/'
+    while i < len && bytes[i] == b' ' {
+        i += 1;
+    }
+    if i < len && bytes[i] == b'/' {
+        i += 1;
+    }
+    while i < len && bytes[i] == b' ' {
+        i += 1;
+    }
+
+    (i < len && bytes[i] == b'>').then_some(i + 1)
 }
 
 fn convert_shape(shape_spec: &ShapeSpec) -> Shape {
@@ -1004,6 +1006,12 @@ mod tests {
     }
 
     #[test]
+    fn test_br_tag_preserves_utf8_text() {
+        assert_eq!(normalize_br_tags("開始<br>処理"), "開始\n処理");
+        assert_eq!(normalize_br_tags("開始<タグ>処理"), "開始<タグ>処理");
+    }
+
+    #[test]
     fn test_br_tag_empty_string() {
         assert_eq!(normalize_br_tags(""), "");
     }
@@ -1031,6 +1039,31 @@ mod tests {
         let flowchart = parse_flowchart("graph TD\nA -->|yes<br>no| B\n").unwrap();
         let diagram = compile_to_graph(&flowchart);
         assert_eq!(diagram.edges[0].label, Some("yes\nno".to_string()));
+    }
+
+    #[test]
+    fn test_node_label_with_utf8_text() {
+        let flowchart = parse_flowchart("graph TD\nA[開始]\n").unwrap();
+        let diagram = compile_to_graph(&flowchart);
+        let node = diagram.get_node("A").unwrap();
+        assert_eq!(node.label, "開始");
+    }
+
+    #[test]
+    fn test_node_label_with_utf8_text_and_br_tag() {
+        let flowchart = parse_flowchart("graph TD\nA[開始<br>処理]\n").unwrap();
+        let diagram = compile_to_graph(&flowchart);
+        let node = diagram.get_node("A").unwrap();
+        assert_eq!(node.label, "開始\n処理");
+    }
+
+    #[test]
+    fn test_edge_label_with_utf8_text() {
+        for input in ["graph TD\nA -- 確認 --> B\n", "graph TD\nA -->|確認| B\n"] {
+            let flowchart = parse_flowchart(input).unwrap();
+            let diagram = compile_to_graph(&flowchart);
+            assert_eq!(diagram.edges[0].label, Some("確認".to_string()));
+        }
     }
 
     mod owner_local_fixture_regressions {

--- a/src/graph/style.rs
+++ b/src/graph/style.rs
@@ -534,13 +534,7 @@ pub fn parse_class_apply_statement(raw: &str) -> Option<ParsedClassApplyDirectiv
     let trimmed = raw.trim();
 
     // Reject "classDef" lines (keyword prefix overlap).
-    if trimmed.len() >= 8
-        && trimmed[..8].eq_ignore_ascii_case("classDef")
-        && trimmed[8..]
-            .chars()
-            .next()
-            .is_none_or(|c| !c.is_alphanumeric() && c != '_')
-    {
+    if strip_keyword(trimmed, "classDef").is_some() {
         return None;
     }
 


### PR DESCRIPTION
Thank you for providing and maintaining this wonderful library.

## Summary

- Keep flowchart `<br>` normalization UTF-8 safe by preserving original string slices and only replacing matched `<br>` tag variants.
- Add regression coverage for Japanese node labels, labels with `<br>`, and edge labels in both supported label syntaxes.
- Reuse the existing keyword helper to avoid a byte-boundary panic in `classDef` overlap detection when a flowchart line contains multi-byte label text.

## Why

Explicit flowchart labels such as `A[開始]` and edge labels such as `A -->|確認| B` were mojibaked because `normalize_br_tags` converted UTF-8 bytes into `char`s one byte at a time. The pipe label form also exposed a UTF-8 byte-boundary panic while checking whether a parsed line was a `classDef` statement.

Related context: #176 / #181 fixed Unicode identifiers; this PR covers explicit labels that pass through label normalization.

## Validation

- `just check`
  - `cog check "origin/main..HEAD"`
  - `cargo +nightly fmt --all -- --check`
  - `cargo +stable xtask lint`
  - `cargo +stable nextest run` (`2830 passed, 8 skipped`)

## Note

This preserves UTF-8 label text but does not change terminal cell-width handling for full-width characters. Full-width layout alignment remains a follow-up.
