### PR TITLE
feat: add materialized diagram views

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Specification) outputs positioned graph data — node coordinates, routed edge
 paths, subgraph bounds — so downstream tools can consume diagram geometry
 without parsing SVG or scraping pixels.
 
+**Materialized diagram views.** Rust adapters can filter canonical MMDS payloads
+into read-side views for focused rendering, traversal, or event correlation
+without inventing a separate graph query language.
+
 **Compound graph layout.** Subgraphs are laid out as part of a single
 compound graph, not rendered recursively. This produces globally optimized
 positioning and consistent cross-boundary edge routing.
@@ -282,6 +286,8 @@ SVG `<defs>` blocks are also pruned to the markers each diagram actually uses, s
 Most Rust integrations should stay on the high-level runtime facade:
 
 - `render_diagram`
+- `materialize_diagram`
+- `render_mmds_document`
 - `detect_diagram`
 - `validate_diagram`
 
@@ -292,11 +298,13 @@ The low-level API is smaller and adapter-focused:
 
 - `mmdflux::builtins::default_registry()` for the builtin diagram registry
 - `registry` and `payload` for explicit detect/parse/payload flows
-- `mmds` for MMDS parsing, replay, and Mermaid generation
+- `graph` and `timeline` for family-specific IR inspection
+- `mmds` for MMDS `Document` parsing, replay, and Mermaid generation
+- `views` for materializing filtered read-side MMDS payloads
 
-The rest of the crate tree (`diagrams`, `engines`, `graph`, `render`,
-`mermaid`, and `timeline`) consists of internal implementation modules and is
-not part of the supported public contract.
+The rest of the crate tree (`diagrams`, `engines`, `render`, and `mermaid`)
+consists of internal implementation modules and is not part of the supported
+public contract.
 
 ### Examples
 
@@ -306,6 +314,8 @@ not part of the supported public contract.
   registry-driven detection and preparation
 - [`examples/mmds_replay.rs`](examples/mmds_replay.rs) — MMDS profile
   negotiation, replay, and Mermaid regeneration
+- [`examples/materialized_view.rs`](examples/materialized_view.rs) —
+  materialize a focused MMDS view and replay it as text
 
 Verify the examples compile with `cargo test --examples`.
 

--- a/boundaries.toml
+++ b/boundaries.toml
@@ -28,6 +28,7 @@ registry = {}
 diagrams = {}
 builtins = { tags = { role = "runtime-facade" } }
 mmds = {}
+views = {}
 frontends = { tags = { role = "runtime-facade" } }
 runtime = {}
 
@@ -155,6 +156,13 @@ source = "mmds"
 allowed = ["errors", "format", "graph", "simplification", "timeline"]
 
 [[rules]]
+id = "allow-views"
+type = "allow"
+[rules.config]
+source = "views"
+allowed = ["mmds"]
+
+[[rules]]
 id = "allow-frontends"
 type = "allow"
 [rules.config]
@@ -169,7 +177,7 @@ source = "runtime"
 allowed = [
     "builtins", "engines", "errors",
     "format", "frontends", "graph", "mermaid", "mmds",
-    "payload", "registry", "render", "simplification", "timeline",
+    "payload", "registry", "render", "simplification", "timeline", "views",
 ]
 
 # --- Layers rule (pipeline spine ordering) ---

--- a/docs/architecture/dependency-rules.md
+++ b/docs/architecture/dependency-rules.md
@@ -13,6 +13,7 @@ contributors:
 - `engines/` own engine adapters and internal algorithm boundaries such as `algorithms::layered::kernel`
 - `render/` owns output production
 - `mmds/` owns the MMDS contract and output helpers
+- `views/` owns materialized read-side views over canonical MMDS payloads
 
 The repo-owned architecture gate should fail when the code drifts away from
 these rules.
@@ -43,8 +44,9 @@ contributors do not need any extra socket setup.
   `validate_diagram`, plus the flat config/format/error types re-exported from
   `lib.rs`.
 - The supported low-level API is `builtins`, `registry`, `payload`, `graph`,
-  `timeline`, and `mmds` for adapter-oriented workflows that need explicit
-  payload construction, graph IR inspection, or MMDS replay control.
+  `timeline`, `mmds`, and `views` for adapter-oriented workflows that need
+  explicit payload construction, graph IR inspection, MMDS replay control, or
+  materialized read-side diagram views.
 - `diagrams`, `engines`, `render`, and `mermaid` are internal implementation modules.
   They are intentionally documented here for contributors, but they are not part
   of the supported low-level contract.
@@ -122,7 +124,16 @@ collapsed back into singleton roots:
     and output helpers live under `src/mmds/`. MMDS is not registered
     in the logical diagram registry.
 
-11. **engines do not know about diagram types or output formats** — Engine
+11. **views/ owns read-side materialized diagram views** — `src/views/` owns
+    the `ViewSpec`, selector, `ViewEvent`, and `apply_view` contracts for
+    filtering canonical `mmds::Document` payloads into materialized view
+    payloads. In the v1 view slice, `views` depends on `mmds` only and derives
+    any adjacency directly from `Document.edges`; it must not import `graph`,
+    `render`, `engines`, `runtime`, Mermaid parser modules, or command/diff
+    machinery. Runtime may consume `views` for replay hooks, but `views` does
+    not own rendering or orchestration.
+
+12. **engines do not know about diagram types or output formats** — Engine
     implementations (`src/engines/`) solve generic graph layout problems and
     own layout building / measurement adapters. They may use shared
     graph-family helpers, but they never reference flowchart, class, sequence,
@@ -138,7 +149,7 @@ collapsed back into singleton roots:
     and float routing. `layered::kernel` stays internal; it is a contributor
     boundary, not a supported public contract.
 
-12. **flat top-level contract modules own the stable public contract** —
+13. **flat top-level contract modules own the stable public contract** —
     Stable public format and error vocabulary live in `src/format.rs` and
     `src/errors.rs`. `RenderConfig` lives in `src/runtime/config.rs`
     (re-exported from `lib.rs`). Diagnostics live in `errors`, family
@@ -147,33 +158,33 @@ collapsed back into singleton roots:
     from `lib.rs`. Other namespaces are either part of the supported
     low-level API or internal implementation modules.
 
-13. **runtime/ is orchestration only** — The runtime layer detects input
+14. **runtime/ is orchestration only** — The runtime layer detects input
     frontends, resolves logical diagram types, manages the registry, consumes
     runtime payloads, and wires the pipeline. Graph-family runtime
     dispatch lives under `src/runtime/`; runtime itself does not own Mermaid
     grammars, layout algorithms, or renderer implementations.
 
-14. **registry is contract-only infrastructure** — `src/registry.rs` defines
+15. **registry is contract-only infrastructure** — `src/registry.rs` defines
     reusable registry contracts (`DiagramRegistry`, `DiagramDefinition`,
     `DiagramInstance`) and does not import concrete diagram modules. Built-in
     diagram wiring lives in the separate public `builtins` namespace.
 
-15. **timeline::sequence owns shared sequence runtime types** — Shared
+16. **timeline::sequence owns shared sequence runtime types** — Shared
     sequence-family model and layout types live under `src/timeline/sequence/`
     so the final text renderer can depend on a neutral timeline namespace
     instead of importing `diagrams::sequence`.
 
 ## Adapter Rules
 
-16. **web main.ts is composition only** — The web playground's `main.ts` is a
+17. **web main.ts is composition only** — The web playground's `main.ts` is a
     composition root that wires stores, services, and controllers. It does not
     contain application logic, state management, or rendering orchestration.
 
-17. **wasm adapter is a thin boundary** — `crates/mmdflux-wasm` deserializes JS
+18. **wasm adapter is a thin boundary** — `crates/mmdflux-wasm` deserializes JS
     requests, calls the Rust facade, and serializes responses. It does not
     duplicate config parsing, registry logic, or format selection.
 
-18. **CLI adapter is a thin boundary** — `src/main.rs` maps CLI flags to the
+19. **CLI adapter is a thin boundary** — `src/main.rs` maps CLI flags to the
     Rust facade contract and formats output. It does not contain business logic
     beyond argument mapping.
 

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -4,7 +4,7 @@ MMDS is the structured JSON output format for graph-family diagrams produced by 
 
 ## Contract Ownership and Parity Harness
 
-Rust owns the canonical MMDS contract, MMDS input helpers, and output helpers under `src/mmds/`, while runtime MMDS frontend detection lives in `src/frontends.rs`.
+Rust owns the canonical MMDS contract, MMDS input helpers, and document helpers under `src/mmds/`, while runtime MMDS frontend detection lives in `src/frontends.rs`.
 
 Locked cross-language contract fixtures live under `tests/fixtures/mmds/contracts/`. They are consumed by:
 
@@ -20,14 +20,21 @@ Most Rust callers should produce MMDS through the high-level runtime facade:
 
 - `render_diagram(input, OutputFormat::Mmds, &RenderConfig::default())`
   (`render_diagram` auto-detects MMDS input and dispatches to the replay path)
+- `materialize_diagram(input, &config)` for materializing a graph-family
+  `mmds::Document` directly from Mermaid or MMDS input
+- `render_mmds_document(&document, output_format, &config)` for rendering an
+  already-parsed graph-family `mmds::Document` without a JSON round trip
 
 Adapter-oriented workflows can use the low-level API:
 
 - `mmdflux::builtins::default_registry()` for builtin registry wiring
 - `mmdflux::registry` and `mmdflux::payload` for explicit payload flows
-- `mmdflux::mmds` for hydration, profile negotiation, and Mermaid generation
+- `mmdflux::mmds` for parsing into `Document`, hydration, profile negotiation,
+  and Mermaid generation
+- `mmdflux::views` for materialized read-side views over canonical MMDS payloads
 
 The current Rust replay example lives at `examples/mmds_replay.rs`.
+The materialized-view example lives at `examples/materialized_view.rs`.
 
 Fixture-backed payloads used throughout the Rust contract tests live at:
 
@@ -52,14 +59,84 @@ MMDS input support is active:
 
 \* For text/ascii, routed path fields are currently ignored and output is re-routed on the text grid from core topology.
 
+## Materialized Views
+
+The Rust `mmdflux::views` module provides a read-side contract for focused
+diagram views over canonical graph-family MMDS payloads. It is intentionally a
+small materialization API, not a general graph query language.
+
+The primary entry point is:
+
+- `mmdflux::views::apply_view(canonical: &mmdflux::mmds::Document, spec: &ViewSpec) -> Result<(Document, Vec<ViewEvent>), ViewError>`
+
+`ViewSpec` v1 supports:
+
+- `Selector::All`
+- `Selector::Anchor(AnchorRef::Node(id))`
+- `Selector::Anchor(AnchorRef::Subgraph(id))` for the subgraph container only
+- `Selector::Traversal` from a node anchor with upstream, downstream, or neighbor hops
+- `Selector::Predicate(NodePredicate::Shape(value))`
+- `Selector::Predicate(NodePredicate::Parent(subgraph_id))`
+- `Selector::SubgraphDescendants(id)` for recursive subgraph contents
+- ordered `Include` and `Exclude` statements
+
+These primitives are present in the public types but intentionally deferred in
+the v1 evaluator:
+
+- tag predicates
+- edge anchors
+- boundary stubs
+- compact, local-reflow, and incremental layout modes
+- compound flattening
+
+Unsupported primitives return `ViewError::NotImplementedYet` rather than
+falling back silently.
+
+### View Payload Contract
+
+`apply_view` returns a normal MMDS `Document` with retained nodes, retained
+subgraphs, surviving edges, and a `Vec<ViewEvent>` describing omitted canonical
+elements. Surviving edge IDs are preserved verbatim from the canonical payload;
+filtered views may therefore contain sparse IDs such as `["e0", "e2", "e4"]`.
+Consumers should not assume edge IDs are contiguous.
+
+Materialized view payloads carry a top-level extension marker:
+
+```json
+{
+  "extensions": {
+    "org.mmdflux.view.v1": {
+      "layout_mode": "shared_coordinates",
+      "boundary_policy": "omit"
+    }
+  }
+}
+```
+
+When the canonical payload contains the text renderer projection extension
+(`org.mmdflux.render.text.v1`), v1 view materialization keeps `projection.node_ranks`
+for retained nodes and drops edge-array-indexed projection maps such as
+`edge_waypoints` and `label_positions`. This avoids reindexing edge projection
+data through sparse view edges.
+
+To render a materialized view, pass the returned `Document` through the typed
+runtime replay helper:
+
+```rust
+use mmdflux::{OutputFormat, RenderConfig, render_mmds_document};
+
+let text = render_mmds_document(&view_payload, OutputFormat::Text, &RenderConfig::default())?;
+println!("{text}");
+```
+
 ## MMDS -> Mermaid Generation Contract
 
 mmdflux provides deterministic Mermaid generation for graph-family MMDS payloads:
 
 - `mmdflux::mmds::generate_mermaid_from_str(input: &str) -> Result<String, GenerationError>`
-- `mmdflux::mmds::generate_mermaid(output: &Output) -> Result<String, GenerationError>`
+- `mmdflux::mmds::generate_mermaid(document: &Document) -> Result<String, GenerationError>`
 
-### Canonical Output Rules
+### Canonical Document Rules
 
 Generated Mermaid is canonicalized as:
 
@@ -67,7 +144,7 @@ Generated Mermaid is canonicalized as:
 2. Subgraphs emitted in deterministic ID order, with nested `subgraph ... end` blocks and optional `direction` lines
 3. Nodes emitted in deterministic ID order within each scope
 4. Edges emitted in deterministic edge-ID order (`e{number}` before non-numeric IDs)
-5. Output always ends with a trailing newline (`\n`)
+5. Generated Mermaid always ends with a trailing newline (`\n`)
 
 ### Identifier and Label Policy
 
@@ -170,7 +247,7 @@ Explicit opt-in via `--geometry-level routed`. Includes everything from layout p
 mmdflux --format mmds --geometry-level routed diagram.mmd
 ```
 
-## Output Envelope
+## Document Envelope
 
 ```json
 {
@@ -423,11 +500,11 @@ just conformance
 | State     | `"state"`      | Graph    | Supported |
 | Sequence  | `"sequence"`   | Timeline | Supported |
 
-### Graph-Family vs Timeline-Family Output
+### Graph-Family vs Timeline-Family Document
 
-Graph-family diagrams (flowchart, class, state) use the standard MMDS envelope with `nodes`, `edges`, `subgraphs`, and `defaults`.
+Graph-family diagrams (flowchart, class, state) use the standard MMDS envelope with `nodes`, `edges`, `subgraphs`, and `defaults`. This is the typed Rust `mmdflux::mmds::Document` contract.
 
-Timeline-family diagrams (sequence) use the same envelope structure (`version`, `geometry_level`, `metadata`, `nodes`, `edges`) for compatibility, but `nodes` and `edges` are always empty arrays. The diagram content is in sequence-specific body fields described below.
+Timeline-family diagrams (sequence) use a separate internal serde envelope with the same top-level compatibility fields (`version`, `geometry_level`, `metadata`, `nodes`, `edges`), but `nodes` and `edges` are always empty arrays. The diagram content is in sequence-specific body fields described below.
 
 ## Sequence MMDS Profile
 

--- a/docs/mmds.schema.json
+++ b/docs/mmds.schema.json
@@ -35,6 +35,9 @@
       "properties": {
         "org.mmdflux.node-style.v1": {
           "$ref": "#/$defs/NodeStyleExtension"
+        },
+        "org.mmdflux.view.v1": {
+          "$ref": "#/$defs/ViewExtension"
         }
       },
       "additionalProperties": {
@@ -404,6 +407,22 @@
           }
         }
       }
+    },
+    "ViewExtension": {
+      "type": "object",
+      "required": ["layout_mode", "boundary_policy"],
+      "properties": {
+        "layout_mode": {
+          "const": "shared_coordinates",
+          "description": "Materialized view layout policy. V1 preserves canonical shared coordinates."
+        },
+        "boundary_policy": {
+          "const": "omit",
+          "description": "Materialized view boundary policy. V1 omits edges connected to nodes outside the view."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Marker for MMDS payloads materialized by the Rust views API."
     },
     "NodeStyle": {
       "type": "object",

--- a/examples/materialized_view.rs
+++ b/examples/materialized_view.rs
@@ -1,0 +1,49 @@
+use mmdflux::mmds::Document;
+use mmdflux::views::{
+    AnchorRef, Selector, TraversalDirection, ViewEvent, ViewSpec, ViewStatement, apply_view,
+};
+use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_mmds_document};
+
+const SOURCE: &str = r#"graph TD
+service_a[Service A] --> service_b[Service B]
+external[External] --> service_a
+service_b --> service_c[Service C]
+service_c --> database[Database]
+service_a --> audit[Audit]
+"#;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let canonical: Document = materialize_diagram(SOURCE, &RenderConfig::default())?;
+    let spec = ViewSpec {
+        statements: vec![ViewStatement::Include(Selector::Traversal {
+            anchor: AnchorRef::Node("service_a".to_string()),
+            direction: TraversalDirection::Downstream,
+            hops: 2,
+        })],
+        ..ViewSpec::default()
+    };
+
+    let (view, events) = apply_view(&canonical, &spec)?;
+    let text = render_mmds_document(&view, OutputFormat::Text, &RenderConfig::default())?;
+
+    println!("retained nodes:");
+    for node in &view.nodes {
+        println!("- {}", node.id);
+    }
+
+    println!("\nelided edges:");
+    for event in &events {
+        if let ViewEvent::EdgeElided {
+            source,
+            target,
+            ordinal,
+            ..
+        } = event
+        {
+            println!("- {source} -> {target} (ordinal {ordinal})");
+        }
+    }
+
+    println!("\n{text}");
+    Ok(())
+}

--- a/examples/mmds_replay.rs
+++ b/examples/mmds_replay.rs
@@ -1,4 +1,4 @@
-use mmdflux::mmds::{generate_mermaid, parse_with_profiles};
+use mmdflux::mmds::{Document, evaluate_profiles_for_document, generate_mermaid};
 use mmdflux::{OutputFormat, RenderConfig};
 
 const MMDS_INPUT: &str = r#"{
@@ -43,8 +43,10 @@ const MMDS_INPUT: &str = r#"{
 }"#;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (payload, negotiation) = parse_with_profiles(MMDS_INPUT)?;
-    let text = mmdflux::render_diagram(MMDS_INPUT, OutputFormat::Text, &RenderConfig::default())?;
+    let payload: Document = MMDS_INPUT.parse()?;
+    let negotiation = evaluate_profiles_for_document(&payload);
+    let text =
+        mmdflux::render_mmds_document(&payload, OutputFormat::Text, &RenderConfig::default())?;
     let mermaid = generate_mermaid(&payload)?;
 
     println!("supported profiles: {:?}", negotiation.supported);

--- a/src/graph/geometry.rs
+++ b/src/graph/geometry.rs
@@ -277,9 +277,8 @@ pub struct RoutedGraphGeometry {
     /// Plan 0146 Task 2.1: this field is populated unconditionally in **all**
     /// builds (no `cfg(test)`, no env-var gating). Consumers may inspect it
     /// to surface a warning. Not serialized in MMDS layout output (it is a
-    /// routing diagnostic, not part of the layout contract); MMDS adds it
-    /// under a separate optional `diagnostics` object — see
-    /// `mmds::output::serialize_routed_graph_with_diagnostics` (Task 2.3).
+    /// routing diagnostic, not part of the layout contract); MMDS can carry
+    /// it under a separate optional `diagnostics` object.
     pub unfit_label_overlaps: Vec<UnfitOverlap>,
 }
 

--- a/src/graph/grid/derive/mod.rs
+++ b/src/graph/grid/derive/mod.rs
@@ -114,6 +114,67 @@ fn expand_canvas_bounds(
     }
 }
 
+fn coordinate_layers(layer_coords: &[(String, f64, f64)]) -> Vec<Vec<String>> {
+    let mut layers: Vec<Vec<String>> = Vec::new();
+    let mut current_layer: Vec<String> = Vec::new();
+    let mut last_primary: Option<f64> = None;
+    for (id, primary, _) in layer_coords {
+        if let Some(last) = last_primary
+            && (*primary - last).abs() > 25.0
+            && !current_layer.is_empty()
+        {
+            layers.push(std::mem::take(&mut current_layer));
+        }
+        current_layer.push(id.clone());
+        last_primary = Some(*primary);
+    }
+    if !current_layer.is_empty() {
+        layers.push(current_layer);
+    }
+    layers
+}
+
+fn pinned_rank_layers(
+    layer_coords: &[(String, f64, f64)],
+    geometry: &GraphGeometry,
+) -> Option<Vec<Vec<String>>> {
+    let projection = geometry.grid_projection.as_ref()?;
+    if projection.node_ranks.is_empty() {
+        return None;
+    }
+
+    let mut ranked_nodes = Vec::with_capacity(layer_coords.len());
+    for (id, _, _) in layer_coords {
+        let rank = *projection.node_ranks.get(id)?;
+        let rank = usize::try_from(rank).ok()?;
+        ranked_nodes.push((id.clone(), rank));
+    }
+
+    let max_rank = ranked_nodes.iter().map(|(_, rank)| *rank).max()?;
+    let mut layers = vec![Vec::new(); max_rank + 1];
+    for (id, rank) in ranked_nodes {
+        layers[rank].push(id);
+    }
+    Some(layers)
+}
+
+fn sort_layers_by_secondary(
+    layers: &mut [Vec<String>],
+    geometry: &GraphGeometry,
+    is_vertical: bool,
+) {
+    let secondary_coord = |id: &String| -> f64 {
+        geometry
+            .nodes
+            .get(id)
+            .map(|n| if is_vertical { n.rect.x } else { n.rect.y })
+            .unwrap_or(0.0)
+    };
+    for layer in layers {
+        layer.sort_by(|a, b| secondary_coord(a).total_cmp(&secondary_coord(b)));
+    }
+}
+
 /// Convert engine-produced `GraphGeometry` (with optional routed edge paths)
 /// to an integer-coordinate `GridLayout`.
 pub fn geometry_to_grid_layout_with_routed(
@@ -149,33 +210,13 @@ pub fn geometry_to_grid_layout_with_routed(
         .collect();
     layer_coords.sort_by(|a, b| a.1.total_cmp(&b.1));
 
-    let mut layers: Vec<Vec<String>> = Vec::new();
-    let mut current_layer: Vec<String> = Vec::new();
-    let mut last_primary: Option<f64> = None;
-    for (id, primary, _) in &layer_coords {
-        if let Some(last) = last_primary
-            && (*primary - last).abs() > 25.0
-            && !current_layer.is_empty()
-        {
-            layers.push(std::mem::take(&mut current_layer));
-        }
-        current_layer.push(id.clone());
-        last_primary = Some(*primary);
-    }
-    if !current_layer.is_empty() {
-        layers.push(current_layer);
-    }
-
-    let secondary_coord = |id: &String| -> f64 {
-        geometry
-            .nodes
-            .get(id)
-            .map(|n| if is_vertical { n.rect.x } else { n.rect.y })
-            .unwrap_or(0.0)
+    let mut layers = if config.use_pinned_ranks {
+        pinned_rank_layers(&layer_coords, geometry)
+            .unwrap_or_else(|| coordinate_layers(&layer_coords))
+    } else {
+        coordinate_layers(&layer_coords)
     };
-    for layer in &mut layers {
-        layer.sort_by(|a, b| secondary_coord(a).total_cmp(&secondary_coord(b)));
-    }
+    sort_layers_by_secondary(&mut layers, geometry, is_vertical);
 
     let grid_positions = compute_grid_positions(&layers);
 

--- a/src/graph/grid/derive/tests.rs
+++ b/src/graph/grid/derive/tests.rs
@@ -1,8 +1,57 @@
 use super::waypoints::transform_label_positions_direct;
 use super::*;
+use crate::graph::geometry::PositionedNode;
 use crate::graph::grid::GridLayoutConfig;
+use crate::graph::projection::GridProjection;
 use crate::graph::space::FPoint;
-use crate::graph::{Direction, Graph, Subgraph};
+use crate::graph::{Direction, Graph, Node, Shape, Subgraph};
+
+fn pinned_rank_fixture(node_ranks: HashMap<String, i32>) -> (Graph, GraphGeometry) {
+    let mut diagram = Graph::new(Direction::TopDown);
+    for id in ["A", "B", "C"] {
+        diagram.add_node(Node::new(id));
+    }
+
+    let nodes = HashMap::from([
+        ("A".to_string(), positioned_node("A", 0.0, 0.0)),
+        ("B".to_string(), positioned_node("B", 20.0, 10.0)),
+        ("C".to_string(), positioned_node("C", 40.0, 20.0)),
+    ]);
+
+    let geometry = GraphGeometry {
+        nodes,
+        edges: Vec::new(),
+        subgraphs: HashMap::new(),
+        self_edges: Vec::new(),
+        direction: Direction::TopDown,
+        node_directions: HashMap::from([
+            ("A".to_string(), Direction::TopDown),
+            ("B".to_string(), Direction::TopDown),
+            ("C".to_string(), Direction::TopDown),
+        ]),
+        bounds: FRect::new(0.0, 0.0, 80.0, 40.0),
+        reversed_edges: Vec::new(),
+        engine_hints: None,
+        grid_projection: Some(GridProjection {
+            node_ranks,
+            ..GridProjection::default()
+        }),
+        rerouted_edges: HashSet::new(),
+        enhanced_backward_routing: false,
+    };
+
+    (diagram, geometry)
+}
+
+fn positioned_node(id: &str, x: f64, y: f64) -> PositionedNode {
+    PositionedNode {
+        id: id.to_string(),
+        rect: FRect::new(x, y, 10.0, 10.0),
+        shape: Shape::Rectangle,
+        label: id.to_string(),
+        parent: None,
+    }
+}
 
 fn test_node_bounds(x: usize, y: usize, width: usize, height: usize) -> NodeBounds {
     NodeBounds {
@@ -163,6 +212,61 @@ fn effective_rank_sep_adds_cluster_spacing_for_subgraphs() {
 
     let config = GridLayoutConfig::default();
     assert_eq!(effective_rank_sep(&diagram, &config), 75.0);
+}
+
+#[test]
+fn pinned_ranks_preserve_sparse_layers_when_requested() {
+    let (diagram, geometry) = pinned_rank_fixture(HashMap::from([
+        ("A".to_string(), 0),
+        ("B".to_string(), 2),
+        ("C".to_string(), 4),
+    ]));
+    let config = GridLayoutConfig {
+        use_pinned_ranks: true,
+        ..GridLayoutConfig::default()
+    };
+
+    let layout = geometry_to_grid_layout_with_routed(&diagram, &geometry, None, &config);
+
+    assert_eq!(layout.grid_positions["A"].layer, 0);
+    assert_eq!(layout.grid_positions["B"].layer, 2);
+    assert_eq!(layout.grid_positions["C"].layer, 4);
+}
+
+#[test]
+fn pinned_ranks_fall_back_to_coordinate_binning_when_disabled() {
+    let (diagram, geometry) = pinned_rank_fixture(HashMap::from([
+        ("A".to_string(), 0),
+        ("B".to_string(), 2),
+        ("C".to_string(), 4),
+    ]));
+
+    let layout = geometry_to_grid_layout_with_routed(
+        &diagram,
+        &geometry,
+        None,
+        &GridLayoutConfig::default(),
+    );
+
+    assert_eq!(layout.grid_positions["A"].layer, 0);
+    assert_eq!(layout.grid_positions["B"].layer, 0);
+    assert_eq!(layout.grid_positions["C"].layer, 0);
+}
+
+#[test]
+fn pinned_ranks_ignore_missing_projection_entries() {
+    let (diagram, geometry) =
+        pinned_rank_fixture(HashMap::from([("A".to_string(), 0), ("C".to_string(), 4)]));
+    let config = GridLayoutConfig {
+        use_pinned_ranks: true,
+        ..GridLayoutConfig::default()
+    };
+
+    let layout = geometry_to_grid_layout_with_routed(&diagram, &geometry, None, &config);
+
+    assert_eq!(layout.grid_positions["A"].layer, 0);
+    assert_eq!(layout.grid_positions["B"].layer, 0);
+    assert_eq!(layout.grid_positions["C"].layer, 0);
 }
 
 // =========================================================================

--- a/src/graph/grid/mod.rs
+++ b/src/graph/grid/mod.rs
@@ -66,6 +66,8 @@ pub struct GridLayoutConfig {
     pub margin: f64,
     /// Additional ranksep applied when subgraphs are present (Mermaid clusters).
     pub cluster_rank_sep: f64,
+    /// Honor hydrated projection ranks when replaying a marked materialized view.
+    pub use_pinned_ranks: bool,
 }
 
 impl Default for GridLayoutConfig {
@@ -82,6 +84,7 @@ impl Default for GridLayoutConfig {
             rank_sep: 50.0,
             margin: 8.0,
             cluster_rank_sep: 25.0,
+            use_pinned_ranks: false,
         }
     }
 }

--- a/src/graph/measure.rs
+++ b/src/graph/measure.rs
@@ -109,9 +109,8 @@ impl ProportionalTextMetrics {
 /// splits when a single word exceeds `max_width`.
 ///
 /// **Sequencing contract:** callers MUST normalize `<br>`/`<br/>`/`<br />`
-/// variants to `'\n'` before calling this function (see
-/// [`crate::diagrams::flowchart::compiler::normalize_br_tags`]). `wrap_lines`
-/// does not inspect the raw Mermaid source.
+/// variants to `'\n'` before calling this function. `wrap_lines` does not
+/// inspect the raw Mermaid source.
 pub fn wrap_lines(metrics: &ProportionalTextMetrics, text: &str, max_width: f64) -> Vec<String> {
     let space_w = metrics.char_width_ratio(' ') * metrics.font_size * TEXT_WIDTH_SCALE;
     let mut out = Vec::new();

--- a/src/internal_tests/layout_stability/mmds_metrics.rs
+++ b/src/internal_tests/layout_stability/mmds_metrics.rs
@@ -207,8 +207,8 @@ pub(crate) enum ShiftConfidence {
 
 pub(crate) fn compare_layout_mmds(
     pair: &mutations::MutationPair,
-    before: &mmds::Output,
-    after: &mmds::Output,
+    before: &mmds::Document,
+    after: &mmds::Document,
 ) -> LayoutMmdsMetrics {
     let before_nodes = nodes_by_id(before);
     let after_nodes = nodes_by_id(after);
@@ -254,8 +254,8 @@ pub(crate) fn compare_layout_mmds(
 
 pub(crate) fn compare_routed_mmds(
     pair: &mutations::MutationPair,
-    before: &mmds::Output,
-    after: &mmds::Output,
+    before: &mmds::Document,
+    after: &mmds::Document,
 ) -> RoutedMmdsMetrics {
     let before_edges = edges_by_id(before);
     let after_edges = edges_by_id(after);
@@ -309,8 +309,8 @@ pub(crate) fn compare_routed_mmds(
 
 pub(crate) fn collect_quality_oracle_metrics(
     pair: &mutations::MutationPair,
-    before: &mmds::Output,
-    after: &mmds::Output,
+    before: &mmds::Document,
+    after: &mmds::Document,
 ) -> QualityOracleMetrics {
     let routed = compare_routed_mmds(pair, before, after);
 
@@ -330,7 +330,7 @@ pub(crate) fn collect_quality_oracle_metrics(
     }
 }
 
-fn nodes_by_id(output: &mmds::Output) -> BTreeMap<String, &mmds::Node> {
+fn nodes_by_id(output: &mmds::Document) -> BTreeMap<String, &mmds::Node> {
     output
         .nodes
         .iter()
@@ -411,8 +411,8 @@ fn bounds_delta(before: &mmds::Bounds, after: &mmds::Bounds) -> BoundsDelta {
 }
 
 fn subgraph_membership_changes(
-    before: &mmds::Output,
-    after: &mmds::Output,
+    before: &mmds::Document,
+    after: &mmds::Document,
 ) -> Vec<SubgraphMembershipDelta> {
     let before_subgraphs = subgraphs_by_id(before);
     let after_subgraphs = subgraphs_by_id(after);
@@ -456,7 +456,7 @@ fn subgraph_membership_changes(
     changes
 }
 
-fn subgraphs_by_id(output: &mmds::Output) -> BTreeMap<String, &mmds::Subgraph> {
+fn subgraphs_by_id(output: &mmds::Document) -> BTreeMap<String, &mmds::Subgraph> {
     output
         .subgraphs
         .iter()
@@ -470,7 +470,7 @@ fn sorted_children(children: &[String]) -> Vec<String> {
     sorted
 }
 
-fn label_side_changes(before: &mmds::Output, after: &mmds::Output) -> Vec<LabelSideDelta> {
+fn label_side_changes(before: &mmds::Document, after: &mmds::Document) -> Vec<LabelSideDelta> {
     let before_edges = edges_by_id(before);
     let after_edges = edges_by_id(after);
     let mut changes = Vec::new();
@@ -491,7 +491,7 @@ fn label_side_changes(before: &mmds::Output, after: &mmds::Output) -> Vec<LabelS
     changes
 }
 
-fn edges_by_id(output: &mmds::Output) -> BTreeMap<String, &mmds::Edge> {
+fn edges_by_id(output: &mmds::Document) -> BTreeMap<String, &mmds::Edge> {
     output
         .edges
         .iter()
@@ -601,7 +601,7 @@ fn rect_center(rect: &mmds::Rect) -> (f64, f64) {
     (rect.x + rect.width / 2.0, rect.y + rect.height / 2.0)
 }
 
-fn label_rect_overlaps(output: &mmds::Output) -> Vec<LabelRectOverlap> {
+fn label_rect_overlaps(output: &mmds::Document) -> Vec<LabelRectOverlap> {
     let rects = output
         .edges
         .iter()
@@ -627,7 +627,7 @@ fn label_rect_overlaps(output: &mmds::Output) -> Vec<LabelRectOverlap> {
     overlaps
 }
 
-fn label_path_drift(output: &mmds::Output) -> Vec<LabelPathDrift> {
+fn label_path_drift(output: &mmds::Document) -> Vec<LabelPathDrift> {
     output
         .edges
         .iter()

--- a/src/internal_tests/layout_stability/render_surfaces.rs
+++ b/src/internal_tests/layout_stability/render_surfaces.rs
@@ -13,8 +13,8 @@ pub(crate) struct RenderedDiagram {
     pub(crate) source: String,
     pub(crate) text: String,
     pub(crate) svg: String,
-    pub(crate) layout_mmds: mmds::Output,
-    pub(crate) routed_mmds: mmds::Output,
+    pub(crate) layout_mmds: mmds::Document,
+    pub(crate) routed_mmds: mmds::Document,
     pub(crate) phase_trace: LayeredPhaseTrace,
     pub(crate) route_trace: RoutingTrace,
 }
@@ -96,7 +96,7 @@ pub(crate) fn render_pair(
 
 pub(crate) fn render_lossless_routed_mmds(
     source: &str,
-) -> Result<(String, mmds::Output), RenderSurfaceError> {
+) -> Result<(String, mmds::Document), RenderSurfaceError> {
     render_mmds_with_simplification(
         "<direct>",
         "input",
@@ -164,7 +164,7 @@ fn render_mmds_with_simplification(
     source: &str,
     geometry_level: GeometryLevel,
     path_simplification: PathSimplification,
-) -> Result<(String, mmds::Output), RenderSurfaceError> {
+) -> Result<(String, mmds::Document), RenderSurfaceError> {
     let config = RenderConfig {
         geometry_level,
         path_simplification,

--- a/src/internal_tests/layout_stability/route_diagnostics.rs
+++ b/src/internal_tests/layout_stability/route_diagnostics.rs
@@ -776,7 +776,7 @@ impl LabelLaneTraceSnapshot {
     }
 }
 
-fn routed_mmds_signature(output: &crate::mmds::Output) -> String {
+fn routed_mmds_signature(output: &crate::mmds::Document) -> String {
     serde_json::to_string(output).expect("MMDS output should serialize")
 }
 

--- a/src/internal_tests/mmds_diff.rs
+++ b/src/internal_tests/mmds_diff.rs
@@ -325,7 +325,7 @@ fn mmds_diff_edge_matching_tier_a_controls_stay_calibrated() {
     assert!(summaries["M10"].has_kind(MmdsDiffKind::SubgraphDirectionChanged));
 }
 
-fn parse_layout(source: &str) -> crate::mmds::Output {
+fn parse_layout(source: &str) -> crate::mmds::Document {
     let config = RenderConfig {
         geometry_level: GeometryLevel::Layout,
         ..RenderConfig::default()
@@ -336,11 +336,11 @@ fn parse_layout(source: &str) -> crate::mmds::Output {
 }
 
 fn output_with_node_shift(
-    output: &crate::mmds::Output,
+    output: &crate::mmds::Document,
     node_id: &str,
     dx: f64,
     dy: f64,
-) -> crate::mmds::Output {
+) -> crate::mmds::Document {
     let mut shifted = output.clone();
     let node = shifted
         .nodes
@@ -390,7 +390,7 @@ fn mutation_input_source(
     }
 }
 
-fn render_pair_before_routed(pair_id: &str) -> crate::mmds::Output {
+fn render_pair_before_routed(pair_id: &str) -> crate::mmds::Document {
     match pair_id {
         "M14" => parse_routed(include_str!(
             "../../tests/fixtures/flowchart/inline_label_flowchart.mmd"
@@ -399,7 +399,7 @@ fn render_pair_before_routed(pair_id: &str) -> crate::mmds::Output {
     }
 }
 
-fn render_pair_after_routed(pair_id: &str) -> crate::mmds::Output {
+fn render_pair_after_routed(pair_id: &str) -> crate::mmds::Document {
     match pair_id {
         "M14" => parse_routed(M14_AFTER),
         _ => panic!("unsupported pair id {pair_id}"),
@@ -444,7 +444,7 @@ const M14_AFTER: &str = "flowchart TD
   metrics --> End((Done))
 ";
 
-fn parse_routed(source: &str) -> crate::mmds::Output {
+fn parse_routed(source: &str) -> crate::mmds::Document {
     let config = RenderConfig {
         geometry_level: GeometryLevel::Routed,
         ..RenderConfig::default()

--- a/src/internal_tests/mmds_document_serialization.rs
+++ b/src/internal_tests/mmds_document_serialization.rs
@@ -1,6 +1,6 @@
-//! MMDS output serialization tests that require engine-produced geometry.
+//! MMDS document serialization tests that require engine-produced geometry.
 //!
-//! Moved from `mmds/output.rs` to respect the mmds→engines boundary:
+//! Moved from `mmds/document.rs` to respect the mmds→engines boundary:
 //! mmds must not import from engines, even in tests.
 
 use crate::engines::graph::EngineConfig;
@@ -10,7 +10,7 @@ use crate::graph::geometry::{GraphGeometry, RoutedGraphGeometry};
 use crate::graph::measure::default_proportional_text_metrics;
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
 use crate::graph::{GeometryLevel, Graph};
-use crate::mmds::output::{Output, to_json, to_layout, to_routed};
+use crate::mmds::document::{Document, to_json, to_layout, to_routed};
 use crate::simplification::PathSimplification;
 
 fn layout_geometry(input: &str) -> (Graph, GraphGeometry) {
@@ -38,7 +38,7 @@ fn routed_geometry(diagram: &Graph, geometry: &GraphGeometry) -> RoutedGraphGeom
 fn layout_json_has_version_and_level() {
     let (diagram, geom) = layout_geometry("graph TD\nA-->B");
     let json = to_layout(&diagram, &geom);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.version, 1);
     assert_eq!(output.geometry_level, "layout");
 }
@@ -47,7 +47,7 @@ fn layout_json_has_version_and_level() {
 fn layout_json_has_metadata() {
     let (diagram, geom) = layout_geometry("graph TD\nA-->B");
     let json = to_layout(&diagram, &geom);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.defaults.node.shape, "rectangle");
     assert_eq!(output.defaults.edge.stroke, "solid");
     assert_eq!(output.defaults.edge.arrow_start, "none");
@@ -63,7 +63,7 @@ fn layout_json_has_metadata() {
 fn layout_json_has_nodes_with_positions() {
     let (diagram, geom) = layout_geometry("graph TD\nA[Start]-->B[End]");
     let json = to_layout(&diagram, &geom);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     assert_eq!(output.nodes.len(), 2);
     let node_a = output.nodes.iter().find(|n| n.id == "A").unwrap();
@@ -83,7 +83,7 @@ fn layout_json_edges_have_no_paths() {
     assert!(!json.contains("\"label_position\""));
     assert!(!json.contains("\"is_backward\""));
 
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.edges.len(), 1);
     assert_eq!(output.edges[0].source, "A");
     assert_eq!(output.edges[0].target, "B");
@@ -94,7 +94,7 @@ fn layout_json_edges_have_no_paths() {
 fn layout_json_edge_semantics() {
     let (diagram, geom) = layout_geometry("graph TD\nA-.label.->B");
     let json = to_layout(&diagram, &geom);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let edge = &output.edges[0];
     assert_eq!(edge.id, "e0");
@@ -189,7 +189,7 @@ fn layout_deserializes_with_defaults() {
         None,
     )
     .unwrap();
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.nodes[0].shape, "rectangle");
     assert_eq!(output.edges[0].stroke, "solid");
     assert_eq!(output.edges[0].arrow_start, "none");
@@ -202,7 +202,7 @@ fn layout_deserializes_with_defaults() {
 fn layout_json_subgraphs() {
     let (diagram, geom) = layout_geometry("graph TD\nsubgraph sg1[Group]\nA-->B\nend");
     let json = to_layout(&diagram, &geom);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     assert_eq!(output.subgraphs.len(), 1);
     assert_eq!(output.subgraphs[0].id, "sg1");
@@ -216,7 +216,7 @@ fn layout_json_subgraph_direction_override() {
     let (diagram, geom) =
         layout_geometry("graph TD\nsubgraph sg1[Group]\ndirection LR\nA-->B\nend");
     let json = to_layout(&diagram, &geom);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.subgraphs[0].direction.as_deref(), Some("LR"));
 }
 
@@ -224,7 +224,7 @@ fn layout_json_subgraph_direction_override() {
 fn layout_json_nodes_sorted_by_id() {
     let (diagram, geom) = layout_geometry("graph TD\nC-->B\nB-->A");
     let json = to_layout(&diagram, &geom);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let ids: Vec<&str> = output.nodes.iter().map(|n| n.id.as_str()).collect();
     assert_eq!(ids, vec!["A", "B", "C"]);
@@ -236,7 +236,7 @@ fn layout_json_direction_variants() {
         let input = format!("graph {dir_str}\nA-->B");
         let (diagram, geom) = layout_geometry(&input);
         let json = to_layout(&diagram, &geom);
-        let output: Output = serde_json::from_str(&json).unwrap();
+        let output: Document = serde_json::from_str(&json).unwrap();
         assert_eq!(output.metadata.direction, expected);
     }
 }
@@ -246,7 +246,7 @@ fn routed_json_has_version_and_level() {
     let (diagram, geom) = layout_geometry("graph TD\nA-->B");
     let routed = routed_geometry(&diagram, &geom);
     let json = to_routed(&diagram, &geom, &routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.version, 1);
     assert_eq!(output.geometry_level, "routed");
 }
@@ -259,7 +259,7 @@ fn routed_json_includes_edge_paths() {
 
     assert!(json.contains("\"path\""));
 
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     let edge = &output.edges[0];
     assert!(edge.path.is_some());
     assert!(edge.path.as_ref().unwrap().len() >= 2);
@@ -271,7 +271,7 @@ fn routed_json_includes_metadata_bounds() {
     let (diagram, geom) = layout_geometry("graph TD\nA-->B");
     let routed = routed_geometry(&diagram, &geom);
     let json = to_routed(&diagram, &geom, &routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let bounds = &output.metadata.bounds;
     assert!(bounds.width > 0.0);
@@ -283,7 +283,7 @@ fn routed_json_subgraph_bounds() {
     let (diagram, geom) = layout_geometry("graph TD\nsubgraph sg1[Group]\nA-->B\nend");
     let routed = routed_geometry(&diagram, &geom);
     let json = to_routed(&diagram, &geom, &routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let sg = &output.subgraphs[0];
     assert!(sg.bounds.is_some());
@@ -324,7 +324,7 @@ fn routed_json_includes_port_metadata() {
     let (diagram, geom) = layout_geometry("graph TD\nA-->B");
     let routed = routed_geometry(&diagram, &geom);
     let json = to_routed(&diagram, &geom, &routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     let edge = &output.edges[0];
     // A simple TD A-->B should have port metadata at routed level
     assert!(edge.source_port.is_some());
@@ -357,7 +357,8 @@ fn routed_mmds_metadata_uses_routed_bounds_not_layout_bounds() {
     let (diagram, geom) = layout_geometry("graph TD\nA-->B\nB-->C\nC-->A");
     let routed = routed_geometry(&diagram, &geom);
 
-    let routed_output: Output = serde_json::from_str(&to_routed(&diagram, &geom, &routed)).unwrap();
+    let routed_output: Document =
+        serde_json::from_str(&to_routed(&diagram, &geom, &routed)).unwrap();
 
     // The MMDS routed bounds must always match the routed geometry bounds.
     assert!(

--- a/src/internal_tests/mod.rs
+++ b/src/internal_tests/mod.rs
@@ -8,7 +8,7 @@ mod layered_adapter_pipeline;
 mod layout_stability;
 mod mmds_commands;
 mod mmds_diff;
-mod mmds_output_serialization;
+mod mmds_document_serialization;
 mod mmds_roundtrip;
 mod port_attachment_observation;
 mod singleton_centering_observation;

--- a/src/internal_tests/port_attachment_observation.rs
+++ b/src/internal_tests/port_attachment_observation.rs
@@ -13,7 +13,7 @@ use crate::graph::grid::{
 };
 use crate::graph::{Edge, GeometryLevel, Graph};
 use crate::mermaid::parse_flowchart;
-use crate::mmds::{Edge as MmdsEdge, Node as MmdsNode, Output, Port};
+use crate::mmds::{Document, Edge as MmdsEdge, Node as MmdsNode, Port};
 use crate::{OutputFormat, RenderConfig};
 
 #[allow(dead_code)]
@@ -239,7 +239,7 @@ fn observe_fixture_edges(fixture: &str, edges: &[(&str, &str)]) -> Vec<PortObser
 
 fn observe_output_edge(
     fixture: &str,
-    output: &Output,
+    output: &Document,
     text_context: &TextContext,
     from: &str,
     to: &str,
@@ -299,7 +299,7 @@ fn load_flowchart_fixture(name: &str) -> String {
         .unwrap_or_else(|err| panic!("failed to read fixture {}: {err}", path.display()))
 }
 
-fn render_routed_mmds(input: &str) -> Output {
+fn render_routed_mmds(input: &str) -> Document {
     let config = RenderConfig {
         geometry_level: GeometryLevel::Routed,
         ..RenderConfig::default()
@@ -423,7 +423,7 @@ fn target_face_from_entry(entry: AttachDirection) -> &'static str {
     }
 }
 
-fn find_edge<'a>(output: &'a Output, from: &str, to: &str) -> &'a MmdsEdge {
+fn find_edge<'a>(output: &'a Document, from: &str, to: &str) -> &'a MmdsEdge {
     let mut matches = output
         .edges
         .iter()
@@ -438,7 +438,7 @@ fn find_edge<'a>(output: &'a Output, from: &str, to: &str) -> &'a MmdsEdge {
     edge
 }
 
-fn find_node<'a>(output: &'a Output, id: &str) -> &'a MmdsNode {
+fn find_node<'a>(output: &'a Document, id: &str) -> &'a MmdsNode {
     output
         .nodes
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,11 @@
 //!
 //! # High-Level API
 //!
-//! Most consumers only need three functions and two config types:
+//! Most consumers only need the facade functions and two config types:
 //!
 //! - [`render_diagram`] — detect, parse, and render in one call
+//! - [`materialize_diagram`] — materialize a graph-family [`mmds::Document`]
+//! - [`render_mmds_document`] — render an already-parsed graph-family MMDS document
 //! - [`detect_diagram`] — detect the diagram type without rendering
 //! - [`validate_diagram`] — parse and return structured JSON diagnostics
 //! - [`OutputFormat`] — `Text`, `Ascii`, `Svg`, or `Mmds`
@@ -87,6 +89,8 @@
 //!   ([`Sequence`](timeline::Sequence))
 //! - [`mmds`] — MMDS parsing, hydration to [`graph::Graph`],
 //!   profile negotiation, and Mermaid regeneration
+//! - [`views`] — materialized read-side views over canonical
+//!   [`mmds::Document`] payloads
 //!
 //! ```no_run
 //! use mmdflux::builtins::default_registry;
@@ -162,6 +166,46 @@
 //! let mermaid = generate_mermaid_from_str(mmds_json).unwrap();
 //! assert!(mermaid.contains("flowchart TD"));
 //! ```
+//!
+//! ## Materialized MMDS views
+//!
+//! Use [`views`] when an adapter needs a focused read model over a canonical
+//! MMDS payload. V1 views preserve shared coordinates, keep surviving edge IDs
+//! sparse and stable, and return [`views::ViewEvent`] values for omitted
+//! elements:
+//!
+//! ```
+//! use mmdflux::mmds::Document;
+//! use mmdflux::views::{
+//!     AnchorRef, Selector, TraversalDirection, ViewSpec, ViewStatement, apply_view,
+//! };
+//! use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_mmds_document};
+//!
+//! let source = "\
+//! graph TD
+//! A[Gateway] --> B[Auth]
+//! B --> C[Database]
+//! A --> D[Audit]
+//! ";
+//! let canonical: Document = materialize_diagram(source, &RenderConfig::default()).unwrap();
+//! let spec = ViewSpec {
+//!     statements: vec![ViewStatement::Include(Selector::Traversal {
+//!         anchor: AnchorRef::Node("A".to_string()),
+//!         direction: TraversalDirection::Downstream,
+//!         hops: 1,
+//!     })],
+//!     ..ViewSpec::default()
+//! };
+//!
+//! let (view, events) = apply_view(&canonical, &spec).unwrap();
+//! let text = render_mmds_document(&view, OutputFormat::Text, &RenderConfig::default()).unwrap();
+//! assert!(text.contains("Gateway"));
+//! assert_eq!(view.nodes.len(), 3);
+//! assert!(events.iter().any(|event| matches!(
+//!     event,
+//!     mmdflux::views::ViewEvent::NodeLeftView { id, .. } if id == "C"
+//! )));
+//! ```
 
 pub mod builtins;
 mod diagrams;
@@ -179,6 +223,7 @@ mod render;
 pub(crate) mod runtime;
 pub mod simplification;
 pub mod timeline;
+pub mod views;
 
 // Public re-exports from public modules (convenience aliases).
 // Re-exports from public modules for convenience at crate root.
@@ -205,8 +250,12 @@ pub use runtime::config_input::RuntimeConfigInput;
 pub use runtime::config_input::apply_svg_surface_defaults;
 /// Detect the diagram type from input text.
 pub use runtime::detect_diagram;
+/// Detect, parse, solve, and materialize a graph-family diagram as MMDS.
+pub use runtime::materialize_diagram;
 /// Detect, parse, and render a diagram in one call.
 pub use runtime::render_diagram;
+/// Render a parsed graph-family MMDS document.
+pub use runtime::render_mmds_document;
 /// Validate input and return structured JSON diagnostics.
 pub use runtime::validate_diagram;
 

--- a/src/mmds/detect.rs
+++ b/src/mmds/detect.rs
@@ -2,7 +2,7 @@
 
 use crate::errors::RenderError;
 use crate::format::OutputFormat;
-use crate::mmds::{Output, ParseError, parse_input};
+use crate::mmds::{Document, ParseError, parse_input};
 
 pub const SUPPORTED_OUTPUT_FORMATS: &[OutputFormat] = &[
     OutputFormat::Text,
@@ -34,7 +34,7 @@ fn contains_json_key(input: &str, key: &str) -> bool {
 }
 
 /// Resolve the logical diagram ID carried by an MMDS payload.
-pub fn resolve_logical_diagram_id(output: &Output) -> Result<&'static str, RenderError> {
+pub fn resolve_logical_diagram_id(output: &Document) -> Result<&'static str, RenderError> {
     match output.metadata.diagram_type.as_str() {
         "flowchart" => Ok("flowchart"),
         "class" => Ok("class"),

--- a/src/mmds/diff.rs
+++ b/src/mmds/diff.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::Value;
 
-use super::output::NODE_STYLE_EXTENSION_NAMESPACE;
-use super::{Bounds, Edge, Node, Output, Port, Position, Rect, Subgraph};
+use super::document::NODE_STYLE_EXTENSION_NAMESPACE;
+use super::{Bounds, Document, Edge, Node, Port, Position, Rect, Subgraph};
 
 const COORD_EPS: f64 = 0.01;
 const DISPLAY_EPS: f64 = 1.0;
@@ -96,7 +96,7 @@ pub(crate) enum MmdsDiffSubject {
     Subgraph(String),
 }
 
-pub(crate) fn diff_outputs(before: &Output, after: &Output) -> MmdsDiff {
+pub(crate) fn diff_outputs(before: &Document, after: &Document) -> MmdsDiff {
     let mut events = Vec::new();
 
     if before.geometry_level != after.geometry_level {
@@ -218,7 +218,7 @@ fn document_event_with_evidence(kind: MmdsDiffKind, evidence: Vec<String>) -> Mm
     }
 }
 
-fn nodes_by_id(output: &Output) -> BTreeMap<String, &Node> {
+fn nodes_by_id(output: &Document) -> BTreeMap<String, &Node> {
     output
         .nodes
         .iter()
@@ -226,7 +226,7 @@ fn nodes_by_id(output: &Output) -> BTreeMap<String, &Node> {
         .collect()
 }
 
-fn edges_by_id(output: &Output) -> BTreeMap<String, &Edge> {
+fn edges_by_id(output: &Document) -> BTreeMap<String, &Edge> {
     output
         .edges
         .iter()
@@ -234,7 +234,7 @@ fn edges_by_id(output: &Output) -> BTreeMap<String, &Edge> {
         .collect()
 }
 
-fn subgraphs_by_id(output: &Output) -> BTreeMap<String, &Subgraph> {
+fn subgraphs_by_id(output: &Document) -> BTreeMap<String, &Subgraph> {
     output
         .subgraphs
         .iter()
@@ -624,8 +624,8 @@ fn edge_match_evidence(edge_match: &EdgeMatch<'_>) -> Vec<String> {
 
 fn push_node_semantic_events(
     events: &mut Vec<MmdsDiffEvent>,
-    before_output: &Output,
-    after_output: &Output,
+    before_output: &Document,
+    after_output: &Document,
     before: &BTreeMap<String, &Node>,
     after: &BTreeMap<String, &Node>,
 ) {
@@ -729,8 +729,8 @@ fn push_node_geometry_events(
 
 fn push_global_reflow_event(
     events: &mut Vec<MmdsDiffEvent>,
-    before_output: &Output,
-    after_output: &Output,
+    before_output: &Document,
+    after_output: &Document,
     before: &BTreeMap<String, &Node>,
     after: &BTreeMap<String, &Node>,
 ) {
@@ -767,8 +767,8 @@ fn push_global_reflow_event(
 }
 
 fn node_semantics_same(
-    before_output: &Output,
-    after_output: &Output,
+    before_output: &Document,
+    after_output: &Document,
     id: &str,
     before: &Node,
     after: &Node,
@@ -1318,7 +1318,7 @@ fn link_related_geometry(events: &mut [MmdsDiffEvent]) {
     }
 }
 
-fn node_style_payload<'a>(output: &'a Output, node_id: &str) -> Option<&'a Value> {
+fn node_style_payload<'a>(output: &'a Document, node_id: &str) -> Option<&'a Value> {
     output
         .extensions
         .get(NODE_STYLE_EXTENSION_NAMESPACE)?

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -1,4 +1,4 @@
-//! MMDS output contract and serialization helpers.
+//! MMDS document contract and serialization helpers.
 //!
 //! Produces structured JSON from graph-family geometry with two levels:
 //! - `layout`: Node geometry + edge topology/semantics (no edge paths).
@@ -46,7 +46,7 @@ pub(crate) fn to_layout_typed(
     diagram: &Graph,
     geometry: &GraphGeometry,
 ) -> String {
-    render_output(
+    render_document_json(
         diagram_type,
         diagram,
         geometry,
@@ -77,7 +77,7 @@ pub(crate) fn to_routed_typed(
     geometry: &GraphGeometry,
     routed: &RoutedGraphGeometry,
 ) -> String {
-    render_output(
+    render_document_json(
         diagram_type,
         diagram,
         geometry,
@@ -109,6 +109,7 @@ pub(crate) fn to_json(
 }
 
 /// Serialize a diagram to MMDS JSON at the specified geometry level with explicit type.
+#[cfg(test)]
 pub(crate) fn to_json_typed(
     diagram_type: &str,
     diagram: &Graph,
@@ -118,8 +119,29 @@ pub(crate) fn to_json_typed(
     path_simplification: PathSimplification,
     engine_id: Option<&str>,
 ) -> Result<String, RenderError> {
+    to_document_typed(
+        diagram_type,
+        diagram,
+        geometry,
+        routed,
+        level,
+        path_simplification,
+        engine_id,
+    )
+    .map(|document| serialize_document(&document))
+}
+
+pub(crate) fn to_document_typed(
+    diagram_type: &str,
+    diagram: &Graph,
+    geometry: &GraphGeometry,
+    routed: Option<&RoutedGraphGeometry>,
+    level: GeometryLevel,
+    path_simplification: PathSimplification,
+    engine_id: Option<&str>,
+) -> Result<Document, RenderError> {
     match level {
-        GeometryLevel::Layout => Ok(render_output(
+        GeometryLevel::Layout => Ok(build_document(
             diagram_type,
             diagram,
             geometry,
@@ -133,7 +155,7 @@ pub(crate) fn to_json_typed(
                     .to_string(),
             })
             .map(|routed| {
-                render_output(
+                build_document(
                     diagram_type,
                     diagram,
                     geometry,
@@ -145,6 +167,10 @@ pub(crate) fn to_json_typed(
     }
 }
 
+/// Serialize a graph-family diagram to MMDS JSON with fallback routing.
+#[deprecated(
+    note = "use materialize_diagram plus serde_json serialization for JSON output, or render_mmds_document for replay"
+)]
 pub fn to_json_typed_with_routing(
     diagram_type: &str,
     diagram: &Graph,
@@ -154,6 +180,27 @@ pub fn to_json_typed_with_routing(
     path_simplification: PathSimplification,
     engine_id: Option<&str>,
 ) -> Result<String, RenderError> {
+    to_document_typed_with_routing(
+        diagram_type,
+        diagram,
+        geometry,
+        routed,
+        level,
+        path_simplification,
+        engine_id,
+    )
+    .map(|document| serialize_document(&document))
+}
+
+pub(crate) fn to_document_typed_with_routing(
+    diagram_type: &str,
+    diagram: &Graph,
+    geometry: &GraphGeometry,
+    routed: Option<&RoutedGraphGeometry>,
+    level: GeometryLevel,
+    path_simplification: PathSimplification,
+    engine_id: Option<&str>,
+) -> Result<Document, RenderError> {
     // MMDS fallback routing: default metrics are sufficient since this path
     // only fires when no pre-routed geometry was provided (design §6.3).
     let metrics = default_proportional_text_metrics();
@@ -161,7 +208,7 @@ pub fn to_json_typed_with_routing(
         .then(|| route_graph_geometry(diagram, geometry, EdgeRouting::OrthogonalRoute, &metrics));
     let routed = routed.or(routed_owned.as_ref());
 
-    to_json_typed(
+    to_document_typed(
         diagram_type,
         diagram,
         geometry,
@@ -172,7 +219,8 @@ pub fn to_json_typed_with_routing(
     )
 }
 
-fn render_output(
+#[cfg(test)]
+fn render_document_json(
     diagram_type: &str,
     diagram: &Graph,
     geometry: &GraphGeometry,
@@ -180,7 +228,7 @@ fn render_output(
     path_simplification: PathSimplification,
     engine_id: Option<&str>,
 ) -> String {
-    let output = build_output(
+    let document = build_document(
         diagram_type,
         diagram,
         geometry,
@@ -188,11 +236,11 @@ fn render_output(
         path_simplification,
         engine_id,
     );
-    serialize_output(&output)
+    serialize_document(&document)
 }
 
-fn serialize_output(output: &Output) -> String {
-    serde_json::to_string_pretty(output).expect("MMDS serialization should not fail")
+fn serialize_document(document: &Document) -> String {
+    serde_json::to_string_pretty(document).expect("MMDS serialization should not fail")
 }
 
 fn edge_port_to_mmds(port: &EdgePort) -> Port {
@@ -247,14 +295,14 @@ fn mmds_edge_label_rect(routed_edge: Option<&RoutedEdgeGeometry>, is_routed: boo
     })
 }
 
-fn build_output(
+fn build_document(
     diagram_type: &str,
     diagram: &Graph,
     geometry: &GraphGeometry,
     routed: Option<&RoutedGraphGeometry>,
     path_simplification: PathSimplification,
     engine_id: Option<&str>,
-) -> Output {
+) -> Document {
     let level = if routed.is_some() { "routed" } else { "layout" };
     let styled_nodes = collect_styled_nodes(diagram);
 
@@ -391,7 +439,7 @@ fn build_output(
         );
     }
 
-    Output {
+    Document {
         version: 1,
         profiles,
         extensions,
@@ -676,9 +724,9 @@ fn arrow_str(arrow: Arrow) -> &'static str {
 // MMDS data types
 // ---------------------------------------------------------------------------
 
-/// Top-level MMDS output envelope.
+/// Top-level graph-family MMDS document envelope.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Output {
+pub struct Document {
     /// Schema version (1 for MMDS).
     pub version: u32,
     /// Optional behavior bundle declarations for capability negotiation.
@@ -704,6 +752,14 @@ pub struct Output {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub subgraphs: Vec<Subgraph>,
 }
+
+/// Legacy name for [`Document`].
+///
+/// New code should use `mmds::Document`. The alias remains available so
+/// existing adapter code that imports `mmds::Output` continues to compile.
+#[doc(hidden)]
+#[deprecated(note = "use mmds::Document instead")]
+pub type Output = Document;
 
 /// Default values for omitted fields in nodes and edges.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -19,7 +19,7 @@ use crate::graph::space::{FPoint, FRect};
 use crate::graph::style::{ColorToken, NodeStyle};
 use crate::graph::{Arrow, Direction, Edge as GraphEdge, Graph, Node, Shape, Stroke, Subgraph};
 use crate::mmds::{
-    Edge, NODE_STYLE_EXTENSION_NAMESPACE, Output, TEXT_EXTENSION_NAMESPACE, parse_input,
+    Document, Edge, NODE_STYLE_EXTENSION_NAMESPACE, TEXT_EXTENSION_NAMESPACE, parse_input,
 };
 
 /// Hydrate a graph `Diagram` from MMDS JSON text.
@@ -27,11 +27,11 @@ pub fn from_str(input: &str) -> Result<Graph, HydrationError> {
     let output = parse_input(input).map_err(|err| HydrationError::Parse {
         message: err.to_string(),
     })?;
-    from_output(&output)
+    from_document(&output)
 }
 
-/// Hydrate a graph `Diagram` from a parsed MMDS envelope.
-pub fn from_output(output: &Output) -> Result<Graph, HydrationError> {
+/// Hydrate a graph `Diagram` from a parsed MMDS document.
+pub fn from_document(output: &Document) -> Result<Graph, HydrationError> {
     validate_output(output)?;
 
     let direction = parse_direction(&output.metadata.direction).ok_or_else(|| {
@@ -217,6 +217,13 @@ pub fn from_output(output: &Output) -> Result<Graph, HydrationError> {
     Ok(diagram)
 }
 
+/// Hydrate a graph `Diagram` from a parsed MMDS document.
+#[doc(hidden)]
+#[deprecated(note = "use from_document instead")]
+pub fn from_output(output: &Document) -> Result<Graph, HydrationError> {
+    from_document(output)
+}
+
 fn hydrate_node_style_extension(
     diagram: &mut Graph,
     extensions: &std::collections::BTreeMap<String, Map<String, Value>>,
@@ -309,25 +316,35 @@ pub(crate) fn hydrate_graph_geometry_from_mmds(
     let output = parse_input(input).map_err(|err| HydrationError::Parse {
         message: err.to_string(),
     })?;
-    hydrate_graph_geometry_from_output(&output)
+    hydrate_graph_geometry_from_document(&output)
 }
 
-/// Hydrate graph geometry IR from parsed MMDS output.
+/// Hydrate graph geometry IR from a parsed MMDS document.
 #[cfg(test)]
-pub(crate) fn hydrate_graph_geometry_from_output(
-    output: &Output,
+pub(crate) fn hydrate_graph_geometry_from_document(
+    output: &Document,
 ) -> Result<GraphGeometry, HydrationError> {
     let (_, geometry) = hydrate_geometry_parts(output)?;
     Ok(geometry)
 }
 
-/// Hydrate graph geometry IR from parsed MMDS output, using a pre-built diagram.
-pub fn hydrate_graph_geometry_from_output_with_diagram(
-    output: &Output,
+/// Hydrate graph geometry IR from a parsed MMDS document, using a pre-built diagram.
+pub fn hydrate_graph_geometry_from_document_with_diagram(
+    output: &Document,
     diagram: &Graph,
 ) -> Result<GraphGeometry, HydrationError> {
     validate_output(output)?;
     build_graph_geometry(output, diagram)
+}
+
+/// Hydrate graph geometry IR from a parsed MMDS document, using a pre-built diagram.
+#[doc(hidden)]
+#[deprecated(note = "use hydrate_graph_geometry_from_document_with_diagram instead")]
+pub fn hydrate_graph_geometry_from_output_with_diagram(
+    output: &Document,
+    diagram: &Graph,
+) -> Result<GraphGeometry, HydrationError> {
+    hydrate_graph_geometry_from_document_with_diagram(output, diagram)
 }
 
 /// Hydrate routed geometry IR from MMDS JSON text.
@@ -338,12 +355,12 @@ pub(crate) fn hydrate_routed_geometry_from_mmds(
     let output = parse_input(input).map_err(|err| HydrationError::Parse {
         message: err.to_string(),
     })?;
-    hydrate_routed_geometry_from_output(&output)
+    hydrate_routed_geometry_from_document(&output)
 }
 
-/// Hydrate routed geometry IR from parsed MMDS output.
-pub fn hydrate_routed_geometry_from_output(
-    output: &Output,
+/// Hydrate routed geometry IR from a parsed MMDS document.
+pub fn hydrate_routed_geometry_from_document(
+    output: &Document,
 ) -> Result<RoutedGraphGeometry, HydrationError> {
     let (diagram, geometry) = hydrate_geometry_parts(output)?;
     let edge_routing = if output.geometry_level == "routed" {
@@ -370,12 +387,21 @@ pub fn hydrate_routed_geometry_from_output(
     Ok(routed)
 }
 
+/// Hydrate routed geometry IR from a parsed MMDS document.
+#[doc(hidden)]
+#[deprecated(note = "use hydrate_routed_geometry_from_document instead")]
+pub fn hydrate_routed_geometry_from_output(
+    output: &Document,
+) -> Result<RoutedGraphGeometry, HydrationError> {
+    hydrate_routed_geometry_from_document(output)
+}
+
 /// Replace synthesized `label_geometry` on routed edges with an
 /// authoritative version derived from the MMDS payload's `label_rect`
 /// and `label_side`.
 fn overlay_authoritative_label_geometry(
     routed: &mut RoutedGraphGeometry,
-    output: &Output,
+    output: &Document,
     metrics: &crate::graph::measure::ProportionalTextMetrics,
 ) {
     let edges = sorted_output_edges(output);
@@ -425,13 +451,16 @@ fn parse_mmds_label_side(value: Option<&str>) -> Option<EdgeLabelSide> {
     }
 }
 
-fn hydrate_geometry_parts(output: &Output) -> Result<(Graph, GraphGeometry), HydrationError> {
-    let diagram = from_output(output)?;
+fn hydrate_geometry_parts(output: &Document) -> Result<(Graph, GraphGeometry), HydrationError> {
+    let diagram = from_document(output)?;
     let geometry = build_graph_geometry(output, &diagram)?;
     Ok((diagram, geometry))
 }
 
-fn build_graph_geometry(output: &Output, diagram: &Graph) -> Result<GraphGeometry, HydrationError> {
+fn build_graph_geometry(
+    output: &Document,
+    diagram: &Graph,
+) -> Result<GraphGeometry, HydrationError> {
     let nodes = build_positioned_nodes(output, diagram)?;
     let (edges, self_edges, reversed_edges) = build_layout_edges(output);
     let subgraphs = build_subgraph_geometry(output, diagram, &nodes);
@@ -458,7 +487,7 @@ fn build_graph_geometry(output: &Output, diagram: &Graph) -> Result<GraphGeometr
     })
 }
 
-fn hydrate_grid_projection(output: &Output) -> Option<GridProjection> {
+fn hydrate_grid_projection(output: &Document) -> Option<GridProjection> {
     let projection = output
         .extensions
         .get(TEXT_EXTENSION_NAMESPACE)?
@@ -578,7 +607,7 @@ fn parse_override_subgraphs(value: Option<&Value>) -> HashMap<String, OverrideSu
 }
 
 fn build_positioned_nodes(
-    output: &Output,
+    output: &Document,
     diagram: &Graph,
 ) -> Result<HashMap<String, PositionedNode>, HydrationError> {
     output
@@ -609,7 +638,7 @@ fn build_positioned_nodes(
         .collect()
 }
 
-fn build_layout_edges(output: &Output) -> (Vec<LayoutEdge>, Vec<SelfEdgeGeometry>, Vec<usize>) {
+fn build_layout_edges(output: &Document) -> (Vec<LayoutEdge>, Vec<SelfEdgeGeometry>, Vec<usize>) {
     let routed_level = output.geometry_level == "routed";
     let edges = sorted_output_edges(output);
 
@@ -663,7 +692,7 @@ fn build_layout_edges(output: &Output) -> (Vec<LayoutEdge>, Vec<SelfEdgeGeometry
     (layout_edges, self_edges, reversed_edges)
 }
 
-fn sorted_output_edges(output: &Output) -> Vec<(usize, &Edge)> {
+fn sorted_output_edges(output: &Document) -> Vec<(usize, &Edge)> {
     let mut edges: Vec<(usize, &Edge)> = output.edges.iter().enumerate().collect();
     edges.sort_by(|(left_index, left), (right_index, right)| {
         compare_edge_ids(&left.id, &right.id).then(left_index.cmp(right_index))
@@ -676,7 +705,7 @@ fn parse_path_points(path: Option<&[[f64; 2]]>) -> Option<Vec<FPoint>> {
 }
 
 fn build_subgraph_geometry(
-    output: &Output,
+    output: &Document,
     diagram: &Graph,
     nodes: &HashMap<String, PositionedNode>,
 ) -> HashMap<String, SubgraphGeometry> {
@@ -761,7 +790,7 @@ fn node_is_within_subgraph(node: &Node, subgraph_id: &str, diagram: &Graph) -> b
     false
 }
 
-fn validate_output(output: &Output) -> Result<(), HydrationError> {
+fn validate_output(output: &Document) -> Result<(), HydrationError> {
     if output.version != 1 {
         return Err(HydrationError::UnsupportedVersion {
             version: output.version,

--- a/src/mmds/mermaid.rs
+++ b/src/mmds/mermaid.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt;
 
-use super::{Edge, Node, Output, Subgraph, parse_input};
+use super::{Document, Edge, Node, Subgraph, parse_input};
 
 /// Error produced when MMDS-to-Mermaid regeneration fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,7 +35,7 @@ struct IdentifierMaps {
 }
 
 /// Generate canonical Mermaid text from parsed MMDS output.
-pub fn generate_mermaid(output: &Output) -> Result<String, GenerationError> {
+pub fn generate_mermaid(output: &Document) -> Result<String, GenerationError> {
     validate_mermaid_generation_scope(output)?;
 
     let identifiers = build_identifier_maps(output);
@@ -56,7 +56,7 @@ pub fn generate_mermaid_from_str(input: &str) -> Result<String, GenerationError>
     generate_mermaid(&output)
 }
 
-fn build_identifier_maps(output: &Output) -> IdentifierMaps {
+fn build_identifier_maps(output: &Document) -> IdentifierMaps {
     IdentifierMaps {
         node_ids: build_identifier_map(output.nodes.iter().map(|node| node.id.as_str()), "node"),
         subgraph_ids: build_identifier_map(
@@ -66,7 +66,7 @@ fn build_identifier_maps(output: &Output) -> IdentifierMaps {
     }
 }
 
-fn validate_mermaid_generation_scope(output: &Output) -> Result<(), GenerationError> {
+fn validate_mermaid_generation_scope(output: &Document) -> Result<(), GenerationError> {
     match output.metadata.diagram_type.as_str() {
         "flowchart" | "class" => Ok(()),
         value => Err(GenerationError::new(format!(
@@ -133,7 +133,7 @@ fn normalize_identifier(raw: &str, fallback_prefix: &str) -> String {
 }
 
 fn emit_nodes(
-    output: &Output,
+    output: &Document,
     identifiers: &IdentifierMaps,
     lines: &mut Vec<String>,
 ) -> Result<(), GenerationError> {
@@ -248,7 +248,7 @@ fn render_subgraph_header(
 }
 
 fn emit_edges(
-    output: &Output,
+    output: &Document,
     identifiers: &IdentifierMaps,
     lines: &mut Vec<String>,
 ) -> Result<(), GenerationError> {

--- a/src/mmds/mod.rs
+++ b/src/mmds/mod.rs
@@ -1,7 +1,7 @@
-//! MMDS interchange contract and output-generation namespace.
+//! MMDS interchange contract and document-generation namespace.
 //!
-//! This module owns the typed MMDS envelope, profile vocabulary, Mermaid
-//! regeneration helpers, validation, and hydration to `Diagram` for
+//! This module owns the typed graph-family MMDS document, profile vocabulary,
+//! Mermaid regeneration helpers, validation, and hydration to `Diagram` for
 //! adapter workflows. Replay rendering lives in `runtime::mmds`.
 
 #[cfg(test)]
@@ -9,9 +9,9 @@ pub(crate) mod commands;
 pub(crate) mod detect;
 #[cfg(test)]
 pub(crate) mod diff;
+pub(crate) mod document;
 pub(crate) mod hydrate;
 mod mermaid;
-pub(crate) mod output;
 pub(crate) mod parse;
 pub(crate) mod sequence;
 
@@ -22,22 +22,33 @@ pub use detect::{
     SUPPORTED_OUTPUT_FORMATS, detect_diagram_type, is_mmds_input, resolve_logical_diagram_id,
     supports_format,
 };
-pub use hydrate::{
-    HydrationError, from_output, from_str, hydrate_graph_geometry_from_output_with_diagram,
-    hydrate_routed_geometry_from_output,
-};
-pub use mermaid::{GenerationError, generate_mermaid, generate_mermaid_from_str};
-pub use output::to_json_typed_with_routing;
+#[doc(hidden)]
+#[allow(deprecated)]
+pub use document::Output;
+#[doc(hidden)]
+#[allow(deprecated)]
+pub use document::to_json_typed_with_routing;
 // Schema types (public adapter contract).
-pub use output::{
-    Bounds, Defaults, Edge, EdgeDefaults, Metadata, Node, NodeDefaults, Output, Port, Position,
+pub use document::{
+    Bounds, Defaults, Document, Edge, EdgeDefaults, Metadata, Node, NodeDefaults, Port, Position,
     Rect, Size, Subgraph,
 };
 // Profile vocabulary constants.
-pub use output::{
+pub use document::{
     CORE_PROFILE, NODE_STYLE_EXTENSION_NAMESPACE, NODE_STYLE_PROFILE, SUPPORTED_PROFILES,
     SVG_PROFILE, TEXT_EXTENSION_NAMESPACE, TEXT_PROFILE,
 };
+pub use hydrate::{
+    HydrationError, from_document, from_str, hydrate_graph_geometry_from_document_with_diagram,
+    hydrate_routed_geometry_from_document,
+};
+#[doc(hidden)]
+#[allow(deprecated)]
+pub use hydrate::{
+    from_output, hydrate_graph_geometry_from_output_with_diagram,
+    hydrate_routed_geometry_from_output,
+};
+pub use mermaid::{GenerationError, generate_mermaid, generate_mermaid_from_str};
 pub use parse::{parse_with_profiles, validate_input};
 use serde_json::{Map, Value};
 
@@ -75,18 +86,36 @@ pub struct ProfileNegotiation {
     pub unknown: Vec<String>,
 }
 
-/// Parse MMDS JSON input into the typed output envelope.
+/// Parse graph-family MMDS JSON input into the typed document envelope.
 ///
 /// Unlike a plain deserialize, this expands omitted node/edge fields using
-/// the top-level `defaults` block before constructing [`Output`].
-pub fn parse_input(input: &str) -> Result<Output, ParseError> {
+/// the top-level `defaults` block before constructing [`Document`]. Callers
+/// that prefer trait syntax can also use `input.parse::<Document>()` or
+/// `Document::try_from(input)`.
+pub fn parse_input(input: &str) -> Result<Document, ParseError> {
     let mut value: Value = serde_json::from_str(input)
         .map_err(|err| ParseError::new(format!("MMDS parse error: {err}")))?;
 
     expand_defaults_in_value(&mut value)?;
 
-    serde_json::from_value::<Output>(value)
+    serde_json::from_value::<Document>(value)
         .map_err(|err| ParseError::new(format!("MMDS parse error: {err}")))
+}
+
+impl std::str::FromStr for Document {
+    type Err = ParseError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        parse_input(input)
+    }
+}
+
+impl TryFrom<&str> for Document {
+    type Error = ParseError;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        parse_input(input)
+    }
 }
 
 /// Evaluate declared profiles against runtime-known profile vocabulary.
@@ -94,11 +123,11 @@ pub fn parse_input(input: &str) -> Result<Output, ParseError> {
 /// This helper is advisory. Hydration remains permissive with unknown profiles.
 pub fn evaluate_profiles(input: &str) -> Result<ProfileNegotiation, ParseError> {
     let output = parse_input(input)?;
-    Ok(evaluate_profiles_for_output(&output))
+    Ok(evaluate_profiles_for_document(&output))
 }
 
 /// Evaluate declared profiles for an already-parsed MMDS payload.
-pub fn evaluate_profiles_for_output(output: &Output) -> ProfileNegotiation {
+pub fn evaluate_profiles_for_document(output: &Document) -> ProfileNegotiation {
     let mut supported = Vec::new();
     let mut unknown = Vec::new();
     let mut seen_supported = std::collections::HashSet::new();
@@ -118,6 +147,13 @@ pub fn evaluate_profiles_for_output(output: &Output) -> ProfileNegotiation {
     }
 
     ProfileNegotiation { supported, unknown }
+}
+
+/// Evaluate declared profiles for an already-parsed MMDS payload.
+#[doc(hidden)]
+#[deprecated(note = "use evaluate_profiles_for_document instead")]
+pub fn evaluate_profiles_for_output(document: &Document) -> ProfileNegotiation {
+    evaluate_profiles_for_document(document)
 }
 
 fn expand_defaults_in_value(value: &mut Value) -> Result<(), ParseError> {

--- a/src/mmds/parse.rs
+++ b/src/mmds/parse.rs
@@ -3,13 +3,13 @@
 use super::detect::resolve_logical_diagram_id;
 use crate::errors::RenderError;
 use crate::mmds::{
-    Output, ParseError, ProfileNegotiation, evaluate_profiles_for_output, parse_input,
+    Document, ParseError, ProfileNegotiation, evaluate_profiles_for_document, parse_input,
 };
 
 /// Parse MMDS input, returning the payload and profile negotiation result.
-pub fn parse_with_profiles(input: &str) -> Result<(Output, ProfileNegotiation), ParseError> {
+pub fn parse_with_profiles(input: &str) -> Result<(Document, ProfileNegotiation), ParseError> {
     let payload = parse_input(input)?;
-    let negotiation = evaluate_profiles_for_output(&payload);
+    let negotiation = evaluate_profiles_for_document(&payload);
     Ok((payload, negotiation))
 }
 

--- a/src/mmds/sequence.rs
+++ b/src/mmds/sequence.rs
@@ -1,4 +1,4 @@
-//! MMDS output types for sequence diagrams.
+//! MMDS document types for sequence diagrams.
 //!
 //! Defines the serde-serializable envelope for sequence MMDS JSON. The builder
 //! that populates these types from layout data lives in `runtime` (which has
@@ -7,11 +7,11 @@
 use serde::Serialize;
 
 // ---------------------------------------------------------------------------
-// Output types
+// Document types
 // ---------------------------------------------------------------------------
 
 #[derive(Serialize)]
-pub(crate) struct SequenceOutput {
+pub(crate) struct SequenceDocument {
     pub version: u32,
     pub geometry_level: String,
     pub metadata: SequenceMetadata,
@@ -127,7 +127,7 @@ pub(crate) struct MmdsParticipantBox {
     pub rect: MmdsRect,
 }
 
-/// Serialize a pre-built sequence output to pretty-printed JSON.
-pub(crate) fn serialize(output: &SequenceOutput) -> String {
-    serde_json::to_string_pretty(output).expect("sequence MMDS serialization should not fail")
+/// Serialize a pre-built sequence document to pretty-printed JSON.
+pub(crate) fn serialize(document: &SequenceDocument) -> String {
+    serde_json::to_string_pretty(document).expect("sequence MMDS serialization should not fail")
 }

--- a/src/render/graph/mod.rs
+++ b/src/render/graph/mod.rs
@@ -38,6 +38,7 @@ pub struct TextRenderOptions {
     pub routing_style: RoutingStyle,
     pub cluster_ranksep: Option<f64>,
     pub padding: Option<usize>,
+    pub use_pinned_ranks: bool,
     #[allow(dead_code)]
     pub path_simplification: PathSimplification,
 }
@@ -50,6 +51,7 @@ impl Default for TextRenderOptions {
             routing_style: RoutingStyle::Orthogonal,
             cluster_ranksep: None,
             padding: None,
+            use_pinned_ranks: false,
             path_simplification: PathSimplification::default(),
         }
     }
@@ -354,6 +356,7 @@ pub(crate) fn layout_config_for_diagram(
     if let Some(padding) = options.padding {
         config.padding = padding;
     }
+    config.use_pinned_ranks = options.use_pinned_ranks;
 
     config
 }

--- a/src/runtime/config.rs
+++ b/src/runtime/config.rs
@@ -93,6 +93,7 @@ impl RenderConfig {
                 .unwrap_or(RoutingStyle::Orthogonal),
             cluster_ranksep: self.cluster_ranksep,
             padding: self.padding,
+            use_pinned_ranks: false,
             path_simplification: self.path_simplification,
         }
     }
@@ -152,6 +153,7 @@ mod tests {
 
         assert_eq!(options.output_format, OutputFormat::Text);
         assert_eq!(options.routing_style, RoutingStyle::Orthogonal);
+        assert!(!options.use_pinned_ranks);
     }
 
     #[test]

--- a/src/runtime/graph_family.rs
+++ b/src/runtime/graph_family.rs
@@ -13,6 +13,7 @@ use crate::graph::measure::{
     DEFAULT_PROPORTIONAL_NODE_PADDING_Y, ProportionalTextMetrics,
 };
 use crate::graph::{GeometryLevel, Graph};
+use crate::mmds::Document;
 use crate::render::graph::{
     SvgRenderOptions, render_svg_from_geometry_with_theme_and_routing,
     render_svg_from_routed_geometry_with_theme, render_text_from_geometry,
@@ -27,35 +28,7 @@ pub(crate) fn render_graph_family(
     format: OutputFormat,
     config: &RenderConfig,
 ) -> Result<String, RenderError> {
-    let engine_id = config
-        .layout_engine
-        .unwrap_or(EngineAlgorithmId::FLUX_LAYERED);
-    engine_id.check_available()?;
-    engine_id.check_routing_style(
-        config
-            .routing_style
-            .or_else(|| config.edge_preset.map(|preset| preset.expand().0)),
-    )?;
-
-    // Pre-engine wrap pass: plan 0147 Task 1.5b / 1.7. Populates
-    // `diagram::Edge.wrapped_label_lines` once per render so the kernel
-    // sizing scan, label geometry, SVG text, and MMDS replay all agree on
-    // the wrap decision. Uses Proportional metrics regardless of render
-    // mode — Grid consumers read the same line splits (see design.md §6.1).
-    // Threshold comes from `RenderConfig.layout.edge_label_max_width`; the
-    // user-facing LayoutConfig default is `Some(200.0)` so wrap is on by
-    // default. Explicit `None` disables wrap (dagre-parity fallback).
-    let wrap_metrics = proportional_text_metrics_for_config(config);
-    prepare_wrapped_labels(
-        &mut diagram.edges,
-        &wrap_metrics,
-        config.layout.edge_label_max_width,
-    );
-
-    let request = graph_solve_request_for(format, config, diagram_id);
-    let engine_config = EngineConfig::Layered(config.layout.clone().into());
-    let engine_id = resolve_graph_engine_for_request(engine_id, &request);
-    let result = solve_graph_family(diagram, engine_id, &engine_config, &request)?;
+    let result = solve_graph_family_for_render(diagram_id, diagram, format, config)?;
 
     match format {
         OutputFormat::Mmds => render_mmds_from_solve_result(
@@ -84,6 +57,58 @@ pub(crate) fn render_graph_family(
             message: format!("{format} output is not supported for {diagram_id} diagrams"),
         }),
     }
+}
+
+pub(crate) fn materialize_graph_family(
+    diagram_id: &str,
+    diagram: &mut Graph,
+    config: &RenderConfig,
+) -> Result<Document, RenderError> {
+    let result = solve_graph_family_for_render(diagram_id, diagram, OutputFormat::Mmds, config)?;
+    mmds_document_from_solve_result(
+        diagram_id,
+        diagram,
+        &result,
+        config.geometry_level,
+        config.path_simplification,
+    )
+}
+
+fn solve_graph_family_for_render(
+    diagram_id: &str,
+    diagram: &mut Graph,
+    format: OutputFormat,
+    config: &RenderConfig,
+) -> Result<GraphSolveResult, RenderError> {
+    let engine_id = config
+        .layout_engine
+        .unwrap_or(EngineAlgorithmId::FLUX_LAYERED);
+    engine_id.check_available()?;
+    engine_id.check_routing_style(
+        config
+            .routing_style
+            .or_else(|| config.edge_preset.map(|preset| preset.expand().0)),
+    )?;
+
+    // Pre-engine wrap pass: plan 0147 Task 1.5b / 1.7. Populates
+    // `diagram::Edge.wrapped_label_lines` once per render so the kernel
+    // sizing scan, label geometry, SVG text, and MMDS replay all agree on
+    // the wrap decision. Uses Proportional metrics regardless of render
+    // mode — Grid consumers read the same line splits (see design.md §6.1).
+    // Threshold comes from `RenderConfig.layout.edge_label_max_width`; the
+    // user-facing LayoutConfig default is `Some(200.0)` so wrap is on by
+    // default. Explicit `None` disables wrap (dagre-parity fallback).
+    let wrap_metrics = proportional_text_metrics_for_config(config);
+    prepare_wrapped_labels(
+        &mut diagram.edges,
+        &wrap_metrics,
+        config.layout.edge_label_max_width,
+    );
+
+    let request = graph_solve_request_for(format, config, diagram_id);
+    let engine_config = EngineConfig::Layered(config.layout.clone().into());
+    let engine_id = resolve_graph_engine_for_request(engine_id, &request);
+    solve_graph_family(diagram, engine_id, &engine_config, &request)
 }
 
 fn subgraph_direction_policy_for(diagram_id: &str) -> SubgraphDirectionPolicy {
@@ -182,8 +207,22 @@ fn render_mmds_from_solve_result(
     level: GeometryLevel,
     path_simplification: PathSimplification,
 ) -> Result<String, RenderError> {
+    let document =
+        mmds_document_from_solve_result(diagram_type, diagram, result, level, path_simplification)?;
+    serde_json::to_string_pretty(&document).map_err(|error| RenderError {
+        message: format!("MMDS serialization error: {error}"),
+    })
+}
+
+fn mmds_document_from_solve_result(
+    diagram_type: &str,
+    diagram: &Graph,
+    result: &GraphSolveResult,
+    level: GeometryLevel,
+    path_simplification: PathSimplification,
+) -> Result<Document, RenderError> {
     let engine_id = result.engine_id.to_string();
-    crate::mmds::to_json_typed_with_routing(
+    crate::mmds::document::to_document_typed_with_routing(
         diagram_type,
         diagram,
         &result.geometry,

--- a/src/runtime/mmds.rs
+++ b/src/runtime/mmds.rs
@@ -9,8 +9,8 @@ use crate::errors::RenderError;
 use crate::format::OutputFormat;
 use crate::graph::GeometryLevel;
 use crate::mmds::{
-    Output, from_output, generate_mermaid, hydrate_graph_geometry_from_output_with_diagram,
-    hydrate_routed_geometry_from_output, parse_input, resolve_logical_diagram_id,
+    Document, from_document, generate_mermaid, hydrate_graph_geometry_from_document_with_diagram,
+    hydrate_routed_geometry_from_document, parse_input, resolve_logical_diagram_id,
 };
 use crate::render::graph::{
     SvgRenderOptions, TextRenderOptions, edge_routing_from_style,
@@ -18,9 +18,10 @@ use crate::render::graph::{
     render_text_from_geometry,
 };
 use crate::render::svg::theme::ResolvedSvgTheme;
+use crate::views::VIEW_EXTENSION_NAMESPACE;
 
 /// Render MMDS input through the MMDS replay path.
-pub fn render_input(
+pub(crate) fn render_input(
     input: &str,
     format: OutputFormat,
     geometry_level: GeometryLevel,
@@ -30,7 +31,7 @@ pub fn render_input(
 ) -> Result<String, RenderError> {
     let payload =
         parse_input(input).map_err(|error| prefixed_display_error("parse error", error))?;
-    render_output(
+    render_document(
         &payload,
         format,
         geometry_level,
@@ -40,9 +41,9 @@ pub fn render_input(
     )
 }
 
-/// Render a parsed MMDS payload through the MMDS replay path.
-pub fn render_output(
-    payload: &Output,
+/// Render a parsed MMDS document through the MMDS replay path.
+pub(crate) fn render_document(
+    payload: &Document,
     format: OutputFormat,
     geometry_level: GeometryLevel,
     text_options: &TextRenderOptions,
@@ -75,7 +76,7 @@ pub fn render_output(
         return generate_mermaid(payload).map_err(display_error);
     }
 
-    let mut diagram = from_output(payload).map_err(display_error)?;
+    let mut diagram = from_document(payload).map_err(display_error)?;
 
     // Plan 0147 Task 1.6 / 1.7: MMDS replay path runs the wrap pass so the
     // hydrated graph's edge labels carry the same `wrapped_label_lines`
@@ -94,10 +95,10 @@ pub fn render_output(
         wrap_max_width,
     );
 
-    let geometry = hydrate_graph_geometry_from_output_with_diagram(payload, &diagram)
+    let geometry = hydrate_graph_geometry_from_document_with_diagram(payload, &diagram)
         .map_err(display_error)?;
     let routed = has_routed_geometry
-        .then(|| hydrate_routed_geometry_from_output(payload))
+        .then(|| hydrate_routed_geometry_from_document(payload))
         .transpose()
         .map_err(display_error)?;
 
@@ -105,6 +106,8 @@ pub fn render_output(
         OutputFormat::Text | OutputFormat::Ascii => {
             let mut options = text_options.clone();
             options.output_format = format;
+            options.use_pinned_ranks =
+                options.use_pinned_ranks || is_shared_coordinates_view(payload);
             Ok(render_text_from_geometry(
                 &diagram,
                 &geometry,
@@ -130,6 +133,15 @@ pub fn render_output(
     }
 }
 
+fn is_shared_coordinates_view(payload: &Document) -> bool {
+    payload
+        .extensions
+        .get(VIEW_EXTENSION_NAMESPACE)
+        .and_then(|extension| extension.get("layout_mode"))
+        .and_then(serde_json::Value::as_str)
+        == Some("shared_coordinates")
+}
+
 fn display_error(error: impl Display) -> RenderError {
     RenderError {
         message: error.to_string(),
@@ -142,7 +154,7 @@ fn prefixed_display_error(prefix: &str, error: impl Display) -> RenderError {
     }
 }
 
-fn strip_routed_fields(payload: &Output) -> Output {
+fn strip_routed_fields(payload: &Document) -> Document {
     let mut output = payload.clone();
     output.geometry_level = "layout".to_string();
     for edge in &mut output.edges {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -104,6 +104,74 @@ pub fn render_diagram(
     payload::render_payload(payload, format, &effective_config)
 }
 
+/// Detect, parse, solve, and materialize a graph-family diagram as MMDS.
+///
+/// This is the typed counterpart to `render_diagram(input,
+/// OutputFormat::Mmds, config)`. It returns a graph-family
+/// [`crate::mmds::Document`] directly instead of serializing to JSON first.
+/// For MMDS input, this is equivalent to [`crate::mmds::Document::try_from`]
+/// and `config` is unused.
+pub fn materialize_diagram(
+    input: &str,
+    config: &RenderConfig,
+) -> Result<crate::mmds::Document, RenderError> {
+    if matches!(detect_input_frontend(input), Some(InputFrontend::Mmds)) {
+        return crate::mmds::parse_input(input).map_err(|error| RenderError {
+            message: format!("parse error: {error}"),
+        });
+    }
+
+    let effective_config = effective_render_config(input, OutputFormat::Mmds, config);
+    let registry = default_registry();
+    let diagram_id = registry.detect(input).ok_or_else(|| RenderError {
+        message: "unknown diagram type".to_string(),
+    })?;
+
+    if !registry.supports_format(diagram_id, OutputFormat::Mmds) {
+        return Err(RenderError {
+            message: format!("{diagram_id} diagrams do not support MMDS output"),
+        });
+    }
+
+    let instance = registry.create(diagram_id).ok_or_else(|| RenderError {
+        message: format!("no implementation for diagram type: {diagram_id}"),
+    })?;
+
+    let parsed = instance.parse(input).map_err(|error| RenderError {
+        message: format!("parse error: {error}"),
+    })?;
+
+    let payload = parsed.into_payload()?;
+    payload::materialize_payload(payload, &effective_config)
+}
+
+/// Render a parsed graph-family MMDS document.
+///
+/// This is the typed replay path for consumers that already hold
+/// [`crate::mmds::Document`], such as materialized view pipelines. It avoids
+/// serializing the document to JSON just to feed it back through
+/// [`render_diagram`].
+pub fn render_mmds_document(
+    document: &crate::mmds::Document,
+    format: OutputFormat,
+    config: &RenderConfig,
+) -> Result<String, RenderError> {
+    let svg_theme = if matches!(format, OutputFormat::Svg) {
+        resolve_configured_svg_theme(config)?
+    } else {
+        None
+    };
+
+    mmds::render_document(
+        document,
+        format,
+        config.geometry_level,
+        &config.text_render_options(format),
+        &config.svg_render_options(),
+        svg_theme.as_ref(),
+    )
+}
+
 /// Validate Mermaid input and return structured diagnostics as JSON.
 ///
 /// Returns a JSON string with shape:

--- a/src/runtime/payload.rs
+++ b/src/runtime/payload.rs
@@ -4,6 +4,7 @@ use super::graph_family;
 use crate::errors::RenderError;
 use crate::format::OutputFormat;
 use crate::graph::measure;
+use crate::mmds::Document;
 use crate::payload::Diagram;
 use crate::render::text::CharSet;
 use crate::render::timeline;
@@ -17,11 +18,7 @@ pub(in crate::runtime) fn render_payload(
 ) -> Result<String, RenderError> {
     // Apply show_ids annotation to graph-family payloads before rendering.
     // This is a presentation concern owned by runtime, not diagrams.
-    let payload = if config.show_ids {
-        annotate_graph_payload_ids(payload)
-    } else {
-        payload
-    };
+    let payload = prepare_payload_for_render(payload, config);
 
     match payload {
         Diagram::Flowchart(mut graph) => {
@@ -58,6 +55,37 @@ pub(in crate::runtime) fn render_payload(
                 Ok(timeline::render(&seq_layout, &charset))
             }
         },
+    }
+}
+
+pub(in crate::runtime) fn materialize_payload(
+    payload: Diagram,
+    config: &RenderConfig,
+) -> Result<Document, RenderError> {
+    let payload = prepare_payload_for_render(payload, config);
+
+    match payload {
+        Diagram::Flowchart(mut graph) => {
+            graph_family::materialize_graph_family("flowchart", &mut graph, config)
+        }
+        Diagram::Class(mut graph) => {
+            graph_family::materialize_graph_family("class", &mut graph, config)
+        }
+        Diagram::State(mut graph) => {
+            graph_family::materialize_graph_family("state", &mut graph, config)
+        }
+        Diagram::Sequence(_) => Err(RenderError {
+            message: "sequence diagrams do not support graph-family MMDS Document materialization"
+                .to_string(),
+        }),
+    }
+}
+
+fn prepare_payload_for_render(payload: Diagram, config: &RenderConfig) -> Diagram {
+    if config.show_ids {
+        annotate_graph_payload_ids(payload)
+    } else {
+        payload
     }
 }
 

--- a/src/runtime/timeline_family.rs
+++ b/src/runtime/timeline_family.rs
@@ -6,8 +6,8 @@
 use crate::graph::measure::ProportionalTextMetrics;
 use crate::mmds::sequence::{
     self, MmdsActivation, MmdsBlock, MmdsBlockDivider, MmdsBounds, MmdsMessage, MmdsNote,
-    MmdsParticipant, MmdsParticipantBox, MmdsPosition, MmdsRect, MmdsSize, SequenceMetadata,
-    SequenceOutput,
+    MmdsParticipant, MmdsParticipantBox, MmdsPosition, MmdsRect, MmdsSize, SequenceDocument,
+    SequenceMetadata,
 };
 use crate::render::timeline::svg_layout::{
     self as svg_layout, SvgBlock, SvgRow, SvgSequenceLayout,
@@ -71,18 +71,18 @@ fn block_divider_kind_str(k: BlockDividerKind) -> &'static str {
 /// positions from the SVG layout engine.
 pub(in crate::runtime) fn to_json(model: &Sequence, metrics: &ProportionalTextMetrics) -> String {
     let svg = svg_layout::layout(model, metrics, "sans-serif");
-    let output = build_output(model, &svg);
-    sequence::serialize(&output)
+    let document = build_document(model, &svg);
+    sequence::serialize(&document)
 }
 
-fn build_output(model: &Sequence, svg: &SvgSequenceLayout) -> SequenceOutput {
+fn build_document(model: &Sequence, svg: &SvgSequenceLayout) -> SequenceDocument {
     let participants = build_participants(model, svg);
     let (messages, notes) = build_messages_and_notes(svg);
     let activations = build_activations(svg);
     let blocks = build_blocks(svg);
     let participant_boxes = build_participant_boxes(model, svg);
 
-    SequenceOutput {
+    SequenceDocument {
         version: 1,
         geometry_level: "layout".to_string(),
         metadata: SequenceMetadata {

--- a/src/views/apply.rs
+++ b/src/views/apply.rs
@@ -1,0 +1,201 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::{Map, Value};
+
+use super::{ElisionReason, ViewError, ViewEvent, ViewSpec};
+use crate::mmds::{Document, TEXT_EXTENSION_NAMESPACE};
+use crate::views::evaluate::evaluate_view;
+
+/// Namespaced marker for payloads materialized by the view subsystem.
+///
+/// V1 view payloads store an extension at this namespace with
+/// `layout_mode: "shared_coordinates"` and `boundary_policy: "omit"`.
+/// Runtime MMDS replay uses the marker to opt into view-specific behavior
+/// without changing the high-level render facade.
+pub const VIEW_EXTENSION_NAMESPACE: &str = "org.mmdflux.view.v1";
+
+const PROJECTION_KEY: &str = "projection";
+const NODE_RANKS_KEY: &str = "node_ranks";
+const EDGE_WAYPOINTS_KEY: &str = "edge_waypoints";
+const LABEL_POSITIONS_KEY: &str = "label_positions";
+
+/// Apply a materialized view specification to a canonical MMDS payload.
+///
+/// The returned [`Document`] is a cloned and pruned payload:
+///
+/// - retained nodes and subgraphs are copied from the canonical payload
+/// - edges survive only when both endpoint nodes are retained
+/// - surviving edge IDs are preserved verbatim, so IDs may be sparse
+/// - the view marker extension is added under [`VIEW_EXTENSION_NAMESPACE`]
+/// - text projection `node_ranks` are filtered to retained nodes when present
+///
+/// The returned [`ViewEvent`] list describes canonical nodes, subgraphs, and
+/// edges that did not survive materialization. Unsupported v1 features return
+/// [`ViewError::NotImplementedYet`] before payload cloning.
+pub fn apply_view(
+    canonical: &Document,
+    spec: &ViewSpec,
+) -> Result<(Document, Vec<ViewEvent>), ViewError> {
+    let evaluation = evaluate_view(canonical, spec)?;
+    let retained_subgraphs =
+        retained_subgraphs(canonical, &evaluation.subgraphs, &evaluation.nodes);
+
+    let mut output = canonical.clone();
+    output.nodes = canonical
+        .nodes
+        .iter()
+        .filter(|node| evaluation.nodes.contains(&node.id))
+        .cloned()
+        .collect();
+    output.edges = canonical
+        .edges
+        .iter()
+        .filter(|edge| {
+            evaluation.nodes.contains(&edge.source) && evaluation.nodes.contains(&edge.target)
+        })
+        .cloned()
+        .collect();
+    output.subgraphs = canonical
+        .subgraphs
+        .iter()
+        .filter(|subgraph| retained_subgraphs.contains(&subgraph.id))
+        .cloned()
+        .map(|mut subgraph| {
+            subgraph.children.retain(|child| {
+                evaluation.nodes.contains(child) || retained_subgraphs.contains(child)
+            });
+            subgraph
+                .concurrent_regions
+                .retain(|child| retained_subgraphs.contains(child));
+            subgraph
+        })
+        .collect();
+    apply_view_extensions(&mut output, &evaluation.nodes);
+
+    let events = view_events(canonical, &evaluation.nodes, &retained_subgraphs);
+    Ok((output, events))
+}
+
+fn apply_view_extensions(output: &mut Document, retained_nodes: &BTreeSet<String>) {
+    output.extensions.insert(
+        VIEW_EXTENSION_NAMESPACE.to_string(),
+        shared_coordinates_view_extension(),
+    );
+
+    if let Some(text_extension) = output.extensions.get_mut(TEXT_EXTENSION_NAMESPACE) {
+        prune_text_projection(text_extension, retained_nodes);
+    }
+}
+
+fn shared_coordinates_view_extension() -> Map<String, Value> {
+    let mut extension = Map::new();
+    extension.insert(
+        "layout_mode".to_string(),
+        Value::String("shared_coordinates".to_string()),
+    );
+    extension.insert(
+        "boundary_policy".to_string(),
+        Value::String("omit".to_string()),
+    );
+    extension
+}
+
+fn prune_text_projection(extension: &mut Map<String, Value>, retained_nodes: &BTreeSet<String>) {
+    let Some(Value::Object(projection)) = extension.get_mut(PROJECTION_KEY) else {
+        return;
+    };
+
+    if let Some(Value::Object(node_ranks)) = projection.get_mut(NODE_RANKS_KEY) {
+        node_ranks.retain(|node_id, _| retained_nodes.contains(node_id));
+    }
+
+    // V1 intentionally drops edge-array-indexed projection maps instead of
+    // remapping them through sparse view-local edges.
+    projection.remove(EDGE_WAYPOINTS_KEY);
+    projection.remove(LABEL_POSITIONS_KEY);
+}
+
+fn retained_subgraphs(
+    output: &Document,
+    explicit_subgraphs: &BTreeSet<String>,
+    retained_nodes: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let parent_by_subgraph: BTreeMap<String, Option<String>> = output
+        .subgraphs
+        .iter()
+        .map(|subgraph| (subgraph.id.clone(), subgraph.parent.clone()))
+        .collect();
+
+    let mut retained = BTreeSet::new();
+    for subgraph in explicit_subgraphs {
+        add_subgraph_with_ancestors(subgraph, &parent_by_subgraph, &mut retained);
+    }
+    for node in &output.nodes {
+        if retained_nodes.contains(&node.id)
+            && let Some(parent) = &node.parent
+        {
+            add_subgraph_with_ancestors(parent, &parent_by_subgraph, &mut retained);
+        }
+    }
+    retained
+}
+
+fn add_subgraph_with_ancestors(
+    subgraph: &str,
+    parent_by_subgraph: &BTreeMap<String, Option<String>>,
+    retained: &mut BTreeSet<String>,
+) {
+    let mut current = Some(subgraph.to_string());
+    while let Some(id) = current {
+        if !retained.insert(id.clone()) {
+            break;
+        }
+        current = parent_by_subgraph.get(&id).and_then(Clone::clone);
+    }
+}
+
+fn view_events(
+    canonical: &Document,
+    retained_nodes: &BTreeSet<String>,
+    retained_subgraphs: &BTreeSet<String>,
+) -> Vec<ViewEvent> {
+    let mut events = Vec::new();
+
+    for node in &canonical.nodes {
+        if !retained_nodes.contains(&node.id) {
+            events.push(ViewEvent::NodeLeftView {
+                id: node.id.clone(),
+                reason: ElisionReason::Excluded,
+            });
+        }
+    }
+
+    for subgraph in &canonical.subgraphs {
+        if !retained_subgraphs.contains(&subgraph.id) {
+            events.push(ViewEvent::SubgraphLeftView {
+                id: subgraph.id.clone(),
+                reason: ElisionReason::Excluded,
+            });
+        }
+    }
+
+    let mut edge_ordinals: BTreeMap<(String, String), usize> = BTreeMap::new();
+    for edge in &canonical.edges {
+        let key = (edge.source.clone(), edge.target.clone());
+        let ordinal = edge_ordinals.entry(key).or_default();
+        let current_ordinal = *ordinal;
+        *ordinal += 1;
+
+        if !(retained_nodes.contains(&edge.source) && retained_nodes.contains(&edge.target)) {
+            events.push(ViewEvent::EdgeElided {
+                source: edge.source.clone(),
+                target: edge.target.clone(),
+                ordinal: current_ordinal,
+                label: edge.label.clone(),
+                reason: ElisionReason::EndpointOutsideView,
+            });
+        }
+    }
+
+    events
+}

--- a/src/views/error.rs
+++ b/src/views/error.rs
@@ -1,0 +1,31 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Error returned while resolving or materializing a view.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ViewError {
+    /// A requested view feature is reserved for a later slice.
+    NotImplementedYet {
+        /// Human-readable feature family that is not available in v1.
+        feature: String,
+    },
+    /// A selector referenced an anchor that does not exist in the payload.
+    UnknownAnchor {
+        /// Missing node or subgraph ID.
+        id: String,
+    },
+}
+
+impl Display for ViewError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotImplementedYet { feature } => {
+                write!(f, "view feature is not implemented yet: {feature}")
+            }
+            Self::UnknownAnchor { id } => write!(f, "unknown view anchor: {id}"),
+        }
+    }
+}
+
+impl std::error::Error for ViewError {}

--- a/src/views/evaluate.rs
+++ b/src/views/evaluate.rs
@@ -1,0 +1,298 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use super::{
+    AnchorRef, BoundaryPolicy, CompoundPolicy, LayoutMode, NodePredicate, Selector,
+    TraversalDirection, ViewError, ViewSpec, ViewStatement,
+};
+use crate::mmds::Document;
+
+/// Deterministic keep-set produced by evaluating a `ViewSpec`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(super) struct ViewEvaluation {
+    /// Node IDs retained by the evaluated view.
+    pub(super) nodes: BTreeSet<String>,
+    /// Subgraph IDs explicitly retained by the evaluated view.
+    ///
+    /// Ancestor subgraphs required to contain retained nodes are added by
+    /// [`apply_view`](crate::views::apply_view) during materialization.
+    pub(super) subgraphs: BTreeSet<String>,
+}
+
+impl ViewEvaluation {
+    fn extend(&mut self, other: ViewEvaluation) {
+        self.nodes.extend(other.nodes);
+        self.subgraphs.extend(other.subgraphs);
+    }
+
+    fn remove(&mut self, other: ViewEvaluation) {
+        for node in other.nodes {
+            self.nodes.remove(&node);
+        }
+        for subgraph in other.subgraphs {
+            self.subgraphs.remove(&subgraph);
+        }
+    }
+}
+
+/// Evaluate a view spec into node and subgraph keep-sets.
+///
+/// This function resolves selectors only. It does not clone or prune the MMDS
+/// payload, preserve ancestor subgraphs, filter edges, or emit elision events;
+/// use [`apply_view`](crate::views::apply_view) for the full materialized view.
+pub(super) fn evaluate_view(
+    output: &Document,
+    spec: &ViewSpec,
+) -> Result<ViewEvaluation, ViewError> {
+    ensure_supported_spec(spec)?;
+
+    let mut evaluation = ViewEvaluation::default();
+    for statement in &spec.statements {
+        match statement {
+            ViewStatement::Include(selector) => {
+                evaluation.extend(evaluate_selector(output, selector)?);
+            }
+            ViewStatement::Exclude(selector) => {
+                evaluation.remove(evaluate_selector(output, selector)?);
+            }
+        }
+    }
+    Ok(evaluation)
+}
+
+fn ensure_supported_spec(spec: &ViewSpec) -> Result<(), ViewError> {
+    if !matches!(spec.layout, LayoutMode::SharedCoordinates) {
+        return not_implemented("non-shared-coordinate layout modes");
+    }
+    if !matches!(spec.boundary, BoundaryPolicy::Omit) {
+        return not_implemented("boundary stubs");
+    }
+    if !matches!(spec.compound, CompoundPolicy::Preserve) {
+        return not_implemented("compound flattening");
+    }
+    Ok(())
+}
+
+fn evaluate_selector(output: &Document, selector: &Selector) -> Result<ViewEvaluation, ViewError> {
+    match selector {
+        Selector::All => Ok(all_elements(output)),
+        Selector::Anchor(anchor) => evaluate_anchor(output, anchor),
+        Selector::Traversal {
+            anchor,
+            direction,
+            hops,
+        } => evaluate_traversal(output, anchor, *direction, *hops),
+        Selector::Predicate(predicate) => evaluate_predicate(output, predicate),
+        Selector::SubgraphDescendants(id) => evaluate_subgraph_descendants(output, id),
+    }
+}
+
+fn all_elements(output: &Document) -> ViewEvaluation {
+    ViewEvaluation {
+        nodes: output.nodes.iter().map(|node| node.id.clone()).collect(),
+        subgraphs: output
+            .subgraphs
+            .iter()
+            .map(|subgraph| subgraph.id.clone())
+            .collect(),
+    }
+}
+
+fn evaluate_anchor(output: &Document, anchor: &AnchorRef) -> Result<ViewEvaluation, ViewError> {
+    match anchor {
+        AnchorRef::Node(id) => {
+            if !has_node(output, id) {
+                return unknown_anchor(id);
+            }
+            Ok(ViewEvaluation {
+                nodes: BTreeSet::from([id.clone()]),
+                subgraphs: BTreeSet::new(),
+            })
+        }
+        AnchorRef::Subgraph(id) => {
+            if !has_subgraph(output, id) {
+                return unknown_anchor(id);
+            }
+            Ok(ViewEvaluation {
+                nodes: BTreeSet::new(),
+                subgraphs: BTreeSet::from([id.clone()]),
+            })
+        }
+        AnchorRef::Edge(_) => not_implemented("edge anchors"),
+    }
+}
+
+fn evaluate_traversal(
+    output: &Document,
+    anchor: &AnchorRef,
+    direction: TraversalDirection,
+    hops: u32,
+) -> Result<ViewEvaluation, ViewError> {
+    let AnchorRef::Node(anchor_id) = anchor else {
+        return match anchor {
+            AnchorRef::Subgraph(_) => not_implemented("subgraph traversal"),
+            AnchorRef::Edge(_) => not_implemented("edge anchors"),
+            AnchorRef::Node(_) => unreachable!(),
+        };
+    };
+    if !has_node(output, anchor_id) {
+        return unknown_anchor(anchor_id);
+    }
+
+    let (outgoing, incoming) = adjacency(output);
+    let mut visited = BTreeSet::new();
+    let mut queue = VecDeque::from([(anchor_id.clone(), 0)]);
+    visited.insert(anchor_id.clone());
+
+    while let Some((node, depth)) = queue.pop_front() {
+        if depth == hops {
+            continue;
+        }
+        for next in traversal_neighbors(&node, direction, &outgoing, &incoming) {
+            if visited.insert(next.clone()) {
+                queue.push_back((next, depth + 1));
+            }
+        }
+    }
+
+    Ok(ViewEvaluation {
+        nodes: visited,
+        subgraphs: BTreeSet::new(),
+    })
+}
+
+fn evaluate_predicate(
+    output: &Document,
+    predicate: &NodePredicate,
+) -> Result<ViewEvaluation, ViewError> {
+    let nodes = match predicate {
+        NodePredicate::Shape(shape) => output
+            .nodes
+            .iter()
+            .filter(|node| node.shape == *shape)
+            .map(|node| node.id.clone())
+            .collect(),
+        NodePredicate::Parent(parent) => output
+            .nodes
+            .iter()
+            .filter(|node| node.parent.as_deref() == Some(parent.as_str()))
+            .map(|node| node.id.clone())
+            .collect(),
+        NodePredicate::Tag(_) => return not_implemented("tag predicates"),
+    };
+
+    Ok(ViewEvaluation {
+        nodes,
+        subgraphs: BTreeSet::new(),
+    })
+}
+
+fn evaluate_subgraph_descendants(output: &Document, id: &str) -> Result<ViewEvaluation, ViewError> {
+    if !has_subgraph(output, id) {
+        return unknown_anchor(id);
+    }
+
+    let node_ids: BTreeSet<&str> = output.nodes.iter().map(|node| node.id.as_str()).collect();
+    let subgraph_ids: BTreeSet<&str> = output
+        .subgraphs
+        .iter()
+        .map(|subgraph| subgraph.id.as_str())
+        .collect();
+    let children_by_parent = subgraphs_by_parent(output);
+
+    let mut evaluation = ViewEvaluation::default();
+    let mut queue = VecDeque::from([id.to_string()]);
+    while let Some(subgraph_id) = queue.pop_front() {
+        if !evaluation.subgraphs.insert(subgraph_id.clone()) {
+            continue;
+        }
+
+        if let Some(subgraph) = output
+            .subgraphs
+            .iter()
+            .find(|subgraph| subgraph.id == subgraph_id)
+        {
+            for child in &subgraph.children {
+                if node_ids.contains(child.as_str()) {
+                    evaluation.nodes.insert(child.clone());
+                }
+                if subgraph_ids.contains(child.as_str()) {
+                    queue.push_back(child.clone());
+                }
+            }
+        }
+
+        if let Some(child_subgraphs) = children_by_parent.get(subgraph_id.as_str()) {
+            for child_subgraph in child_subgraphs {
+                queue.push_back((*child_subgraph).to_string());
+            }
+        }
+    }
+
+    Ok(evaluation)
+}
+
+fn adjacency(output: &Document) -> (BTreeMap<String, Vec<String>>, BTreeMap<String, Vec<String>>) {
+    let mut outgoing: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut incoming: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    for edge in &output.edges {
+        outgoing
+            .entry(edge.source.clone())
+            .or_default()
+            .push(edge.target.clone());
+        incoming
+            .entry(edge.target.clone())
+            .or_default()
+            .push(edge.source.clone());
+    }
+
+    (outgoing, incoming)
+}
+
+fn traversal_neighbors(
+    node: &str,
+    direction: TraversalDirection,
+    outgoing: &BTreeMap<String, Vec<String>>,
+    incoming: &BTreeMap<String, Vec<String>>,
+) -> Vec<String> {
+    match direction {
+        TraversalDirection::Downstream => outgoing.get(node).cloned().unwrap_or_default(),
+        TraversalDirection::Upstream => incoming.get(node).cloned().unwrap_or_default(),
+        TraversalDirection::Neighbors => {
+            let mut neighbors = outgoing.get(node).cloned().unwrap_or_default();
+            neighbors.extend(incoming.get(node).cloned().unwrap_or_default());
+            neighbors
+        }
+    }
+}
+
+fn subgraphs_by_parent(output: &Document) -> BTreeMap<&str, Vec<&str>> {
+    let mut by_parent: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for subgraph in &output.subgraphs {
+        if let Some(parent) = subgraph.parent.as_deref() {
+            by_parent
+                .entry(parent)
+                .or_default()
+                .push(subgraph.id.as_str());
+        }
+    }
+    by_parent
+}
+
+fn has_node(output: &Document, id: &str) -> bool {
+    output.nodes.iter().any(|node| node.id == id)
+}
+
+fn has_subgraph(output: &Document, id: &str) -> bool {
+    output.subgraphs.iter().any(|subgraph| subgraph.id == id)
+}
+
+fn unknown_anchor<T>(id: &str) -> Result<T, ViewError> {
+    Err(ViewError::UnknownAnchor { id: id.to_string() })
+}
+
+fn not_implemented<T>(feature: &str) -> Result<T, ViewError> {
+    Err(ViewError::NotImplementedYet {
+        feature: feature.to_string(),
+    })
+}

--- a/src/views/events.rs
+++ b/src/views/events.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+
+/// Reason an element is absent from a materialized view.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ElisionReason {
+    /// The element did not match the active view selectors.
+    Excluded,
+    /// The element references at least one endpoint outside the view.
+    EndpointOutsideView,
+    /// The element needs a feature deferred from the v1 view slice.
+    NotImplementedYet,
+}
+
+/// Diagnostic event emitted while materializing a view.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ViewEvent {
+    /// A canonical node was omitted from the materialized view.
+    NodeLeftView {
+        /// MMDS node ID from the canonical payload.
+        id: String,
+        /// Why the node is absent from the view.
+        reason: ElisionReason,
+    },
+    /// A canonical subgraph was omitted from the materialized view.
+    SubgraphLeftView {
+        /// MMDS subgraph ID from the canonical payload.
+        id: String,
+        /// Why the subgraph is absent from the view.
+        reason: ElisionReason,
+    },
+    /// A canonical edge was omitted from the materialized view.
+    EdgeElided {
+        /// Source node ID from the canonical edge.
+        source: String,
+        /// Target node ID from the canonical edge.
+        target: String,
+        /// Zero-based ordinal among canonical edges with the same source and target.
+        ordinal: usize,
+        /// Canonical edge label, when present.
+        label: Option<String>,
+        /// Why the edge is absent from the view.
+        reason: ElisionReason,
+    },
+}

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -1,0 +1,64 @@
+//! Materialized diagram views over canonical MMDS payloads.
+//!
+//! This module owns the read-side `ViewSpec` contract. It intentionally works
+//! over `mmds::Document` rather than renderer or engine internals.
+//!
+//! The v1 surface is intentionally small: materialize a filtered MMDS payload
+//! from a `ViewSpec` and emit events for elements that leave the view.
+//! Rendering remains a runtime concern; pass the returned document to
+//! [`crate::render_mmds_document`] when a text, SVG, or MMDS rendering is
+//! needed.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use mmdflux::mmds::Document;
+//! use mmdflux::views::{
+//!     AnchorRef, Selector, TraversalDirection, ViewSpec, ViewStatement, apply_view,
+//! };
+//! use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_mmds_document};
+//!
+//! let source = "\
+//! graph TD
+//! service_a[Service A] --> service_b[Service B]
+//! external[External] --> service_a
+//! service_b --> service_c[Service C]
+//! service_c --> database[Database]
+//! service_a --> audit[Audit]
+//! ";
+//!
+//! let canonical: Document = materialize_diagram(source, &RenderConfig::default())?;
+//! let spec = ViewSpec {
+//!     statements: vec![ViewStatement::Include(Selector::Traversal {
+//!         anchor: AnchorRef::Node("service_a".to_string()),
+//!         direction: TraversalDirection::Downstream,
+//!         hops: 2,
+//!     })],
+//!     ..ViewSpec::default()
+//! };
+//!
+//! let (view, events) = apply_view(&canonical, &spec)?;
+//! assert!(view.nodes.iter().any(|node| node.id == "service_c"));
+//! assert!(events.iter().any(|event| matches!(
+//!     event,
+//!     mmdflux::views::ViewEvent::NodeLeftView { id, .. } if id == "external"
+//! )));
+//!
+//! let text = render_mmds_document(&view, OutputFormat::Text, &RenderConfig::default())?;
+//! assert!(text.contains("Service A"));
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+
+mod apply;
+mod error;
+mod evaluate;
+mod events;
+mod spec;
+
+pub use apply::{VIEW_EXTENSION_NAMESPACE, apply_view};
+pub use error::ViewError;
+pub use events::{ElisionReason, ViewEvent};
+pub use spec::{
+    AnchorRef, BoundaryPolicy, CompoundPolicy, EdgeAnchor, LayoutMode, NodePredicate, Selector,
+    TraversalDirection, ViewSpec, ViewStatement,
+};

--- a/src/views/spec.rs
+++ b/src/views/spec.rs
@@ -1,0 +1,160 @@
+use serde::{Deserialize, Serialize};
+
+/// Materialized view request over a canonical MMDS payload.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViewSpec {
+    /// Ordered include/exclude statements used to build the view keep-set.
+    ///
+    /// Statements are evaluated in order. `Include` adds matching elements and
+    /// `Exclude` removes matching elements from the accumulated keep-set.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub statements: Vec<ViewStatement>,
+    /// Layout policy for the returned view payload.
+    ///
+    /// V1 supports [`LayoutMode::SharedCoordinates`] only.
+    #[serde(default)]
+    pub layout: LayoutMode,
+    /// Policy for edges that touch nodes outside the view.
+    ///
+    /// V1 supports [`BoundaryPolicy::Omit`] only; omitted edges are reported
+    /// as [`crate::views::ViewEvent::EdgeElided`].
+    #[serde(default)]
+    pub boundary: BoundaryPolicy,
+    /// Policy for retained subgraph structure.
+    ///
+    /// V1 supports [`CompoundPolicy::Preserve`] only.
+    #[serde(default)]
+    pub compound: CompoundPolicy,
+}
+
+/// Include or exclude a selector from the view keep-set.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ViewStatement {
+    /// Add the selector result to the current keep-set.
+    Include(Selector),
+    /// Remove the selector result from the current keep-set.
+    Exclude(Selector),
+}
+
+/// Selector expression for v1 and forward-compatible follow-up view slices.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Selector {
+    /// Select every node and subgraph in the payload.
+    All,
+    /// Select one anchor.
+    Anchor(AnchorRef),
+    /// Select a node anchor plus graph neighbors within `hops` edge hops.
+    Traversal {
+        /// Starting anchor for the traversal.
+        ///
+        /// V1 supports node anchors only for traversal.
+        anchor: AnchorRef,
+        /// Direction to follow through the graph edge topology.
+        direction: TraversalDirection,
+        /// Maximum number of edge hops from the anchor.
+        hops: u32,
+    },
+    /// Select nodes matching a node predicate.
+    Predicate(NodePredicate),
+    /// Recursively include a subgraph, child subgraphs, and descendant nodes.
+    SubgraphDescendants(String),
+}
+
+/// Stable anchor reference used by view selectors.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AnchorRef {
+    /// Anchor on a node ID.
+    Node(String),
+    /// Select only the subgraph container. Use `Selector::SubgraphDescendants`
+    /// when the view should include the subgraph contents.
+    Subgraph(String),
+    /// Anchor on an edge identity tuple.
+    ///
+    /// Reserved for a later edge-aware view slice.
+    Edge(EdgeAnchor),
+}
+
+/// Edge anchor shape reserved for a later edge-aware view slice.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EdgeAnchor {
+    /// Source node ID.
+    pub source: String,
+    /// Target node ID.
+    pub target: String,
+    /// Zero-based ordinal among edges with the same source and target.
+    pub ordinal: usize,
+    /// Optional edge label used to disambiguate human-authored anchors.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// Direction used by hop traversal selectors.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TraversalDirection {
+    /// Follow incoming edges toward dependencies or callers.
+    Upstream,
+    /// Follow outgoing edges toward dependents or callees.
+    Downstream,
+    /// Follow both incoming and outgoing edges.
+    Neighbors,
+}
+
+/// Node predicate for selector filters.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NodePredicate {
+    /// Select nodes whose MMDS `shape` equals the supplied value.
+    Shape(String),
+    /// Select nodes whose `parent` subgraph ID equals the supplied value.
+    Parent(String),
+    /// Select nodes by tag metadata.
+    ///
+    /// Reserved for a later tag-aware view slice.
+    Tag(String),
+}
+
+/// Layout policy for the materialized view.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LayoutMode {
+    /// Preserve canonical coordinates and mark the payload as a shared-coordinate view.
+    #[default]
+    SharedCoordinates,
+    /// Repack the retained subgraph into a compact layout.
+    ///
+    /// Reserved for a later layout slice.
+    Compact,
+    /// Reflow locally around the selected anchor.
+    ///
+    /// Reserved for a later layout slice.
+    LocalReflow,
+    /// Update a prior view incrementally.
+    ///
+    /// Reserved for a later layout slice.
+    Incremental,
+}
+
+/// Boundary policy for elements connected to elided endpoints.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BoundaryPolicy {
+    /// Drop edges whose source or target node is outside the view.
+    #[default]
+    Omit,
+    /// Replace omitted boundary edges with aggregate stubs.
+    ///
+    /// Reserved for a later boundary slice.
+    Stub {
+        /// Minimum number of omitted edges before a grouped stub may be used.
+        aggregate_threshold: u32,
+    },
+}
+
+/// Compound/subgraph handling policy.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CompoundPolicy {
+    /// Preserve retained subgraphs and their ancestor chain.
+    #[default]
+    Preserve,
+    /// Remove subgraph containers and keep only retained leaf nodes.
+    ///
+    /// Reserved for a later compound-layout slice.
+    Flatten,
+}

--- a/tests/lib_exports.rs
+++ b/tests/lib_exports.rs
@@ -99,6 +99,7 @@ fn crate_root_only_exports_supported_public_modules() {
         "registry",
         "simplification",
         "timeline",
+        "views",
     ] {
         assert!(
             modules.contains(required),
@@ -121,6 +122,59 @@ fn crate_root_only_exports_supported_public_modules() {
             "{forbidden} should no longer be a public crate-root module"
         );
     }
+}
+
+#[test]
+fn views_module_is_public_low_level_api() {
+    let modules = public_modules_for_test();
+
+    assert!(
+        modules.contains("views"),
+        "views should be a supported low-level public module"
+    );
+}
+
+#[test]
+fn view_contract_types_compile() {
+    use mmdflux::views::{
+        AnchorRef, BoundaryPolicy, CompoundPolicy, EdgeAnchor, LayoutMode, NodePredicate, Selector,
+        TraversalDirection, ViewError, ViewEvent, ViewSpec, ViewStatement, apply_view,
+    };
+
+    let spec = ViewSpec::default();
+    let statement = ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("gateway".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 2,
+    });
+    let edge_anchor = AnchorRef::Edge(EdgeAnchor {
+        source: "gateway".to_string(),
+        target: "auth".to_string(),
+        ordinal: 0,
+        label: Some("calls".to_string()),
+    });
+    let stub_policy = BoundaryPolicy::Stub {
+        aggregate_threshold: 4,
+    };
+    let tag_predicate = NodePredicate::Tag("database".to_string());
+
+    let _ = (
+        spec,
+        statement,
+        edge_anchor,
+        stub_policy,
+        tag_predicate,
+        LayoutMode::SharedCoordinates,
+        CompoundPolicy::Preserve,
+        ViewEvent::NodeLeftView {
+            id: "internal".to_string(),
+            reason: mmdflux::views::ElisionReason::Excluded,
+        },
+        ViewError::NotImplementedYet {
+            feature: "edge anchors".to_string(),
+        },
+        apply_view,
+    );
 }
 
 #[test]
@@ -171,6 +225,15 @@ fn crate_root_reexports_curated_runtime_and_value_types() {
             "PathSimplification",
             "ColorToken",
             "NodeStyle",
+            "ViewSpec",
+            "ViewStatement",
+            "Selector",
+            "AnchorRef",
+            "LayoutMode",
+            "BoundaryPolicy",
+            "CompoundPolicy",
+            "ViewEvent",
+            "ViewError",
         ],
         "the crate-root export surface (types moved to home modules)",
     );
@@ -251,28 +314,43 @@ fn builtin_registry_module_is_public_and_registry_default_registry_is_gone() {
 
 #[test]
 fn mmds_module_keeps_supported_adapter_helpers_public() {
-    let _ = std::any::type_name::<mmdflux::mmds::Output>();
+    let _ = std::any::type_name::<mmdflux::mmds::Document>();
     let _ = std::any::type_name::<mmdflux::mmds::HydrationError>();
     let _ = std::any::type_name::<mmdflux::mmds::GenerationError>();
 
     let _parse_with_profiles: fn(
         &str,
     ) -> Result<
-        (mmdflux::mmds::Output, mmdflux::mmds::ProfileNegotiation),
+        (mmdflux::mmds::Document, mmdflux::mmds::ProfileNegotiation),
         mmdflux::mmds::ParseError,
     > = mmdflux::mmds::parse_with_profiles;
     let _validate_input: fn(&str) -> Result<(), mmdflux::RenderError> =
         mmdflux::mmds::validate_input;
     let _from_mmds_str: fn(&str) -> Result<mmdflux::graph::Graph, mmdflux::mmds::HydrationError> =
         mmdflux::mmds::from_str;
+    let _from_mmds_document: fn(
+        &mmdflux::mmds::Document,
+    )
+        -> Result<mmdflux::graph::Graph, mmdflux::mmds::HydrationError> =
+        mmdflux::mmds::from_document;
     let _generate_mermaid_from_mmds_str: fn(
         &str,
     ) -> Result<String, mmdflux::mmds::GenerationError> = mmdflux::mmds::generate_mermaid_from_str;
+    let _materialize_diagram: fn(
+        &str,
+        &mmdflux::RenderConfig,
+    ) -> Result<mmdflux::mmds::Document, mmdflux::RenderError> = mmdflux::materialize_diagram;
+    let _render_mmds_document: fn(
+        &mmdflux::mmds::Document,
+        mmdflux::OutputFormat,
+        &mmdflux::RenderConfig,
+    ) -> Result<String, mmdflux::RenderError> = mmdflux::render_mmds_document;
 }
 
 #[test]
 fn mmds_module_hides_geometry_coupled_helpers() {
     let source = repo_file("src/mmds/mod.rs");
+    let document_source = repo_file("src/mmds/document.rs");
 
     // These geometry-coupled helpers must not appear on the public surface.
     // The single runtime helper (to_mmds_json_typed_with_routing) may appear
@@ -302,4 +380,25 @@ fn mmds_module_hides_geometry_coupled_helpers() {
             panic!("to_mmds_json* helpers must be re-exports only, found: {trimmed}");
         }
     }
+
+    let reexport_lines: Vec<_> = source.lines().map(str::trim).collect();
+    let reexport_index = reexport_lines
+        .iter()
+        .position(|line| *line == "pub use document::to_json_typed_with_routing;")
+        .expect("legacy typed JSON routing helper should remain re-exported for compatibility");
+    let reexport_attrs = &reexport_lines[reexport_index.saturating_sub(3)..reexport_index];
+
+    assert!(
+        reexport_attrs.contains(&"#[doc(hidden)]"),
+        "legacy typed JSON routing helper should stay hidden on the mmds public surface"
+    );
+    assert!(
+        reexport_attrs.contains(&"#[allow(deprecated)]"),
+        "legacy typed JSON routing helper re-export should suppress its own deprecation warning"
+    );
+    assert!(
+        document_source.contains("#[deprecated(")
+            && document_source.contains("pub fn to_json_typed_with_routing("),
+        "legacy typed JSON routing helper should remain deprecated"
+    );
 }

--- a/tests/mmds_conformance.rs
+++ b/tests/mmds_conformance.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use mmdflux::builtins::default_registry;
 use mmdflux::graph::Graph;
 use mmdflux::mmds::{
-    Bounds, Edge, Node, Output, Port, Position, Subgraph, from_str, generate_mermaid_from_str,
+    Bounds, Document, Edge, Node, Port, Position, Subgraph, from_str, generate_mermaid_from_str,
     parse_input,
 };
 use mmdflux::payload::Diagram as Payload;
@@ -287,7 +287,7 @@ fn floats_eq(a: f64, b: f64) -> bool {
 /// Compare layout geometry for equivalence.
 ///
 /// Compares direct routed MMDS output against MMDS regenerated Mermaid rerender.
-fn check_layout(direct: &Output, roundtrip: &Output) -> TierResult {
+fn check_layout(direct: &Document, roundtrip: &Document) -> TierResult {
     let mismatches = compare_layout_payloads(direct, roundtrip);
 
     TierResult {
@@ -300,7 +300,7 @@ fn check_layout(direct: &Output, roundtrip: &Output) -> TierResult {
     }
 }
 
-fn compare_layout_payloads(direct: &Output, roundtrip: &Output) -> Vec<String> {
+fn compare_layout_payloads(direct: &Document, roundtrip: &Document) -> Vec<String> {
     let mut mismatches = Vec::new();
 
     if direct.metadata.direction != roundtrip.metadata.direction {
@@ -534,19 +534,19 @@ fn normalize_roundtrip_identifier(value: &str) -> String {
     value.replace('-', "_")
 }
 
-fn sorted_nodes(output: &Output) -> Vec<&Node> {
+fn sorted_nodes(output: &Document) -> Vec<&Node> {
     let mut nodes: Vec<_> = output.nodes.iter().collect();
     nodes.sort_by(|left, right| left.id.cmp(&right.id));
     nodes
 }
 
-fn sorted_edges(output: &Output) -> Vec<&Edge> {
+fn sorted_edges(output: &Document) -> Vec<&Edge> {
     let mut edges: Vec<_> = output.edges.iter().collect();
     edges.sort_by(|left, right| left.id.cmp(&right.id));
     edges
 }
 
-fn sorted_subgraphs(output: &Output) -> Vec<&Subgraph> {
+fn sorted_subgraphs(output: &Document) -> Vec<&Subgraph> {
     let mut subgraphs: Vec<_> = output.subgraphs.iter().collect();
     subgraphs.sort_by(|left, right| {
         left.title.cmp(&right.title).then(
@@ -578,14 +578,14 @@ fn prepare_graph_diagram(diagram_id: &str, input: &str) -> Graph {
     }
 }
 
-fn render_mmds_output(input: &str, config: &RenderConfig) -> (String, Output) {
+fn render_mmds_json_and_document(input: &str, config: &RenderConfig) -> (String, Document) {
     let json =
         render_diagram(input, OutputFormat::Mmds, config).expect("MMDS render should succeed");
-    let output = parse_input(&json).expect("MMDS output should parse");
+    let output = parse_input(&json).expect("MMDS document should parse");
     (json, output)
 }
 
-fn rerender_mmds_output_from_generated_mermaid(mmds_json: &str, config: &RenderConfig) -> Output {
+fn rerender_mmds_json_from_generated_mermaid(mmds_json: &str, config: &RenderConfig) -> Document {
     let generated =
         generate_mermaid_from_str(mmds_json).expect("MMDS Mermaid generation should succeed");
     let rerendered = render_diagram(&generated, OutputFormat::Mmds, config)
@@ -599,10 +599,10 @@ fn run_flowchart_conformance(name: &str) -> ConformanceReport {
     let mmds_config = RenderConfig::default();
 
     let direct_diagram = prepare_graph_diagram("flowchart", &input);
-    let (mmds_json, direct_output) = render_mmds_output(&input, &mmds_config);
+    let (mmds_json, direct_output) = render_mmds_json_and_document(&input, &mmds_config);
     let generated = generate_mermaid_from_str(&mmds_json).unwrap();
     let roundtrip_diagram = from_str(&mmds_json).unwrap();
-    let roundtrip_output = rerender_mmds_output_from_generated_mermaid(&mmds_json, &mmds_config);
+    let roundtrip_output = rerender_mmds_json_from_generated_mermaid(&mmds_json, &mmds_config);
 
     ConformanceReport {
         fixture_path: format!("flowchart/{name}"),
@@ -621,7 +621,7 @@ fn run_class_conformance(name: &str) -> ConformanceReport {
     let input = fixture_input("class", name);
 
     let direct_diagram = prepare_graph_diagram("class", &input);
-    let (mmds_json, _) = render_mmds_output(&input, &RenderConfig::default());
+    let (mmds_json, _) = render_mmds_json_and_document(&input, &RenderConfig::default());
     let roundtrip_diagram = from_str(&mmds_json).unwrap();
 
     ConformanceReport {

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -10,11 +10,11 @@ use std::path::Path;
 
 use mmdflux::graph::GeometryLevel;
 use mmdflux::mmds::{
-    Edge as MmdsEdge, Output, Port as MmdsPort, Position as MmdsPosition, Rect as MmdsRect,
-    SUPPORTED_PROFILES, evaluate_profiles, hydrate_routed_geometry_from_output, parse_input,
+    Document, Edge as MmdsEdge, Port as MmdsPort, Position as MmdsPosition, Rect as MmdsRect,
+    SUPPORTED_PROFILES, evaluate_profiles, hydrate_routed_geometry_from_document, parse_input,
 };
 use mmdflux::simplification::PathSimplification;
-use mmdflux::{EngineAlgorithmId, OutputFormat, RenderConfig, TextColorMode};
+use mmdflux::{EngineAlgorithmId, OutputFormat, RenderConfig, TextColorMode, materialize_diagram};
 use serde_json::Value;
 
 const STYLED_MMDS_LAYOUT: &str = r##"{
@@ -196,15 +196,37 @@ fn top_level_mmds_contract_helpers_parse_and_negotiate_shared_fixture_profiles()
     let payload = mmds_contract_fixture_text("flowchart-simple.layout.json");
 
     let parsed = parse_input(&payload).expect("shared contract fixture should parse");
+    let parsed_from_str: Document = payload
+        .parse()
+        .expect("Document FromStr should use MMDS parse semantics");
+    let parsed_try_from =
+        Document::try_from(payload.as_str()).expect("Document TryFrom should parse MMDS JSON");
     let negotiation =
         evaluate_profiles(&payload).expect("shared contract fixture profile evaluation");
 
     assert_eq!(parsed.metadata.diagram_type, "flowchart");
+    assert_eq!(parsed_from_str.metadata.diagram_type, "flowchart");
+    assert_eq!(parsed_try_from.metadata.diagram_type, "flowchart");
     assert_eq!(
         negotiation.supported,
         vec!["mmds-core-v1".to_string(), "mmdflux-text-v1".to_string()]
     );
     assert_eq!(negotiation.unknown, Vec::<String>::new());
+}
+
+#[test]
+fn materialize_diagram_matches_mmds_json_render_for_graph_family() {
+    let source = "graph TD\n    A[Start] --> B[End]";
+    let config = RenderConfig::default();
+    let document = materialize_diagram(source, &config).expect("source should materialize");
+    let json = render_json_with_config(source, &config);
+    let rendered_document: Document =
+        serde_json::from_str(&json).expect("MMDS JSON render should parse as a document");
+
+    assert_eq!(document.metadata.diagram_type, "flowchart");
+    assert_eq!(document.nodes.len(), rendered_document.nodes.len());
+    assert_eq!(document.edges.len(), rendered_document.edges.len());
+    assert_eq!(document.edges[0].id, rendered_document.edges[0].id);
 }
 
 // -----------------------------------------------------------------------
@@ -214,21 +236,21 @@ fn top_level_mmds_contract_helpers_parse_and_negotiate_shared_fixture_profiles()
 #[test]
 fn mmds_default_has_version_1() {
     let json = render_json("graph TD\nA-->B");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.version, 1);
 }
 
 #[test]
 fn mmds_default_geometry_level_is_layout() {
     let json = render_json("graph TD\nA-->B");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.geometry_level, "layout");
 }
 
 #[test]
 fn mmds_has_metadata_with_direction() {
     let json = render_json("graph LR\nA-->B");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.metadata.diagram_type, "flowchart");
     assert_eq!(output.metadata.direction, "LR");
 }
@@ -236,7 +258,7 @@ fn mmds_has_metadata_with_direction() {
 #[test]
 fn mmds_has_nodes_and_edges() {
     let json = render_json("graph TD\nA[Start]-->B[End]");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.nodes.len(), 2);
     assert_eq!(output.edges.len(), 1);
 }
@@ -361,7 +383,7 @@ fn mmds_hydration_replays_node_styles_into_svg_and_text_rendering() {
 #[test]
 fn mmds_layout_nodes_have_positions_and_sizes() {
     let json = render_json("graph TD\nA[Start]-->B[End]");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let node_a = output.nodes.iter().find(|n| n.id == "A").unwrap();
     assert_eq!(node_a.label, "Start");
@@ -373,7 +395,7 @@ fn mmds_layout_nodes_have_positions_and_sizes() {
 #[test]
 fn mmds_layout_nodes_sorted_by_id() {
     let json = render_json("graph TD\nC-->B\nB-->A");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     let ids: Vec<&str> = output.nodes.iter().map(|n| n.id.as_str()).collect();
     assert_eq!(ids, vec!["A", "B", "C"]);
 }
@@ -381,7 +403,7 @@ fn mmds_layout_nodes_sorted_by_id() {
 #[test]
 fn mmds_layout_node_shapes() {
     let json = render_json("graph TD\nA[Rect]\nB(Round)\nC{Diamond}\nD([Stadium])");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let shapes: std::collections::HashMap<String, String> = output
         .nodes
@@ -413,9 +435,9 @@ fn mmds_lossless_path_simplification_sits_between_none_and_lossy() {
     let compact = render_for(PathSimplification::Lossless);
     let simplified = render_for(PathSimplification::Lossy);
 
-    let full: Output = serde_json::from_str(&full).unwrap();
-    let compact: Output = serde_json::from_str(&compact).unwrap();
-    let simplified: Output = serde_json::from_str(&simplified).unwrap();
+    let full: Document = serde_json::from_str(&full).unwrap();
+    let compact: Document = serde_json::from_str(&compact).unwrap();
+    let simplified: Document = serde_json::from_str(&simplified).unwrap();
 
     let full_len = full
         .edges
@@ -455,7 +477,7 @@ fn compound_backward_disconnected_routed_mmds_engine_contracts() {
     let input = flowchart_fixture("compound_backward_disconnected.mmd");
     let edge_is_backward = |engine: &str, edge_id: &str| {
         let json = render_routed_mmds_with_engine(&input, engine);
-        let output: Output = serde_json::from_str(&json).unwrap();
+        let output: Document = serde_json::from_str(&json).unwrap();
         output
             .edges
             .iter()
@@ -485,7 +507,7 @@ fn routed_mmds_defaults_to_lossless_path_simplification() {
         render_json_with_config(&input, &config)
     };
     let edge_len = |json: &str| {
-        let output: Output = serde_json::from_str(json).unwrap();
+        let output: Document = serde_json::from_str(json).unwrap();
         output
             .edges
             .iter()
@@ -539,7 +561,7 @@ fn path_simplification_monotonicity_holds_none_lossless_lossy() {
         )
     };
     let edge_len = |json: &str| {
-        let output: Output = serde_json::from_str(json).unwrap();
+        let output: Document = serde_json::from_str(json).unwrap();
         output
             .edges
             .iter()
@@ -577,7 +599,7 @@ fn tier_a_bent_paths_preserved_in_mmds_routed_output() {
             ..RenderConfig::default()
         },
     );
-    let output: Output = serde_json::from_str(&json).expect("routed MMDS parses");
+    let output: Document = serde_json::from_str(&json).expect("routed MMDS parses");
 
     let labeled: Vec<&MmdsEdge> = output
         .edges
@@ -618,7 +640,7 @@ fn tier_a_bent_paths_round_trip_byte_stable_through_mmds() {
     // Semantic equality via JSON value comparison (ignores cosmetic whitespace).
     let v1: Value = serde_json::to_value(&output1).unwrap();
     let v2: Value = serde_json::to_value(&output2).unwrap();
-    assert_eq!(v1, v2, "MMDS Output is not round-trip stable");
+    assert_eq!(v1, v2, "MMDS Document is not round-trip stable");
 
     // And the bend waypoints survive the round-trip per-edge.
     for edge in output2.edges.iter() {
@@ -666,7 +688,7 @@ fn mmds_node_sizes_are_in_svg_pixel_dimensions() {
     // This test catches the bug where MMDS emits text-grid char dimensions
     // instead of pixel dimensions.
     let json = render_json("graph TD\nA-->B");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let node_a = output.nodes.iter().find(|n| n.id == "A").unwrap();
     assert!(
@@ -690,7 +712,7 @@ fn mmds_routed_subgraph_bounds_are_reasonable() {
         "graph TD\nsubgraph sg1[Group]\nA-->B\nend\nC-->A",
         GeometryLevel::Routed,
     );
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let sg = &output.subgraphs[0];
     let bounds = sg
@@ -743,7 +765,7 @@ fn mmds_layout_edges_exclude_label_position() {
 #[test]
 fn mmds_layout_edges_have_topology() {
     let json = render_json("graph TD\nA-.label.->B");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let edge = &output.edges[0];
     assert_eq!(edge.id, "e0");
@@ -793,7 +815,7 @@ fn mmds_edge_serializes_optional_subgraph_endpoint_intent_for_subgraph_to_subgra
 #[test]
 fn mmds_layout_metadata_includes_bounds() {
     let json = render_json("graph TD\nA-->B");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert!(output.metadata.bounds.width > 0.0);
     assert!(output.metadata.bounds.height > 0.0);
 }
@@ -805,7 +827,7 @@ fn mmds_layout_metadata_includes_bounds() {
 #[test]
 fn mmds_layout_subgraphs() {
     let json = render_json("graph TD\nsubgraph sg1[Group]\nA-->B\nend");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     assert_eq!(output.subgraphs.len(), 1);
     assert_eq!(output.subgraphs[0].id, "sg1");
@@ -817,7 +839,7 @@ fn mmds_layout_subgraphs() {
 #[test]
 fn mmds_layout_subgraph_direction_override() {
     let json = render_json("graph TD\nsubgraph sg1[Group]\ndirection LR\nA-->B\nend");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.subgraphs[0].direction.as_deref(), Some("LR"));
 }
 
@@ -828,14 +850,14 @@ fn mmds_layout_subgraph_direction_override() {
 #[test]
 fn mmds_routed_has_geometry_level_routed() {
     let json = render_json_with_level("graph TD\nA-->B", GeometryLevel::Routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.geometry_level, "routed");
 }
 
 #[test]
 fn mmds_routed_includes_edge_paths() {
     let json = render_json_with_level("graph TD\nA-->B", GeometryLevel::Routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let edge = &output.edges[0];
     assert!(edge.path.is_some());
@@ -846,7 +868,7 @@ fn mmds_routed_includes_edge_paths() {
 #[test]
 fn mmds_routed_includes_metadata_bounds() {
     let json = render_json_with_level("graph TD\nA-->B", GeometryLevel::Routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let bounds = &output.metadata.bounds;
     assert!(bounds.width > 0.0);
@@ -859,7 +881,7 @@ fn mmds_routed_subgraph_bounds() {
         "graph TD\nsubgraph sg1[Group]\nA-->B\nend",
         GeometryLevel::Routed,
     );
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let sg = &output.subgraphs[0];
     assert!(sg.bounds.is_some());
@@ -869,7 +891,7 @@ fn mmds_routed_subgraph_bounds() {
 #[test]
 fn mmds_routed_label_position_for_labeled_edge() {
     let json = render_json_with_level("graph TD\nA--label-->B", GeometryLevel::Routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let edge = &output.edges[0];
     assert!(edge.label_position.is_some());
@@ -945,7 +967,7 @@ fn mmds_routed_still_includes_paths() {
 #[test]
 fn mmds_deserializes_with_defaults() {
     let json = render_json("graph TD\nA-->B");
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.nodes[0].shape, "rectangle");
     assert_eq!(output.edges[0].stroke, "solid");
     assert_eq!(output.edges[0].arrow_start, "none");
@@ -965,7 +987,7 @@ fn mmds_direction_variants() {
     for (dir_str, expected) in [("TD", "TD"), ("LR", "LR"), ("BT", "BT"), ("RL", "RL")] {
         let input = format!("graph {dir_str}\nA-->B");
         let json = render_json(&input);
-        let output: Output = serde_json::from_str(&json).unwrap();
+        let output: Document = serde_json::from_str(&json).unwrap();
         assert_eq!(output.metadata.direction, expected);
     }
 }
@@ -978,7 +1000,7 @@ fn mmds_direction_variants() {
 fn mmds_class_diagram_produces_json() {
     let config = RenderConfig::default();
     let output = render_json_with_config("classDiagram\nA --> B", &config);
-    let parsed: Output = serde_json::from_str(&output).unwrap();
+    let parsed: Document = serde_json::from_str(&output).unwrap();
 
     assert_eq!(parsed.version, 1);
     assert_eq!(parsed.geometry_level, "layout");
@@ -993,7 +1015,7 @@ fn mmds_class_diagram_routed_level() {
         ..RenderConfig::default()
     };
     let output = render_json_with_config("classDiagram\nA --> B", &config);
-    let parsed: Output = serde_json::from_str(&output).unwrap();
+    let parsed: Document = serde_json::from_str(&output).unwrap();
 
     assert_eq!(parsed.geometry_level, "routed");
     assert!(output.contains("\"path\""));
@@ -1064,7 +1086,7 @@ fn schema_rejects_invalid_extension_namespace_shape() {
 #[test]
 fn mmds_profiles_and_extensions_roundtrip_through_serde() {
     let payload = mmds_profile_fixture_text("profiles-svg-v1.json");
-    let parsed: Output = serde_json::from_str(&payload).unwrap();
+    let parsed: Document = serde_json::from_str(&payload).unwrap();
     let json = serde_json::to_string(&parsed).unwrap();
 
     assert!(json.contains("profiles"));
@@ -1081,6 +1103,7 @@ fn rust_api_examples_exist() {
     assert!(Path::new("examples/high_level_render.rs").exists());
     assert!(Path::new("examples/registry_adapter.rs").exists());
     assert!(Path::new("examples/mmds_replay.rs").exists());
+    assert!(Path::new("examples/materialized_view.rs").exists());
     assert!(!Path::new("examples/mmds").exists());
 }
 
@@ -1102,6 +1125,7 @@ fn readme_describes_high_level_and_low_level_rust_api_tiers() {
         "`registry`",
         "`payload`",
         "`mmds`",
+        "`views`",
         "internal implementation modules",
     ] {
         assert!(
@@ -1140,6 +1164,23 @@ fn docs_and_schema_reference_node_style_extension_contract() {
 }
 
 #[test]
+fn docs_and_schema_reference_view_extension_contract() {
+    let docs = std::fs::read_to_string("docs/mmds.md").unwrap();
+    assert!(docs.contains("mmdflux::views"));
+    assert!(docs.contains("ViewSpec"));
+    assert!(docs.contains("apply_view"));
+    assert!(docs.contains("ViewEvent"));
+    assert!(docs.contains("org.mmdflux.view.v1"));
+    assert!(docs.contains("[\"e0\", \"e2\", \"e4\"]"));
+    assert!(docs.contains("examples/materialized_view.rs"));
+
+    let schema = std::fs::read_to_string("docs/mmds.schema.json").unwrap();
+    assert!(schema.contains("org.mmdflux.view.v1"));
+    assert!(schema.contains("shared_coordinates"));
+    assert!(schema.contains("boundary_policy"));
+}
+
+#[test]
 fn docs_cover_live_style_scope_and_wasm_color_config() {
     let mmds_docs = std::fs::read_to_string("docs/mmds.md").unwrap();
     assert!(!mmds_docs.contains("Style/class/link directives are out of scope"));
@@ -1162,6 +1203,7 @@ fn mmds_docs_point_to_fixture_backed_examples_and_rust_replay_example() {
 
     for required in [
         "examples/mmds_replay.rs",
+        "examples/materialized_view.rs",
         "tests/fixtures/mmds/generation/basic-flow.json",
         "tests/fixtures/mmds/positioned/routed-basic.json",
     ] {
@@ -1184,7 +1226,7 @@ fn mmds_docs_point_to_fixture_backed_examples_and_rust_replay_example() {
 #[test]
 fn mmds_routed_includes_port_metadata() {
     let json = render_json_with_level("graph TD\nA-->B", GeometryLevel::Routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     let edge = &output.edges[0];
     assert!(
         edge.source_port.is_some(),
@@ -1199,7 +1241,7 @@ fn mmds_routed_includes_port_metadata() {
 #[test]
 fn mmds_routed_port_faces_correct_td() {
     let json = render_json_with_level("graph TD\nA-->B", GeometryLevel::Routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     let edge = &output.edges[0];
     let sp = edge.source_port.as_ref().unwrap();
     let tp = edge.target_port.as_ref().unwrap();
@@ -1210,7 +1252,7 @@ fn mmds_routed_port_faces_correct_td() {
 #[test]
 fn mmds_routed_port_fractions_fan_in() {
     let json = render_json_with_level("graph TD\nA-->C\nB-->C", GeometryLevel::Routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
     let e0 = output.edges.iter().find(|e| e.source == "A").unwrap();
     let e1 = output.edges.iter().find(|e| e.source == "B").unwrap();
     let f0 = e0.target_port.as_ref().unwrap().fraction;
@@ -1225,7 +1267,7 @@ fn mmds_routed_port_fractions_fan_in() {
 fn mmds_routed_port_roundtrip_preserves_direction_override_boundary_ports_and_path() {
     let input = flowchart_fixture("subgraph_direction_lr.mmd");
     let direct_json = render_json_with_level(&input, GeometryLevel::Routed);
-    let direct: Output = serde_json::from_str(&direct_json).unwrap();
+    let direct: Document = serde_json::from_str(&direct_json).unwrap();
     let roundtrip_json = render_mmds_input(
         &direct_json,
         OutputFormat::Mmds,
@@ -1234,7 +1276,7 @@ fn mmds_routed_port_roundtrip_preserves_direction_override_boundary_ports_and_pa
             ..RenderConfig::default()
         },
     );
-    let roundtrip: Output = serde_json::from_str(&roundtrip_json).unwrap();
+    let roundtrip: Document = serde_json::from_str(&roundtrip_json).unwrap();
 
     let direct_edge = find_mmds_edge(&direct, "C", "End");
     let roundtrip_edge = find_mmds_edge(&roundtrip, "C", "End");
@@ -1298,7 +1340,7 @@ fn assert_contract_terms_near(document: &str, needle: &str, terms: &[&str]) {
     panic!("expected {needle:?} to appear near contract terms {terms:?}");
 }
 
-fn find_mmds_edge<'a>(output: &'a Output, source: &str, target: &str) -> &'a MmdsEdge {
+fn find_mmds_edge<'a>(output: &'a Document, source: &str, target: &str) -> &'a MmdsEdge {
     output
         .edges
         .iter()
@@ -1688,7 +1730,7 @@ fn mmds_output_populates_label_side_at_layout_level() {
     // Reciprocal edges trigger label-side selection in the engine.
     let input = "graph TD\n    A -->|forward| B\n    B -->|reverse| A";
     let json = render_json_with_level(input, GeometryLevel::Layout);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let has_side = output.edges.iter().any(|e| e.label_side.is_some());
     assert!(
@@ -1718,7 +1760,7 @@ fn mmds_output_populates_label_rect_at_routed_level_only() {
 
     // Layout level: label_rect must NOT appear.
     let layout_json = render_json_with_level(input, GeometryLevel::Layout);
-    let layout_output: Output = serde_json::from_str(&layout_json).unwrap();
+    let layout_output: Document = serde_json::from_str(&layout_json).unwrap();
     assert!(
         layout_output.edges[0].label_rect.is_none(),
         "label_rect must not appear at layout level"
@@ -1726,7 +1768,7 @@ fn mmds_output_populates_label_rect_at_routed_level_only() {
 
     // Routed level: label_rect MUST appear for a labeled edge.
     let routed_json = render_json_with_level(input, GeometryLevel::Routed);
-    let routed_output: Output = serde_json::from_str(&routed_json).unwrap();
+    let routed_output: Document = serde_json::from_str(&routed_json).unwrap();
     let rect = routed_output.edges[0]
         .label_rect
         .as_ref()
@@ -1739,7 +1781,7 @@ fn mmds_output_populates_label_rect_at_routed_level_only() {
 fn mmds_output_label_rect_absent_for_unlabeled_edges() {
     let input = "graph TD\n    A --> B";
     let routed_json = render_json_with_level(input, GeometryLevel::Routed);
-    let routed_output: Output = serde_json::from_str(&routed_json).unwrap();
+    let routed_output: Document = serde_json::from_str(&routed_json).unwrap();
     assert!(
         routed_output.edges[0].label_rect.is_none(),
         "unlabeled edges must not have label_rect"
@@ -1751,7 +1793,7 @@ fn mmds_output_label_side_present_at_routed_level_too() {
     // label_side should appear at BOTH levels, not just layout.
     let input = "graph TD\n    A -->|forward| B\n    B -->|reverse| A";
     let json = render_json_with_level(input, GeometryLevel::Routed);
-    let output: Output = serde_json::from_str(&json).unwrap();
+    let output: Document = serde_json::from_str(&json).unwrap();
 
     let has_side = output.edges.iter().any(|e| e.label_side.is_some());
     assert!(
@@ -1810,7 +1852,7 @@ fn mmds_routed_to_layout_down_conversion_strips_routed_only_edge_fields() {
             ..RenderConfig::default()
         },
     );
-    let parsed: Output = serde_json::from_str(&layout_output).unwrap();
+    let parsed: Document = serde_json::from_str(&layout_output).unwrap();
     assert_eq!(parsed.geometry_level, "layout");
     for edge in &parsed.edges {
         assert!(edge.path.is_none(), "path must be stripped at layout level");
@@ -1847,7 +1889,7 @@ fn mmds_routed_to_layout_down_conversion_strips_routed_only_edge_fields() {
 // adapter or a future producer change leaves the two fields disagreeing,
 // MMDS replay must prefer the rect.
 //
-// Today `hydrate_routed_geometry_from_output` rebuilds `label_geometry`
+// Today `hydrate_routed_geometry_from_document` rebuilds `label_geometry`
 // from `label_position` inside `populate_label_geometry`, ignoring the
 // serialized `label_rect`. Replay silently loses authoritative routed
 // label placement whenever the producer anchor and raw position disagree.
@@ -1861,7 +1903,7 @@ fn mmds_routed_to_layout_down_conversion_strips_routed_only_edge_fields() {
 mod plan_0151_routed_mmds_replay_contract {
     use super::*;
 
-    fn poisoned_synthetic_routed_output() -> Output {
+    fn poisoned_synthetic_routed_document() -> Document {
         let input = std::fs::read_to_string(
             std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
                 .join("tests")
@@ -1871,7 +1913,7 @@ mod plan_0151_routed_mmds_replay_contract {
         )
         .unwrap();
         let routed_json = render_json_with_level(&input, GeometryLevel::Routed);
-        let mut output: Output = serde_json::from_str(&routed_json).unwrap();
+        let mut output: Document = serde_json::from_str(&routed_json).unwrap();
 
         let e3 = output
             .edges
@@ -1898,7 +1940,7 @@ mod plan_0151_routed_mmds_replay_contract {
 
     #[test]
     fn hydrate_routed_geometry_preserves_authoritative_label_rect_when_label_position_disagrees() {
-        let output = poisoned_synthetic_routed_output();
+        let output = poisoned_synthetic_routed_document();
         let e3_rect = output
             .edges
             .iter()
@@ -1908,7 +1950,7 @@ mod plan_0151_routed_mmds_replay_contract {
         let expected_center_x = e3_rect.x + e3_rect.width / 2.0;
         let expected_center_y = e3_rect.y + e3_rect.height / 2.0;
 
-        let routed = hydrate_routed_geometry_from_output(&output)
+        let routed = hydrate_routed_geometry_from_document(&output)
             .expect("hydration should succeed for a valid routed payload");
         let edge = routed
             .edges
@@ -1960,7 +2002,7 @@ mod plan_0151_routed_mmds_replay_contract {
 
     #[test]
     fn synthetic_shifted_label_survives_routed_mmds_svg_replay() {
-        let output = poisoned_synthetic_routed_output();
+        let output = poisoned_synthetic_routed_document();
         let rect = output
             .edges
             .iter()
@@ -2006,7 +2048,7 @@ mod plan_0151_routed_mmds_replay_contract {
         )
         .unwrap();
         let routed_mmds = render_json_with_level(&input, GeometryLevel::Routed);
-        let output: Output = serde_json::from_str(&routed_mmds).unwrap();
+        let output: Document = serde_json::from_str(&routed_mmds).unwrap();
         let rect = output
             .edges
             .iter()

--- a/tests/mmds_views.rs
+++ b/tests/mmds_views.rs
@@ -1,0 +1,935 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use mmdflux::mmds::{
+    Bounds, Defaults, Document, Edge, Metadata, Node, Position, Size, Subgraph,
+    TEXT_EXTENSION_NAMESPACE,
+};
+use mmdflux::views::{
+    AnchorRef, ElisionReason, LayoutMode, NodePredicate, Selector, TraversalDirection,
+    VIEW_EXTENSION_NAMESPACE, ViewError, ViewEvent, ViewSpec, ViewStatement, apply_view,
+};
+use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_mmds_document};
+use serde_json::{Map, Value, json};
+
+const LEGACY_TEXT_EXTENSION_NAMESPACE: &str = "org.mmdflux.text.v1.projection";
+const CANARY_SOURCE: &str = r#"graph TD
+service_a[Service A] --> service_b[Service B]
+external[External] --> service_a
+service_b --> service_c[Service C]
+service_c --> database[Database]
+service_a --> audit[Audit]
+"#;
+
+fn ids(values: &[&str]) -> BTreeSet<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}
+
+fn output(nodes: Vec<Node>, edges: Vec<Edge>, subgraphs: Vec<Subgraph>) -> Document {
+    Document {
+        version: 1,
+        profiles: Vec::new(),
+        extensions: BTreeMap::new(),
+        defaults: Defaults::default(),
+        geometry_level: "layout".to_string(),
+        metadata: Metadata {
+            diagram_type: "flowchart".to_string(),
+            direction: "TD".to_string(),
+            bounds: Bounds {
+                width: 200.0,
+                height: 200.0,
+            },
+            engine: None,
+        },
+        nodes,
+        edges,
+        subgraphs,
+    }
+}
+
+fn node(id: &str, shape: &str, parent: Option<&str>) -> Node {
+    Node {
+        id: id.to_string(),
+        label: id.to_string(),
+        shape: shape.to_string(),
+        parent: parent.map(str::to_string),
+        position: Position { x: 0.0, y: 0.0 },
+        size: Size {
+            width: 40.0,
+            height: 20.0,
+        },
+    }
+}
+
+fn edge(id: &str, source: &str, target: &str) -> Edge {
+    Edge {
+        id: id.to_string(),
+        source: source.to_string(),
+        target: target.to_string(),
+        from_subgraph: None,
+        to_subgraph: None,
+        label: None,
+        stroke: "solid".to_string(),
+        arrow_start: "none".to_string(),
+        arrow_end: "normal".to_string(),
+        minlen: 1,
+        path: None,
+        label_position: None,
+        is_backward: None,
+        source_port: None,
+        target_port: None,
+        label_side: None,
+        label_rect: None,
+    }
+}
+
+fn edge_with_label(id: &str, source: &str, target: &str, label: &str) -> Edge {
+    Edge {
+        label: Some(label.to_string()),
+        ..edge(id, source, target)
+    }
+}
+
+fn subgraph(id: &str, children: &[&str], parent: Option<&str>) -> Subgraph {
+    Subgraph {
+        id: id.to_string(),
+        title: id.to_string(),
+        children: children.iter().map(|child| (*child).to_string()).collect(),
+        parent: parent.map(str::to_string),
+        direction: None,
+        bounds: None,
+        invisible: false,
+        concurrent_regions: Vec::new(),
+    }
+}
+
+fn view(statements: Vec<ViewStatement>) -> ViewSpec {
+    ViewSpec {
+        statements,
+        ..ViewSpec::default()
+    }
+}
+
+fn text_projection_extension() -> Map<String, Value> {
+    let mut extension = Map::new();
+    extension.insert(
+        "projection".to_string(),
+        json!({
+            "node_ranks": {
+                "gateway": 0,
+                "auth": 2,
+                "db": 4,
+                "internal": 6
+            },
+            "edge_waypoints": {
+                "0": [{"x": 12.0, "y": 20.0, "rank": 0}],
+                "1": [{"x": 48.0, "y": 60.0, "rank": 2}]
+            },
+            "label_positions": {
+                "0": {"x": 18.0, "y": 24.0, "rank": 0},
+                "1": {"x": 54.0, "y": 66.0, "rank": 2}
+            }
+        }),
+    );
+    extension
+}
+
+fn projection<'a>(payload: &'a Document, namespace: &str) -> &'a Map<String, Value> {
+    payload
+        .extensions
+        .get(namespace)
+        .and_then(|extension| extension.get("projection"))
+        .and_then(Value::as_object)
+        .expect("projection extension should be present")
+}
+
+fn view_replay_payloads() -> (Document, Document, Document) {
+    let mut payload = output(
+        vec![
+            Node {
+                position: Position { x: 0.0, y: 0.0 },
+                ..node("gateway", "rectangle", None)
+            },
+            Node {
+                position: Position { x: 20.0, y: 10.0 },
+                ..node("auth", "rectangle", None)
+            },
+        ],
+        vec![edge("e0", "gateway", "auth")],
+        vec![],
+    );
+    payload.extensions.insert(
+        TEXT_EXTENSION_NAMESPACE.to_string(),
+        text_projection_extension(),
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("gateway".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 1,
+    })]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let mut plain_payload = view_payload.clone();
+    plain_payload.extensions.remove(VIEW_EXTENSION_NAMESPACE);
+    let mut no_projection_payload = plain_payload.clone();
+    no_projection_payload
+        .extensions
+        .remove(TEXT_EXTENSION_NAMESPACE);
+
+    (view_payload, plain_payload, no_projection_payload)
+}
+
+fn canary_view_replay_payloads() -> (Document, Document) {
+    let view_payload = canary_view_payload();
+    let mut plain_payload = view_payload.clone();
+    plain_payload.extensions.remove(VIEW_EXTENSION_NAMESPACE);
+    (view_payload, plain_payload)
+}
+
+fn render_mmds_payload(payload: &Document, format: OutputFormat) -> String {
+    render_mmds_document(payload, format, &RenderConfig::default()).expect("payload should render")
+}
+
+fn canary_canonical_output() -> Document {
+    materialize_diagram(CANARY_SOURCE, &RenderConfig::default())
+        .expect("canary source should materialize to MMDS")
+}
+
+fn canary_view_spec() -> ViewSpec {
+    view(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("service_a".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 2,
+    })])
+}
+
+fn canary_view_payload() -> Document {
+    let canonical = canary_canonical_output();
+    apply_view(&canonical, &canary_view_spec())
+        .expect("canary view should materialize")
+        .0
+}
+
+fn render_canary_view(format: OutputFormat) -> String {
+    render_mmds_payload(&canary_view_payload(), format)
+}
+
+fn edge_ids(payload: &Document) -> Vec<&str> {
+    payload.edges.iter().map(|edge| edge.id.as_str()).collect()
+}
+
+fn node_ids(payload: &Document) -> BTreeSet<String> {
+    payload.nodes.iter().map(|node| node.id.clone()).collect()
+}
+
+fn subgraph_ids(payload: &Document) -> BTreeSet<String> {
+    payload
+        .subgraphs
+        .iter()
+        .map(|subgraph| subgraph.id.clone())
+        .collect()
+}
+
+#[test]
+fn view_selector_downstream_hops_include_anchor() {
+    let payload = output(
+        vec![
+            node("gateway", "rectangle", None),
+            node("auth", "rectangle", None),
+            node("db", "cylinder", None),
+            node("monitor", "rectangle", None),
+        ],
+        vec![
+            edge("e0", "gateway", "auth"),
+            edge("e1", "auth", "db"),
+            edge("e2", "monitor", "gateway"),
+        ],
+        vec![],
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("gateway".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 2,
+    })]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert_eq!(node_ids(&view_payload), ids(&["gateway", "auth", "db"]));
+    assert!(view_payload.subgraphs.is_empty());
+}
+
+#[test]
+fn view_selector_upstream_hops_follow_incoming_edges() {
+    let payload = output(
+        vec![
+            node("gateway", "rectangle", None),
+            node("auth", "rectangle", None),
+            node("client", "rectangle", None),
+            node("monitor", "rectangle", None),
+        ],
+        vec![
+            edge("e0", "client", "gateway"),
+            edge("e1", "gateway", "auth"),
+            edge("e2", "monitor", "gateway"),
+        ],
+        vec![],
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("gateway".to_string()),
+        direction: TraversalDirection::Upstream,
+        hops: 1,
+    })]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert_eq!(
+        node_ids(&view_payload),
+        ids(&["client", "gateway", "monitor"])
+    );
+}
+
+#[test]
+fn view_selector_neighbors_combines_directions() {
+    let payload = output(
+        vec![
+            node("gateway", "rectangle", None),
+            node("auth", "rectangle", None),
+            node("client", "rectangle", None),
+            node("monitor", "rectangle", None),
+        ],
+        vec![
+            edge("e0", "client", "gateway"),
+            edge("e1", "gateway", "auth"),
+            edge("e2", "monitor", "gateway"),
+        ],
+        vec![],
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("gateway".to_string()),
+        direction: TraversalDirection::Neighbors,
+        hops: 1,
+    })]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert_eq!(
+        node_ids(&view_payload),
+        ids(&["auth", "client", "gateway", "monitor"])
+    );
+}
+
+#[test]
+fn view_selector_subgraph_descendants_recurse() {
+    let payload = output(
+        vec![
+            node("gateway", "rectangle", Some("root")),
+            node("auth", "rectangle", Some("payments")),
+            node("charge", "rectangle", Some("payments")),
+            node("unrelated", "rectangle", None),
+        ],
+        vec![],
+        vec![
+            subgraph("root", &["gateway"], None),
+            subgraph("payments", &["auth", "charge"], Some("root")),
+        ],
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::SubgraphDescendants(
+        "root".to_string(),
+    ))]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert_eq!(node_ids(&view_payload), ids(&["auth", "charge", "gateway"]));
+    assert_eq!(subgraph_ids(&view_payload), ids(&["payments", "root"]));
+}
+
+#[test]
+fn view_selector_subgraph_anchor_keeps_container_without_descendants() {
+    let payload = output(
+        vec![
+            node("auth", "rectangle", Some("payments")),
+            node("charge", "rectangle", Some("payments")),
+        ],
+        vec![],
+        vec![subgraph("payments", &["auth", "charge"], None)],
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Anchor(
+        AnchorRef::Subgraph("payments".to_string()),
+    ))]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert!(view_payload.nodes.is_empty());
+    assert_eq!(view_payload.subgraphs.len(), 1);
+    assert_eq!(view_payload.subgraphs[0].id, "payments");
+    assert!(view_payload.subgraphs[0].children.is_empty());
+}
+
+#[test]
+fn view_selector_parent_and_shape_predicates_filter_nodes() {
+    let payload = output(
+        vec![
+            node("auth", "rectangle", Some("payments")),
+            node("db", "cylinder", Some("payments")),
+            node("cache", "cylinder", Some("internal")),
+        ],
+        vec![],
+        vec![
+            subgraph("payments", &["auth", "db"], None),
+            subgraph("internal", &["cache"], None),
+        ],
+    );
+    let spec = view(vec![
+        ViewStatement::Include(Selector::Predicate(NodePredicate::Parent(
+            "payments".to_string(),
+        ))),
+        ViewStatement::Exclude(Selector::Predicate(NodePredicate::Shape(
+            "rectangle".to_string(),
+        ))),
+    ]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert_eq!(node_ids(&view_payload), ids(&["db"]));
+}
+
+#[test]
+fn view_selector_unknown_anchor_returns_error() {
+    let payload = output(vec![node("gateway", "rectangle", None)], vec![], vec![]);
+    let spec = view(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("missing".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 1,
+    })]);
+
+    let error = apply_view(&payload, &spec).expect_err("missing anchor should fail");
+
+    assert_eq!(
+        error,
+        ViewError::UnknownAnchor {
+            id: "missing".to_string()
+        }
+    );
+}
+
+#[test]
+fn view_apply_keeps_node_positions_and_canonical_bounds() {
+    let payload = output(
+        vec![
+            Node {
+                position: Position { x: 20.0, y: 30.0 },
+                size: Size {
+                    width: 44.0,
+                    height: 22.0,
+                },
+                ..node("gateway", "rectangle", None)
+            },
+            node("internal", "rectangle", None),
+        ],
+        vec![],
+        vec![],
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Anchor(
+        AnchorRef::Node("gateway".to_string()),
+    ))]);
+
+    let (view_payload, events) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert_eq!(
+        view_payload.metadata.bounds.width,
+        payload.metadata.bounds.width
+    );
+    assert_eq!(
+        view_payload.metadata.bounds.height,
+        payload.metadata.bounds.height
+    );
+    assert_eq!(view_payload.nodes.len(), 1);
+    assert_eq!(view_payload.nodes[0].id, "gateway");
+    assert_eq!(view_payload.nodes[0].position.x, 20.0);
+    assert_eq!(view_payload.nodes[0].position.y, 30.0);
+    assert_eq!(view_payload.nodes[0].size.width, 44.0);
+    assert_eq!(view_payload.nodes[0].size.height, 22.0);
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ViewEvent::NodeLeftView { id, .. } if id == "internal"
+    )));
+}
+
+#[test]
+fn view_apply_preserves_sparse_surviving_edge_ids() {
+    let payload = output(
+        vec![
+            node("external", "rectangle", None),
+            node("gateway", "rectangle", None),
+            node("auth", "rectangle", None),
+            node("db", "cylinder", None),
+        ],
+        vec![
+            edge("e0", "external", "gateway"),
+            edge("e1", "gateway", "auth"),
+            edge("e2", "auth", "db"),
+        ],
+        vec![],
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("gateway".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 2,
+    })]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    let edge_ids: Vec<&str> = view_payload
+        .edges
+        .iter()
+        .map(|edge| edge.id.as_str())
+        .collect();
+    assert_eq!(edge_ids, vec!["e1", "e2"]);
+}
+
+#[test]
+fn view_apply_drops_edges_with_elided_endpoints() {
+    let payload = output(
+        vec![
+            node("gateway", "rectangle", None),
+            node("auth", "rectangle", None),
+            node("db", "cylinder", None),
+        ],
+        vec![edge("e0", "gateway", "auth"), edge("e1", "auth", "db")],
+        vec![],
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Anchor(
+        AnchorRef::Node("gateway".to_string()),
+    ))]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert!(view_payload.edges.is_empty());
+}
+
+#[test]
+fn view_apply_emits_node_and_edge_elision_events() {
+    let payload = output(
+        vec![
+            node("gateway", "rectangle", None),
+            node("auth", "rectangle", None),
+            node("db", "cylinder", None),
+        ],
+        vec![
+            edge_with_label("e0", "gateway", "auth", "first"),
+            edge_with_label("e1", "gateway", "auth", "second"),
+            edge("e2", "auth", "db"),
+        ],
+        vec![],
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Anchor(
+        AnchorRef::Node("gateway".to_string()),
+    ))]);
+
+    let (_, events) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert!(events.contains(&ViewEvent::NodeLeftView {
+        id: "auth".to_string(),
+        reason: ElisionReason::Excluded,
+    }));
+    assert!(events.contains(&ViewEvent::NodeLeftView {
+        id: "db".to_string(),
+        reason: ElisionReason::Excluded,
+    }));
+    assert!(events.contains(&ViewEvent::EdgeElided {
+        source: "gateway".to_string(),
+        target: "auth".to_string(),
+        ordinal: 0,
+        label: Some("first".to_string()),
+        reason: ElisionReason::EndpointOutsideView,
+    }));
+    assert!(events.contains(&ViewEvent::EdgeElided {
+        source: "gateway".to_string(),
+        target: "auth".to_string(),
+        ordinal: 1,
+        label: Some("second".to_string()),
+        reason: ElisionReason::EndpointOutsideView,
+    }));
+}
+
+#[test]
+fn view_apply_preserves_ancestor_subgraph_containers() {
+    let payload = output(
+        vec![
+            node("gateway", "rectangle", Some("root")),
+            node("auth", "rectangle", Some("payments")),
+            node("charge", "rectangle", Some("payments")),
+        ],
+        vec![],
+        vec![
+            subgraph("root", &["gateway"], None),
+            subgraph("payments", &["auth", "charge"], Some("root")),
+        ],
+    );
+    let spec = view(vec![
+        ViewStatement::Include(Selector::Predicate(NodePredicate::Parent(
+            "payments".to_string(),
+        ))),
+        ViewStatement::Exclude(Selector::Anchor(AnchorRef::Node("charge".to_string()))),
+    ]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    let node_ids: Vec<&str> = view_payload
+        .nodes
+        .iter()
+        .map(|node| node.id.as_str())
+        .collect();
+    let subgraph_ids: Vec<&str> = view_payload
+        .subgraphs
+        .iter()
+        .map(|subgraph| subgraph.id.as_str())
+        .collect();
+
+    assert_eq!(node_ids, vec!["auth"]);
+    assert_eq!(subgraph_ids, vec!["root", "payments"]);
+    assert_eq!(view_payload.subgraphs[0].children, Vec::<String>::new());
+    assert_eq!(view_payload.subgraphs[1].children, vec!["auth".to_string()]);
+}
+
+#[test]
+fn view_apply_rejects_unimplemented_layout_modes() {
+    let payload = output(vec![node("gateway", "rectangle", None)], vec![], vec![]);
+    let spec = ViewSpec {
+        layout: LayoutMode::Compact,
+        statements: vec![ViewStatement::Include(Selector::Anchor(AnchorRef::Node(
+            "gateway".to_string(),
+        )))],
+        ..ViewSpec::default()
+    };
+
+    let error = apply_view(&payload, &spec).expect_err("compact mode is deferred");
+
+    assert_eq!(
+        error,
+        ViewError::NotImplementedYet {
+            feature: "non-shared-coordinate layout modes".to_string()
+        }
+    );
+}
+
+#[test]
+fn view_apply_marks_shared_coordinates_view_payload() {
+    let payload = output(vec![node("gateway", "rectangle", None)], vec![], vec![]);
+    let spec = view(vec![ViewStatement::Include(Selector::Anchor(
+        AnchorRef::Node("gateway".to_string()),
+    ))]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    let marker = view_payload
+        .extensions
+        .get(VIEW_EXTENSION_NAMESPACE)
+        .expect("view payload should carry a view extension marker");
+    assert_eq!(
+        marker.get("layout_mode").and_then(Value::as_str),
+        Some("shared_coordinates")
+    );
+    assert_eq!(
+        marker.get("boundary_policy").and_then(Value::as_str),
+        Some("omit")
+    );
+}
+
+#[test]
+fn view_apply_preserves_text_projection_under_render_namespace() {
+    let mut payload = output(
+        vec![
+            node("gateway", "rectangle", None),
+            node("auth", "rectangle", None),
+        ],
+        vec![edge("e0", "gateway", "auth")],
+        vec![],
+    );
+    payload.extensions.insert(
+        TEXT_EXTENSION_NAMESPACE.to_string(),
+        text_projection_extension(),
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("gateway".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 1,
+    })]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert!(
+        view_payload
+            .extensions
+            .contains_key(TEXT_EXTENSION_NAMESPACE)
+    );
+    let projection = projection(&view_payload, TEXT_EXTENSION_NAMESPACE);
+    assert!(projection.contains_key("node_ranks"));
+}
+
+#[test]
+fn view_apply_prunes_node_ranks_to_retained_nodes() {
+    let mut payload = output(
+        vec![
+            node("gateway", "rectangle", None),
+            node("auth", "rectangle", None),
+            node("db", "cylinder", None),
+            node("internal", "rectangle", None),
+        ],
+        vec![edge("e0", "gateway", "auth"), edge("e1", "auth", "db")],
+        vec![],
+    );
+    payload.extensions.insert(
+        TEXT_EXTENSION_NAMESPACE.to_string(),
+        text_projection_extension(),
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("gateway".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 1,
+    })]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    let node_ranks = projection(&view_payload, TEXT_EXTENSION_NAMESPACE)
+        .get("node_ranks")
+        .and_then(Value::as_object)
+        .expect("node ranks should remain present");
+    let retained: BTreeSet<&str> = node_ranks.keys().map(String::as_str).collect();
+    assert_eq!(retained, BTreeSet::from(["auth", "gateway"]));
+    assert_eq!(node_ranks.get("gateway"), Some(&json!(0)));
+    assert_eq!(node_ranks.get("auth"), Some(&json!(2)));
+}
+
+#[test]
+fn view_apply_does_not_emit_legacy_text_namespace() {
+    let mut payload = output(vec![node("gateway", "rectangle", None)], vec![], vec![]);
+    payload.extensions.insert(
+        TEXT_EXTENSION_NAMESPACE.to_string(),
+        text_projection_extension(),
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Anchor(
+        AnchorRef::Node("gateway".to_string()),
+    ))]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    assert!(
+        !view_payload
+            .extensions
+            .contains_key(LEGACY_TEXT_EXTENSION_NAMESPACE)
+    );
+}
+
+#[test]
+fn view_apply_drops_edge_indexed_text_projection_keys() {
+    let mut payload = output(
+        vec![
+            node("gateway", "rectangle", None),
+            node("auth", "rectangle", None),
+            node("db", "cylinder", None),
+        ],
+        vec![edge("e0", "gateway", "auth"), edge("e1", "auth", "db")],
+        vec![],
+    );
+    payload.extensions.insert(
+        TEXT_EXTENSION_NAMESPACE.to_string(),
+        text_projection_extension(),
+    );
+    let spec = view(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("gateway".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 1,
+    })]);
+
+    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+
+    let projection = projection(&view_payload, TEXT_EXTENSION_NAMESPACE);
+    assert!(!projection.contains_key("edge_waypoints"));
+    assert!(!projection.contains_key("label_positions"));
+}
+
+#[test]
+fn view_mmds_replay_enables_pinned_text_ranks_for_marked_payload() {
+    let (view_payload, plain_payload, _) = view_replay_payloads();
+
+    let marked_text = render_mmds_payload(&view_payload, OutputFormat::Text);
+    let plain_text = render_mmds_payload(&plain_payload, OutputFormat::Text);
+
+    assert!(
+        marked_text.lines().count() > plain_text.lines().count(),
+        "marked view replay should preserve sparse pinned ranks\nmarked:\n{marked_text}\nplain:\n{plain_text}"
+    );
+}
+
+#[test]
+fn plain_mmds_replay_keeps_pinned_text_ranks_disabled() {
+    let (_, plain_payload, no_projection_payload) = view_replay_payloads();
+
+    let plain_text = render_mmds_payload(&plain_payload, OutputFormat::Text);
+    let no_projection_text = render_mmds_payload(&no_projection_payload, OutputFormat::Text);
+
+    assert_eq!(plain_text, no_projection_text);
+}
+
+#[test]
+fn view_mmds_replay_leaves_svg_and_mmds_paths_schema_clean() {
+    let (view_payload, _, _) = view_replay_payloads();
+
+    let svg = render_mmds_payload(&view_payload, OutputFormat::Svg);
+    let mmds = render_mmds_payload(&view_payload, OutputFormat::Mmds);
+    let replayed: Document =
+        serde_json::from_str(&mmds).expect("MMDS replay should stay valid JSON");
+
+    assert!(svg.starts_with("<svg"));
+    assert!(!svg.contains(VIEW_EXTENSION_NAMESPACE));
+    assert!(replayed.extensions.contains_key(VIEW_EXTENSION_NAMESPACE));
+    assert!(replayed.extensions.contains_key(TEXT_EXTENSION_NAMESPACE));
+}
+
+#[test]
+fn view_canary_mmds_output_preserves_sparse_edge_ids() {
+    let replayed: Document = serde_json::from_str(&render_canary_view(OutputFormat::Mmds))
+        .expect("view replay should produce valid MMDS");
+
+    assert_eq!(edge_ids(&replayed), vec!["e0", "e2", "e4"]);
+}
+
+#[test]
+fn view_canary_sparse_edge_ids_render_across_all_surfaces() {
+    let mmds = render_canary_view(OutputFormat::Mmds);
+    let svg = render_canary_view(OutputFormat::Svg);
+    let text = render_canary_view(OutputFormat::Text);
+    let replayed: Document = serde_json::from_str(&mmds).expect("view MMDS should parse");
+
+    assert_eq!(edge_ids(&replayed), vec!["e0", "e2", "e4"]);
+    assert!(svg.starts_with("<svg"));
+    assert!(text.contains("Service A"));
+}
+
+#[test]
+fn view_canary_svg_renders_filtered_payload() {
+    let svg = render_canary_view(OutputFormat::Svg);
+
+    assert!(svg.contains("Service A"));
+    assert!(svg.contains("Service B"));
+    assert!(svg.contains("Service C"));
+    assert!(svg.contains("Audit"));
+    assert!(!svg.contains("External"));
+    assert!(!svg.contains("Database"));
+}
+
+#[test]
+fn view_replay_text_renders_with_pinned_shared_coordinates() {
+    let (view_payload, plain_payload, _) = view_replay_payloads();
+
+    let marked_text = render_mmds_payload(&view_payload, OutputFormat::Text);
+    let plain_text = render_mmds_payload(&plain_payload, OutputFormat::Text);
+
+    assert!(marked_text.contains("gateway"));
+    assert!(marked_text.contains("auth"));
+    assert!(marked_text.lines().count() > plain_text.lines().count());
+}
+
+#[test]
+fn view_canary_text_carries_producer_generated_pinned_ranks() {
+    let (view_payload, plain_payload) = canary_view_replay_payloads();
+
+    let node_ids: BTreeSet<&str> = view_payload
+        .nodes
+        .iter()
+        .map(|node| node.id.as_str())
+        .collect();
+    let node_ranks = projection(&view_payload, TEXT_EXTENSION_NAMESPACE)
+        .get("node_ranks")
+        .and_then(Value::as_object)
+        .expect("producer-generated node ranks should be retained");
+    let rank_ids: BTreeSet<&str> = node_ranks.keys().map(String::as_str).collect();
+
+    assert!(
+        view_payload
+            .extensions
+            .contains_key(VIEW_EXTENSION_NAMESPACE)
+    );
+    assert!(
+        !plain_payload
+            .extensions
+            .contains_key(VIEW_EXTENSION_NAMESPACE)
+    );
+    assert_eq!(edge_ids(&view_payload), vec!["e0", "e2", "e4"]);
+    assert_eq!(
+        node_ids,
+        BTreeSet::from(["audit", "service_a", "service_b", "service_c"])
+    );
+    assert_eq!(rank_ids, node_ids);
+    assert!(!node_ranks.contains_key("external"));
+    assert!(!node_ranks.contains_key("database"));
+    assert!(node_ranks.values().all(Value::is_number));
+
+    let marked_text = render_mmds_payload(&view_payload, OutputFormat::Text);
+    let plain_text = render_mmds_payload(&plain_payload, OutputFormat::Text);
+
+    assert!(marked_text.contains("Service A"));
+    assert!(marked_text.contains("Service B"));
+    assert!(marked_text.contains("Service C"));
+    assert!(marked_text.contains("Audit"));
+    assert!(!marked_text.contains("External"));
+    assert!(!marked_text.contains("Database"));
+    assert!(plain_text.contains("Service A"));
+}
+
+#[test]
+fn view_canary_deferred_primitives_return_not_implemented() {
+    let payload = canary_canonical_output();
+    let cases = [
+        (
+            ViewSpec {
+                boundary: mmdflux::views::BoundaryPolicy::Stub {
+                    aggregate_threshold: 3,
+                },
+                ..canary_view_spec()
+            },
+            "boundary stubs",
+        ),
+        (
+            view(vec![ViewStatement::Include(Selector::Predicate(
+                NodePredicate::Tag("critical".to_string()),
+            ))]),
+            "tag predicates",
+        ),
+        (
+            view(vec![ViewStatement::Include(Selector::Anchor(
+                AnchorRef::Edge(mmdflux::views::EdgeAnchor {
+                    source: "service_a".to_string(),
+                    target: "service_b".to_string(),
+                    ordinal: 0,
+                    label: None,
+                }),
+            ))]),
+            "edge anchors",
+        ),
+        (
+            ViewSpec {
+                layout: LayoutMode::Compact,
+                ..canary_view_spec()
+            },
+            "non-shared-coordinate layout modes",
+        ),
+        (
+            ViewSpec {
+                compound: mmdflux::views::CompoundPolicy::Flatten,
+                ..canary_view_spec()
+            },
+            "compound flattening",
+        ),
+    ];
+
+    for (spec, feature) in cases {
+        let error = apply_view(&payload, &spec).expect_err("deferred feature should fail");
+        assert_eq!(
+            error,
+            ViewError::NotImplementedYet {
+                feature: feature.to_string()
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the first materialized diagram view slice for graph-family MMDS documents. This introduces a public `views` module with `ViewSpec`, selectors, `apply_view`, view events, view errors, and explicit `NotImplementedYet` handling for follow-up primitives.

The v1 contract supports node anchors, traversal selectors, parent and shape predicates, recursive subgraph inclusion, shared-coordinate view materialization, sparse canonical edge ID preservation, and filtered text projection metadata. It marks materialized MMDS views with a top-level view extension so replay can opt into pinned text ranks.

The public view surface is intentionally narrow: callers get `apply_view` plus the spec, event, error, and namespace types needed to materialize a document. Selector keep-set evaluation remains internal so we do not freeze an intermediate API shape before edge anchors, boundary stubs, and richer view events land.

This also renames the graph-family typed MMDS envelope from `mmds::Output` to `mmds::Document` and moves the crate-private implementation module from `mmds::output` to `mmds::document`. Hidden deprecated compatibility shims remain for the old `Output`/`from_output` names, while internal code, tests, rustdocs, examples, and Markdown docs now use `Document` terminology.

The typed runtime API now includes `materialize_diagram` for materializing an `mmds::Document` directly and `render_mmds_document` for replaying an already parsed document without a JSON intermediary. `Document` also implements `FromStr` and `TryFrom<&str>` for idiomatic MMDS JSON parsing.

## Why

Plan 0171 frames diagram querying as a CQRS-style read-side/materialized-view contract rather than a general graph query language. This gives larger diagrams a small, explicit API for filtered/pivoted read models while keeping unsupported primitives honest and forward-compatible.

The `Document` naming better matches how the value is used now: it is not merely renderer output, but the typed graph-family MMDS document that can be parsed, materialized, viewed, and replay-rendered.

## User / Developer Impact

- Public API callers can materialize filtered MMDS diagram views through `mmdflux::views::apply_view`.
- `materialize_diagram` returns a typed `mmds::Document` directly from Mermaid or graph-family MMDS input.
- `render_mmds_document` renders a typed document to Text, SVG, or MMDS without serializing through `render_diagram`.
- `runtime::mmds` replay helpers remain crate-private; rendering stays behind the runtime facade.
- Consumers can correlate surviving edges by their original sparse `e{i}` IDs.
- Deferred features such as tag predicates, edge anchors, boundary stubs, and non-shared layout modes return `NotImplementedYet` instead of silently degrading.
- Architecture boundaries keep `views` dependent only on `mmds`.
- Docs and examples describe the supported v1 surface and the direct typed replay path.

## Validation

- `cargo run --example materialized_view`
- `cargo test --examples`
- `cargo test --doc`
- `cargo nextest run --test mmds_views --test lib_exports --test mmds_json`
- `RUSTDOCFLAGS="-D warnings" cargo +stable doc --no-deps`
- `just architecture-check`
- `just check`
- `cog check "origin/main..HEAD"`
