### PR TITLE
test: add synchronous MMDS command processor

### DIFF
--- a/src/internal_tests/mmds_commands.rs
+++ b/src/internal_tests/mmds_commands.rs
@@ -1,10 +1,1212 @@
-use serde_json::json;
+use std::fs;
+use std::path::Path;
 
+use serde_json::{Map, Value, json};
+
+use super::layout_stability::mutations;
+use crate::graph::GeometryLevel;
 use crate::mmds::commands::{
-    Command, EdgeSelector, MmdsDiffKindRole, commandable_diff_kinds, diff_kind_for_command,
-    diff_kind_role, geometry_effect_diff_kinds,
+    Command, CommandApplyError, EdgeSelector, MmdsDiffKindRole, apply, commandable_diff_kinds,
+    diff_kind_for_command, diff_kind_role, geometry_effect_diff_kinds,
+    relayout_output_for_command_apply,
 };
-use crate::mmds::diff::MmdsDiffKind;
+use crate::mmds::diff::{MmdsDiffKind, MmdsDiffSubject};
+use crate::mmds::{NODE_STYLE_EXTENSION_NAMESPACE, TEXT_EXTENSION_NAMESPACE};
+use crate::{OutputFormat, RenderConfig};
+
+#[test]
+fn mmds_command_apply_returns_result_error_surface() {
+    let mut output = parse_routed_for_command_apply("graph TD; A --> B");
+
+    let result = apply(
+        &Command::RemoveNode {
+            id: "Missing".to_string(),
+        },
+        &mut output,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::NodeNotFound { id }) if id == "Missing"
+    ));
+}
+
+#[test]
+fn mmds_command_apply_target_relayout_preserves_semantic_output() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    output
+        .nodes
+        .iter_mut()
+        .find(|node| node.id == "A")
+        .expect("node A should exist")
+        .label = "Alpha".into();
+
+    let relaid = relayout_output_for_command_apply(&output).expect("relayout should succeed");
+
+    assert_eq!(node_label(&relaid, "A"), "Alpha");
+    assert_eq!(relaid.geometry_level, output.geometry_level);
+    assert!(relaid.metadata.bounds.width > 0.0);
+}
+
+#[test]
+fn mmds_command_apply_target_relayout_preserves_existing_dense_edge_ids() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    B --> C\n");
+    let before_ids = edge_ids(&output);
+    output
+        .nodes
+        .iter_mut()
+        .find(|node| node.id == "A")
+        .expect("node A should exist")
+        .label = "Alpha".into();
+
+    let relaid = relayout_output_for_command_apply(&output).expect("relayout should succeed");
+
+    assert_eq!(edge_ids(&relaid), before_ids);
+}
+
+#[test]
+fn mmds_command_apply_target_relayout_documents_profile_and_extension_policy() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    output.profiles = vec!["custom-profile".to_string()];
+    output.extensions.insert(
+        TEXT_EXTENSION_NAMESPACE.to_string(),
+        map_from_pairs([("projection", json!({ "note": "caller-owned" }))]),
+    );
+    output.extensions.insert(
+        NODE_STYLE_EXTENSION_NAMESPACE.to_string(),
+        map_from_pairs([(
+            "nodes",
+            json!({
+                "A": {
+                    "fill": "#abcdef",
+                    "color": "#123456"
+                }
+            }),
+        )]),
+    );
+
+    let relaid = relayout_output_for_command_apply(&output).expect("relayout should succeed");
+
+    assert!(!relaid.profiles.contains(&"custom-profile".to_string()));
+    assert!(relaid.extensions.contains_key(TEXT_EXTENSION_NAMESPACE));
+    assert!(
+        relaid.extensions[TEXT_EXTENSION_NAMESPACE]["projection"]
+            .get("note")
+            .is_none()
+    );
+    assert_eq!(
+        relaid.extensions[NODE_STYLE_EXTENSION_NAMESPACE]["nodes"]["A"]["fill"],
+        "#abcdef"
+    );
+    assert_eq!(
+        relaid.extensions[NODE_STYLE_EXTENSION_NAMESPACE]["nodes"]["A"]["color"],
+        "#123456"
+    );
+}
+
+#[test]
+fn mmds_command_apply_target_reconnect_diff_is_edge_reconnected() {
+    let before = parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n");
+    let mut changed = before.clone();
+    changed
+        .edges
+        .iter_mut()
+        .find(|edge| edge.id == "e0")
+        .expect("edge e0 should exist")
+        .target = "C".into();
+
+    let relaid = relayout_output_for_command_apply(&changed).expect("relayout should succeed");
+    let diff = crate::mmds::diff::diff_outputs(&before, &relaid);
+
+    assert!(diff.has_event(MmdsDiffKind::EdgeReconnected, "e0"));
+    assert!(diff.events.iter().any(|event| {
+        event.kind == MmdsDiffKind::EdgeReconnected
+            && event.evidence_mentions("matched_by=id_reconnected")
+    }));
+}
+
+#[test]
+fn mmds_command_apply_edge_selector_id_matches_exact_edge() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A -->|old| B\n");
+
+    let events = apply(
+        &Command::ChangeEdgeLabel {
+            edge: EdgeSelector::Id("e0".to_string()),
+            label: Some("new".to_string()),
+        },
+        &mut output,
+    )
+    .expect("edge selector should resolve");
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].kind, MmdsDiffKind::EdgeLabelChanged);
+    assert!(matches!(
+        &events[0].subject,
+        crate::mmds::diff::MmdsDiffSubject::Edge(id) if id == "e0"
+    ));
+}
+
+#[test]
+fn mmds_command_apply_edge_selector_semantic_ambiguous_errors() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    A --> B\n");
+
+    let result = apply(
+        &Command::ChangeEdgeLabel {
+            edge: EdgeSelector::Semantic {
+                source: "A".to_string(),
+                target: "B".to_string(),
+                label: None,
+                stroke: None,
+                arrow_start: None,
+                arrow_end: None,
+                minlen: None,
+            },
+            label: Some("new".to_string()),
+        },
+        &mut output,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::EdgeSelectorAmbiguous { matches, .. })
+            if matches == vec!["e0".to_string(), "e1".to_string()]
+    ));
+}
+
+#[test]
+fn mmds_command_apply_edge_selector_semantic_no_match_errors() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+
+    let result = apply(
+        &Command::ChangeEdgeLabel {
+            edge: EdgeSelector::Semantic {
+                source: "A".to_string(),
+                target: "C".to_string(),
+                label: None,
+                stroke: None,
+                arrow_start: None,
+                arrow_end: None,
+                minlen: None,
+            },
+            label: Some("new".to_string()),
+        },
+        &mut output,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::EdgeSelectorNoMatch { .. })
+    ));
+}
+
+#[test]
+fn mmds_command_apply_add_edge_id_none_uses_next_dense_id() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n");
+
+    let events = apply(&add_edge_command(None), &mut output).expect("add edge should apply");
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].kind, MmdsDiffKind::EdgeAdded);
+    assert!(matches!(
+        &events[0].subject,
+        crate::mmds::diff::MmdsDiffSubject::Edge(id) if id == "e1"
+    ));
+    assert!(output.edges.iter().any(|edge| edge.id == "e1"));
+}
+
+#[test]
+fn mmds_command_apply_add_edge_id_accepts_next_dense_id() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n");
+
+    let events = apply(&add_edge_command(Some("e1")), &mut output).expect("add edge should apply");
+
+    assert_eq!(events[0].kind, MmdsDiffKind::EdgeAdded);
+    assert!(output.edges.iter().any(|edge| edge.id == "e1"));
+}
+
+#[test]
+fn mmds_command_apply_add_edge_id_rejects_collision() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n");
+
+    let result = apply(&add_edge_command(Some("e0")), &mut output);
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::AddEdgeIdCollision { id }) if id == "e0"
+    ));
+}
+
+#[test]
+fn mmds_command_apply_add_edge_id_rejects_custom_id() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n");
+
+    let result = apply(&add_edge_command(Some("edge-stable")), &mut output);
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::AddEdgeIdUnsupported { id, expected })
+            if id == "edge-stable" && expected == "e1"
+    ));
+}
+
+#[test]
+fn mmds_command_apply_in_place_sets_profiles_without_geometry_change() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetProfiles {
+            profiles: vec!["custom-profile".to_string()],
+        },
+        &mut output,
+    )
+    .expect("set profiles should apply");
+
+    assert_eq!(output.profiles, vec!["custom-profile".to_string()]);
+    assert_primary_event(&events, MmdsDiffKind::ProfileChanged, "");
+    assert_in_place_diff(&before, &output, MmdsDiffKind::ProfileChanged, "");
+}
+
+#[test]
+fn mmds_command_apply_in_place_sets_extension_without_geometry_change() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetExtension {
+            namespace: "example.extension".to_string(),
+            value: json!({ "enabled": true }),
+        },
+        &mut output,
+    )
+    .expect("set extension should apply");
+
+    assert_eq!(output.extensions["example.extension"]["enabled"], true);
+    assert_primary_event(&events, MmdsDiffKind::ExtensionChanged, "");
+    assert_in_place_diff(&before, &output, MmdsDiffKind::ExtensionChanged, "");
+}
+
+#[test]
+fn mmds_command_apply_in_place_sets_node_style_extension() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetNodeStyleExtension {
+            node: "A".to_string(),
+            value: json!({ "fill": "#abcdef" }),
+        },
+        &mut output,
+    )
+    .expect("set node style extension should apply");
+
+    assert_eq!(
+        output.extensions[NODE_STYLE_EXTENSION_NAMESPACE]["nodes"]["A"]["fill"],
+        "#abcdef"
+    );
+    assert_primary_event(&events, MmdsDiffKind::NodeStyleChanged, "A");
+    assert_in_place_diff(&before, &output, MmdsDiffKind::NodeStyleChanged, "A");
+}
+
+#[test]
+fn mmds_command_apply_in_place_sets_node_style_extension_missing_node_errors() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+
+    let result = apply(
+        &Command::SetNodeStyleExtension {
+            node: "Missing".to_string(),
+            value: json!({ "fill": "#abcdef" }),
+        },
+        &mut output,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::NodeNotFound { id }) if id == "Missing"
+    ));
+}
+
+#[test]
+fn mmds_command_apply_in_place_changes_subgraph_title() {
+    let mut output =
+        parse_routed_for_command_apply("graph TD\n    subgraph sg1[Group]\n    A --> B\n    end\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::ChangeSubgraphTitle {
+            subgraph: "sg1".to_string(),
+            title: Some("Pipeline".to_string()),
+        },
+        &mut output,
+    )
+    .expect("change subgraph title should apply");
+
+    assert_eq!(subgraph_title(&output, "sg1"), "Pipeline");
+    assert_primary_event(&events, MmdsDiffKind::SubgraphTitleChanged, "sg1");
+    assert_in_place_diff(&before, &output, MmdsDiffKind::SubgraphTitleChanged, "sg1");
+}
+
+#[test]
+fn mmds_command_apply_in_place_changes_subgraph_title_missing_subgraph_errors() {
+    let mut output =
+        parse_routed_for_command_apply("graph TD\n    subgraph sg1[Group]\n    A --> B\n    end\n");
+
+    let result = apply(
+        &Command::ChangeSubgraphTitle {
+            subgraph: "missing".to_string(),
+            title: Some("Pipeline".to_string()),
+        },
+        &mut output,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::SubgraphNotFound { id }) if id == "missing"
+    ));
+}
+
+#[test]
+fn mmds_command_apply_relayout_sets_geometry_level() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetGeometryLevel {
+            level: "layout".to_string(),
+        },
+        &mut output,
+    )
+    .expect("set geometry level should apply");
+
+    assert_eq!(output.geometry_level, "layout");
+    assert_primary_event(&events, MmdsDiffKind::GeometryLevelChanged, "");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::GeometryLevelChanged, "")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_sets_direction() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetDirection {
+            direction: "LR".to_string(),
+        },
+        &mut output,
+    )
+    .expect("set direction should apply");
+
+    assert_eq!(output.metadata.direction, "LR");
+    assert_primary_event(&events, MmdsDiffKind::DirectionChanged, "");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::DirectionChanged, "")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_sets_engine() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetEngine {
+            engine: Some("mermaid-layered".to_string()),
+        },
+        &mut output,
+    )
+    .expect("set engine should apply");
+
+    assert_eq!(output.metadata.engine.as_deref(), Some("mermaid-layered"));
+    assert_primary_event(&events, MmdsDiffKind::EngineChanged, "");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::EngineChanged, "")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_invalid_document_config_rolls_back() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let result = apply(
+        &Command::SetDirection {
+            direction: "SIDEWAYS".to_string(),
+        },
+        &mut output,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::RelayoutFailed { .. })
+    ));
+    assert_output_eq(&output, &before);
+}
+
+#[test]
+fn mmds_command_apply_relayout_invalid_engine_config_rolls_back() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    assert_apply_error_preserves_output(
+        &mut output,
+        Command::SetEngine {
+            engine: Some("not-a-real-engine".to_string()),
+        },
+        |error| matches!(error, CommandApplyError::RelayoutFailed { stage, .. } if stage == "config"),
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_adds_node() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::AddNode {
+            id: "C".to_string(),
+            label: "Gamma".to_string(),
+            shape: "rectangle".to_string(),
+            parent: None,
+        },
+        &mut output,
+    )
+    .expect("add node should apply");
+
+    assert_eq!(node_label(&output, "C"), "Gamma");
+    assert_primary_event(&events, MmdsDiffKind::NodeAdded, "C");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output).has_event(MmdsDiffKind::NodeAdded, "C")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_removes_node() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::RemoveNode {
+            id: "C".to_string(),
+        },
+        &mut output,
+    )
+    .expect("remove node should apply");
+
+    assert!(!output.nodes.iter().any(|node| node.id == "C"));
+    assert_primary_event(&events, MmdsDiffKind::NodeRemoved, "C");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output).has_event(MmdsDiffKind::NodeRemoved, "C")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_changes_node_label() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A[Old] --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::ChangeNodeLabel {
+            node: "A".to_string(),
+            label: "Alpha".to_string(),
+        },
+        &mut output,
+    )
+    .expect("change node label should apply");
+
+    assert_eq!(node_label(&output, "A"), "Alpha");
+    assert_primary_event(&events, MmdsDiffKind::NodeLabelChanged, "A");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::NodeLabelChanged, "A")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_changes_node_shape() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A[Old] --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::ChangeNodeShape {
+            node: "A".to_string(),
+            shape: "stadium".to_string(),
+        },
+        &mut output,
+    )
+    .expect("change node shape should apply");
+
+    assert_eq!(node_shape(&output, "A"), "stadium");
+    assert_primary_event(&events, MmdsDiffKind::NodeShapeChanged, "A");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::NodeShapeChanged, "A")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_sets_node_parent() {
+    let mut output = parse_routed_for_command_apply(
+        "graph TD\n    subgraph sg1[Group]\n    B\n    end\n    A[Alpha]\n",
+    );
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetNodeParent {
+            node: "A".to_string(),
+            parent: Some("sg1".to_string()),
+        },
+        &mut output,
+    )
+    .expect("set node parent should apply");
+
+    assert_eq!(node_parent(&output, "A").as_deref(), Some("sg1"));
+    assert_primary_event(&events, MmdsDiffKind::NodeParentChanged, "A");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::NodeParentChanged, "A")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_add_node_duplicate_errors_without_mutation() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let result = apply(
+        &Command::AddNode {
+            id: "A".to_string(),
+            label: "Duplicate".to_string(),
+            shape: "rectangle".to_string(),
+            parent: None,
+        },
+        &mut output,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::SubjectAlreadyExists { id }) if id == "A"
+    ));
+    assert_output_eq(&output, &before);
+}
+
+#[test]
+fn mmds_command_apply_relayout_set_node_parent_missing_subgraph_errors_without_mutation() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let result = apply(
+        &Command::SetNodeParent {
+            node: "A".to_string(),
+            parent: Some("missing".to_string()),
+        },
+        &mut output,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::SubgraphNotFound { id }) if id == "missing"
+    ));
+    assert_output_eq(&output, &before);
+}
+
+#[test]
+fn mmds_command_apply_relayout_adds_edge() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n");
+    let before = output.clone();
+
+    let events = apply(&add_edge_command(None), &mut output).expect("add edge should apply");
+
+    let edge = edge_by_id(&output, "e1");
+    assert_eq!(edge.source, "A");
+    assert_eq!(edge.target, "C");
+    assert!(edge.path.is_some(), "added edge should be routed");
+    assert_primary_event(&events, MmdsDiffKind::EdgeAdded, "e1");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output).has_event(MmdsDiffKind::EdgeAdded, "e1")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_removes_edge() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    B --> C\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::RemoveEdge {
+            edge: EdgeSelector::Id("e1".to_string()),
+        },
+        &mut output,
+    )
+    .expect("remove edge should apply");
+
+    assert!(!output.edges.iter().any(|edge| edge.id == "e1"));
+    assert_primary_event(&events, MmdsDiffKind::EdgeRemoved, "e1");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::EdgeRemoved, "e1")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_reconnects_edge() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::ReconnectEdge {
+            edge: EdgeSelector::Id("e0".to_string()),
+            source: "A".to_string(),
+            target: "C".to_string(),
+        },
+        &mut output,
+    )
+    .expect("reconnect edge should apply");
+
+    let edge = edge_by_id(&output, "e0");
+    assert_eq!(edge.source, "A");
+    assert_eq!(edge.target, "C");
+    assert_primary_event(&events, MmdsDiffKind::EdgeReconnected, "e0");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::EdgeReconnected, "e0")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_sets_edge_endpoint_intent() {
+    let mut output = parse_routed_for_command_apply(
+        "graph TD\n    subgraph sg1[Source]\n    A\n    end\n    subgraph sg2[Target]\n    B\n    end\n    A --> B\n",
+    );
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetEdgeEndpointIntent {
+            edge: EdgeSelector::Id("e0".to_string()),
+            from_subgraph: Some("sg1".to_string()),
+            to_subgraph: Some("sg2".to_string()),
+        },
+        &mut output,
+    )
+    .expect("set endpoint intent should apply");
+
+    let edge = edge_by_id(&output, "e0");
+    assert_eq!(edge.from_subgraph.as_deref(), Some("sg1"));
+    assert_eq!(edge.to_subgraph.as_deref(), Some("sg2"));
+    assert_primary_event(&events, MmdsDiffKind::EdgeEndpointIntentChanged, "e0");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::EdgeEndpointIntentChanged, "e0")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_changes_edge_label() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A -->|x| B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::ChangeEdgeLabel {
+            edge: EdgeSelector::Id("e0".to_string()),
+            label: Some("much longer label".to_string()),
+        },
+        &mut output,
+    )
+    .expect("change edge label should apply");
+
+    let edge = edge_by_id(&output, "e0");
+    assert_eq!(edge.label.as_deref(), Some("much longer label"));
+    assert_ne!(
+        before.edges[0].label_rect.as_ref().map(|rect| rect.width),
+        edge.label_rect.as_ref().map(|rect| rect.width)
+    );
+    assert_primary_event(&events, MmdsDiffKind::EdgeLabelChanged, "e0");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::EdgeLabelChanged, "e0")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_changes_edge_style() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::ChangeEdgeStyle {
+            edge: EdgeSelector::Id("e0".to_string()),
+            stroke: Some("dotted".to_string()),
+            arrow_start: Some("circle".to_string()),
+            arrow_end: Some("diamond".to_string()),
+            minlen: Some(2),
+        },
+        &mut output,
+    )
+    .expect("change edge style should apply");
+
+    let edge = edge_by_id(&output, "e0");
+    assert_eq!(edge.stroke, "dotted");
+    assert_eq!(edge.arrow_start, "circle");
+    assert_eq!(edge.arrow_end, "diamond");
+    assert_eq!(edge.minlen, 2);
+    assert_primary_event(&events, MmdsDiffKind::EdgeStyleChanged, "e0");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::EdgeStyleChanged, "e0")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_ambiguous_selector_errors_without_mutation() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    A --> B\n");
+    let before = output.clone();
+
+    let result = apply(
+        &Command::RemoveEdge {
+            edge: EdgeSelector::Semantic {
+                source: "A".to_string(),
+                target: "B".to_string(),
+                label: None,
+                stroke: None,
+                arrow_start: None,
+                arrow_end: None,
+                minlen: None,
+            },
+        },
+        &mut output,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::EdgeSelectorAmbiguous { .. })
+    ));
+    assert_output_eq(&output, &before);
+}
+
+#[test]
+fn mmds_command_apply_relayout_reconnect_preserves_edge_fields() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A -->|calls| B\n    C[Gamma]\n");
+    {
+        let edge = output
+            .edges
+            .iter_mut()
+            .find(|edge| edge.id == "e0")
+            .expect("edge e0 should exist");
+        edge.stroke = "dashed".to_string();
+        edge.arrow_start = "circle".to_string();
+        edge.arrow_end = "diamond".to_string();
+        edge.minlen = 2;
+    }
+
+    apply(
+        &Command::ReconnectEdge {
+            edge: EdgeSelector::Id("e0".to_string()),
+            source: "A".to_string(),
+            target: "C".to_string(),
+        },
+        &mut output,
+    )
+    .expect("reconnect edge should apply");
+
+    let edge = edge_by_id(&output, "e0");
+    assert_eq!(edge.source, "A");
+    assert_eq!(edge.target, "C");
+    assert_eq!(edge.label.as_deref(), Some("calls"));
+    assert_eq!(edge.stroke, "dashed");
+    assert_eq!(edge.arrow_start, "circle");
+    assert_eq!(edge.arrow_end, "diamond");
+    assert_eq!(edge.minlen, 2);
+}
+
+#[test]
+fn mmds_command_apply_relayout_adds_subgraph() {
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::AddSubgraph {
+            id: "sg1".to_string(),
+            title: Some("Group".to_string()),
+            parent: None,
+            direction: Some("LR".to_string()),
+            children: vec!["A".to_string()],
+            concurrent_regions: Vec::new(),
+            invisible: false,
+        },
+        &mut output,
+    )
+    .expect("add subgraph should apply");
+
+    assert_eq!(subgraph_title(&output, "sg1"), "Group");
+    assert_eq!(node_parent(&output, "A").as_deref(), Some("sg1"));
+    assert_primary_event(&events, MmdsDiffKind::SubgraphAdded, "sg1");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::SubgraphAdded, "sg1")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_removes_subgraph() {
+    let mut output =
+        parse_routed_for_command_apply("graph TD\n    subgraph sg1[Group]\n    A\n    end\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::RemoveSubgraph {
+            id: "sg1".to_string(),
+        },
+        &mut output,
+    )
+    .expect("remove subgraph should apply");
+
+    assert!(!output.subgraphs.iter().any(|subgraph| subgraph.id == "sg1"));
+    assert_eq!(node_parent(&output, "A"), None);
+    assert_primary_event(&events, MmdsDiffKind::SubgraphRemoved, "sg1");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::SubgraphRemoved, "sg1")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_sets_subgraph_direction() {
+    let mut output =
+        parse_routed_for_command_apply("graph TD\n    subgraph sg1[Group]\n    A\n    end\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetSubgraphDirection {
+            subgraph: "sg1".to_string(),
+            direction: Some("LR".to_string()),
+        },
+        &mut output,
+    )
+    .expect("set subgraph direction should apply");
+
+    assert_eq!(
+        subgraph_by_id(&output, "sg1").direction.as_deref(),
+        Some("LR")
+    );
+    assert_primary_event(&events, MmdsDiffKind::SubgraphDirectionChanged, "sg1");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::SubgraphDirectionChanged, "sg1")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_sets_subgraph_parent() {
+    let mut output = parse_routed_for_command_apply(
+        "graph TD\n    subgraph outer[Outer]\n    X\n    end\n    subgraph sg1[Group]\n    A\n    end\n",
+    );
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetSubgraphParent {
+            subgraph: "sg1".to_string(),
+            parent: Some("outer".to_string()),
+        },
+        &mut output,
+    )
+    .expect("set subgraph parent should apply");
+
+    assert_eq!(
+        subgraph_by_id(&output, "sg1").parent.as_deref(),
+        Some("outer")
+    );
+    assert_primary_event(&events, MmdsDiffKind::SubgraphParentChanged, "sg1");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::SubgraphParentChanged, "sg1")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_changes_subgraph_membership() {
+    let mut output = parse_routed_for_command_apply(
+        "graph TD\n    A[Alpha]\n    subgraph sg1[Group]\n    B\n    end\n",
+    );
+    let before = output.clone();
+
+    let events = apply(
+        &Command::ChangeSubgraphMembership {
+            subgraph: "sg1".to_string(),
+            added_children: vec!["A".to_string()],
+            removed_children: vec!["B".to_string()],
+            added_concurrent_regions: Vec::new(),
+            removed_concurrent_regions: Vec::new(),
+        },
+        &mut output,
+    )
+    .expect("change subgraph membership should apply");
+
+    assert_eq!(node_parent(&output, "A").as_deref(), Some("sg1"));
+    assert_eq!(node_parent(&output, "B"), None);
+    assert!(
+        subgraph_by_id(&output, "sg1")
+            .children
+            .contains(&"A".to_string())
+    );
+    assert!(
+        !subgraph_by_id(&output, "sg1")
+            .children
+            .contains(&"B".to_string())
+    );
+    assert_primary_event(&events, MmdsDiffKind::SubgraphMembershipChanged, "sg1");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::SubgraphMembershipChanged, "sg1")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_changes_subgraph_membership_concurrent_regions_only() {
+    let mut output = parse_routed_for_command_apply(
+        "graph TD\n    subgraph parent[Parent]\n    A\n    end\n    subgraph r0[R0]\n    B\n    end\n    subgraph r1[R1]\n    C\n    end\n",
+    );
+    output
+        .subgraphs
+        .iter_mut()
+        .find(|subgraph| subgraph.id == "parent")
+        .expect("parent subgraph should exist")
+        .concurrent_regions = vec!["r0".to_string()];
+    output
+        .subgraphs
+        .iter_mut()
+        .find(|subgraph| subgraph.id == "r0")
+        .expect("r0 should exist")
+        .parent = Some("parent".to_string());
+    let before = output.clone();
+
+    let events = apply(
+        &Command::ChangeSubgraphMembership {
+            subgraph: "parent".to_string(),
+            added_children: Vec::new(),
+            removed_children: Vec::new(),
+            added_concurrent_regions: vec!["r1".to_string()],
+            removed_concurrent_regions: vec!["r0".to_string()],
+        },
+        &mut output,
+    )
+    .expect("change concurrent membership should apply");
+
+    let parent = subgraph_by_id(&output, "parent");
+    assert!(parent.concurrent_regions.contains(&"r1".to_string()));
+    assert!(!parent.concurrent_regions.contains(&"r0".to_string()));
+    assert_eq!(
+        subgraph_by_id(&output, "r1").parent.as_deref(),
+        Some("parent")
+    );
+    assert_ne!(
+        subgraph_by_id(&output, "r0").parent.as_deref(),
+        Some("parent")
+    );
+    assert_primary_event(&events, MmdsDiffKind::SubgraphMembershipChanged, "parent");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::SubgraphMembershipChanged, "parent")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_sets_subgraph_visibility() {
+    let mut output =
+        parse_routed_for_command_apply("graph TD\n    subgraph sg1[Group]\n    A\n    end\n");
+    let before = output.clone();
+
+    let events = apply(
+        &Command::SetSubgraphVisibility {
+            subgraph: "sg1".to_string(),
+            invisible: true,
+        },
+        &mut output,
+    )
+    .expect("set subgraph visibility should apply");
+
+    assert!(subgraph_by_id(&output, "sg1").invisible);
+    assert_primary_event(&events, MmdsDiffKind::SubgraphVisibilityChanged, "sg1");
+    assert!(
+        crate::mmds::diff::diff_outputs(&before, &output)
+            .has_event(MmdsDiffKind::SubgraphVisibilityChanged, "sg1")
+    );
+}
+
+#[test]
+fn mmds_command_apply_relayout_add_subgraph_duplicate_errors_without_mutation() {
+    let mut output =
+        parse_routed_for_command_apply("graph TD\n    subgraph sg1[Group]\n    A\n    end\n");
+    let before = output.clone();
+
+    let result = apply(
+        &Command::AddSubgraph {
+            id: "sg1".to_string(),
+            title: Some("Duplicate".to_string()),
+            parent: None,
+            direction: None,
+            children: Vec::new(),
+            concurrent_regions: Vec::new(),
+            invisible: false,
+        },
+        &mut output,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CommandApplyError::SubjectAlreadyExists { id }) if id == "sg1"
+    ));
+    assert_output_eq(&output, &before);
+}
+
+#[test]
+fn mmds_command_apply_round_trip_primary_event_matches_diff() {
+    let cases = apply_round_trip_cases();
+    for expected_kind in commandable_diff_kinds() {
+        assert!(
+            cases
+                .iter()
+                .any(|case| case.expected_kind == *expected_kind),
+            "missing round-trip case for {expected_kind:?}"
+        );
+    }
+
+    for case in cases {
+        let mut after = case.before.clone();
+        let apply_events = apply(&case.command, &mut after).unwrap_or_else(|err| {
+            panic!("{} should apply successfully: {err:?}", case.name);
+        });
+        let diff = crate::mmds::diff::diff_outputs(&case.before, &after);
+
+        assert_has_event_pair(&apply_events, case.expected_kind, &case.expected_subject);
+        assert_has_event_pair(&diff.events, case.expected_kind, &case.expected_subject);
+
+        if case.expect_no_geometry_effects {
+            assert!(
+                !diff
+                    .events
+                    .iter()
+                    .any(|event| event.kind.is_geometry_effect()),
+                "{} produced geometry effects: {diff:#?}",
+                case.name
+            );
+        }
+    }
+}
+
+#[test]
+fn mmds_command_apply_failure_modes_are_structured() {
+    let mut ambiguous = parse_routed_for_command_apply("graph TD\n    A --> B\n    A --> B\n");
+    assert_apply_error_preserves_output(
+        &mut ambiguous,
+        Command::RemoveEdge {
+            edge: EdgeSelector::Semantic {
+                source: "A".to_string(),
+                target: "B".to_string(),
+                label: None,
+                stroke: None,
+                arrow_start: None,
+                arrow_end: None,
+                minlen: None,
+            },
+        },
+        |error| matches!(error, CommandApplyError::EdgeSelectorAmbiguous { .. }),
+    );
+
+    let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n");
+    assert_apply_error_preserves_output(
+        &mut output,
+        Command::RemoveEdge {
+            edge: EdgeSelector::Id("missing".to_string()),
+        },
+        |error| matches!(error, CommandApplyError::EdgeSelectorNoMatch { .. }),
+    );
+    assert_apply_error_preserves_output(
+        &mut output,
+        add_edge_command(Some("e0")),
+        |error| matches!(error, CommandApplyError::AddEdgeIdCollision { id } if id == "e0"),
+    );
+    assert_apply_error_preserves_output(
+        &mut output,
+        add_edge_command(Some("edge-stable")),
+        |error| matches!(error, CommandApplyError::AddEdgeIdUnsupported { id, expected } if id == "edge-stable" && expected == "e1"),
+    );
+    assert_apply_error_preserves_output(
+        &mut output,
+        Command::RemoveNode {
+            id: "Missing".to_string(),
+        },
+        |error| matches!(error, CommandApplyError::NodeNotFound { id } if id == "Missing"),
+    );
+    assert_apply_error_preserves_output(
+        &mut output,
+        Command::SetSubgraphDirection {
+            subgraph: "missing".to_string(),
+            direction: Some("LR".to_string()),
+        },
+        |error| matches!(error, CommandApplyError::SubgraphNotFound { id } if id == "missing"),
+    );
+    assert_apply_error_preserves_output(
+        &mut output,
+        Command::AddNode {
+            id: "A".to_string(),
+            label: "Duplicate".to_string(),
+            shape: "rectangle".to_string(),
+            parent: None,
+        },
+        |error| matches!(error, CommandApplyError::SubjectAlreadyExists { id } if id == "A"),
+    );
+    assert_apply_error_preserves_output(
+        &mut output,
+        Command::SetDirection {
+            direction: "SIDEWAYS".to_string(),
+        },
+        |error| matches!(error, CommandApplyError::RelayoutFailed { stage, .. } if stage == "hydrate"),
+    );
+}
+
+#[test]
+fn mmds_command_apply_tier_a_representative_canaries_hold() {
+    for case in tier_a_representative_command_cases() {
+        let (before, after) = render_tier_a_pair(case.pair_id);
+        let canary_diff = crate::mmds::diff::diff_outputs(&before, &after);
+
+        assert_has_event_pair(
+            &canary_diff.events,
+            case.expected_kind,
+            &case.expected_subject,
+        );
+        if case.pair_id == "M07" {
+            assert!(
+                !canary_diff.has_kind(MmdsDiffKind::EdgeRerouted),
+                "M07 should remain style-only with no edge reroute: {canary_diff:#?}"
+            );
+        }
+
+        let mut applied = before.clone();
+        let apply_events = apply(&case.command, &mut applied).unwrap_or_else(|error| {
+            panic!(
+                "{} representative command should apply: {error:?}",
+                case.pair_id
+            )
+        });
+
+        assert_has_event_pair(&apply_events, case.expected_kind, &case.expected_subject);
+        let applied_diff = crate::mmds::diff::diff_outputs(&before, &applied);
+        assert_has_event_pair(
+            &applied_diff.events,
+            case.expected_kind,
+            &case.expected_subject,
+        );
+        if case.pair_id == "M07" {
+            assert!(
+                !applied_diff.has_kind(MmdsDiffKind::EdgeRerouted),
+                "M07 apply should remain style-only with no edge reroute: {applied_diff:#?}"
+            );
+        }
+    }
+}
 
 #[test]
 fn mmds_command_vocabulary_classifies_all_diff_kinds() {
@@ -497,6 +1699,391 @@ fn all_command_examples() -> Vec<(Command, MmdsDiffKind)> {
     examples
 }
 
+struct ApplyRoundTripCase {
+    name: &'static str,
+    before: crate::mmds::Document,
+    command: Command,
+    expected_kind: MmdsDiffKind,
+    expected_subject: MmdsDiffSubject,
+    expect_no_geometry_effects: bool,
+}
+
+struct TierARepresentativeCommandCase {
+    pair_id: &'static str,
+    command: Command,
+    expected_kind: MmdsDiffKind,
+    expected_subject: MmdsDiffSubject,
+}
+
+fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
+    vec![
+        round_trip_case(
+            "set geometry level",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n"),
+            Command::SetGeometryLevel {
+                level: "layout".to_string(),
+            },
+            MmdsDiffKind::GeometryLevelChanged,
+            MmdsDiffSubject::Document,
+        ),
+        round_trip_case(
+            "set direction",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n"),
+            Command::SetDirection {
+                direction: "LR".to_string(),
+            },
+            MmdsDiffKind::DirectionChanged,
+            MmdsDiffSubject::Document,
+        ),
+        round_trip_case(
+            "set engine some",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n"),
+            Command::SetEngine {
+                engine: Some("mermaid-layered".to_string()),
+            },
+            MmdsDiffKind::EngineChanged,
+            MmdsDiffSubject::Document,
+        ),
+        round_trip_case(
+            "set engine none",
+            parse_routed_with_engine("graph TD\n    A --> B\n", "mermaid-layered"),
+            Command::SetEngine { engine: None },
+            MmdsDiffKind::EngineChanged,
+            MmdsDiffSubject::Document,
+        ),
+        round_trip_case(
+            "add node",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n"),
+            Command::AddNode {
+                id: "C".to_string(),
+                label: "Gamma".to_string(),
+                shape: "rectangle".to_string(),
+                parent: None,
+            },
+            MmdsDiffKind::NodeAdded,
+            MmdsDiffSubject::Node("C".to_string()),
+        ),
+        round_trip_case(
+            "remove node",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n"),
+            Command::RemoveNode {
+                id: "C".to_string(),
+            },
+            MmdsDiffKind::NodeRemoved,
+            MmdsDiffSubject::Node("C".to_string()),
+        ),
+        round_trip_case(
+            "change node label",
+            parse_routed_for_command_apply("graph TD\n    A[Old] --> B\n"),
+            Command::ChangeNodeLabel {
+                node: "A".to_string(),
+                label: "Alpha".to_string(),
+            },
+            MmdsDiffKind::NodeLabelChanged,
+            MmdsDiffSubject::Node("A".to_string()),
+        ),
+        round_trip_case(
+            "change node shape",
+            parse_routed_for_command_apply("graph TD\n    A[Old] --> B\n"),
+            Command::ChangeNodeShape {
+                node: "A".to_string(),
+                shape: "stadium".to_string(),
+            },
+            MmdsDiffKind::NodeShapeChanged,
+            MmdsDiffSubject::Node("A".to_string()),
+        ),
+        round_trip_case(
+            "set node parent",
+            parse_routed_for_command_apply(
+                "graph TD\n    subgraph sg1[Group]\n    B\n    end\n    A[Alpha]\n",
+            ),
+            Command::SetNodeParent {
+                node: "A".to_string(),
+                parent: Some("sg1".to_string()),
+            },
+            MmdsDiffKind::NodeParentChanged,
+            MmdsDiffSubject::Node("A".to_string()),
+        ),
+        round_trip_case_no_geometry(
+            "set node style extension insert",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n"),
+            Command::SetNodeStyleExtension {
+                node: "A".to_string(),
+                value: json!({ "fill": "#abcdef" }),
+            },
+            MmdsDiffKind::NodeStyleChanged,
+            MmdsDiffSubject::Node("A".to_string()),
+        ),
+        round_trip_case_no_geometry(
+            "set node style extension update",
+            output_with_node_style("graph TD\n    A --> B\n", "A", json!({ "fill": "#111111" })),
+            Command::SetNodeStyleExtension {
+                node: "A".to_string(),
+                value: json!({ "fill": "#abcdef" }),
+            },
+            MmdsDiffKind::NodeStyleChanged,
+            MmdsDiffSubject::Node("A".to_string()),
+        ),
+        round_trip_case_no_geometry(
+            "set profiles",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n"),
+            Command::SetProfiles {
+                profiles: vec!["custom-profile".to_string()],
+            },
+            MmdsDiffKind::ProfileChanged,
+            MmdsDiffSubject::Document,
+        ),
+        round_trip_case_no_geometry(
+            "set extension insert",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n"),
+            Command::SetExtension {
+                namespace: "example.extension".to_string(),
+                value: json!({ "enabled": true }),
+            },
+            MmdsDiffKind::ExtensionChanged,
+            MmdsDiffSubject::Document,
+        ),
+        round_trip_case_no_geometry(
+            "set extension update",
+            output_with_extension(
+                "graph TD\n    A --> B\n",
+                "example.extension",
+                json!({ "enabled": false }),
+            ),
+            Command::SetExtension {
+                namespace: "example.extension".to_string(),
+                value: json!({ "enabled": true }),
+            },
+            MmdsDiffKind::ExtensionChanged,
+            MmdsDiffSubject::Document,
+        ),
+        round_trip_case(
+            "add edge",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n"),
+            add_edge_command(None),
+            MmdsDiffKind::EdgeAdded,
+            MmdsDiffSubject::Edge("e1".to_string()),
+        ),
+        round_trip_case(
+            "remove edge",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n    B --> C\n"),
+            Command::RemoveEdge {
+                edge: EdgeSelector::Id("e1".to_string()),
+            },
+            MmdsDiffKind::EdgeRemoved,
+            MmdsDiffSubject::Edge("e1".to_string()),
+        ),
+        round_trip_case(
+            "reconnect edge",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n"),
+            Command::ReconnectEdge {
+                edge: EdgeSelector::Id("e0".to_string()),
+                source: "A".to_string(),
+                target: "C".to_string(),
+            },
+            MmdsDiffKind::EdgeReconnected,
+            MmdsDiffSubject::Edge("e0".to_string()),
+        ),
+        round_trip_case(
+            "set edge endpoint intent",
+            parse_routed_for_command_apply(
+                "graph TD\n    subgraph sg1[Source]\n    A\n    end\n    subgraph sg2[Target]\n    B\n    end\n    A --> B\n",
+            ),
+            Command::SetEdgeEndpointIntent {
+                edge: EdgeSelector::Id("e0".to_string()),
+                from_subgraph: Some("sg1".to_string()),
+                to_subgraph: Some("sg2".to_string()),
+            },
+            MmdsDiffKind::EdgeEndpointIntentChanged,
+            MmdsDiffSubject::Edge("e0".to_string()),
+        ),
+        round_trip_case(
+            "change edge label",
+            parse_routed_for_command_apply("graph TD\n    A -->|x| B\n"),
+            Command::ChangeEdgeLabel {
+                edge: EdgeSelector::Id("e0".to_string()),
+                label: Some("much longer label".to_string()),
+            },
+            MmdsDiffKind::EdgeLabelChanged,
+            MmdsDiffSubject::Edge("e0".to_string()),
+        ),
+        round_trip_case(
+            "change edge style",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n"),
+            Command::ChangeEdgeStyle {
+                edge: EdgeSelector::Id("e0".to_string()),
+                stroke: Some("dotted".to_string()),
+                arrow_start: Some("circle".to_string()),
+                arrow_end: Some("diamond".to_string()),
+                minlen: Some(2),
+            },
+            MmdsDiffKind::EdgeStyleChanged,
+            MmdsDiffSubject::Edge("e0".to_string()),
+        ),
+        round_trip_case(
+            "add subgraph",
+            parse_routed_for_command_apply("graph TD\n    A --> B\n"),
+            Command::AddSubgraph {
+                id: "sg1".to_string(),
+                title: Some("Group".to_string()),
+                parent: None,
+                direction: Some("LR".to_string()),
+                children: vec!["A".to_string()],
+                concurrent_regions: Vec::new(),
+                invisible: false,
+            },
+            MmdsDiffKind::SubgraphAdded,
+            MmdsDiffSubject::Subgraph("sg1".to_string()),
+        ),
+        round_trip_case(
+            "remove subgraph",
+            parse_routed_for_command_apply("graph TD\n    subgraph sg1[Group]\n    A\n    end\n"),
+            Command::RemoveSubgraph {
+                id: "sg1".to_string(),
+            },
+            MmdsDiffKind::SubgraphRemoved,
+            MmdsDiffSubject::Subgraph("sg1".to_string()),
+        ),
+        round_trip_case_no_geometry(
+            "change subgraph title",
+            parse_routed_for_command_apply("graph TD\n    subgraph sg1[Group]\n    A\n    end\n"),
+            Command::ChangeSubgraphTitle {
+                subgraph: "sg1".to_string(),
+                title: Some("Pipeline".to_string()),
+            },
+            MmdsDiffKind::SubgraphTitleChanged,
+            MmdsDiffSubject::Subgraph("sg1".to_string()),
+        ),
+        round_trip_case(
+            "set subgraph direction",
+            parse_routed_for_command_apply("graph TD\n    subgraph sg1[Group]\n    A\n    end\n"),
+            Command::SetSubgraphDirection {
+                subgraph: "sg1".to_string(),
+                direction: Some("LR".to_string()),
+            },
+            MmdsDiffKind::SubgraphDirectionChanged,
+            MmdsDiffSubject::Subgraph("sg1".to_string()),
+        ),
+        round_trip_case(
+            "set subgraph parent",
+            parse_routed_for_command_apply(
+                "graph TD\n    subgraph outer[Outer]\n    X\n    end\n    subgraph sg1[Group]\n    A\n    end\n",
+            ),
+            Command::SetSubgraphParent {
+                subgraph: "sg1".to_string(),
+                parent: Some("outer".to_string()),
+            },
+            MmdsDiffKind::SubgraphParentChanged,
+            MmdsDiffSubject::Subgraph("sg1".to_string()),
+        ),
+        round_trip_case(
+            "change subgraph membership",
+            parse_routed_for_command_apply(
+                "graph TD\n    A[Alpha]\n    subgraph sg1[Group]\n    B\n    end\n",
+            ),
+            Command::ChangeSubgraphMembership {
+                subgraph: "sg1".to_string(),
+                added_children: vec!["A".to_string()],
+                removed_children: vec!["B".to_string()],
+                added_concurrent_regions: Vec::new(),
+                removed_concurrent_regions: Vec::new(),
+            },
+            MmdsDiffKind::SubgraphMembershipChanged,
+            MmdsDiffSubject::Subgraph("sg1".to_string()),
+        ),
+        round_trip_case(
+            "set subgraph visibility",
+            parse_routed_for_command_apply("graph TD\n    subgraph sg1[Group]\n    A\n    end\n"),
+            Command::SetSubgraphVisibility {
+                subgraph: "sg1".to_string(),
+                invisible: true,
+            },
+            MmdsDiffKind::SubgraphVisibilityChanged,
+            MmdsDiffSubject::Subgraph("sg1".to_string()),
+        ),
+    ]
+}
+
+fn round_trip_case(
+    name: &'static str,
+    before: crate::mmds::Document,
+    command: Command,
+    expected_kind: MmdsDiffKind,
+    expected_subject: MmdsDiffSubject,
+) -> ApplyRoundTripCase {
+    ApplyRoundTripCase {
+        name,
+        before,
+        command,
+        expected_kind,
+        expected_subject,
+        expect_no_geometry_effects: false,
+    }
+}
+
+fn round_trip_case_no_geometry(
+    name: &'static str,
+    before: crate::mmds::Document,
+    command: Command,
+    expected_kind: MmdsDiffKind,
+    expected_subject: MmdsDiffSubject,
+) -> ApplyRoundTripCase {
+    ApplyRoundTripCase {
+        name,
+        before,
+        command,
+        expected_kind,
+        expected_subject,
+        expect_no_geometry_effects: true,
+    }
+}
+
+fn tier_a_representative_command_cases() -> Vec<TierARepresentativeCommandCase> {
+    vec![
+        TierARepresentativeCommandCase {
+            pair_id: "M01",
+            command: Command::AddNode {
+                id: "X".to_string(),
+                label: "Inserted".to_string(),
+                shape: "rectangle".to_string(),
+                parent: None,
+            },
+            expected_kind: MmdsDiffKind::NodeAdded,
+            expected_subject: MmdsDiffSubject::Node("X".to_string()),
+        },
+        TierARepresentativeCommandCase {
+            pair_id: "M05",
+            command: Command::ChangeNodeLabel {
+                node: "Lint".to_string(),
+                label: "Static Analysis".to_string(),
+            },
+            expected_kind: MmdsDiffKind::NodeLabelChanged,
+            expected_subject: MmdsDiffSubject::Node("Lint".to_string()),
+        },
+        TierARepresentativeCommandCase {
+            pair_id: "M07",
+            command: Command::ChangeEdgeStyle {
+                edge: EdgeSelector::Id("e0".to_string()),
+                stroke: Some("dotted".to_string()),
+                arrow_start: None,
+                arrow_end: None,
+                minlen: None,
+            },
+            expected_kind: MmdsDiffKind::EdgeStyleChanged,
+            expected_subject: MmdsDiffSubject::Edge("e0".to_string()),
+        },
+        TierARepresentativeCommandCase {
+            pair_id: "M10",
+            command: Command::SetSubgraphDirection {
+                subgraph: "sg1".to_string(),
+                direction: Some("TD".to_string()),
+            },
+            expected_kind: MmdsDiffKind::SubgraphDirectionChanged,
+            expected_subject: MmdsDiffSubject::Subgraph("sg1".to_string()),
+        },
+    ]
+}
+
 fn all_diff_kinds() -> [MmdsDiffKind; 36] {
     [
         MmdsDiffKind::GeometryLevelChanged,
@@ -567,4 +2154,277 @@ fn assert_same_kinds(left: &[MmdsDiffKind], right: &[MmdsDiffKind]) {
 
 fn contains_kind(kinds: &[MmdsDiffKind], needle: MmdsDiffKind) -> bool {
     kinds.contains(&needle)
+}
+
+fn node_label(output: &crate::mmds::Document, id: &str) -> String {
+    output
+        .nodes
+        .iter()
+        .find(|node| node.id == id)
+        .unwrap_or_else(|| panic!("node {id} should exist"))
+        .label
+        .clone()
+}
+
+fn node_shape(output: &crate::mmds::Document, id: &str) -> String {
+    output
+        .nodes
+        .iter()
+        .find(|node| node.id == id)
+        .unwrap_or_else(|| panic!("node {id} should exist"))
+        .shape
+        .clone()
+}
+
+fn node_parent(output: &crate::mmds::Document, id: &str) -> Option<String> {
+    output
+        .nodes
+        .iter()
+        .find(|node| node.id == id)
+        .unwrap_or_else(|| panic!("node {id} should exist"))
+        .parent
+        .clone()
+}
+
+fn edge_ids(output: &crate::mmds::Document) -> Vec<String> {
+    output.edges.iter().map(|edge| edge.id.clone()).collect()
+}
+
+fn edge_by_id<'a>(output: &'a crate::mmds::Document, id: &str) -> &'a crate::mmds::Edge {
+    output
+        .edges
+        .iter()
+        .find(|edge| edge.id == id)
+        .unwrap_or_else(|| panic!("edge {id} should exist"))
+}
+
+fn subgraph_title(output: &crate::mmds::Document, id: &str) -> String {
+    subgraph_by_id(output, id).title.clone()
+}
+
+fn subgraph_by_id<'a>(output: &'a crate::mmds::Document, id: &str) -> &'a crate::mmds::Subgraph {
+    output
+        .subgraphs
+        .iter()
+        .find(|subgraph| subgraph.id == id)
+        .unwrap_or_else(|| panic!("subgraph {id} should exist"))
+}
+
+fn map_from_pairs<const N: usize>(
+    pairs: [(&str, serde_json::Value); N],
+) -> Map<String, serde_json::Value> {
+    pairs
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
+}
+
+fn assert_primary_event(
+    events: &[crate::mmds::diff::MmdsDiffEvent],
+    kind: MmdsDiffKind,
+    subject_id: &str,
+) {
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].kind, kind);
+    assert!(subject_matches(&events[0].subject, subject_id));
+}
+
+fn assert_has_event_pair(
+    events: &[crate::mmds::diff::MmdsDiffEvent],
+    kind: MmdsDiffKind,
+    subject: &MmdsDiffSubject,
+) {
+    assert!(
+        events
+            .iter()
+            .any(|event| event.kind == kind && event.subject == *subject),
+        "missing ({kind:?}, {subject:?}) in {events:#?}"
+    );
+}
+
+fn assert_in_place_diff(
+    before: &crate::mmds::Document,
+    after: &crate::mmds::Document,
+    kind: MmdsDiffKind,
+    subject_id: &str,
+) {
+    assert_geometry_unchanged(before, after);
+    let diff = crate::mmds::diff::diff_outputs(before, after);
+    assert!(diff.has_event(kind, subject_id), "{diff:#?}");
+    assert!(
+        !diff
+            .events
+            .iter()
+            .any(|event| event.kind.is_geometry_effect()),
+        "{diff:#?}"
+    );
+}
+
+fn assert_geometry_unchanged(before: &crate::mmds::Document, after: &crate::mmds::Document) {
+    assert_eq!(
+        serde_json::to_value(&before.metadata.bounds).expect("bounds should serialize"),
+        serde_json::to_value(&after.metadata.bounds).expect("bounds should serialize")
+    );
+    assert_eq!(
+        serde_json::to_value(&before.nodes).expect("nodes should serialize"),
+        serde_json::to_value(&after.nodes).expect("nodes should serialize")
+    );
+    assert_eq!(
+        serde_json::to_value(&before.edges).expect("edges should serialize"),
+        serde_json::to_value(&after.edges).expect("edges should serialize")
+    );
+    assert_eq!(
+        subgraph_geometry(before),
+        subgraph_geometry(after),
+        "subgraph geometry changed"
+    );
+}
+
+fn assert_output_eq(left: &crate::mmds::Document, right: &crate::mmds::Document) {
+    assert_eq!(
+        serde_json::to_value(left).expect("left output should serialize"),
+        serde_json::to_value(right).expect("right output should serialize")
+    );
+}
+
+fn assert_apply_error_preserves_output(
+    output: &mut crate::mmds::Document,
+    command: Command,
+    matches_error: impl FnOnce(&CommandApplyError) -> bool,
+) {
+    let before = output.clone();
+    let error = match apply(&command, output) {
+        Ok(events) => panic!("{command:?} should return an error, got {events:#?}"),
+        Err(error) => error,
+    };
+
+    assert!(matches_error(&error), "unexpected error: {error:?}");
+    assert_output_eq(output, &before);
+}
+
+fn subgraph_geometry(output: &crate::mmds::Document) -> Vec<serde_json::Value> {
+    output
+        .subgraphs
+        .iter()
+        .map(|subgraph| {
+            json!({
+                "id": subgraph.id,
+                "bounds": subgraph.bounds,
+            })
+        })
+        .collect()
+}
+
+fn subject_matches(subject: &crate::mmds::diff::MmdsDiffSubject, subject_id: &str) -> bool {
+    match subject {
+        crate::mmds::diff::MmdsDiffSubject::Document => subject_id.is_empty(),
+        crate::mmds::diff::MmdsDiffSubject::Node(id)
+        | crate::mmds::diff::MmdsDiffSubject::Edge(id)
+        | crate::mmds::diff::MmdsDiffSubject::Subgraph(id) => id == subject_id,
+    }
+}
+
+fn output_with_extension(source: &str, namespace: &str, value: Value) -> crate::mmds::Document {
+    let mut output = parse_routed_for_command_apply(source);
+    output
+        .extensions
+        .insert(namespace.to_string(), object_payload(value));
+    output
+}
+
+fn output_with_node_style(source: &str, node: &str, value: Value) -> crate::mmds::Document {
+    let mut output = parse_routed_for_command_apply(source);
+    let mut nodes = Map::new();
+    nodes.insert(node.to_string(), value);
+    let mut extension = Map::new();
+    extension.insert("nodes".to_string(), Value::Object(nodes));
+    output
+        .extensions
+        .insert(NODE_STYLE_EXTENSION_NAMESPACE.to_string(), extension);
+    output
+}
+
+fn object_payload(value: Value) -> Map<String, Value> {
+    value.as_object().cloned().unwrap_or_else(|| {
+        let mut payload = Map::new();
+        payload.insert("value".to_string(), value);
+        payload
+    })
+}
+
+fn render_tier_a_pair(pair_id: &'static str) -> (crate::mmds::Document, crate::mmds::Document) {
+    let pair = mutations::pair_by_id(pair_id)
+        .unwrap_or_else(|| panic!("Tier A pair {pair_id} should exist"));
+    (
+        parse_routed_for_command_apply(&mutation_input_source(pair_id, "before", pair.base)),
+        parse_routed_for_command_apply(&mutation_input_source(pair_id, "after", pair.mutated)),
+    )
+}
+
+fn mutation_input_source(
+    pair_id: &'static str,
+    side: &'static str,
+    input: mutations::MutationInput,
+) -> String {
+    match input {
+        mutations::MutationInput::Inline(source) => source.to_string(),
+        mutations::MutationInput::Fixture { family, name } => {
+            let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests")
+                .join("fixtures")
+                .join(family)
+                .join(name);
+            fs::read_to_string(&path).unwrap_or_else(|error| {
+                panic!(
+                    "failed to read {side} fixture for {pair_id} from {}: {error}",
+                    path.display()
+                )
+            })
+        }
+    }
+}
+
+fn add_edge_command(id: Option<&str>) -> Command {
+    Command::AddEdge {
+        id: id.map(str::to_string),
+        source: "A".to_string(),
+        target: "C".to_string(),
+        from_subgraph: None,
+        to_subgraph: None,
+        label: Some("new".to_string()),
+        stroke: "solid".to_string(),
+        arrow_start: "none".to_string(),
+        arrow_end: "normal".to_string(),
+        minlen: 1,
+    }
+}
+
+fn parse_routed_for_command_apply(source: &str) -> crate::mmds::Document {
+    parse_routed_with_config(
+        source,
+        RenderConfig {
+            geometry_level: GeometryLevel::Routed,
+            ..RenderConfig::default()
+        },
+    )
+}
+
+fn parse_routed_with_engine(source: &str, engine: &str) -> crate::mmds::Document {
+    parse_routed_with_config(
+        source,
+        RenderConfig {
+            geometry_level: GeometryLevel::Routed,
+            layout_engine: Some(
+                crate::engines::graph::EngineAlgorithmId::parse(engine)
+                    .expect("engine id should parse"),
+            ),
+            ..RenderConfig::default()
+        },
+    )
+}
+
+fn parse_routed_with_config(source: &str, config: RenderConfig) -> crate::mmds::Document {
+    let json = crate::render_diagram(source, OutputFormat::Mmds, &config)
+        .expect("routed MMDS should render");
+    crate::mmds::parse_input(&json).expect("rendered MMDS should parse")
 }

--- a/src/mmds/commands.rs
+++ b/src/mmds/commands.rs
@@ -1,6 +1,10 @@
 use serde_json::Value;
 
-use super::diff::MmdsDiffKind;
+use super::diff::{MmdsDiffEvent, MmdsDiffKind, MmdsDiffSubject};
+use super::{Document, Edge, NODE_STYLE_EXTENSION_NAMESPACE, Node, Position, Size, Subgraph};
+use crate::engines::graph::EngineAlgorithmId;
+use crate::graph::GeometryLevel;
+use crate::{OutputFormat, RenderConfig};
 
 const COMMANDABLE_DIFF_KINDS: &[MmdsDiffKind] = &[
     MmdsDiffKind::GeometryLevelChanged,
@@ -180,6 +184,37 @@ pub(crate) enum MmdsDiffKindRole {
     GeometryEffect,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CommandApplyError {
+    NodeNotFound {
+        id: String,
+    },
+    SubgraphNotFound {
+        id: String,
+    },
+    SubjectAlreadyExists {
+        id: String,
+    },
+    EdgeSelectorNoMatch {
+        selector: Box<EdgeSelector>,
+    },
+    EdgeSelectorAmbiguous {
+        selector: Box<EdgeSelector>,
+        matches: Vec<String>,
+    },
+    AddEdgeIdCollision {
+        id: String,
+    },
+    AddEdgeIdUnsupported {
+        id: String,
+        expected: String,
+    },
+    RelayoutFailed {
+        stage: String,
+        source: String,
+    },
+}
+
 pub(crate) fn commandable_diff_kinds() -> &'static [MmdsDiffKind] {
     COMMANDABLE_DIFF_KINDS
 }
@@ -261,5 +296,733 @@ pub(crate) fn diff_kind_for_command(command: &Command) -> MmdsDiffKind {
         Command::SetSubgraphParent { .. } => MmdsDiffKind::SubgraphParentChanged,
         Command::ChangeSubgraphMembership { .. } => MmdsDiffKind::SubgraphMembershipChanged,
         Command::SetSubgraphVisibility { .. } => MmdsDiffKind::SubgraphVisibilityChanged,
+    }
+}
+
+pub(crate) fn apply(
+    command: &Command,
+    output: &mut Document,
+) -> Result<Vec<MmdsDiffEvent>, CommandApplyError> {
+    match command {
+        Command::RemoveNode { id } => {
+            node_index(output, id)?;
+            apply_with_relayout_event(
+                output,
+                node_event(MmdsDiffKind::NodeRemoved, id.clone()),
+                |candidate| {
+                    candidate.nodes.retain(|node| node.id != *id);
+                    candidate
+                        .edges
+                        .retain(|edge| edge.source != *id && edge.target != *id);
+                    for subgraph in &mut candidate.subgraphs {
+                        subgraph.children.retain(|child| child != id);
+                        subgraph.concurrent_regions.retain(|region| region != id);
+                    }
+                    Ok(())
+                },
+            )
+        }
+        Command::ChangeEdgeLabel { edge, label } => {
+            let edge_index = resolve_edge_index(output, edge)?;
+            let edge_id = output.edges[edge_index].id.clone();
+            apply_with_relayout_event(
+                output,
+                edge_event(MmdsDiffKind::EdgeLabelChanged, edge_id),
+                |candidate| {
+                    let edge_index = resolve_edge_index(candidate, edge)?;
+                    candidate.edges[edge_index].label = label.clone();
+                    Ok(())
+                },
+            )
+        }
+        Command::AddEdge {
+            id,
+            source,
+            target,
+            from_subgraph,
+            to_subgraph,
+            label,
+            stroke,
+            arrow_start,
+            arrow_end,
+            minlen,
+        } => {
+            let edge_id = resolve_new_edge_id(output, id.as_deref())?;
+            node_index(output, source)?;
+            node_index(output, target)?;
+            if let Some(from_subgraph) = from_subgraph {
+                subgraph_index(output, from_subgraph)?;
+            }
+            if let Some(to_subgraph) = to_subgraph {
+                subgraph_index(output, to_subgraph)?;
+            }
+            apply_with_relayout_event(
+                output,
+                edge_event(MmdsDiffKind::EdgeAdded, edge_id.clone()),
+                |candidate| {
+                    candidate.edges.push(Edge {
+                        id: edge_id,
+                        source: source.clone(),
+                        target: target.clone(),
+                        from_subgraph: from_subgraph.clone(),
+                        to_subgraph: to_subgraph.clone(),
+                        label: label.clone(),
+                        stroke: stroke.clone(),
+                        arrow_start: arrow_start.clone(),
+                        arrow_end: arrow_end.clone(),
+                        minlen: *minlen,
+                        path: None,
+                        label_position: None,
+                        is_backward: None,
+                        source_port: None,
+                        target_port: None,
+                        label_side: None,
+                        label_rect: None,
+                    });
+                    Ok(())
+                },
+            )
+        }
+        Command::RemoveEdge { edge } => {
+            let edge_index = resolve_edge_index(output, edge)?;
+            let edge_id = output.edges[edge_index].id.clone();
+            apply_with_relayout_event(
+                output,
+                edge_event(MmdsDiffKind::EdgeRemoved, edge_id),
+                |candidate| {
+                    let edge_index = resolve_edge_index(candidate, edge)?;
+                    candidate.edges.remove(edge_index);
+                    Ok(())
+                },
+            )
+        }
+        Command::ReconnectEdge {
+            edge,
+            source,
+            target,
+        } => {
+            let edge_index = resolve_edge_index(output, edge)?;
+            let edge_id = output.edges[edge_index].id.clone();
+            node_index(output, source)?;
+            node_index(output, target)?;
+            apply_with_relayout_event(
+                output,
+                edge_event(MmdsDiffKind::EdgeReconnected, edge_id),
+                |candidate| {
+                    let edge_index = resolve_edge_index(candidate, edge)?;
+                    candidate.edges[edge_index].source = source.clone();
+                    candidate.edges[edge_index].target = target.clone();
+                    Ok(())
+                },
+            )
+        }
+        Command::SetEdgeEndpointIntent {
+            edge,
+            from_subgraph,
+            to_subgraph,
+        } => {
+            let edge_index = resolve_edge_index(output, edge)?;
+            let edge_id = output.edges[edge_index].id.clone();
+            if let Some(from_subgraph) = from_subgraph {
+                subgraph_index(output, from_subgraph)?;
+            }
+            if let Some(to_subgraph) = to_subgraph {
+                subgraph_index(output, to_subgraph)?;
+            }
+            apply_with_relayout_event(
+                output,
+                edge_event(MmdsDiffKind::EdgeEndpointIntentChanged, edge_id),
+                |candidate| {
+                    let edge_index = resolve_edge_index(candidate, edge)?;
+                    candidate.edges[edge_index].from_subgraph = from_subgraph.clone();
+                    candidate.edges[edge_index].to_subgraph = to_subgraph.clone();
+                    Ok(())
+                },
+            )
+        }
+        Command::ChangeEdgeStyle {
+            edge,
+            stroke,
+            arrow_start,
+            arrow_end,
+            minlen,
+        } => {
+            let edge_index = resolve_edge_index(output, edge)?;
+            let edge_id = output.edges[edge_index].id.clone();
+            apply_with_relayout_event(
+                output,
+                edge_event(MmdsDiffKind::EdgeStyleChanged, edge_id),
+                |candidate| {
+                    let edge_index = resolve_edge_index(candidate, edge)?;
+                    if let Some(stroke) = stroke {
+                        candidate.edges[edge_index].stroke = stroke.clone();
+                    }
+                    if let Some(arrow_start) = arrow_start {
+                        candidate.edges[edge_index].arrow_start = arrow_start.clone();
+                    }
+                    if let Some(arrow_end) = arrow_end {
+                        candidate.edges[edge_index].arrow_end = arrow_end.clone();
+                    }
+                    if let Some(minlen) = minlen {
+                        candidate.edges[edge_index].minlen = *minlen;
+                    }
+                    Ok(())
+                },
+            )
+        }
+        Command::SetGeometryLevel { level } => {
+            apply_with_relayout(output, MmdsDiffKind::GeometryLevelChanged, |candidate| {
+                candidate.geometry_level = level.clone();
+                Ok(())
+            })
+        }
+        Command::SetDirection { direction } => {
+            apply_with_relayout(output, MmdsDiffKind::DirectionChanged, |candidate| {
+                candidate.metadata.direction = direction.clone();
+                Ok(())
+            })
+        }
+        Command::SetEngine { engine } => {
+            apply_with_relayout(output, MmdsDiffKind::EngineChanged, |candidate| {
+                candidate.metadata.engine = engine.clone();
+                Ok(())
+            })
+        }
+        Command::AddNode {
+            id,
+            label,
+            shape,
+            parent,
+        } => {
+            if output.nodes.iter().any(|node| node.id == *id) {
+                return Err(CommandApplyError::SubjectAlreadyExists { id: id.clone() });
+            }
+            if let Some(parent) = parent {
+                subgraph_index(output, parent)?;
+            }
+            apply_with_relayout_event(
+                output,
+                node_event(MmdsDiffKind::NodeAdded, id.clone()),
+                |candidate| {
+                    candidate.nodes.push(Node {
+                        id: id.clone(),
+                        label: label.clone(),
+                        shape: shape.clone(),
+                        parent: parent.clone(),
+                        position: Position { x: 0.0, y: 0.0 },
+                        size: Size {
+                            width: 0.0,
+                            height: 0.0,
+                        },
+                    });
+                    Ok(())
+                },
+            )
+        }
+        Command::ChangeNodeLabel { node, label } => {
+            node_index(output, node)?;
+            apply_with_relayout_event(
+                output,
+                node_event(MmdsDiffKind::NodeLabelChanged, node.clone()),
+                |candidate| {
+                    let index = node_index(candidate, node)?;
+                    candidate.nodes[index].label = label.clone();
+                    Ok(())
+                },
+            )
+        }
+        Command::ChangeNodeShape { node, shape } => {
+            node_index(output, node)?;
+            apply_with_relayout_event(
+                output,
+                node_event(MmdsDiffKind::NodeShapeChanged, node.clone()),
+                |candidate| {
+                    let index = node_index(candidate, node)?;
+                    candidate.nodes[index].shape = shape.clone();
+                    Ok(())
+                },
+            )
+        }
+        Command::SetNodeParent { node, parent } => {
+            node_index(output, node)?;
+            if let Some(parent) = parent {
+                subgraph_index(output, parent)?;
+            }
+            apply_with_relayout_event(
+                output,
+                node_event(MmdsDiffKind::NodeParentChanged, node.clone()),
+                |candidate| {
+                    let index = node_index(candidate, node)?;
+                    candidate.nodes[index].parent = parent.clone();
+                    Ok(())
+                },
+            )
+        }
+        Command::SetProfiles { profiles } => {
+            output.profiles = profiles.clone();
+            Ok(vec![document_event(MmdsDiffKind::ProfileChanged)])
+        }
+        Command::SetExtension { namespace, value } => {
+            output.extensions.insert(
+                namespace.clone(),
+                value.as_object().cloned().unwrap_or_else(|| {
+                    let mut payload = serde_json::Map::new();
+                    payload.insert("value".to_string(), value.clone());
+                    payload
+                }),
+            );
+            Ok(vec![document_event(MmdsDiffKind::ExtensionChanged)])
+        }
+        Command::SetNodeStyleExtension { node, value } => {
+            if !output.nodes.iter().any(|candidate| candidate.id == *node) {
+                return Err(CommandApplyError::NodeNotFound { id: node.clone() });
+            }
+            set_node_style_extension(output, node, value.clone());
+            Ok(vec![MmdsDiffEvent {
+                kind: MmdsDiffKind::NodeStyleChanged,
+                subject: MmdsDiffSubject::Node(node.clone()),
+                evidence: Vec::new(),
+                related_event_ids: Vec::new(),
+            }])
+        }
+        Command::ChangeSubgraphTitle { subgraph, title } => {
+            let subgraph_index = output
+                .subgraphs
+                .iter()
+                .position(|candidate| candidate.id == *subgraph)
+                .ok_or_else(|| CommandApplyError::SubgraphNotFound {
+                    id: subgraph.clone(),
+                })?;
+            output.subgraphs[subgraph_index].title = title
+                .clone()
+                .unwrap_or_else(|| output.subgraphs[subgraph_index].id.clone());
+            Ok(vec![MmdsDiffEvent {
+                kind: MmdsDiffKind::SubgraphTitleChanged,
+                subject: MmdsDiffSubject::Subgraph(subgraph.clone()),
+                evidence: Vec::new(),
+                related_event_ids: Vec::new(),
+            }])
+        }
+        Command::AddSubgraph {
+            id,
+            title,
+            parent,
+            direction,
+            children,
+            concurrent_regions,
+            invisible,
+        } => {
+            if output.subgraphs.iter().any(|subgraph| subgraph.id == *id) {
+                return Err(CommandApplyError::SubjectAlreadyExists { id: id.clone() });
+            }
+            if let Some(parent) = parent {
+                subgraph_index(output, parent)?;
+            }
+            for child in children {
+                node_index(output, child)?;
+            }
+            for region in concurrent_regions {
+                subgraph_index(output, region)?;
+            }
+            apply_with_relayout_event(
+                output,
+                subgraph_event(MmdsDiffKind::SubgraphAdded, id.clone()),
+                |candidate| {
+                    sync_subgraph_children_from_node_parents(candidate);
+                    candidate.subgraphs.push(Subgraph {
+                        id: id.clone(),
+                        title: title.clone().unwrap_or_else(|| id.clone()),
+                        children: Vec::new(),
+                        parent: parent.clone(),
+                        direction: direction.clone(),
+                        bounds: None,
+                        invisible: *invisible,
+                        concurrent_regions: concurrent_regions.clone(),
+                    });
+                    for child in children {
+                        let node_index = node_index(candidate, child)?;
+                        candidate.nodes[node_index].parent = Some(id.clone());
+                    }
+                    for region in concurrent_regions {
+                        let region_index = subgraph_index(candidate, region)?;
+                        candidate.subgraphs[region_index].parent = Some(id.clone());
+                    }
+                    sync_subgraph_children_from_node_parents(candidate);
+                    Ok(())
+                },
+            )
+        }
+        Command::RemoveSubgraph { id } => {
+            subgraph_index(output, id)?;
+            apply_with_relayout_event(
+                output,
+                subgraph_event(MmdsDiffKind::SubgraphRemoved, id.clone()),
+                |candidate| {
+                    candidate.subgraphs.retain(|subgraph| subgraph.id != *id);
+                    for node in &mut candidate.nodes {
+                        if node.parent.as_deref() == Some(id.as_str()) {
+                            node.parent = None;
+                        }
+                    }
+                    for subgraph in &mut candidate.subgraphs {
+                        if subgraph.parent.as_deref() == Some(id.as_str()) {
+                            subgraph.parent = None;
+                        }
+                        subgraph.concurrent_regions.retain(|region| region != id);
+                    }
+                    sync_subgraph_children_from_node_parents(candidate);
+                    Ok(())
+                },
+            )
+        }
+        Command::SetSubgraphDirection {
+            subgraph,
+            direction,
+        } => {
+            subgraph_index(output, subgraph)?;
+            apply_with_relayout_event(
+                output,
+                subgraph_event(MmdsDiffKind::SubgraphDirectionChanged, subgraph.clone()),
+                |candidate| {
+                    let subgraph_index = subgraph_index(candidate, subgraph)?;
+                    candidate.subgraphs[subgraph_index].direction = direction.clone();
+                    Ok(())
+                },
+            )
+        }
+        Command::SetSubgraphParent { subgraph, parent } => {
+            subgraph_index(output, subgraph)?;
+            if let Some(parent) = parent {
+                subgraph_index(output, parent)?;
+            }
+            apply_with_relayout_event(
+                output,
+                subgraph_event(MmdsDiffKind::SubgraphParentChanged, subgraph.clone()),
+                |candidate| {
+                    let subgraph_index = subgraph_index(candidate, subgraph)?;
+                    candidate.subgraphs[subgraph_index].parent = parent.clone();
+                    Ok(())
+                },
+            )
+        }
+        Command::ChangeSubgraphMembership {
+            subgraph,
+            added_children,
+            removed_children,
+            added_concurrent_regions,
+            removed_concurrent_regions,
+        } => {
+            subgraph_index(output, subgraph)?;
+            for child in added_children.iter().chain(removed_children.iter()) {
+                node_index(output, child)?;
+            }
+            for region in added_concurrent_regions
+                .iter()
+                .chain(removed_concurrent_regions.iter())
+            {
+                subgraph_index(output, region)?;
+            }
+            apply_with_relayout_event(
+                output,
+                subgraph_event(MmdsDiffKind::SubgraphMembershipChanged, subgraph.clone()),
+                |candidate| {
+                    sync_subgraph_children_from_node_parents(candidate);
+                    for child in removed_children {
+                        let node_index = node_index(candidate, child)?;
+                        if candidate.nodes[node_index].parent.as_deref() == Some(subgraph.as_str())
+                        {
+                            candidate.nodes[node_index].parent = None;
+                        }
+                    }
+                    for child in added_children {
+                        let node_index = node_index(candidate, child)?;
+                        candidate.nodes[node_index].parent = Some(subgraph.clone());
+                    }
+                    let target_subgraph_index = subgraph_index(candidate, subgraph)?;
+                    for region in removed_concurrent_regions {
+                        candidate.subgraphs[target_subgraph_index]
+                            .concurrent_regions
+                            .retain(|candidate| candidate != region);
+                        let region_index = subgraph_index(candidate, region)?;
+                        if candidate.subgraphs[region_index].parent.as_deref()
+                            == Some(subgraph.as_str())
+                        {
+                            candidate.subgraphs[region_index].parent = None;
+                        }
+                    }
+                    for region in added_concurrent_regions {
+                        if !candidate.subgraphs[target_subgraph_index]
+                            .concurrent_regions
+                            .contains(region)
+                        {
+                            candidate.subgraphs[target_subgraph_index]
+                                .concurrent_regions
+                                .push(region.clone());
+                        }
+                        let region_index = subgraph_index(candidate, region)?;
+                        candidate.subgraphs[region_index].parent = Some(subgraph.clone());
+                    }
+                    sync_subgraph_children_from_node_parents(candidate);
+                    Ok(())
+                },
+            )
+        }
+        Command::SetSubgraphVisibility {
+            subgraph,
+            invisible,
+        } => {
+            subgraph_index(output, subgraph)?;
+            apply_with_relayout_event(
+                output,
+                subgraph_event(MmdsDiffKind::SubgraphVisibilityChanged, subgraph.clone()),
+                |candidate| {
+                    let subgraph_index = subgraph_index(candidate, subgraph)?;
+                    candidate.subgraphs[subgraph_index].invisible = *invisible;
+                    Ok(())
+                },
+            )
+        }
+    }
+}
+
+fn apply_with_relayout(
+    output: &mut Document,
+    kind: MmdsDiffKind,
+    mutate: impl FnOnce(&mut Document) -> Result<(), CommandApplyError>,
+) -> Result<Vec<MmdsDiffEvent>, CommandApplyError> {
+    apply_with_relayout_event(output, document_event(kind), mutate)
+}
+
+fn apply_with_relayout_event(
+    output: &mut Document,
+    event: MmdsDiffEvent,
+    mutate: impl FnOnce(&mut Document) -> Result<(), CommandApplyError>,
+) -> Result<Vec<MmdsDiffEvent>, CommandApplyError> {
+    let mut candidate = output.clone();
+    mutate(&mut candidate)?;
+    let relaid = relayout_output_for_command_apply(&candidate)?;
+    *output = relaid;
+    Ok(vec![event])
+}
+
+fn set_node_style_extension(output: &mut Document, node: &str, value: Value) {
+    let extension = output
+        .extensions
+        .entry(NODE_STYLE_EXTENSION_NAMESPACE.to_string())
+        .or_default();
+    let nodes = extension
+        .entry("nodes".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    if !nodes.is_object() {
+        *nodes = Value::Object(serde_json::Map::new());
+    }
+    nodes
+        .as_object_mut()
+        .expect("nodes style extension should be an object")
+        .insert(node.to_string(), value);
+}
+
+fn document_event(kind: MmdsDiffKind) -> MmdsDiffEvent {
+    MmdsDiffEvent {
+        kind,
+        subject: MmdsDiffSubject::Document,
+        evidence: Vec::new(),
+        related_event_ids: Vec::new(),
+    }
+}
+
+fn node_event(kind: MmdsDiffKind, id: String) -> MmdsDiffEvent {
+    MmdsDiffEvent {
+        kind,
+        subject: MmdsDiffSubject::Node(id),
+        evidence: Vec::new(),
+        related_event_ids: Vec::new(),
+    }
+}
+
+fn edge_event(kind: MmdsDiffKind, id: String) -> MmdsDiffEvent {
+    MmdsDiffEvent {
+        kind,
+        subject: MmdsDiffSubject::Edge(id),
+        evidence: Vec::new(),
+        related_event_ids: Vec::new(),
+    }
+}
+
+fn subgraph_event(kind: MmdsDiffKind, id: String) -> MmdsDiffEvent {
+    MmdsDiffEvent {
+        kind,
+        subject: MmdsDiffSubject::Subgraph(id),
+        evidence: Vec::new(),
+        related_event_ids: Vec::new(),
+    }
+}
+
+fn node_index(output: &Document, id: &str) -> Result<usize, CommandApplyError> {
+    output
+        .nodes
+        .iter()
+        .position(|node| node.id == id)
+        .ok_or_else(|| CommandApplyError::NodeNotFound { id: id.to_string() })
+}
+
+fn subgraph_index(output: &Document, id: &str) -> Result<usize, CommandApplyError> {
+    output
+        .subgraphs
+        .iter()
+        .position(|subgraph| subgraph.id == id)
+        .ok_or_else(|| CommandApplyError::SubgraphNotFound { id: id.to_string() })
+}
+
+fn sync_subgraph_children_from_node_parents(output: &mut Document) {
+    for subgraph in &mut output.subgraphs {
+        subgraph.children.clear();
+    }
+
+    let memberships: Vec<(String, String)> = output
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            node.parent
+                .as_ref()
+                .map(|parent| (node.id.clone(), parent.clone()))
+        })
+        .collect();
+
+    for (node, parent) in memberships {
+        if let Some(subgraph) = output
+            .subgraphs
+            .iter_mut()
+            .find(|subgraph| subgraph.id == parent)
+        {
+            subgraph.children.push(node);
+        }
+    }
+}
+
+fn resolve_new_edge_id(
+    output: &Document,
+    requested: Option<&str>,
+) -> Result<String, CommandApplyError> {
+    let expected = format!("e{}", output.edges.len());
+    match requested {
+        None => Ok(expected),
+        Some(id) if output.edges.iter().any(|edge| edge.id == id) => {
+            Err(CommandApplyError::AddEdgeIdCollision { id: id.to_string() })
+        }
+        Some(id) if id == expected => Ok(expected),
+        Some(id) => Err(CommandApplyError::AddEdgeIdUnsupported {
+            id: id.to_string(),
+            expected,
+        }),
+    }
+}
+
+fn resolve_edge_index(
+    output: &Document,
+    selector: &EdgeSelector,
+) -> Result<usize, CommandApplyError> {
+    match selector {
+        EdgeSelector::Id(id) => output
+            .edges
+            .iter()
+            .position(|edge| edge.id == *id)
+            .ok_or_else(|| CommandApplyError::EdgeSelectorNoMatch {
+                selector: Box::new(selector.clone()),
+            }),
+        EdgeSelector::Semantic { .. } => {
+            let matches: Vec<usize> = output
+                .edges
+                .iter()
+                .enumerate()
+                .filter_map(|(index, edge)| {
+                    semantic_selector_matches(edge, selector).then_some(index)
+                })
+                .collect();
+
+            match matches.as_slice() {
+                [] => Err(CommandApplyError::EdgeSelectorNoMatch {
+                    selector: Box::new(selector.clone()),
+                }),
+                [index] => Ok(*index),
+                _ => Err(CommandApplyError::EdgeSelectorAmbiguous {
+                    selector: Box::new(selector.clone()),
+                    matches: matches
+                        .into_iter()
+                        .map(|index| output.edges[index].id.clone())
+                        .collect(),
+                }),
+            }
+        }
+    }
+}
+
+fn semantic_selector_matches(edge: &super::Edge, selector: &EdgeSelector) -> bool {
+    let EdgeSelector::Semantic {
+        source,
+        target,
+        label,
+        stroke,
+        arrow_start,
+        arrow_end,
+        minlen,
+    } = selector
+    else {
+        return false;
+    };
+
+    edge.source == *source
+        && edge.target == *target
+        && label
+            .as_ref()
+            .is_none_or(|expected| edge.label.as_ref() == Some(expected))
+        && stroke
+            .as_ref()
+            .is_none_or(|expected| edge.stroke == *expected)
+        && arrow_start
+            .as_ref()
+            .is_none_or(|expected| edge.arrow_start == *expected)
+        && arrow_end
+            .as_ref()
+            .is_none_or(|expected| edge.arrow_end == *expected)
+        && minlen.is_none_or(|expected| edge.minlen == expected)
+}
+
+pub(crate) fn relayout_output_for_command_apply(
+    output: &Document,
+) -> Result<Document, CommandApplyError> {
+    let mut diagram = crate::mmds::from_document(output)
+        .map_err(|err| relayout_failed("hydrate", err.to_string()))?;
+    let geometry_level = output
+        .geometry_level
+        .parse::<GeometryLevel>()
+        .map_err(|err| relayout_failed("config", err.to_string()))?;
+    let layout_engine = output
+        .metadata
+        .engine
+        .as_deref()
+        .map(EngineAlgorithmId::parse)
+        .transpose()
+        .map_err(|err| relayout_failed("config", err.to_string()))?;
+    let config = RenderConfig {
+        geometry_level,
+        layout_engine,
+        ..RenderConfig::default()
+    };
+    let json = crate::runtime::graph_family::render_graph_family(
+        &output.metadata.diagram_type,
+        &mut diagram,
+        OutputFormat::Mmds,
+        &config,
+    )
+    .map_err(|err| relayout_failed("solve-render", err.to_string()))?;
+
+    crate::mmds::parse_input(&json).map_err(|err| relayout_failed("parse", err.to_string()))
+}
+
+fn relayout_failed(stage: &str, source: String) -> CommandApplyError {
+    CommandApplyError::RelayoutFailed {
+        stage: stage.to_string(),
+        source,
     }
 }


### PR DESCRIPTION
## Summary

Adds the test-only synchronous MMDS command processor for the internal command vocabulary introduced by the previous command-vocabulary work. The processor applies `Command` values to MMDS `Document` values, returns structured `MmdsDiffEvent` results or structured `CommandApplyError` failures, and uses a full relayout fallback for layout-affecting edits. This remains behind `#[cfg(test)]`; it does not add public API, CLI behavior, schema changes, or production command processing.

## What this includes

- Command apply surface for document, node, edge, and subgraph commands.
- In-place handling for metadata-only commands such as profiles, generic extensions, node style extension payloads, and subgraph title changes.
- Full relayout fallback for layout-affecting commands through `Document -> Graph -> MMDS -> Document`.
- Edge selector resolution with no-match and ambiguity errors.
- Dense `AddEdge` ID policy: omitted ID or next dense `e{i}` accepted; collisions and unsupported explicit IDs return structured errors.
- Compute-then-commit rollback behavior for failed relayout paths.
- Round-trip command/diff validation that asserts the expected `(MmdsDiffKind, subject)` appears after applying each command.

## Scope boundaries

- No public API or public exports.
- No CLI or TypeScript surface.
- No MMDS schema changes.
- No command synthesis from diffs.
- No incremental layout, route caching, previous-layout state, async processing, or transport layer.
- No productionization of the command processor; all code is crate-internal and test-gated.

## Validation

- `cog check "origin/main..HEAD"` passed after squashing.
- `cargo nextest run -E 'test(mmds_command_apply_relayout_invalid_engine_config_rolls_back) | test(mmds_command_apply_tier_a_representative_canaries_hold) | test(mmds_command_apply_failure_modes)'` passed.
- `cargo nextest run -E 'test(mmds_command_apply) | test(mmds_command_vocabulary) | test(mmds_diff) | test(layout_stability)'` passed: 169 tests.
- `just check` passed: 2913 tests passed, 8 skipped.

## Notes

The relayout helper uses the current `Document` / `from_document` MMDS names and intentionally reconstructs render output from standalone MMDS state. Settings not carried by MMDS fall back to `RenderConfig::default()` except for `geometry_level` and `metadata.engine`, which are read from the document.
