### PR TITLE
feat: expose mmds diff and commands APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Most Rust integrations should stay on the high-level runtime facade:
 
 - `render_diagram`
 - `materialize_diagram`
-- `render_mmds_document`
+- `render_document`
 - `detect_diagram`
 - `validate_diagram`
 

--- a/boundaries.toml
+++ b/boundaries.toml
@@ -27,6 +27,7 @@ payload = {}
 registry = {}
 diagrams = {}
 builtins = { tags = { role = "runtime-facade" } }
+commands = {}
 mmds = {}
 views = {}
 frontends = { tags = { role = "runtime-facade" } }
@@ -146,6 +147,13 @@ type = "allow"
 [rules.config]
 source = "builtins"
 allowed = ["diagrams", "format", "registry"]
+
+[[rules]]
+id = "allow-commands"
+type = "allow"
+[rules.config]
+source = "commands"
+allowed = ["errors", "format", "graph", "mmds", "runtime"]
 
 # Must not import diagrams, config, engines, render, or runtime.
 [[rules]]

--- a/docs/architecture/dependency-rules.md
+++ b/docs/architecture/dependency-rules.md
@@ -9,6 +9,7 @@ contributors:
 - `diagrams/` own compilation and instance behavior
 - `payload/` owns the runtime payload contract
 - `builtins/` owns default registry wiring for the supported low-level API
+- `commands.rs` owns synchronous command application over MMDS documents
 - `graph/` owns graph-family IR, float-space geometry, and shared policy/measurement helpers
 - `engines/` own engine adapters and internal algorithm boundaries such as `algorithms::layered::kernel`
 - `render/` owns output production
@@ -44,9 +45,9 @@ contributors do not need any extra socket setup.
   `validate_diagram`, plus the flat config/format/error types re-exported from
   `lib.rs`.
 - The supported low-level API is `builtins`, `registry`, `payload`, `graph`,
-  `timeline`, `mmds`, and `views` for adapter-oriented workflows that need
-  explicit payload construction, graph IR inspection, MMDS replay control, or
-  materialized read-side diagram views.
+  `timeline`, `mmds`, `commands`, and `views` for adapter-oriented workflows
+  that need explicit payload construction, graph IR inspection, MMDS command
+  application, MMDS replay control, or materialized read-side diagram views.
 - `diagrams`, `engines`, `render`, and `mermaid` are internal implementation modules.
   They are intentionally documented here for contributors, but they are not part
   of the supported low-level contract.
@@ -125,7 +126,7 @@ collapsed back into singleton roots:
     in the logical diagram registry.
 
 11. **views/ owns read-side materialized diagram views** — `src/views/` owns
-    the `ViewSpec`, selector, `ViewEvent`, and `apply_view` contracts for
+    the `ViewSpec`, selector, `ViewEvent`, and `project` contracts for
     filtering canonical `mmds::Document` payloads into materialized view
     payloads. In the v1 view slice, `views` depends on `mmds` only and derives
     any adjacency directly from `Document.edges`; it must not import `graph`,
@@ -133,7 +134,23 @@ collapsed back into singleton roots:
     machinery. Runtime may consume `views` for replay hooks, but `views` does
     not own rendering or orchestration.
 
-12. **engines do not know about diagram types or output formats** — Engine
+12. **commands.rs owns MMDS command application orchestration** —
+    `src/commands.rs` owns the public `Command`, `EdgeSelector`,
+    `CommandApplyError`, `apply`, and `apply_with_config` contracts. It may
+    depend on `mmds` for the document and diff vocabulary, and on `runtime` for
+    full relayout fallback. `mmds/` stays a pure interchange layer; command
+    application is a separate supported low-level API surface rather than a
+    child of `mmds/`.
+
+    The split between `mmds::events` and top-level `commands` / `views` is
+    intentional: `mmds/` owns the canonical document plus the portable
+    vocabulary that describes it (`Subject`, model events, and snapshot diff
+    changes), while top-level operation surfaces own functions that act on
+    those documents. This keeps MMDS vocabulary reusable by adapters and future
+    bindings without pulling in command processing, projection, runtime,
+    engine, or render infrastructure.
+
+13. **engines do not know about diagram types or output formats** — Engine
     implementations (`src/engines/`) solve generic graph layout problems and
     own layout building / measurement adapters. They may use shared
     graph-family helpers, but they never reference flowchart, class, sequence,
@@ -149,7 +166,7 @@ collapsed back into singleton roots:
     and float routing. `layered::kernel` stays internal; it is a contributor
     boundary, not a supported public contract.
 
-13. **flat top-level contract modules own the stable public contract** —
+14. **flat top-level contract modules own the stable public contract** —
     Stable public format and error vocabulary live in `src/format.rs` and
     `src/errors.rs`. `RenderConfig` lives in `src/runtime/config.rs`
     (re-exported from `lib.rs`). Diagnostics live in `errors`, family
@@ -158,33 +175,33 @@ collapsed back into singleton roots:
     from `lib.rs`. Other namespaces are either part of the supported
     low-level API or internal implementation modules.
 
-14. **runtime/ is orchestration only** — The runtime layer detects input
+15. **runtime/ is orchestration only** — The runtime layer detects input
     frontends, resolves logical diagram types, manages the registry, consumes
     runtime payloads, and wires the pipeline. Graph-family runtime
     dispatch lives under `src/runtime/`; runtime itself does not own Mermaid
     grammars, layout algorithms, or renderer implementations.
 
-15. **registry is contract-only infrastructure** — `src/registry.rs` defines
+16. **registry is contract-only infrastructure** — `src/registry.rs` defines
     reusable registry contracts (`DiagramRegistry`, `DiagramDefinition`,
     `DiagramInstance`) and does not import concrete diagram modules. Built-in
     diagram wiring lives in the separate public `builtins` namespace.
 
-16. **timeline::sequence owns shared sequence runtime types** — Shared
+17. **timeline::sequence owns shared sequence runtime types** — Shared
     sequence-family model and layout types live under `src/timeline/sequence/`
     so the final text renderer can depend on a neutral timeline namespace
     instead of importing `diagrams::sequence`.
 
 ## Adapter Rules
 
-17. **web main.ts is composition only** — The web playground's `main.ts` is a
+18. **web main.ts is composition only** — The web playground's `main.ts` is a
     composition root that wires stores, services, and controllers. It does not
     contain application logic, state management, or rendering orchestration.
 
-18. **wasm adapter is a thin boundary** — `crates/mmdflux-wasm` deserializes JS
+19. **wasm adapter is a thin boundary** — `crates/mmdflux-wasm` deserializes JS
     requests, calls the Rust facade, and serializes responses. It does not
     duplicate config parsing, registry logic, or format selection.
 
-19. **CLI adapter is a thin boundary** — `src/main.rs` maps CLI flags to the
+20. **CLI adapter is a thin boundary** — `src/main.rs` maps CLI flags to the
     Rust facade contract and formats output. It does not contain business logic
     beyond argument mapping.
 

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -22,7 +22,7 @@ Most Rust callers should produce MMDS through the high-level runtime facade:
   (`render_diagram` auto-detects MMDS input and dispatches to the replay path)
 - `materialize_diagram(input, &config)` for materializing a graph-family
   `mmds::Document` directly from Mermaid or MMDS input
-- `render_mmds_document(&document, output_format, &config)` for rendering an
+- `render_document(&document, output_format, &config)` for rendering an
   already-parsed graph-family `mmds::Document` without a JSON round trip
 
 Adapter-oriented workflows can use the low-level API:
@@ -67,7 +67,7 @@ small materialization API, not a general graph query language.
 
 The primary entry point is:
 
-- `mmdflux::views::apply_view(canonical: &mmdflux::mmds::Document, spec: &ViewSpec) -> Result<(Document, Vec<ViewEvent>), ViewError>`
+- `mmdflux::views::project(canonical: &mmdflux::mmds::Document, spec: &ViewSpec) -> Result<(Document, Vec<ViewEvent>), ViewError>`
 
 `ViewSpec` v1 supports:
 
@@ -94,7 +94,7 @@ falling back silently.
 
 ### View Payload Contract
 
-`apply_view` returns a normal MMDS `Document` with retained nodes, retained
+`project` returns a normal MMDS `Document` with retained nodes, retained
 subgraphs, surviving edges, and a `Vec<ViewEvent>` describing omitted canonical
 elements. Surviving edge IDs are preserved verbatim from the canonical payload;
 filtered views may therefore contain sparse IDs such as `["e0", "e2", "e4"]`.
@@ -123,9 +123,9 @@ To render a materialized view, pass the returned `Document` through the typed
 runtime replay helper:
 
 ```rust
-use mmdflux::{OutputFormat, RenderConfig, render_mmds_document};
+use mmdflux::{OutputFormat, RenderConfig, render_document};
 
-let text = render_mmds_document(&view_payload, OutputFormat::Text, &RenderConfig::default())?;
+let text = render_document(&view_payload, OutputFormat::Text, &RenderConfig::default())?;
 println!("{text}");
 ```
 

--- a/examples/materialized_view.rs
+++ b/examples/materialized_view.rs
@@ -1,8 +1,8 @@
 use mmdflux::mmds::Document;
 use mmdflux::views::{
-    AnchorRef, Selector, TraversalDirection, ViewEvent, ViewSpec, ViewStatement, apply_view,
+    AnchorRef, Selector, TraversalDirection, ViewEvent, ViewSpec, ViewStatement, project,
 };
-use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_mmds_document};
+use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_document};
 
 const SOURCE: &str = r#"graph TD
 service_a[Service A] --> service_b[Service B]
@@ -23,8 +23,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..ViewSpec::default()
     };
 
-    let (view, events) = apply_view(&canonical, &spec)?;
-    let text = render_mmds_document(&view, OutputFormat::Text, &RenderConfig::default())?;
+    let (view, events) = project(&canonical, &spec)?;
+    let text = render_document(&view, OutputFormat::Text, &RenderConfig::default())?;
 
     println!("retained nodes:");
     for node in &view.nodes {

--- a/examples/mmds_replay.rs
+++ b/examples/mmds_replay.rs
@@ -45,8 +45,7 @@ const MMDS_INPUT: &str = r#"{
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let payload: Document = MMDS_INPUT.parse()?;
     let negotiation = evaluate_profiles_for_document(&payload);
-    let text =
-        mmdflux::render_mmds_document(&payload, OutputFormat::Text, &RenderConfig::default())?;
+    let text = mmdflux::render_document(&payload, OutputFormat::Text, &RenderConfig::default())?;
     let mermaid = generate_mermaid(&payload)?;
 
     println!("supported profiles: {:?}", negotiation.supported);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,55 +1,95 @@
+//! Command vocabulary and synchronous MMDS command application.
+//!
+//! This module applies one [`Command`] to a fully materialized MMDS [`Document`] and
+//! returns model events. Model events describe accepted model mutations. They are
+//! intentionally different from the snapshot diff returned by
+//! [`crate::mmds::diff::diff_documents`], which compares two document states and can
+//! collapse, reorder, or expand command headlines.
+//!
+//! Use [`apply`] when default relayout configuration is acceptable. Use
+//! [`apply_with_config`] when layout-affecting commands should preserve caller-owned
+//! [`RenderConfig`] fields. In both cases, document-owned fields remain authoritative:
+//! the document `geometry_level` is parsed into the effective relayout config, and
+//! `metadata.engine` overrides the caller engine when it is present.
+//!
+//! Edge commands can use [`EdgeSelector::Id`] for exact edge identity or
+//! [`EdgeSelector::Semantic`] for best-effort matching by endpoint and optional edge
+//! fields. Semantic selectors can be ambiguous for parallel edges and return
+//! [`CommandApplyError::EdgeSelectorAmbiguous`].
+//!
+//! `AddEdge.id` accepts `None` to allocate the next dense `e{index}` identifier. An
+//! explicit ID must be that next dense ID; existing IDs and arbitrary non-next IDs are
+//! rejected with structured errors. [`Command::SetExtension`] wraps non-object JSON
+//! values under a `"value"` key because [`Document::extensions`] stores object payloads.
+//!
+//! [`CommandApplyError`] implements [`std::error::Error`] and keeps its variants public
+//! so callers can either bubble errors through trait objects or match precise failure
+//! policies.
+
 use serde_json::Value;
+use thiserror::Error;
 
-use super::diff::{MmdsDiffEvent, MmdsDiffKind, MmdsDiffSubject};
-use super::{Document, Edge, NODE_STYLE_EXTENSION_NAMESPACE, Node, Position, Size, Subgraph};
-use crate::engines::graph::EngineAlgorithmId;
+use crate::format::OutputFormat;
 use crate::graph::GeometryLevel;
-use crate::{OutputFormat, RenderConfig};
+#[cfg(test)]
+use crate::mmds::diff::ChangeKind;
+use crate::mmds::events::{ModelEvent, ModelEventKind};
+use crate::mmds::{
+    Document, Edge, NODE_STYLE_EXTENSION_NAMESPACE, Node, Position, Size, Subgraph, Subject,
+};
+use crate::runtime::config::RenderConfig;
 
-const COMMANDABLE_DIFF_KINDS: &[MmdsDiffKind] = &[
-    MmdsDiffKind::GeometryLevelChanged,
-    MmdsDiffKind::DirectionChanged,
-    MmdsDiffKind::EngineChanged,
-    MmdsDiffKind::NodeAdded,
-    MmdsDiffKind::NodeRemoved,
-    MmdsDiffKind::EdgeAdded,
-    MmdsDiffKind::EdgeRemoved,
-    MmdsDiffKind::SubgraphAdded,
-    MmdsDiffKind::SubgraphRemoved,
-    MmdsDiffKind::NodeLabelChanged,
-    MmdsDiffKind::NodeShapeChanged,
-    MmdsDiffKind::NodeParentChanged,
-    MmdsDiffKind::NodeStyleChanged,
-    MmdsDiffKind::EdgeReconnected,
-    MmdsDiffKind::EdgeEndpointIntentChanged,
-    MmdsDiffKind::EdgeLabelChanged,
-    MmdsDiffKind::EdgeStyleChanged,
-    MmdsDiffKind::SubgraphTitleChanged,
-    MmdsDiffKind::SubgraphDirectionChanged,
-    MmdsDiffKind::SubgraphParentChanged,
-    MmdsDiffKind::SubgraphMembershipChanged,
-    MmdsDiffKind::SubgraphVisibilityChanged,
-    MmdsDiffKind::ProfileChanged,
-    MmdsDiffKind::ExtensionChanged,
+#[cfg(test)]
+const COMMANDABLE_MODEL_EVENT_KINDS: &[ModelEventKind] = &[
+    ModelEventKind::GeometryLevelChanged,
+    ModelEventKind::DirectionChanged,
+    ModelEventKind::EngineChanged,
+    ModelEventKind::NodeAdded,
+    ModelEventKind::NodeRemoved,
+    ModelEventKind::EdgeAdded,
+    ModelEventKind::EdgeRemoved,
+    ModelEventKind::SubgraphAdded,
+    ModelEventKind::SubgraphRemoved,
+    ModelEventKind::NodeLabelChanged,
+    ModelEventKind::NodeShapeChanged,
+    ModelEventKind::NodeParentChanged,
+    ModelEventKind::NodeStyleChanged,
+    ModelEventKind::EdgeReconnected,
+    ModelEventKind::EdgeEndpointIntentChanged,
+    ModelEventKind::EdgeLabelChanged,
+    ModelEventKind::EdgeStyleChanged,
+    ModelEventKind::SubgraphTitleChanged,
+    ModelEventKind::SubgraphDirectionChanged,
+    ModelEventKind::SubgraphParentChanged,
+    ModelEventKind::SubgraphMembershipChanged,
+    ModelEventKind::SubgraphVisibilityChanged,
+    ModelEventKind::ProfileChanged,
+    ModelEventKind::ExtensionChanged,
 ];
 
-const GEOMETRY_EFFECT_DIFF_KINDS: &[MmdsDiffKind] = &[
-    MmdsDiffKind::NodeMoved,
-    MmdsDiffKind::NodeResized,
-    MmdsDiffKind::CanvasResized,
-    MmdsDiffKind::SubgraphBoundsChanged,
-    MmdsDiffKind::EdgeRerouted,
-    MmdsDiffKind::EndpointFaceChanged,
-    MmdsDiffKind::PortIntentChanged,
-    MmdsDiffKind::LabelMoved,
-    MmdsDiffKind::LabelResized,
-    MmdsDiffKind::LabelSideChanged,
-    MmdsDiffKind::PathPortDivergenceChanged,
-    MmdsDiffKind::GlobalReflowDetected,
+#[cfg(test)]
+const GEOMETRY_EFFECT_DIFF_KINDS: &[ChangeKind] = &[
+    ChangeKind::NodeMoved,
+    ChangeKind::NodeResized,
+    ChangeKind::CanvasResized,
+    ChangeKind::SubgraphBoundsChanged,
+    ChangeKind::EdgeRerouted,
+    ChangeKind::EndpointFaceChanged,
+    ChangeKind::PortIntentChanged,
+    ChangeKind::LabelMoved,
+    ChangeKind::LabelResized,
+    ChangeKind::LabelSideChanged,
+    ChangeKind::PathPortDivergenceChanged,
+    ChangeKind::GlobalReflowDetected,
 ];
 
+/// Command vocabulary for crate-owned MMDS document edits.
+///
+/// Commands describe intent, not transport. Applying a command can update semantic
+/// fields directly or run a full relayout depending on the variant, but the returned
+/// events remain model events rather than snapshot diff changes.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) enum Command {
+pub enum Command {
     SetGeometryLevel {
         level: String,
     },
@@ -164,8 +204,14 @@ pub(crate) enum Command {
     },
 }
 
+/// Selector used by commands that operate on an existing edge.
+///
+/// Prefer [`EdgeSelector::Id`] when the caller has a stable MMDS edge ID. Use
+/// [`EdgeSelector::Semantic`] when selecting by source, target, and optional edge
+/// attributes is acceptable. Semantic selectors intentionally return ambiguity errors
+/// instead of guessing when multiple parallel edges match.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum EdgeSelector {
+pub enum EdgeSelector {
     Id(String),
     Semantic {
         source: String,
@@ -178,137 +224,158 @@ pub(crate) enum EdgeSelector {
     },
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum MmdsDiffKindRole {
-    Commandable,
-    GeometryEffect,
+pub(crate) enum ChangeKindLayer {
+    Model,
+    Geometry,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum CommandApplyError {
-    NodeNotFound {
-        id: String,
-    },
-    SubgraphNotFound {
-        id: String,
-    },
-    SubjectAlreadyExists {
-        id: String,
-    },
-    EdgeSelectorNoMatch {
-        selector: Box<EdgeSelector>,
-    },
+/// Structured failures produced while applying an MMDS command.
+///
+/// Variants are part of the public command contract and can be matched directly.
+/// The type also implements [`std::error::Error`] through `thiserror`.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum CommandApplyError {
+    #[error("node not found: {id}")]
+    NodeNotFound { id: String },
+    #[error("subgraph not found: {id}")]
+    SubgraphNotFound { id: String },
+    #[error("subject already exists: {id}")]
+    SubjectAlreadyExists { id: String },
+    #[error("edge selector did not match any edge: {selector:?}")]
+    EdgeSelectorNoMatch { selector: Box<EdgeSelector> },
+    #[error("edge selector matched multiple edges {matches:?}: {selector:?}")]
     EdgeSelectorAmbiguous {
         selector: Box<EdgeSelector>,
         matches: Vec<String>,
     },
-    AddEdgeIdCollision {
-        id: String,
-    },
-    AddEdgeIdUnsupported {
-        id: String,
-        expected: String,
-    },
-    RelayoutFailed {
-        stage: String,
-        source: String,
-    },
+    #[error("edge id already exists: {id}")]
+    AddEdgeIdCollision { id: String },
+    #[error("unsupported edge id {id}; expected {expected}")]
+    AddEdgeIdUnsupported { id: String, expected: String },
+    #[error("relayout failed during {stage}: {message}")]
+    RelayoutFailed { stage: String, message: String },
 }
 
-pub(crate) fn commandable_diff_kinds() -> &'static [MmdsDiffKind] {
-    COMMANDABLE_DIFF_KINDS
+#[cfg(test)]
+pub(crate) fn commandable_model_event_kinds() -> &'static [ModelEventKind] {
+    COMMANDABLE_MODEL_EVENT_KINDS
 }
 
-pub(crate) fn geometry_effect_diff_kinds() -> &'static [MmdsDiffKind] {
+#[cfg(test)]
+pub(crate) fn geometry_effect_change_kinds() -> &'static [ChangeKind] {
     GEOMETRY_EFFECT_DIFF_KINDS
 }
 
-pub(crate) fn diff_kind_role(kind: MmdsDiffKind) -> MmdsDiffKindRole {
+#[cfg(test)]
+pub(crate) fn change_kind_layer(kind: ChangeKind) -> ChangeKindLayer {
     let role = match kind {
-        MmdsDiffKind::GeometryLevelChanged
-        | MmdsDiffKind::DirectionChanged
-        | MmdsDiffKind::EngineChanged
-        | MmdsDiffKind::NodeAdded
-        | MmdsDiffKind::NodeRemoved
-        | MmdsDiffKind::EdgeAdded
-        | MmdsDiffKind::EdgeRemoved
-        | MmdsDiffKind::SubgraphAdded
-        | MmdsDiffKind::SubgraphRemoved
-        | MmdsDiffKind::NodeLabelChanged
-        | MmdsDiffKind::NodeShapeChanged
-        | MmdsDiffKind::NodeParentChanged
-        | MmdsDiffKind::NodeStyleChanged
-        | MmdsDiffKind::EdgeReconnected
-        | MmdsDiffKind::EdgeEndpointIntentChanged
-        | MmdsDiffKind::EdgeLabelChanged
-        | MmdsDiffKind::EdgeStyleChanged
-        | MmdsDiffKind::SubgraphTitleChanged
-        | MmdsDiffKind::SubgraphDirectionChanged
-        | MmdsDiffKind::SubgraphParentChanged
-        | MmdsDiffKind::SubgraphMembershipChanged
-        | MmdsDiffKind::SubgraphVisibilityChanged
-        | MmdsDiffKind::ProfileChanged
-        | MmdsDiffKind::ExtensionChanged => MmdsDiffKindRole::Commandable,
-        MmdsDiffKind::NodeMoved
-        | MmdsDiffKind::NodeResized
-        | MmdsDiffKind::CanvasResized
-        | MmdsDiffKind::SubgraphBoundsChanged
-        | MmdsDiffKind::EdgeRerouted
-        | MmdsDiffKind::EndpointFaceChanged
-        | MmdsDiffKind::PortIntentChanged
-        | MmdsDiffKind::LabelMoved
-        | MmdsDiffKind::LabelResized
-        | MmdsDiffKind::LabelSideChanged
-        | MmdsDiffKind::PathPortDivergenceChanged
-        | MmdsDiffKind::GlobalReflowDetected => MmdsDiffKindRole::GeometryEffect,
+        ChangeKind::GeometryLevelChanged
+        | ChangeKind::DirectionChanged
+        | ChangeKind::EngineChanged
+        | ChangeKind::NodeAdded
+        | ChangeKind::NodeRemoved
+        | ChangeKind::EdgeAdded
+        | ChangeKind::EdgeRemoved
+        | ChangeKind::SubgraphAdded
+        | ChangeKind::SubgraphRemoved
+        | ChangeKind::NodeLabelChanged
+        | ChangeKind::NodeShapeChanged
+        | ChangeKind::NodeParentChanged
+        | ChangeKind::NodeStyleChanged
+        | ChangeKind::EdgeReconnected
+        | ChangeKind::EdgeEndpointIntentChanged
+        | ChangeKind::EdgeLabelChanged
+        | ChangeKind::EdgeStyleChanged
+        | ChangeKind::SubgraphTitleChanged
+        | ChangeKind::SubgraphDirectionChanged
+        | ChangeKind::SubgraphParentChanged
+        | ChangeKind::SubgraphMembershipChanged
+        | ChangeKind::SubgraphVisibilityChanged
+        | ChangeKind::ProfileChanged
+        | ChangeKind::ExtensionChanged => ChangeKindLayer::Model,
+        ChangeKind::NodeMoved
+        | ChangeKind::NodeResized
+        | ChangeKind::CanvasResized
+        | ChangeKind::SubgraphBoundsChanged
+        | ChangeKind::EdgeRerouted
+        | ChangeKind::EndpointFaceChanged
+        | ChangeKind::PortIntentChanged
+        | ChangeKind::LabelMoved
+        | ChangeKind::LabelResized
+        | ChangeKind::LabelSideChanged
+        | ChangeKind::PathPortDivergenceChanged
+        | ChangeKind::GlobalReflowDetected => ChangeKindLayer::Geometry,
     };
 
-    debug_assert_eq!(
-        kind.is_geometry_effect(),
-        role == MmdsDiffKindRole::GeometryEffect
-    );
+    debug_assert_eq!(kind.is_geometry(), role == ChangeKindLayer::Geometry);
     role
 }
 
-pub(crate) fn diff_kind_for_command(command: &Command) -> MmdsDiffKind {
+#[cfg(test)]
+pub(crate) fn model_event_kind_for_command(command: &Command) -> ModelEventKind {
     match command {
-        Command::SetGeometryLevel { .. } => MmdsDiffKind::GeometryLevelChanged,
-        Command::SetDirection { .. } => MmdsDiffKind::DirectionChanged,
-        Command::SetEngine { .. } => MmdsDiffKind::EngineChanged,
-        Command::AddNode { .. } => MmdsDiffKind::NodeAdded,
-        Command::RemoveNode { .. } => MmdsDiffKind::NodeRemoved,
-        Command::ChangeNodeLabel { .. } => MmdsDiffKind::NodeLabelChanged,
-        Command::ChangeNodeShape { .. } => MmdsDiffKind::NodeShapeChanged,
-        Command::SetNodeParent { .. } => MmdsDiffKind::NodeParentChanged,
-        Command::SetNodeStyleExtension { .. } => MmdsDiffKind::NodeStyleChanged,
-        Command::SetProfiles { .. } => MmdsDiffKind::ProfileChanged,
-        Command::SetExtension { .. } => MmdsDiffKind::ExtensionChanged,
-        Command::AddEdge { .. } => MmdsDiffKind::EdgeAdded,
-        Command::RemoveEdge { .. } => MmdsDiffKind::EdgeRemoved,
-        Command::ReconnectEdge { .. } => MmdsDiffKind::EdgeReconnected,
-        Command::SetEdgeEndpointIntent { .. } => MmdsDiffKind::EdgeEndpointIntentChanged,
-        Command::ChangeEdgeLabel { .. } => MmdsDiffKind::EdgeLabelChanged,
-        Command::ChangeEdgeStyle { .. } => MmdsDiffKind::EdgeStyleChanged,
-        Command::AddSubgraph { .. } => MmdsDiffKind::SubgraphAdded,
-        Command::RemoveSubgraph { .. } => MmdsDiffKind::SubgraphRemoved,
-        Command::ChangeSubgraphTitle { .. } => MmdsDiffKind::SubgraphTitleChanged,
-        Command::SetSubgraphDirection { .. } => MmdsDiffKind::SubgraphDirectionChanged,
-        Command::SetSubgraphParent { .. } => MmdsDiffKind::SubgraphParentChanged,
-        Command::ChangeSubgraphMembership { .. } => MmdsDiffKind::SubgraphMembershipChanged,
-        Command::SetSubgraphVisibility { .. } => MmdsDiffKind::SubgraphVisibilityChanged,
+        Command::SetGeometryLevel { .. } => ModelEventKind::GeometryLevelChanged,
+        Command::SetDirection { .. } => ModelEventKind::DirectionChanged,
+        Command::SetEngine { .. } => ModelEventKind::EngineChanged,
+        Command::AddNode { .. } => ModelEventKind::NodeAdded,
+        Command::RemoveNode { .. } => ModelEventKind::NodeRemoved,
+        Command::ChangeNodeLabel { .. } => ModelEventKind::NodeLabelChanged,
+        Command::ChangeNodeShape { .. } => ModelEventKind::NodeShapeChanged,
+        Command::SetNodeParent { .. } => ModelEventKind::NodeParentChanged,
+        Command::SetNodeStyleExtension { .. } => ModelEventKind::NodeStyleChanged,
+        Command::SetProfiles { .. } => ModelEventKind::ProfileChanged,
+        Command::SetExtension { .. } => ModelEventKind::ExtensionChanged,
+        Command::AddEdge { .. } => ModelEventKind::EdgeAdded,
+        Command::RemoveEdge { .. } => ModelEventKind::EdgeRemoved,
+        Command::ReconnectEdge { .. } => ModelEventKind::EdgeReconnected,
+        Command::SetEdgeEndpointIntent { .. } => ModelEventKind::EdgeEndpointIntentChanged,
+        Command::ChangeEdgeLabel { .. } => ModelEventKind::EdgeLabelChanged,
+        Command::ChangeEdgeStyle { .. } => ModelEventKind::EdgeStyleChanged,
+        Command::AddSubgraph { .. } => ModelEventKind::SubgraphAdded,
+        Command::RemoveSubgraph { .. } => ModelEventKind::SubgraphRemoved,
+        Command::ChangeSubgraphTitle { .. } => ModelEventKind::SubgraphTitleChanged,
+        Command::SetSubgraphDirection { .. } => ModelEventKind::SubgraphDirectionChanged,
+        Command::SetSubgraphParent { .. } => ModelEventKind::SubgraphParentChanged,
+        Command::ChangeSubgraphMembership { .. } => ModelEventKind::SubgraphMembershipChanged,
+        Command::SetSubgraphVisibility { .. } => ModelEventKind::SubgraphVisibilityChanged,
     }
 }
 
-pub(crate) fn apply(
+/// Apply a command using [`RenderConfig::default`] for any required relayout.
+///
+/// The returned events describe the accepted model mutation. To compare the final
+/// document against an earlier snapshot, use [`crate::mmds::diff::diff_documents`] and
+/// inspect the resulting snapshot diff.
+pub fn apply(
     command: &Command,
     output: &mut Document,
-) -> Result<Vec<MmdsDiffEvent>, CommandApplyError> {
+) -> Result<Vec<ModelEvent>, CommandApplyError> {
+    apply_with_config(command, output, &RenderConfig::default())
+}
+
+/// Apply a command using caller-provided relayout configuration.
+///
+/// The supplied [`RenderConfig`] is used as the base configuration for layout-affecting
+/// commands. Document-owned fields still win: `Document::geometry_level` replaces the
+/// caller geometry level, and `Document::metadata.engine` replaces the caller engine
+/// when the document records one. Caller-owned fields such as spacing, routing, padding,
+/// and simplification settings flow through.
+///
+/// Like [`apply`], this returns model events rather than snapshot diff changes.
+pub fn apply_with_config(
+    command: &Command,
+    output: &mut Document,
+    config: &RenderConfig,
+) -> Result<Vec<ModelEvent>, CommandApplyError> {
     match command {
         Command::RemoveNode { id } => {
             node_index(output, id)?;
             apply_with_relayout_event(
                 output,
-                node_event(MmdsDiffKind::NodeRemoved, id.clone()),
+                config,
+                node_event(ModelEventKind::NodeRemoved, id.clone()),
                 |candidate| {
                     candidate.nodes.retain(|node| node.id != *id);
                     candidate
@@ -327,7 +394,8 @@ pub(crate) fn apply(
             let edge_id = output.edges[edge_index].id.clone();
             apply_with_relayout_event(
                 output,
-                edge_event(MmdsDiffKind::EdgeLabelChanged, edge_id),
+                config,
+                edge_event(ModelEventKind::EdgeLabelChanged, edge_id),
                 |candidate| {
                     let edge_index = resolve_edge_index(candidate, edge)?;
                     candidate.edges[edge_index].label = label.clone();
@@ -358,7 +426,8 @@ pub(crate) fn apply(
             }
             apply_with_relayout_event(
                 output,
-                edge_event(MmdsDiffKind::EdgeAdded, edge_id.clone()),
+                config,
+                edge_event(ModelEventKind::EdgeAdded, edge_id.clone()),
                 |candidate| {
                     candidate.edges.push(Edge {
                         id: edge_id,
@@ -388,7 +457,8 @@ pub(crate) fn apply(
             let edge_id = output.edges[edge_index].id.clone();
             apply_with_relayout_event(
                 output,
-                edge_event(MmdsDiffKind::EdgeRemoved, edge_id),
+                config,
+                edge_event(ModelEventKind::EdgeRemoved, edge_id),
                 |candidate| {
                     let edge_index = resolve_edge_index(candidate, edge)?;
                     candidate.edges.remove(edge_index);
@@ -407,7 +477,8 @@ pub(crate) fn apply(
             node_index(output, target)?;
             apply_with_relayout_event(
                 output,
-                edge_event(MmdsDiffKind::EdgeReconnected, edge_id),
+                config,
+                edge_event(ModelEventKind::EdgeReconnected, edge_id),
                 |candidate| {
                     let edge_index = resolve_edge_index(candidate, edge)?;
                     candidate.edges[edge_index].source = source.clone();
@@ -431,7 +502,8 @@ pub(crate) fn apply(
             }
             apply_with_relayout_event(
                 output,
-                edge_event(MmdsDiffKind::EdgeEndpointIntentChanged, edge_id),
+                config,
+                edge_event(ModelEventKind::EdgeEndpointIntentChanged, edge_id),
                 |candidate| {
                     let edge_index = resolve_edge_index(candidate, edge)?;
                     candidate.edges[edge_index].from_subgraph = from_subgraph.clone();
@@ -451,7 +523,8 @@ pub(crate) fn apply(
             let edge_id = output.edges[edge_index].id.clone();
             apply_with_relayout_event(
                 output,
-                edge_event(MmdsDiffKind::EdgeStyleChanged, edge_id),
+                config,
+                edge_event(ModelEventKind::EdgeStyleChanged, edge_id),
                 |candidate| {
                     let edge_index = resolve_edge_index(candidate, edge)?;
                     if let Some(stroke) = stroke {
@@ -470,20 +543,26 @@ pub(crate) fn apply(
                 },
             )
         }
-        Command::SetGeometryLevel { level } => {
-            apply_with_relayout(output, MmdsDiffKind::GeometryLevelChanged, |candidate| {
+        Command::SetGeometryLevel { level } => apply_with_relayout(
+            output,
+            config,
+            ModelEventKind::GeometryLevelChanged,
+            |candidate| {
                 candidate.geometry_level = level.clone();
                 Ok(())
-            })
-        }
-        Command::SetDirection { direction } => {
-            apply_with_relayout(output, MmdsDiffKind::DirectionChanged, |candidate| {
+            },
+        ),
+        Command::SetDirection { direction } => apply_with_relayout(
+            output,
+            config,
+            ModelEventKind::DirectionChanged,
+            |candidate| {
                 candidate.metadata.direction = direction.clone();
                 Ok(())
-            })
-        }
+            },
+        ),
         Command::SetEngine { engine } => {
-            apply_with_relayout(output, MmdsDiffKind::EngineChanged, |candidate| {
+            apply_with_relayout(output, config, ModelEventKind::EngineChanged, |candidate| {
                 candidate.metadata.engine = engine.clone();
                 Ok(())
             })
@@ -502,7 +581,8 @@ pub(crate) fn apply(
             }
             apply_with_relayout_event(
                 output,
-                node_event(MmdsDiffKind::NodeAdded, id.clone()),
+                config,
+                node_event(ModelEventKind::NodeAdded, id.clone()),
                 |candidate| {
                     candidate.nodes.push(Node {
                         id: id.clone(),
@@ -523,7 +603,8 @@ pub(crate) fn apply(
             node_index(output, node)?;
             apply_with_relayout_event(
                 output,
-                node_event(MmdsDiffKind::NodeLabelChanged, node.clone()),
+                config,
+                node_event(ModelEventKind::NodeLabelChanged, node.clone()),
                 |candidate| {
                     let index = node_index(candidate, node)?;
                     candidate.nodes[index].label = label.clone();
@@ -535,7 +616,8 @@ pub(crate) fn apply(
             node_index(output, node)?;
             apply_with_relayout_event(
                 output,
-                node_event(MmdsDiffKind::NodeShapeChanged, node.clone()),
+                config,
+                node_event(ModelEventKind::NodeShapeChanged, node.clone()),
                 |candidate| {
                     let index = node_index(candidate, node)?;
                     candidate.nodes[index].shape = shape.clone();
@@ -550,7 +632,8 @@ pub(crate) fn apply(
             }
             apply_with_relayout_event(
                 output,
-                node_event(MmdsDiffKind::NodeParentChanged, node.clone()),
+                config,
+                node_event(ModelEventKind::NodeParentChanged, node.clone()),
                 |candidate| {
                     let index = node_index(candidate, node)?;
                     candidate.nodes[index].parent = parent.clone();
@@ -560,7 +643,7 @@ pub(crate) fn apply(
         }
         Command::SetProfiles { profiles } => {
             output.profiles = profiles.clone();
-            Ok(vec![document_event(MmdsDiffKind::ProfileChanged)])
+            Ok(vec![document_event(ModelEventKind::ProfileChanged)])
         }
         Command::SetExtension { namespace, value } => {
             output.extensions.insert(
@@ -571,19 +654,17 @@ pub(crate) fn apply(
                     payload
                 }),
             );
-            Ok(vec![document_event(MmdsDiffKind::ExtensionChanged)])
+            Ok(vec![document_event(ModelEventKind::ExtensionChanged)])
         }
         Command::SetNodeStyleExtension { node, value } => {
             if !output.nodes.iter().any(|candidate| candidate.id == *node) {
                 return Err(CommandApplyError::NodeNotFound { id: node.clone() });
             }
             set_node_style_extension(output, node, value.clone());
-            Ok(vec![MmdsDiffEvent {
-                kind: MmdsDiffKind::NodeStyleChanged,
-                subject: MmdsDiffSubject::Node(node.clone()),
-                evidence: Vec::new(),
-                related_event_ids: Vec::new(),
-            }])
+            Ok(vec![node_event(
+                ModelEventKind::NodeStyleChanged,
+                node.clone(),
+            )])
         }
         Command::ChangeSubgraphTitle { subgraph, title } => {
             let subgraph_index = output
@@ -596,12 +677,10 @@ pub(crate) fn apply(
             output.subgraphs[subgraph_index].title = title
                 .clone()
                 .unwrap_or_else(|| output.subgraphs[subgraph_index].id.clone());
-            Ok(vec![MmdsDiffEvent {
-                kind: MmdsDiffKind::SubgraphTitleChanged,
-                subject: MmdsDiffSubject::Subgraph(subgraph.clone()),
-                evidence: Vec::new(),
-                related_event_ids: Vec::new(),
-            }])
+            Ok(vec![subgraph_event(
+                ModelEventKind::SubgraphTitleChanged,
+                subgraph.clone(),
+            )])
         }
         Command::AddSubgraph {
             id,
@@ -626,7 +705,8 @@ pub(crate) fn apply(
             }
             apply_with_relayout_event(
                 output,
-                subgraph_event(MmdsDiffKind::SubgraphAdded, id.clone()),
+                config,
+                subgraph_event(ModelEventKind::SubgraphAdded, id.clone()),
                 |candidate| {
                     sync_subgraph_children_from_node_parents(candidate);
                     candidate.subgraphs.push(Subgraph {
@@ -656,7 +736,8 @@ pub(crate) fn apply(
             subgraph_index(output, id)?;
             apply_with_relayout_event(
                 output,
-                subgraph_event(MmdsDiffKind::SubgraphRemoved, id.clone()),
+                config,
+                subgraph_event(ModelEventKind::SubgraphRemoved, id.clone()),
                 |candidate| {
                     candidate.subgraphs.retain(|subgraph| subgraph.id != *id);
                     for node in &mut candidate.nodes {
@@ -682,7 +763,8 @@ pub(crate) fn apply(
             subgraph_index(output, subgraph)?;
             apply_with_relayout_event(
                 output,
-                subgraph_event(MmdsDiffKind::SubgraphDirectionChanged, subgraph.clone()),
+                config,
+                subgraph_event(ModelEventKind::SubgraphDirectionChanged, subgraph.clone()),
                 |candidate| {
                     let subgraph_index = subgraph_index(candidate, subgraph)?;
                     candidate.subgraphs[subgraph_index].direction = direction.clone();
@@ -697,7 +779,8 @@ pub(crate) fn apply(
             }
             apply_with_relayout_event(
                 output,
-                subgraph_event(MmdsDiffKind::SubgraphParentChanged, subgraph.clone()),
+                config,
+                subgraph_event(ModelEventKind::SubgraphParentChanged, subgraph.clone()),
                 |candidate| {
                     let subgraph_index = subgraph_index(candidate, subgraph)?;
                     candidate.subgraphs[subgraph_index].parent = parent.clone();
@@ -724,7 +807,8 @@ pub(crate) fn apply(
             }
             apply_with_relayout_event(
                 output,
-                subgraph_event(MmdsDiffKind::SubgraphMembershipChanged, subgraph.clone()),
+                config,
+                subgraph_event(ModelEventKind::SubgraphMembershipChanged, subgraph.clone()),
                 |candidate| {
                     sync_subgraph_children_from_node_parents(candidate);
                     for child in removed_children {
@@ -774,7 +858,8 @@ pub(crate) fn apply(
             subgraph_index(output, subgraph)?;
             apply_with_relayout_event(
                 output,
-                subgraph_event(MmdsDiffKind::SubgraphVisibilityChanged, subgraph.clone()),
+                config,
+                subgraph_event(ModelEventKind::SubgraphVisibilityChanged, subgraph.clone()),
                 |candidate| {
                     let subgraph_index = subgraph_index(candidate, subgraph)?;
                     candidate.subgraphs[subgraph_index].invisible = *invisible;
@@ -787,20 +872,22 @@ pub(crate) fn apply(
 
 fn apply_with_relayout(
     output: &mut Document,
-    kind: MmdsDiffKind,
+    config: &RenderConfig,
+    kind: ModelEventKind,
     mutate: impl FnOnce(&mut Document) -> Result<(), CommandApplyError>,
-) -> Result<Vec<MmdsDiffEvent>, CommandApplyError> {
-    apply_with_relayout_event(output, document_event(kind), mutate)
+) -> Result<Vec<ModelEvent>, CommandApplyError> {
+    apply_with_relayout_event(output, config, document_event(kind), mutate)
 }
 
 fn apply_with_relayout_event(
     output: &mut Document,
-    event: MmdsDiffEvent,
+    config: &RenderConfig,
+    event: ModelEvent,
     mutate: impl FnOnce(&mut Document) -> Result<(), CommandApplyError>,
-) -> Result<Vec<MmdsDiffEvent>, CommandApplyError> {
+) -> Result<Vec<ModelEvent>, CommandApplyError> {
     let mut candidate = output.clone();
     mutate(&mut candidate)?;
-    let relaid = relayout_output_for_command_apply(&candidate)?;
+    let relaid = relayout_output_for_command_apply_with_config(&candidate, config)?;
     *output = relaid;
     Ok(vec![event])
 }
@@ -822,39 +909,31 @@ fn set_node_style_extension(output: &mut Document, node: &str, value: Value) {
         .insert(node.to_string(), value);
 }
 
-fn document_event(kind: MmdsDiffKind) -> MmdsDiffEvent {
-    MmdsDiffEvent {
+fn document_event(kind: ModelEventKind) -> ModelEvent {
+    ModelEvent {
         kind,
-        subject: MmdsDiffSubject::Document,
-        evidence: Vec::new(),
-        related_event_ids: Vec::new(),
+        subject: Subject::Document,
     }
 }
 
-fn node_event(kind: MmdsDiffKind, id: String) -> MmdsDiffEvent {
-    MmdsDiffEvent {
+fn node_event(kind: ModelEventKind, id: String) -> ModelEvent {
+    ModelEvent {
         kind,
-        subject: MmdsDiffSubject::Node(id),
-        evidence: Vec::new(),
-        related_event_ids: Vec::new(),
+        subject: Subject::Node(id),
     }
 }
 
-fn edge_event(kind: MmdsDiffKind, id: String) -> MmdsDiffEvent {
-    MmdsDiffEvent {
+fn edge_event(kind: ModelEventKind, id: String) -> ModelEvent {
+    ModelEvent {
         kind,
-        subject: MmdsDiffSubject::Edge(id),
-        evidence: Vec::new(),
-        related_event_ids: Vec::new(),
+        subject: Subject::Edge(id),
     }
 }
 
-fn subgraph_event(kind: MmdsDiffKind, id: String) -> MmdsDiffEvent {
-    MmdsDiffEvent {
+fn subgraph_event(kind: ModelEventKind, id: String) -> ModelEvent {
+    ModelEvent {
         kind,
-        subject: MmdsDiffSubject::Subgraph(id),
-        evidence: Vec::new(),
-        related_event_ids: Vec::new(),
+        subject: Subject::Subgraph(id),
     }
 }
 
@@ -957,7 +1036,7 @@ fn resolve_edge_index(
     }
 }
 
-fn semantic_selector_matches(edge: &super::Edge, selector: &EdgeSelector) -> bool {
+fn semantic_selector_matches(edge: &Edge, selector: &EdgeSelector) -> bool {
     let EdgeSelector::Semantic {
         source,
         target,
@@ -988,8 +1067,16 @@ fn semantic_selector_matches(edge: &super::Edge, selector: &EdgeSelector) -> boo
         && minlen.is_none_or(|expected| edge.minlen == expected)
 }
 
+#[cfg(test)]
 pub(crate) fn relayout_output_for_command_apply(
     output: &Document,
+) -> Result<Document, CommandApplyError> {
+    relayout_output_for_command_apply_with_config(output, &RenderConfig::default())
+}
+
+fn relayout_output_for_command_apply_with_config(
+    output: &Document,
+    config: &RenderConfig,
 ) -> Result<Document, CommandApplyError> {
     let mut diagram = crate::mmds::from_document(output)
         .map_err(|err| relayout_failed("hydrate", err.to_string()))?;
@@ -997,18 +1084,14 @@ pub(crate) fn relayout_output_for_command_apply(
         .geometry_level
         .parse::<GeometryLevel>()
         .map_err(|err| relayout_failed("config", err.to_string()))?;
-    let layout_engine = output
-        .metadata
-        .engine
-        .as_deref()
-        .map(EngineAlgorithmId::parse)
-        .transpose()
-        .map_err(|err| relayout_failed("config", err.to_string()))?;
-    let config = RenderConfig {
-        geometry_level,
-        layout_engine,
-        ..RenderConfig::default()
-    };
+    let mut config = config.clone();
+    config.geometry_level = geometry_level;
+    if let Some(engine) = output.metadata.engine.as_deref() {
+        config.layout_engine =
+            Some(engine.parse().map_err(|err: crate::errors::RenderError| {
+                relayout_failed("config", err.to_string())
+            })?);
+    }
     let json = crate::runtime::graph_family::render_graph_family(
         &output.metadata.diagram_type,
         &mut diagram,
@@ -1023,6 +1106,6 @@ pub(crate) fn relayout_output_for_command_apply(
 fn relayout_failed(stage: &str, source: String) -> CommandApplyError {
     CommandApplyError::RelayoutFailed {
         stage: stage.to_string(),
-        source,
+        message: source,
     }
 }

--- a/src/internal_tests/composition_probe.rs
+++ b/src/internal_tests/composition_probe.rs
@@ -1,9 +1,11 @@
 use serde_json::json;
 
-use crate::mmds::Document;
-use crate::mmds::commands::{Command, apply};
-use crate::mmds::diff::{MmdsDiffEvent, MmdsDiffKind, MmdsDiffSubject, diff_outputs};
-use crate::views::{Selector, ViewEvent, ViewSpec, ViewStatement, apply_view};
+use super::event_change_mapping::model_event_kind_to_change_kind;
+use crate::commands::{Command, apply};
+use crate::mmds::diff::{Change, ChangeKind, diff_documents};
+use crate::mmds::events::{ModelEvent, ModelEventKind};
+use crate::mmds::{Document, Subject};
+use crate::views::{Selector, ViewEvent, ViewSpec, ViewStatement, project};
 use crate::{RenderConfig, materialize_diagram};
 
 #[derive(Debug)]
@@ -17,8 +19,8 @@ struct ProbeScenario {
 struct ProbeCommandStep {
     name: &'static str,
     command: Command,
-    expected_kind: MmdsDiffKind,
-    expected_subject: MmdsDiffSubject,
+    expected_kind: ModelEventKind,
+    expected_subject: Subject,
 }
 
 #[derive(Debug)]
@@ -37,7 +39,7 @@ struct CommandProbeResult {
 #[derive(Debug)]
 struct CommandObservation {
     command_name: &'static str,
-    returned_event_pairs: Vec<(MmdsDiffKind, MmdsDiffSubject)>,
+    returned_event_pairs: Vec<(ModelEventKind, Subject)>,
     returned_expected_primary: bool,
     error: Option<String>,
 }
@@ -72,8 +74,8 @@ impl ViewObservation {
 #[derive(Debug)]
 struct CompositionObservations {
     unexpected_command_failures: Vec<String>,
-    unexpected_missing_semantic_events: Vec<&'static str>,
-    temporal_collapses: Vec<&'static str>,
+    unexpected_missing_semantic_changes: Vec<&'static str>,
+    snapshot_diff_collapses: Vec<&'static str>,
     view_materialization_failures: Vec<String>,
     private_internal_requirements: Vec<String>,
     gating_notes: Vec<GatingNote>,
@@ -82,7 +84,7 @@ struct CompositionObservations {
 impl CompositionObservations {
     fn no_unexpected_failures(&self) -> bool {
         self.unexpected_command_failures.is_empty()
-            && self.unexpected_missing_semantic_events.is_empty()
+            && self.unexpected_missing_semantic_changes.is_empty()
             && self.view_materialization_failures.is_empty()
     }
 }
@@ -95,17 +97,17 @@ struct GatingNote {
 
 #[derive(Debug)]
 struct DiffObservations {
-    raw_diff_event_pairs: Vec<(MmdsDiffKind, MmdsDiffSubject)>,
+    raw_diff_change_pairs: Vec<(ChangeKind, Subject)>,
     command_classifications: Vec<CommandDiffClassification>,
-    unexpected_extra_semantic_events: Vec<(MmdsDiffKind, MmdsDiffSubject)>,
+    unexpected_extra_semantic_changes: Vec<(ChangeKind, Subject)>,
     has_expected_stable_headlines: bool,
 }
 
 #[derive(Debug)]
 struct CommandDiffClassification {
     command_name: &'static str,
-    expected_kind: MmdsDiffKind,
-    expected_subject: MmdsDiffSubject,
+    expected_kind: ModelEventKind,
+    expected_subject: Subject,
     classification: CommandDiffClassificationKind,
 }
 
@@ -113,7 +115,7 @@ struct CommandDiffClassification {
 enum CommandDiffClassificationKind {
     PresentInBoth,
     GeometryOnlySideEffect,
-    TemporalCollapse,
+    CollapsedInSnapshotDiff,
     UnexpectedMissing,
 }
 
@@ -140,8 +142,8 @@ fn build_probe_scenario() -> ProbeScenario {
                     concurrent_regions: Vec::new(),
                     invisible: false,
                 },
-                expected_kind: MmdsDiffKind::SubgraphAdded,
-                expected_subject: MmdsDiffSubject::Subgraph("auth".to_string()),
+                expected_kind: ModelEventKind::SubgraphAdded,
+                expected_subject: Subject::Subgraph("auth".to_string()),
             },
             ProbeCommandStep {
                 name: "add-login",
@@ -151,8 +153,8 @@ fn build_probe_scenario() -> ProbeScenario {
                     shape: "rectangle".to_string(),
                     parent: Some("auth".to_string()),
                 },
-                expected_kind: MmdsDiffKind::NodeAdded,
-                expected_subject: MmdsDiffSubject::Node("login".to_string()),
+                expected_kind: ModelEventKind::NodeAdded,
+                expected_subject: Subject::Node("login".to_string()),
             },
             ProbeCommandStep {
                 name: "move-users-into-auth",
@@ -163,8 +165,8 @@ fn build_probe_scenario() -> ProbeScenario {
                     added_concurrent_regions: Vec::new(),
                     removed_concurrent_regions: Vec::new(),
                 },
-                expected_kind: MmdsDiffKind::SubgraphMembershipChanged,
-                expected_subject: MmdsDiffSubject::Subgraph("auth".to_string()),
+                expected_kind: ModelEventKind::SubgraphMembershipChanged,
+                expected_subject: Subject::Subgraph("auth".to_string()),
             },
             ProbeCommandStep {
                 name: "add-login-db-edge",
@@ -180,8 +182,8 @@ fn build_probe_scenario() -> ProbeScenario {
                     arrow_end: "normal".to_string(),
                     minlen: 1,
                 },
-                expected_kind: MmdsDiffKind::EdgeAdded,
-                expected_subject: MmdsDiffSubject::Edge("e5".to_string()),
+                expected_kind: ModelEventKind::EdgeAdded,
+                expected_subject: Subject::Edge("e5".to_string()),
             },
             ProbeCommandStep {
                 name: "change-login-label",
@@ -189,16 +191,16 @@ fn build_probe_scenario() -> ProbeScenario {
                     node: "login".to_string(),
                     label: "Login Service :8443".to_string(),
                 },
-                expected_kind: MmdsDiffKind::NodeLabelChanged,
-                expected_subject: MmdsDiffSubject::Node("login".to_string()),
+                expected_kind: ModelEventKind::NodeLabelChanged,
+                expected_subject: Subject::Node("login".to_string()),
             },
             ProbeCommandStep {
                 name: "set-review-profile",
                 command: Command::SetProfiles {
                     profiles: vec!["composition-probe".to_string()],
                 },
-                expected_kind: MmdsDiffKind::ProfileChanged,
-                expected_subject: MmdsDiffSubject::Document,
+                expected_kind: ModelEventKind::ProfileChanged,
+                expected_subject: Subject::Document,
             },
             ProbeCommandStep {
                 name: "style-login",
@@ -209,8 +211,8 @@ fn build_probe_scenario() -> ProbeScenario {
                         "stroke": "#586e75",
                     }),
                 },
-                expected_kind: MmdsDiffKind::NodeStyleChanged,
-                expected_subject: MmdsDiffSubject::Node("login".to_string()),
+                expected_kind: ModelEventKind::NodeStyleChanged,
+                expected_subject: Subject::Node("login".to_string()),
             },
         ],
         view_specs: vec![
@@ -255,10 +257,10 @@ fn run_command_probe(scenario: &ProbeScenario) -> CommandProbeResult {
         match apply(&step.command, &mut document) {
             Ok(events) => {
                 let returned_expected_primary =
-                    has_event_pair(&events, step.expected_kind, &step.expected_subject);
+                    has_model_event_pair(&events, step.expected_kind, &step.expected_subject);
                 command_observations.push(CommandObservation {
                     command_name: step.name,
-                    returned_event_pairs: event_pairs(&events),
+                    returned_event_pairs: model_event_pairs(&events),
                     returned_expected_primary,
                     error: None,
                 });
@@ -285,13 +287,18 @@ fn run_command_probe(scenario: &ProbeScenario) -> CommandProbeResult {
 
 fn run_composed_probe(scenario: &ProbeScenario) -> CompositionProbeResult {
     let command_result = run_command_probe(scenario);
-    let diff = diff_outputs(&scenario.initial, &command_result.final_document);
-    let raw_diff_event_pairs = event_pairs(&diff.events);
-    let semantic_diff_event_pairs = semantic_event_pairs(&diff.events);
+    let diff = diff_documents(&scenario.initial, &command_result.final_document);
+    let raw_diff_change_pairs = change_pairs(&diff.changes);
+    let semantic_diff_change_pairs = semantic_change_pairs(&diff.changes);
     let command_expected_pairs: Vec<_> = scenario
         .commands
         .iter()
-        .map(|step| (step.expected_kind, step.expected_subject.clone()))
+        .map(|step| {
+            (
+                model_event_kind_to_change_kind(step.expected_kind),
+                step.expected_subject.clone(),
+            )
+        })
         .collect();
     let mut created_subjects = Vec::new();
     let mut command_classifications = Vec::new();
@@ -299,14 +306,14 @@ fn run_composed_probe(scenario: &ProbeScenario) -> CompositionProbeResult {
     for step in &scenario.commands {
         let classification = classify_command_diff_relationship(
             step,
-            &semantic_diff_event_pairs,
-            &diff.events,
+            &semantic_diff_change_pairs,
+            &diff.changes,
             &created_subjects,
         );
 
         if matches!(
-            step.expected_kind,
-            MmdsDiffKind::NodeAdded | MmdsDiffKind::EdgeAdded | MmdsDiffKind::SubgraphAdded
+            model_event_kind_to_change_kind(step.expected_kind),
+            ChangeKind::NodeAdded | ChangeKind::EdgeAdded | ChangeKind::SubgraphAdded
         ) {
             created_subjects.push(step.expected_subject.clone());
         }
@@ -319,7 +326,7 @@ fn run_composed_probe(scenario: &ProbeScenario) -> CompositionProbeResult {
         });
     }
 
-    let unexpected_extra_semantic_events = semantic_diff_event_pairs
+    let unexpected_extra_semantic_changes = semantic_diff_change_pairs
         .iter()
         .filter(|(kind, subject)| {
             !command_expected_pairs
@@ -338,9 +345,9 @@ fn run_composed_probe(scenario: &ProbeScenario) -> CompositionProbeResult {
     });
 
     let diff_observations = DiffObservations {
-        raw_diff_event_pairs,
+        raw_diff_change_pairs,
         command_classifications,
-        unexpected_extra_semantic_events,
+        unexpected_extra_semantic_changes,
         has_expected_stable_headlines,
     };
     let view_observations = collect_view_observations(&command_result.final_document, scenario);
@@ -362,7 +369,7 @@ fn summarize_composition(
 ) -> CompositionObservations {
     CompositionObservations {
         unexpected_command_failures: command_result.unexpected_failures.clone(),
-        unexpected_missing_semantic_events: diff_observations
+        unexpected_missing_semantic_changes: diff_observations
             .command_classifications
             .iter()
             .filter(|classification| {
@@ -373,13 +380,13 @@ fn summarize_composition(
             })
             .map(|classification| classification.command_name)
             .collect(),
-        temporal_collapses: diff_observations
+        snapshot_diff_collapses: diff_observations
             .command_classifications
             .iter()
             .filter(|classification| {
                 matches!(
                     classification.classification,
-                    CommandDiffClassificationKind::TemporalCollapse
+                    CommandDiffClassificationKind::CollapsedInSnapshotDiff
                 )
             })
             .map(|classification| classification.command_name)
@@ -393,10 +400,7 @@ fn summarize_composition(
                     .map(|error| format!("{} failed: {error}", observation.name))
             })
             .collect(),
-        private_internal_requirements: vec![
-            "diff_outputs is crate-internal and test-gated".to_string(),
-            "commands::apply is crate-internal and test-gated".to_string(),
-        ],
+        private_internal_requirements: Vec::new(),
         gating_notes: vec![
             GatingNote {
                 primitive: "views",
@@ -404,11 +408,11 @@ fn summarize_composition(
             },
             GatingNote {
                 primitive: "diff",
-                surface: "test-gated",
+                surface: "public",
             },
             GatingNote {
                 primitive: "commands",
-                surface: "test-gated",
+                surface: "public",
             },
         ],
     }
@@ -422,7 +426,7 @@ fn collect_view_observations(
         .view_specs
         .iter()
         .map(
-            |probe_view| match apply_view(final_document, &probe_view.spec) {
+            |probe_view| match project(final_document, &probe_view.spec) {
                 Ok((view, events)) => {
                     let canonical_edge_ids = edge_ids(final_document);
                     let retained_edge_ids = edge_ids(&view);
@@ -462,13 +466,13 @@ fn collect_view_observations(
 
 fn classify_command_diff_relationship(
     step: &ProbeCommandStep,
-    semantic_diff_event_pairs: &[(MmdsDiffKind, MmdsDiffSubject)],
-    raw_diff_events: &[MmdsDiffEvent],
-    created_subjects: &[MmdsDiffSubject],
+    semantic_diff_change_pairs: &[(ChangeKind, Subject)],
+    raw_diff_events: &[Change],
+    created_subjects: &[Subject],
 ) -> CommandDiffClassificationKind {
     if event_pair_is_present(
-        semantic_diff_event_pairs,
-        step.expected_kind,
+        semantic_diff_change_pairs,
+        model_event_kind_to_change_kind(step.expected_kind),
         &step.expected_subject,
     ) {
         return CommandDiffClassificationKind::PresentInBoth;
@@ -476,7 +480,7 @@ fn classify_command_diff_relationship(
 
     if raw_diff_events
         .iter()
-        .any(|event| event.kind.is_geometry_effect() && event.subject == step.expected_subject)
+        .any(|event| event.kind.is_geometry() && event.subject == step.expected_subject)
     {
         return CommandDiffClassificationKind::GeometryOnlySideEffect;
     }
@@ -485,36 +489,43 @@ fn classify_command_diff_relationship(
         .iter()
         .any(|subject| subject == &step.expected_subject)
     {
-        return CommandDiffClassificationKind::TemporalCollapse;
+        return CommandDiffClassificationKind::CollapsedInSnapshotDiff;
     }
 
     CommandDiffClassificationKind::UnexpectedMissing
 }
 
-fn has_event_pair(events: &[MmdsDiffEvent], kind: MmdsDiffKind, subject: &MmdsDiffSubject) -> bool {
+fn has_model_event_pair(events: &[ModelEvent], kind: ModelEventKind, subject: &Subject) -> bool {
     events
         .iter()
         .any(|event| event.kind == kind && &event.subject == subject)
 }
 
-fn event_pairs(events: &[MmdsDiffEvent]) -> Vec<(MmdsDiffKind, MmdsDiffSubject)> {
+fn model_event_pairs(events: &[ModelEvent]) -> Vec<(ModelEventKind, Subject)> {
     events
         .iter()
         .map(|event| (event.kind, event.subject.clone()))
         .collect()
 }
 
-fn semantic_event_pairs(events: &[MmdsDiffEvent]) -> Vec<(MmdsDiffKind, MmdsDiffSubject)> {
-    event_pairs(events)
+fn change_pairs(changes: &[Change]) -> Vec<(ChangeKind, Subject)> {
+    changes
+        .iter()
+        .map(|change| (change.kind, change.subject.clone()))
+        .collect()
+}
+
+fn semantic_change_pairs(changes: &[Change]) -> Vec<(ChangeKind, Subject)> {
+    change_pairs(changes)
         .into_iter()
-        .filter(|(kind, _)| !kind.is_geometry_effect())
+        .filter(|(kind, _)| !kind.is_geometry())
         .collect()
 }
 
 fn event_pair_is_present(
-    pairs: &[(MmdsDiffKind, MmdsDiffSubject)],
-    kind: MmdsDiffKind,
-    subject: &MmdsDiffSubject,
+    pairs: &[(ChangeKind, Subject)],
+    kind: ChangeKind,
+    subject: &Subject,
 ) -> bool {
     pairs
         .iter()
@@ -591,10 +602,10 @@ fn composition_probe_scenario_covers_required_surfaces() {
         .iter()
         .find(|step| step.name == "add-login")
         .expect("add-login command exists");
-    assert_eq!(add_login.expected_kind, MmdsDiffKind::NodeAdded);
+    assert_eq!(add_login.expected_kind, ModelEventKind::NodeAdded);
     assert_eq!(
         add_login.expected_subject,
-        MmdsDiffSubject::Node("login".to_string())
+        Subject::Node("login".to_string())
     );
 }
 
@@ -620,7 +631,7 @@ fn composition_probe_command_log_records_expected_primary_events() {
 }
 
 #[test]
-fn composition_probe_diff_cumulative_classifies_command_log_relationship() {
+fn composition_probe_snapshot_diff_classifies_command_log_relationship() {
     let scenario = build_probe_scenario();
     let result = run_composed_probe(&scenario);
 
@@ -628,14 +639,14 @@ fn composition_probe_diff_cumulative_classifies_command_log_relationship() {
         result.diff_observations.has_expected_stable_headlines,
         "{result:#?}"
     );
-    assert!(!result.diff_observations.raw_diff_event_pairs.is_empty());
+    assert!(!result.diff_observations.raw_diff_change_pairs.is_empty());
     assert!(
         result
             .diff_observations
-            .unexpected_extra_semantic_events
+            .unexpected_extra_semantic_changes
             .iter()
             .any(|(kind, subject)| {
-                *kind == MmdsDiffKind::ExtensionChanged && *subject == MmdsDiffSubject::Document
+                *kind == ChangeKind::ExtensionChanged && *subject == Subject::Document
             })
     );
     assert!(
@@ -654,11 +665,11 @@ fn composition_probe_diff_cumulative_classifies_command_log_relationship() {
         .expect("change-login-label classification exists");
     assert_eq!(
         label_classification.expected_kind,
-        MmdsDiffKind::NodeLabelChanged
+        ModelEventKind::NodeLabelChanged
     );
     assert_eq!(
         label_classification.expected_subject,
-        MmdsDiffSubject::Node("login".to_string())
+        Subject::Node("login".to_string())
     );
 }
 
@@ -692,7 +703,7 @@ fn composition_probe_view_materializes_filtered_and_full_views() {
 }
 
 #[test]
-fn composition_probe_observations_include_gating_asymmetry() {
+fn composition_probe_observations_reflect_public_surfaces() {
     let scenario = build_probe_scenario();
     let result = run_composed_probe(&scenario);
 
@@ -712,27 +723,26 @@ fn composition_probe_observations_include_gating_asymmetry() {
             .composition_observations
             .gating_notes
             .iter()
-            .any(|note| note.primitive == "diff" && note.surface == "test-gated")
+            .any(|note| note.primitive == "diff" && note.surface == "public")
     );
     assert!(
         result
             .composition_observations
             .gating_notes
             .iter()
-            .any(|note| note.primitive == "commands" && note.surface == "test-gated")
+            .any(|note| note.primitive == "commands" && note.surface == "public")
     );
     assert!(
         result
             .composition_observations
-            .temporal_collapses
+            .snapshot_diff_collapses
             .contains(&"change-login-label")
     );
     assert!(
         result
             .composition_observations
             .private_internal_requirements
-            .iter()
-            .any(|requirement| requirement.contains("diff_outputs"))
+            .is_empty()
     );
 
     eprintln!("{result:#?}");

--- a/src/internal_tests/event_change_mapping.rs
+++ b/src/internal_tests/event_change_mapping.rs
@@ -1,0 +1,36 @@
+use crate::mmds::diff::ChangeKind;
+use crate::mmds::events::ModelEventKind;
+
+// Test-only parity helper for checking that model events and snapshot diffs
+// stay aligned where their vocabularies intentionally overlap. Production
+// callers should not generally convert events into diff changes: events record
+// accepted model mutations, while snapshot diffs report observable differences
+// between two materialized documents.
+pub(crate) fn model_event_kind_to_change_kind(kind: ModelEventKind) -> ChangeKind {
+    match kind {
+        ModelEventKind::GeometryLevelChanged => ChangeKind::GeometryLevelChanged,
+        ModelEventKind::DirectionChanged => ChangeKind::DirectionChanged,
+        ModelEventKind::EngineChanged => ChangeKind::EngineChanged,
+        ModelEventKind::NodeAdded => ChangeKind::NodeAdded,
+        ModelEventKind::NodeRemoved => ChangeKind::NodeRemoved,
+        ModelEventKind::EdgeAdded => ChangeKind::EdgeAdded,
+        ModelEventKind::EdgeRemoved => ChangeKind::EdgeRemoved,
+        ModelEventKind::SubgraphAdded => ChangeKind::SubgraphAdded,
+        ModelEventKind::SubgraphRemoved => ChangeKind::SubgraphRemoved,
+        ModelEventKind::NodeLabelChanged => ChangeKind::NodeLabelChanged,
+        ModelEventKind::NodeShapeChanged => ChangeKind::NodeShapeChanged,
+        ModelEventKind::NodeParentChanged => ChangeKind::NodeParentChanged,
+        ModelEventKind::NodeStyleChanged => ChangeKind::NodeStyleChanged,
+        ModelEventKind::EdgeReconnected => ChangeKind::EdgeReconnected,
+        ModelEventKind::EdgeEndpointIntentChanged => ChangeKind::EdgeEndpointIntentChanged,
+        ModelEventKind::EdgeLabelChanged => ChangeKind::EdgeLabelChanged,
+        ModelEventKind::EdgeStyleChanged => ChangeKind::EdgeStyleChanged,
+        ModelEventKind::SubgraphTitleChanged => ChangeKind::SubgraphTitleChanged,
+        ModelEventKind::SubgraphDirectionChanged => ChangeKind::SubgraphDirectionChanged,
+        ModelEventKind::SubgraphParentChanged => ChangeKind::SubgraphParentChanged,
+        ModelEventKind::SubgraphMembershipChanged => ChangeKind::SubgraphMembershipChanged,
+        ModelEventKind::SubgraphVisibilityChanged => ChangeKind::SubgraphVisibilityChanged,
+        ModelEventKind::ProfileChanged => ChangeKind::ProfileChanged,
+        ModelEventKind::ExtensionChanged => ChangeKind::ExtensionChanged,
+    }
+}

--- a/src/internal_tests/mmds_commands.rs
+++ b/src/internal_tests/mmds_commands.rs
@@ -3,15 +3,17 @@ use std::path::Path;
 
 use serde_json::{Map, Value, json};
 
+use super::event_change_mapping::model_event_kind_to_change_kind;
 use super::layout_stability::mutations;
-use crate::graph::GeometryLevel;
-use crate::mmds::commands::{
-    Command, CommandApplyError, EdgeSelector, MmdsDiffKindRole, apply, commandable_diff_kinds,
-    diff_kind_for_command, diff_kind_role, geometry_effect_diff_kinds,
+use crate::commands::{
+    ChangeKindLayer, Command, CommandApplyError, EdgeSelector, apply, change_kind_layer,
+    commandable_model_event_kinds, geometry_effect_change_kinds, model_event_kind_for_command,
     relayout_output_for_command_apply,
 };
-use crate::mmds::diff::{MmdsDiffKind, MmdsDiffSubject};
-use crate::mmds::{NODE_STYLE_EXTENSION_NAMESPACE, TEXT_EXTENSION_NAMESPACE};
+use crate::graph::GeometryLevel;
+use crate::mmds::diff::ChangeKind;
+use crate::mmds::events::{ModelEvent, ModelEventKind};
+use crate::mmds::{NODE_STYLE_EXTENSION_NAMESPACE, Subject, TEXT_EXTENSION_NAMESPACE};
 use crate::{OutputFormat, RenderConfig};
 
 #[test]
@@ -116,11 +118,11 @@ fn mmds_command_apply_target_reconnect_diff_is_edge_reconnected() {
         .target = "C".into();
 
     let relaid = relayout_output_for_command_apply(&changed).expect("relayout should succeed");
-    let diff = crate::mmds::diff::diff_outputs(&before, &relaid);
+    let diff = crate::mmds::diff::diff_documents(&before, &relaid);
 
-    assert!(diff.has_event(MmdsDiffKind::EdgeReconnected, "e0"));
-    assert!(diff.events.iter().any(|event| {
-        event.kind == MmdsDiffKind::EdgeReconnected
+    assert!(diff.has_change(ChangeKind::EdgeReconnected, "e0"));
+    assert!(diff.changes.iter().any(|event| {
+        event.kind == ChangeKind::EdgeReconnected
             && event.evidence_mentions("matched_by=id_reconnected")
     }));
 }
@@ -139,10 +141,10 @@ fn mmds_command_apply_edge_selector_id_matches_exact_edge() {
     .expect("edge selector should resolve");
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events[0].kind, MmdsDiffKind::EdgeLabelChanged);
+    assert_eq!(events[0].kind, ModelEventKind::EdgeLabelChanged);
     assert!(matches!(
         &events[0].subject,
-        crate::mmds::diff::MmdsDiffSubject::Edge(id) if id == "e0"
+        crate::mmds::Subject::Edge(id) if id == "e0"
     ));
 }
 
@@ -206,10 +208,10 @@ fn mmds_command_apply_add_edge_id_none_uses_next_dense_id() {
     let events = apply(&add_edge_command(None), &mut output).expect("add edge should apply");
 
     assert_eq!(events.len(), 1);
-    assert_eq!(events[0].kind, MmdsDiffKind::EdgeAdded);
+    assert_eq!(events[0].kind, ModelEventKind::EdgeAdded);
     assert!(matches!(
         &events[0].subject,
-        crate::mmds::diff::MmdsDiffSubject::Edge(id) if id == "e1"
+        crate::mmds::Subject::Edge(id) if id == "e1"
     ));
     assert!(output.edges.iter().any(|edge| edge.id == "e1"));
 }
@@ -220,7 +222,7 @@ fn mmds_command_apply_add_edge_id_accepts_next_dense_id() {
 
     let events = apply(&add_edge_command(Some("e1")), &mut output).expect("add edge should apply");
 
-    assert_eq!(events[0].kind, MmdsDiffKind::EdgeAdded);
+    assert_eq!(events[0].kind, ModelEventKind::EdgeAdded);
     assert!(output.edges.iter().any(|edge| edge.id == "e1"));
 }
 
@@ -263,8 +265,8 @@ fn mmds_command_apply_in_place_sets_profiles_without_geometry_change() {
     .expect("set profiles should apply");
 
     assert_eq!(output.profiles, vec!["custom-profile".to_string()]);
-    assert_primary_event(&events, MmdsDiffKind::ProfileChanged, "");
-    assert_in_place_diff(&before, &output, MmdsDiffKind::ProfileChanged, "");
+    assert_primary_event(&events, ModelEventKind::ProfileChanged, "");
+    assert_in_place_diff(&before, &output, ChangeKind::ProfileChanged, "");
 }
 
 #[test]
@@ -282,8 +284,8 @@ fn mmds_command_apply_in_place_sets_extension_without_geometry_change() {
     .expect("set extension should apply");
 
     assert_eq!(output.extensions["example.extension"]["enabled"], true);
-    assert_primary_event(&events, MmdsDiffKind::ExtensionChanged, "");
-    assert_in_place_diff(&before, &output, MmdsDiffKind::ExtensionChanged, "");
+    assert_primary_event(&events, ModelEventKind::ExtensionChanged, "");
+    assert_in_place_diff(&before, &output, ChangeKind::ExtensionChanged, "");
 }
 
 #[test]
@@ -304,8 +306,8 @@ fn mmds_command_apply_in_place_sets_node_style_extension() {
         output.extensions[NODE_STYLE_EXTENSION_NAMESPACE]["nodes"]["A"]["fill"],
         "#abcdef"
     );
-    assert_primary_event(&events, MmdsDiffKind::NodeStyleChanged, "A");
-    assert_in_place_diff(&before, &output, MmdsDiffKind::NodeStyleChanged, "A");
+    assert_primary_event(&events, ModelEventKind::NodeStyleChanged, "A");
+    assert_in_place_diff(&before, &output, ChangeKind::NodeStyleChanged, "A");
 }
 
 #[test]
@@ -342,8 +344,8 @@ fn mmds_command_apply_in_place_changes_subgraph_title() {
     .expect("change subgraph title should apply");
 
     assert_eq!(subgraph_title(&output, "sg1"), "Pipeline");
-    assert_primary_event(&events, MmdsDiffKind::SubgraphTitleChanged, "sg1");
-    assert_in_place_diff(&before, &output, MmdsDiffKind::SubgraphTitleChanged, "sg1");
+    assert_primary_event(&events, ModelEventKind::SubgraphTitleChanged, "sg1");
+    assert_in_place_diff(&before, &output, ChangeKind::SubgraphTitleChanged, "sg1");
 }
 
 #[test]
@@ -379,10 +381,10 @@ fn mmds_command_apply_relayout_sets_geometry_level() {
     .expect("set geometry level should apply");
 
     assert_eq!(output.geometry_level, "layout");
-    assert_primary_event(&events, MmdsDiffKind::GeometryLevelChanged, "");
+    assert_primary_event(&events, ModelEventKind::GeometryLevelChanged, "");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::GeometryLevelChanged, "")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::GeometryLevelChanged, "")
     );
 }
 
@@ -400,10 +402,10 @@ fn mmds_command_apply_relayout_sets_direction() {
     .expect("set direction should apply");
 
     assert_eq!(output.metadata.direction, "LR");
-    assert_primary_event(&events, MmdsDiffKind::DirectionChanged, "");
+    assert_primary_event(&events, ModelEventKind::DirectionChanged, "");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::DirectionChanged, "")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::DirectionChanged, "")
     );
 }
 
@@ -421,10 +423,10 @@ fn mmds_command_apply_relayout_sets_engine() {
     .expect("set engine should apply");
 
     assert_eq!(output.metadata.engine.as_deref(), Some("mermaid-layered"));
-    assert_primary_event(&events, MmdsDiffKind::EngineChanged, "");
+    assert_primary_event(&events, ModelEventKind::EngineChanged, "");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::EngineChanged, "")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::EngineChanged, "")
     );
 }
 
@@ -476,9 +478,9 @@ fn mmds_command_apply_relayout_adds_node() {
     .expect("add node should apply");
 
     assert_eq!(node_label(&output, "C"), "Gamma");
-    assert_primary_event(&events, MmdsDiffKind::NodeAdded, "C");
+    assert_primary_event(&events, ModelEventKind::NodeAdded, "C");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output).has_event(MmdsDiffKind::NodeAdded, "C")
+        crate::mmds::diff::diff_documents(&before, &output).has_change(ChangeKind::NodeAdded, "C")
     );
 }
 
@@ -496,9 +498,10 @@ fn mmds_command_apply_relayout_removes_node() {
     .expect("remove node should apply");
 
     assert!(!output.nodes.iter().any(|node| node.id == "C"));
-    assert_primary_event(&events, MmdsDiffKind::NodeRemoved, "C");
+    assert_primary_event(&events, ModelEventKind::NodeRemoved, "C");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output).has_event(MmdsDiffKind::NodeRemoved, "C")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::NodeRemoved, "C")
     );
 }
 
@@ -517,10 +520,10 @@ fn mmds_command_apply_relayout_changes_node_label() {
     .expect("change node label should apply");
 
     assert_eq!(node_label(&output, "A"), "Alpha");
-    assert_primary_event(&events, MmdsDiffKind::NodeLabelChanged, "A");
+    assert_primary_event(&events, ModelEventKind::NodeLabelChanged, "A");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::NodeLabelChanged, "A")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::NodeLabelChanged, "A")
     );
 }
 
@@ -539,10 +542,10 @@ fn mmds_command_apply_relayout_changes_node_shape() {
     .expect("change node shape should apply");
 
     assert_eq!(node_shape(&output, "A"), "stadium");
-    assert_primary_event(&events, MmdsDiffKind::NodeShapeChanged, "A");
+    assert_primary_event(&events, ModelEventKind::NodeShapeChanged, "A");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::NodeShapeChanged, "A")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::NodeShapeChanged, "A")
     );
 }
 
@@ -563,10 +566,10 @@ fn mmds_command_apply_relayout_sets_node_parent() {
     .expect("set node parent should apply");
 
     assert_eq!(node_parent(&output, "A").as_deref(), Some("sg1"));
-    assert_primary_event(&events, MmdsDiffKind::NodeParentChanged, "A");
+    assert_primary_event(&events, ModelEventKind::NodeParentChanged, "A");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::NodeParentChanged, "A")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::NodeParentChanged, "A")
     );
 }
 
@@ -623,9 +626,9 @@ fn mmds_command_apply_relayout_adds_edge() {
     assert_eq!(edge.source, "A");
     assert_eq!(edge.target, "C");
     assert!(edge.path.is_some(), "added edge should be routed");
-    assert_primary_event(&events, MmdsDiffKind::EdgeAdded, "e1");
+    assert_primary_event(&events, ModelEventKind::EdgeAdded, "e1");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output).has_event(MmdsDiffKind::EdgeAdded, "e1")
+        crate::mmds::diff::diff_documents(&before, &output).has_change(ChangeKind::EdgeAdded, "e1")
     );
 }
 
@@ -643,10 +646,10 @@ fn mmds_command_apply_relayout_removes_edge() {
     .expect("remove edge should apply");
 
     assert!(!output.edges.iter().any(|edge| edge.id == "e1"));
-    assert_primary_event(&events, MmdsDiffKind::EdgeRemoved, "e1");
+    assert_primary_event(&events, ModelEventKind::EdgeRemoved, "e1");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::EdgeRemoved, "e1")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::EdgeRemoved, "e1")
     );
 }
 
@@ -668,10 +671,10 @@ fn mmds_command_apply_relayout_reconnects_edge() {
     let edge = edge_by_id(&output, "e0");
     assert_eq!(edge.source, "A");
     assert_eq!(edge.target, "C");
-    assert_primary_event(&events, MmdsDiffKind::EdgeReconnected, "e0");
+    assert_primary_event(&events, ModelEventKind::EdgeReconnected, "e0");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::EdgeReconnected, "e0")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::EdgeReconnected, "e0")
     );
 }
 
@@ -695,10 +698,10 @@ fn mmds_command_apply_relayout_sets_edge_endpoint_intent() {
     let edge = edge_by_id(&output, "e0");
     assert_eq!(edge.from_subgraph.as_deref(), Some("sg1"));
     assert_eq!(edge.to_subgraph.as_deref(), Some("sg2"));
-    assert_primary_event(&events, MmdsDiffKind::EdgeEndpointIntentChanged, "e0");
+    assert_primary_event(&events, ModelEventKind::EdgeEndpointIntentChanged, "e0");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::EdgeEndpointIntentChanged, "e0")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::EdgeEndpointIntentChanged, "e0")
     );
 }
 
@@ -722,10 +725,10 @@ fn mmds_command_apply_relayout_changes_edge_label() {
         before.edges[0].label_rect.as_ref().map(|rect| rect.width),
         edge.label_rect.as_ref().map(|rect| rect.width)
     );
-    assert_primary_event(&events, MmdsDiffKind::EdgeLabelChanged, "e0");
+    assert_primary_event(&events, ModelEventKind::EdgeLabelChanged, "e0");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::EdgeLabelChanged, "e0")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::EdgeLabelChanged, "e0")
     );
 }
 
@@ -751,10 +754,10 @@ fn mmds_command_apply_relayout_changes_edge_style() {
     assert_eq!(edge.arrow_start, "circle");
     assert_eq!(edge.arrow_end, "diamond");
     assert_eq!(edge.minlen, 2);
-    assert_primary_event(&events, MmdsDiffKind::EdgeStyleChanged, "e0");
+    assert_primary_event(&events, ModelEventKind::EdgeStyleChanged, "e0");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::EdgeStyleChanged, "e0")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::EdgeStyleChanged, "e0")
     );
 }
 
@@ -841,10 +844,10 @@ fn mmds_command_apply_relayout_adds_subgraph() {
 
     assert_eq!(subgraph_title(&output, "sg1"), "Group");
     assert_eq!(node_parent(&output, "A").as_deref(), Some("sg1"));
-    assert_primary_event(&events, MmdsDiffKind::SubgraphAdded, "sg1");
+    assert_primary_event(&events, ModelEventKind::SubgraphAdded, "sg1");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::SubgraphAdded, "sg1")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::SubgraphAdded, "sg1")
     );
 }
 
@@ -864,10 +867,10 @@ fn mmds_command_apply_relayout_removes_subgraph() {
 
     assert!(!output.subgraphs.iter().any(|subgraph| subgraph.id == "sg1"));
     assert_eq!(node_parent(&output, "A"), None);
-    assert_primary_event(&events, MmdsDiffKind::SubgraphRemoved, "sg1");
+    assert_primary_event(&events, ModelEventKind::SubgraphRemoved, "sg1");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::SubgraphRemoved, "sg1")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::SubgraphRemoved, "sg1")
     );
 }
 
@@ -890,10 +893,10 @@ fn mmds_command_apply_relayout_sets_subgraph_direction() {
         subgraph_by_id(&output, "sg1").direction.as_deref(),
         Some("LR")
     );
-    assert_primary_event(&events, MmdsDiffKind::SubgraphDirectionChanged, "sg1");
+    assert_primary_event(&events, ModelEventKind::SubgraphDirectionChanged, "sg1");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::SubgraphDirectionChanged, "sg1")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::SubgraphDirectionChanged, "sg1")
     );
 }
 
@@ -917,10 +920,10 @@ fn mmds_command_apply_relayout_sets_subgraph_parent() {
         subgraph_by_id(&output, "sg1").parent.as_deref(),
         Some("outer")
     );
-    assert_primary_event(&events, MmdsDiffKind::SubgraphParentChanged, "sg1");
+    assert_primary_event(&events, ModelEventKind::SubgraphParentChanged, "sg1");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::SubgraphParentChanged, "sg1")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::SubgraphParentChanged, "sg1")
     );
 }
 
@@ -955,10 +958,10 @@ fn mmds_command_apply_relayout_changes_subgraph_membership() {
             .children
             .contains(&"B".to_string())
     );
-    assert_primary_event(&events, MmdsDiffKind::SubgraphMembershipChanged, "sg1");
+    assert_primary_event(&events, ModelEventKind::SubgraphMembershipChanged, "sg1");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::SubgraphMembershipChanged, "sg1")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::SubgraphMembershipChanged, "sg1")
     );
 }
 
@@ -1004,10 +1007,10 @@ fn mmds_command_apply_relayout_changes_subgraph_membership_concurrent_regions_on
         subgraph_by_id(&output, "r0").parent.as_deref(),
         Some("parent")
     );
-    assert_primary_event(&events, MmdsDiffKind::SubgraphMembershipChanged, "parent");
+    assert_primary_event(&events, ModelEventKind::SubgraphMembershipChanged, "parent");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::SubgraphMembershipChanged, "parent")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::SubgraphMembershipChanged, "parent")
     );
 }
 
@@ -1027,10 +1030,10 @@ fn mmds_command_apply_relayout_sets_subgraph_visibility() {
     .expect("set subgraph visibility should apply");
 
     assert!(subgraph_by_id(&output, "sg1").invisible);
-    assert_primary_event(&events, MmdsDiffKind::SubgraphVisibilityChanged, "sg1");
+    assert_primary_event(&events, ModelEventKind::SubgraphVisibilityChanged, "sg1");
     assert!(
-        crate::mmds::diff::diff_outputs(&before, &output)
-            .has_event(MmdsDiffKind::SubgraphVisibilityChanged, "sg1")
+        crate::mmds::diff::diff_documents(&before, &output)
+            .has_change(ChangeKind::SubgraphVisibilityChanged, "sg1")
     );
 }
 
@@ -1063,11 +1066,11 @@ fn mmds_command_apply_relayout_add_subgraph_duplicate_errors_without_mutation() 
 #[test]
 fn mmds_command_apply_round_trip_primary_event_matches_diff() {
     let cases = apply_round_trip_cases();
-    for expected_kind in commandable_diff_kinds() {
+    for expected_kind in commandable_model_event_kinds() {
         assert!(
             cases
                 .iter()
-                .any(|case| case.expected_kind == *expected_kind),
+                .any(|case| case.expected_kind == model_event_kind_to_change_kind(*expected_kind)),
             "missing round-trip case for {expected_kind:?}"
         );
     }
@@ -1077,17 +1080,18 @@ fn mmds_command_apply_round_trip_primary_event_matches_diff() {
         let apply_events = apply(&case.command, &mut after).unwrap_or_else(|err| {
             panic!("{} should apply successfully: {err:?}", case.name);
         });
-        let diff = crate::mmds::diff::diff_outputs(&case.before, &after);
+        let diff = crate::mmds::diff::diff_documents(&case.before, &after);
 
-        assert_has_event_pair(&apply_events, case.expected_kind, &case.expected_subject);
-        assert_has_event_pair(&diff.events, case.expected_kind, &case.expected_subject);
+        assert_has_model_event_change_pair(
+            &apply_events,
+            case.expected_kind,
+            &case.expected_subject,
+        );
+        assert_has_change_pair(&diff.changes, case.expected_kind, &case.expected_subject);
 
         if case.expect_no_geometry_effects {
             assert!(
-                !diff
-                    .events
-                    .iter()
-                    .any(|event| event.kind.is_geometry_effect()),
+                !diff.changes.iter().any(|event| event.kind.is_geometry()),
                 "{} produced geometry effects: {diff:#?}",
                 case.name
             );
@@ -1170,16 +1174,16 @@ fn mmds_command_apply_failure_modes_are_structured() {
 fn mmds_command_apply_tier_a_representative_canaries_hold() {
     for case in tier_a_representative_command_cases() {
         let (before, after) = render_tier_a_pair(case.pair_id);
-        let canary_diff = crate::mmds::diff::diff_outputs(&before, &after);
+        let canary_diff = crate::mmds::diff::diff_documents(&before, &after);
 
-        assert_has_event_pair(
-            &canary_diff.events,
+        assert_has_change_pair(
+            &canary_diff.changes,
             case.expected_kind,
             &case.expected_subject,
         );
         if case.pair_id == "M07" {
             assert!(
-                !canary_diff.has_kind(MmdsDiffKind::EdgeRerouted),
+                !canary_diff.has_change_kind(ChangeKind::EdgeRerouted),
                 "M07 should remain style-only with no edge reroute: {canary_diff:#?}"
             );
         }
@@ -1192,16 +1196,20 @@ fn mmds_command_apply_tier_a_representative_canaries_hold() {
             )
         });
 
-        assert_has_event_pair(&apply_events, case.expected_kind, &case.expected_subject);
-        let applied_diff = crate::mmds::diff::diff_outputs(&before, &applied);
-        assert_has_event_pair(
-            &applied_diff.events,
+        assert_has_model_event_change_pair(
+            &apply_events,
+            case.expected_kind,
+            &case.expected_subject,
+        );
+        let applied_diff = crate::mmds::diff::diff_documents(&before, &applied);
+        assert_has_change_pair(
+            &applied_diff.changes,
             case.expected_kind,
             &case.expected_subject,
         );
         if case.pair_id == "M07" {
             assert!(
-                !applied_diff.has_kind(MmdsDiffKind::EdgeRerouted),
+                !applied_diff.has_change_kind(ChangeKind::EdgeRerouted),
                 "M07 apply should remain style-only with no edge reroute: {applied_diff:#?}"
             );
         }
@@ -1211,119 +1219,65 @@ fn mmds_command_apply_tier_a_representative_canaries_hold() {
 #[test]
 fn mmds_command_vocabulary_classifies_all_diff_kinds() {
     let cases = [
+        (ChangeKind::GeometryLevelChanged, ChangeKindLayer::Model),
+        (ChangeKind::DirectionChanged, ChangeKindLayer::Model),
+        (ChangeKind::EngineChanged, ChangeKindLayer::Model),
+        (ChangeKind::NodeAdded, ChangeKindLayer::Model),
+        (ChangeKind::NodeRemoved, ChangeKindLayer::Model),
+        (ChangeKind::EdgeAdded, ChangeKindLayer::Model),
+        (ChangeKind::EdgeRemoved, ChangeKindLayer::Model),
+        (ChangeKind::SubgraphAdded, ChangeKindLayer::Model),
+        (ChangeKind::SubgraphRemoved, ChangeKindLayer::Model),
+        (ChangeKind::NodeLabelChanged, ChangeKindLayer::Model),
+        (ChangeKind::NodeShapeChanged, ChangeKindLayer::Model),
+        (ChangeKind::NodeParentChanged, ChangeKindLayer::Model),
+        (ChangeKind::NodeStyleChanged, ChangeKindLayer::Model),
+        (ChangeKind::EdgeReconnected, ChangeKindLayer::Model),
         (
-            MmdsDiffKind::GeometryLevelChanged,
-            MmdsDiffKindRole::Commandable,
+            ChangeKind::EdgeEndpointIntentChanged,
+            ChangeKindLayer::Model,
+        ),
+        (ChangeKind::EdgeLabelChanged, ChangeKindLayer::Model),
+        (ChangeKind::EdgeStyleChanged, ChangeKindLayer::Model),
+        (ChangeKind::SubgraphTitleChanged, ChangeKindLayer::Model),
+        (ChangeKind::SubgraphDirectionChanged, ChangeKindLayer::Model),
+        (ChangeKind::SubgraphParentChanged, ChangeKindLayer::Model),
+        (
+            ChangeKind::SubgraphMembershipChanged,
+            ChangeKindLayer::Model,
         ),
         (
-            MmdsDiffKind::DirectionChanged,
-            MmdsDiffKindRole::Commandable,
+            ChangeKind::SubgraphVisibilityChanged,
+            ChangeKindLayer::Model,
         ),
-        (MmdsDiffKind::EngineChanged, MmdsDiffKindRole::Commandable),
-        (MmdsDiffKind::NodeAdded, MmdsDiffKindRole::Commandable),
-        (MmdsDiffKind::NodeRemoved, MmdsDiffKindRole::Commandable),
-        (MmdsDiffKind::EdgeAdded, MmdsDiffKindRole::Commandable),
-        (MmdsDiffKind::EdgeRemoved, MmdsDiffKindRole::Commandable),
-        (MmdsDiffKind::SubgraphAdded, MmdsDiffKindRole::Commandable),
-        (MmdsDiffKind::SubgraphRemoved, MmdsDiffKindRole::Commandable),
+        (ChangeKind::ProfileChanged, ChangeKindLayer::Model),
+        (ChangeKind::ExtensionChanged, ChangeKindLayer::Model),
+        (ChangeKind::NodeMoved, ChangeKindLayer::Geometry),
+        (ChangeKind::NodeResized, ChangeKindLayer::Geometry),
+        (ChangeKind::CanvasResized, ChangeKindLayer::Geometry),
+        (ChangeKind::SubgraphBoundsChanged, ChangeKindLayer::Geometry),
+        (ChangeKind::EdgeRerouted, ChangeKindLayer::Geometry),
+        (ChangeKind::EndpointFaceChanged, ChangeKindLayer::Geometry),
+        (ChangeKind::PortIntentChanged, ChangeKindLayer::Geometry),
+        (ChangeKind::LabelMoved, ChangeKindLayer::Geometry),
+        (ChangeKind::LabelResized, ChangeKindLayer::Geometry),
+        (ChangeKind::LabelSideChanged, ChangeKindLayer::Geometry),
         (
-            MmdsDiffKind::NodeLabelChanged,
-            MmdsDiffKindRole::Commandable,
+            ChangeKind::PathPortDivergenceChanged,
+            ChangeKindLayer::Geometry,
         ),
-        (
-            MmdsDiffKind::NodeShapeChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (
-            MmdsDiffKind::NodeParentChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (
-            MmdsDiffKind::NodeStyleChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (MmdsDiffKind::EdgeReconnected, MmdsDiffKindRole::Commandable),
-        (
-            MmdsDiffKind::EdgeEndpointIntentChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (
-            MmdsDiffKind::EdgeLabelChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (
-            MmdsDiffKind::EdgeStyleChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (
-            MmdsDiffKind::SubgraphTitleChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (
-            MmdsDiffKind::SubgraphDirectionChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (
-            MmdsDiffKind::SubgraphParentChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (
-            MmdsDiffKind::SubgraphMembershipChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (
-            MmdsDiffKind::SubgraphVisibilityChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (MmdsDiffKind::ProfileChanged, MmdsDiffKindRole::Commandable),
-        (
-            MmdsDiffKind::ExtensionChanged,
-            MmdsDiffKindRole::Commandable,
-        ),
-        (MmdsDiffKind::NodeMoved, MmdsDiffKindRole::GeometryEffect),
-        (MmdsDiffKind::NodeResized, MmdsDiffKindRole::GeometryEffect),
-        (
-            MmdsDiffKind::CanvasResized,
-            MmdsDiffKindRole::GeometryEffect,
-        ),
-        (
-            MmdsDiffKind::SubgraphBoundsChanged,
-            MmdsDiffKindRole::GeometryEffect,
-        ),
-        (MmdsDiffKind::EdgeRerouted, MmdsDiffKindRole::GeometryEffect),
-        (
-            MmdsDiffKind::EndpointFaceChanged,
-            MmdsDiffKindRole::GeometryEffect,
-        ),
-        (
-            MmdsDiffKind::PortIntentChanged,
-            MmdsDiffKindRole::GeometryEffect,
-        ),
-        (MmdsDiffKind::LabelMoved, MmdsDiffKindRole::GeometryEffect),
-        (MmdsDiffKind::LabelResized, MmdsDiffKindRole::GeometryEffect),
-        (
-            MmdsDiffKind::LabelSideChanged,
-            MmdsDiffKindRole::GeometryEffect,
-        ),
-        (
-            MmdsDiffKind::PathPortDivergenceChanged,
-            MmdsDiffKindRole::GeometryEffect,
-        ),
-        (
-            MmdsDiffKind::GlobalReflowDetected,
-            MmdsDiffKindRole::GeometryEffect,
-        ),
+        (ChangeKind::GlobalReflowDetected, ChangeKindLayer::Geometry),
     ];
 
-    // The exhaustive matches in `mmds::commands` are the compile-time drift
+    // The exhaustive matches in `commands` are the compile-time drift
     // guard. This count keeps the test fixture's explicit variant list honest.
     assert_eq!(cases.len(), 36);
 
     for (kind, expected_role) in cases {
-        assert_eq!(diff_kind_role(kind), expected_role, "{kind:?}");
+        assert_eq!(change_kind_layer(kind), expected_role, "{kind:?}");
         assert_eq!(
-            kind.is_geometry_effect(),
-            expected_role == MmdsDiffKindRole::GeometryEffect,
+            kind.is_geometry(),
+            expected_role == ChangeKindLayer::Geometry,
             "{kind:?}"
         );
     }
@@ -1333,7 +1287,7 @@ fn mmds_command_vocabulary_classifies_all_diff_kinds() {
 fn mmds_command_vocabulary_document_node_examples_map_to_diff_kinds() {
     for (command, expected_kind) in document_node_command_examples() {
         assert_eq!(
-            diff_kind_for_command(&command),
+            model_event_kind_to_change_kind(model_event_kind_for_command(&command)),
             expected_kind,
             "{command:?}"
         );
@@ -1387,25 +1341,25 @@ fn mmds_command_vocabulary_document_node_commands_are_semantic_only() {
     }
 }
 
-fn document_node_command_examples() -> Vec<(Command, MmdsDiffKind)> {
+fn document_node_command_examples() -> Vec<(Command, ChangeKind)> {
     vec![
         (
             Command::SetGeometryLevel {
                 level: "routed".to_string(),
             },
-            MmdsDiffKind::GeometryLevelChanged,
+            ChangeKind::GeometryLevelChanged,
         ),
         (
             Command::SetDirection {
                 direction: "LR".to_string(),
             },
-            MmdsDiffKind::DirectionChanged,
+            ChangeKind::DirectionChanged,
         ),
         (
             Command::SetEngine {
                 engine: Some("flux-layered".to_string()),
             },
-            MmdsDiffKind::EngineChanged,
+            ChangeKind::EngineChanged,
         ),
         (
             Command::AddNode {
@@ -1414,54 +1368,54 @@ fn document_node_command_examples() -> Vec<(Command, MmdsDiffKind)> {
                 shape: "stadium".to_string(),
                 parent: Some("cluster_0".to_string()),
             },
-            MmdsDiffKind::NodeAdded,
+            ChangeKind::NodeAdded,
         ),
         (
             Command::RemoveNode {
                 id: "A".to_string(),
             },
-            MmdsDiffKind::NodeRemoved,
+            ChangeKind::NodeRemoved,
         ),
         (
             Command::ChangeNodeLabel {
                 node: "A".to_string(),
                 label: "Alpha".to_string(),
             },
-            MmdsDiffKind::NodeLabelChanged,
+            ChangeKind::NodeLabelChanged,
         ),
         (
             Command::ChangeNodeShape {
                 node: "A".to_string(),
                 shape: "stadium".to_string(),
             },
-            MmdsDiffKind::NodeShapeChanged,
+            ChangeKind::NodeShapeChanged,
         ),
         (
             Command::SetNodeParent {
                 node: "A".to_string(),
                 parent: Some("cluster_0".to_string()),
             },
-            MmdsDiffKind::NodeParentChanged,
+            ChangeKind::NodeParentChanged,
         ),
         (
             Command::SetNodeStyleExtension {
                 node: "A".to_string(),
                 value: json!({ "fill": "#fff" }),
             },
-            MmdsDiffKind::NodeStyleChanged,
+            ChangeKind::NodeStyleChanged,
         ),
         (
             Command::SetProfiles {
                 profiles: vec!["mmds-core-v1".to_string()],
             },
-            MmdsDiffKind::ProfileChanged,
+            ChangeKind::ProfileChanged,
         ),
         (
             Command::SetExtension {
                 namespace: "example.extension".to_string(),
                 value: json!({ "enabled": true }),
             },
-            MmdsDiffKind::ExtensionChanged,
+            ChangeKind::ExtensionChanged,
         ),
     ]
 }
@@ -1470,7 +1424,7 @@ fn document_node_command_examples() -> Vec<(Command, MmdsDiffKind)> {
 fn mmds_command_vocabulary_edge_examples_map_to_diff_kinds() {
     for (command, expected_kind) in edge_command_examples() {
         assert_eq!(
-            diff_kind_for_command(&command),
+            model_event_kind_to_change_kind(model_event_kind_for_command(&command)),
             expected_kind,
             "{command:?}"
         );
@@ -1511,7 +1465,7 @@ fn mmds_command_vocabulary_edge_selector_names_identity_without_layout() {
     }
 }
 
-fn edge_command_examples() -> Vec<(Command, MmdsDiffKind)> {
+fn edge_command_examples() -> Vec<(Command, ChangeKind)> {
     let selector = EdgeSelector::Id("e0".to_string());
 
     vec![
@@ -1528,13 +1482,13 @@ fn edge_command_examples() -> Vec<(Command, MmdsDiffKind)> {
                 arrow_end: "normal".to_string(),
                 minlen: 1,
             },
-            MmdsDiffKind::EdgeAdded,
+            ChangeKind::EdgeAdded,
         ),
         (
             Command::RemoveEdge {
                 edge: selector.clone(),
             },
-            MmdsDiffKind::EdgeRemoved,
+            ChangeKind::EdgeRemoved,
         ),
         (
             Command::ReconnectEdge {
@@ -1542,7 +1496,7 @@ fn edge_command_examples() -> Vec<(Command, MmdsDiffKind)> {
                 source: "A".to_string(),
                 target: "C".to_string(),
             },
-            MmdsDiffKind::EdgeReconnected,
+            ChangeKind::EdgeReconnected,
         ),
         (
             Command::SetEdgeEndpointIntent {
@@ -1550,14 +1504,14 @@ fn edge_command_examples() -> Vec<(Command, MmdsDiffKind)> {
                 from_subgraph: Some("cluster_a".to_string()),
                 to_subgraph: Some("cluster_b".to_string()),
             },
-            MmdsDiffKind::EdgeEndpointIntentChanged,
+            ChangeKind::EdgeEndpointIntentChanged,
         ),
         (
             Command::ChangeEdgeLabel {
                 edge: selector.clone(),
                 label: Some("calls".to_string()),
             },
-            MmdsDiffKind::EdgeLabelChanged,
+            ChangeKind::EdgeLabelChanged,
         ),
         (
             Command::ChangeEdgeStyle {
@@ -1567,7 +1521,7 @@ fn edge_command_examples() -> Vec<(Command, MmdsDiffKind)> {
                 arrow_end: Some("normal".to_string()),
                 minlen: Some(2),
             },
-            MmdsDiffKind::EdgeStyleChanged,
+            ChangeKind::EdgeStyleChanged,
         ),
     ]
 }
@@ -1576,7 +1530,7 @@ fn edge_command_examples() -> Vec<(Command, MmdsDiffKind)> {
 fn mmds_command_vocabulary_subgraph_examples_map_to_diff_kinds() {
     for (command, expected_kind) in subgraph_command_examples() {
         assert_eq!(
-            diff_kind_for_command(&command),
+            model_event_kind_to_change_kind(model_event_kind_for_command(&command)),
             expected_kind,
             "{command:?}"
         );
@@ -1611,7 +1565,7 @@ fn mmds_command_vocabulary_subgraph_membership_is_canonical() {
     }
 }
 
-fn subgraph_command_examples() -> Vec<(Command, MmdsDiffKind)> {
+fn subgraph_command_examples() -> Vec<(Command, ChangeKind)> {
     vec![
         (
             Command::AddSubgraph {
@@ -1623,34 +1577,34 @@ fn subgraph_command_examples() -> Vec<(Command, MmdsDiffKind)> {
                 concurrent_regions: vec!["region_0".to_string()],
                 invisible: false,
             },
-            MmdsDiffKind::SubgraphAdded,
+            ChangeKind::SubgraphAdded,
         ),
         (
             Command::RemoveSubgraph {
                 id: "cluster_0".to_string(),
             },
-            MmdsDiffKind::SubgraphRemoved,
+            ChangeKind::SubgraphRemoved,
         ),
         (
             Command::ChangeSubgraphTitle {
                 subgraph: "cluster_0".to_string(),
                 title: Some("Cluster".to_string()),
             },
-            MmdsDiffKind::SubgraphTitleChanged,
+            ChangeKind::SubgraphTitleChanged,
         ),
         (
             Command::SetSubgraphDirection {
                 subgraph: "cluster_0".to_string(),
                 direction: Some("LR".to_string()),
             },
-            MmdsDiffKind::SubgraphDirectionChanged,
+            ChangeKind::SubgraphDirectionChanged,
         ),
         (
             Command::SetSubgraphParent {
                 subgraph: "cluster_0".to_string(),
                 parent: Some("root".to_string()),
             },
-            MmdsDiffKind::SubgraphParentChanged,
+            ChangeKind::SubgraphParentChanged,
         ),
         (
             Command::ChangeSubgraphMembership {
@@ -1660,14 +1614,14 @@ fn subgraph_command_examples() -> Vec<(Command, MmdsDiffKind)> {
                 added_concurrent_regions: vec!["region_1".to_string()],
                 removed_concurrent_regions: vec!["region_0".to_string()],
             },
-            MmdsDiffKind::SubgraphMembershipChanged,
+            ChangeKind::SubgraphMembershipChanged,
         ),
         (
             Command::SetSubgraphVisibility {
                 subgraph: "cluster_0".to_string(),
                 invisible: true,
             },
-            MmdsDiffKind::SubgraphVisibilityChanged,
+            ChangeKind::SubgraphVisibilityChanged,
         ),
     ]
 }
@@ -1675,24 +1629,32 @@ fn subgraph_command_examples() -> Vec<(Command, MmdsDiffKind)> {
 #[test]
 fn mmds_command_vocabulary_is_symmetric_with_diff_kinds() {
     let command_examples = all_command_examples();
-    let command_kinds: Vec<MmdsDiffKind> = command_examples
+    let command_kinds: Vec<ChangeKind> = command_examples
         .iter()
-        .map(|(command, _)| diff_kind_for_command(command))
+        .map(|(command, _)| model_event_kind_to_change_kind(model_event_kind_for_command(command)))
         .collect();
 
-    assert_same_kinds(&command_kinds, commandable_diff_kinds());
-    assert_same_kinds(geometry_effect_diff_kinds(), &geometry_effect_kinds());
+    assert_same_kinds(
+        &command_kinds,
+        &commandable_model_event_kinds()
+            .iter()
+            .map(|kind| model_event_kind_to_change_kind(*kind))
+            .collect::<Vec<_>>(),
+    );
+    assert_same_kinds(geometry_effect_change_kinds(), &geometry_effect_kinds());
 
     for kind in all_diff_kinds() {
-        let is_effect = contains_kind(geometry_effect_diff_kinds(), kind);
-        let is_commandable = contains_kind(commandable_diff_kinds(), kind);
+        let is_effect = contains_kind(geometry_effect_change_kinds(), kind);
+        let is_commandable = commandable_model_event_kinds()
+            .iter()
+            .any(|command_kind| model_event_kind_to_change_kind(*command_kind) == kind);
 
         assert_ne!(is_effect, is_commandable, "{kind:?}");
-        assert_eq!(kind.is_geometry_effect(), is_effect, "{kind:?}");
+        assert_eq!(kind.is_geometry(), is_effect, "{kind:?}");
     }
 }
 
-fn all_command_examples() -> Vec<(Command, MmdsDiffKind)> {
+fn all_command_examples() -> Vec<(Command, ChangeKind)> {
     let mut examples = document_node_command_examples();
     examples.extend(edge_command_examples());
     examples.extend(subgraph_command_examples());
@@ -1703,16 +1665,16 @@ struct ApplyRoundTripCase {
     name: &'static str,
     before: crate::mmds::Document,
     command: Command,
-    expected_kind: MmdsDiffKind,
-    expected_subject: MmdsDiffSubject,
+    expected_kind: ChangeKind,
+    expected_subject: Subject,
     expect_no_geometry_effects: bool,
 }
 
 struct TierARepresentativeCommandCase {
     pair_id: &'static str,
     command: Command,
-    expected_kind: MmdsDiffKind,
-    expected_subject: MmdsDiffSubject,
+    expected_kind: ChangeKind,
+    expected_subject: Subject,
 }
 
 fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
@@ -1723,8 +1685,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
             Command::SetGeometryLevel {
                 level: "layout".to_string(),
             },
-            MmdsDiffKind::GeometryLevelChanged,
-            MmdsDiffSubject::Document,
+            ChangeKind::GeometryLevelChanged,
+            Subject::Document,
         ),
         round_trip_case(
             "set direction",
@@ -1732,8 +1694,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
             Command::SetDirection {
                 direction: "LR".to_string(),
             },
-            MmdsDiffKind::DirectionChanged,
-            MmdsDiffSubject::Document,
+            ChangeKind::DirectionChanged,
+            Subject::Document,
         ),
         round_trip_case(
             "set engine some",
@@ -1741,15 +1703,15 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
             Command::SetEngine {
                 engine: Some("mermaid-layered".to_string()),
             },
-            MmdsDiffKind::EngineChanged,
-            MmdsDiffSubject::Document,
+            ChangeKind::EngineChanged,
+            Subject::Document,
         ),
         round_trip_case(
             "set engine none",
             parse_routed_with_engine("graph TD\n    A --> B\n", "mermaid-layered"),
             Command::SetEngine { engine: None },
-            MmdsDiffKind::EngineChanged,
-            MmdsDiffSubject::Document,
+            ChangeKind::EngineChanged,
+            Subject::Document,
         ),
         round_trip_case(
             "add node",
@@ -1760,8 +1722,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 shape: "rectangle".to_string(),
                 parent: None,
             },
-            MmdsDiffKind::NodeAdded,
-            MmdsDiffSubject::Node("C".to_string()),
+            ChangeKind::NodeAdded,
+            Subject::Node("C".to_string()),
         ),
         round_trip_case(
             "remove node",
@@ -1769,8 +1731,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
             Command::RemoveNode {
                 id: "C".to_string(),
             },
-            MmdsDiffKind::NodeRemoved,
-            MmdsDiffSubject::Node("C".to_string()),
+            ChangeKind::NodeRemoved,
+            Subject::Node("C".to_string()),
         ),
         round_trip_case(
             "change node label",
@@ -1779,8 +1741,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 node: "A".to_string(),
                 label: "Alpha".to_string(),
             },
-            MmdsDiffKind::NodeLabelChanged,
-            MmdsDiffSubject::Node("A".to_string()),
+            ChangeKind::NodeLabelChanged,
+            Subject::Node("A".to_string()),
         ),
         round_trip_case(
             "change node shape",
@@ -1789,8 +1751,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 node: "A".to_string(),
                 shape: "stadium".to_string(),
             },
-            MmdsDiffKind::NodeShapeChanged,
-            MmdsDiffSubject::Node("A".to_string()),
+            ChangeKind::NodeShapeChanged,
+            Subject::Node("A".to_string()),
         ),
         round_trip_case(
             "set node parent",
@@ -1801,8 +1763,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 node: "A".to_string(),
                 parent: Some("sg1".to_string()),
             },
-            MmdsDiffKind::NodeParentChanged,
-            MmdsDiffSubject::Node("A".to_string()),
+            ChangeKind::NodeParentChanged,
+            Subject::Node("A".to_string()),
         ),
         round_trip_case_no_geometry(
             "set node style extension insert",
@@ -1811,8 +1773,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 node: "A".to_string(),
                 value: json!({ "fill": "#abcdef" }),
             },
-            MmdsDiffKind::NodeStyleChanged,
-            MmdsDiffSubject::Node("A".to_string()),
+            ChangeKind::NodeStyleChanged,
+            Subject::Node("A".to_string()),
         ),
         round_trip_case_no_geometry(
             "set node style extension update",
@@ -1821,8 +1783,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 node: "A".to_string(),
                 value: json!({ "fill": "#abcdef" }),
             },
-            MmdsDiffKind::NodeStyleChanged,
-            MmdsDiffSubject::Node("A".to_string()),
+            ChangeKind::NodeStyleChanged,
+            Subject::Node("A".to_string()),
         ),
         round_trip_case_no_geometry(
             "set profiles",
@@ -1830,8 +1792,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
             Command::SetProfiles {
                 profiles: vec!["custom-profile".to_string()],
             },
-            MmdsDiffKind::ProfileChanged,
-            MmdsDiffSubject::Document,
+            ChangeKind::ProfileChanged,
+            Subject::Document,
         ),
         round_trip_case_no_geometry(
             "set extension insert",
@@ -1840,8 +1802,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 namespace: "example.extension".to_string(),
                 value: json!({ "enabled": true }),
             },
-            MmdsDiffKind::ExtensionChanged,
-            MmdsDiffSubject::Document,
+            ChangeKind::ExtensionChanged,
+            Subject::Document,
         ),
         round_trip_case_no_geometry(
             "set extension update",
@@ -1854,15 +1816,15 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 namespace: "example.extension".to_string(),
                 value: json!({ "enabled": true }),
             },
-            MmdsDiffKind::ExtensionChanged,
-            MmdsDiffSubject::Document,
+            ChangeKind::ExtensionChanged,
+            Subject::Document,
         ),
         round_trip_case(
             "add edge",
             parse_routed_for_command_apply("graph TD\n    A --> B\n    C[Gamma]\n"),
             add_edge_command(None),
-            MmdsDiffKind::EdgeAdded,
-            MmdsDiffSubject::Edge("e1".to_string()),
+            ChangeKind::EdgeAdded,
+            Subject::Edge("e1".to_string()),
         ),
         round_trip_case(
             "remove edge",
@@ -1870,8 +1832,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
             Command::RemoveEdge {
                 edge: EdgeSelector::Id("e1".to_string()),
             },
-            MmdsDiffKind::EdgeRemoved,
-            MmdsDiffSubject::Edge("e1".to_string()),
+            ChangeKind::EdgeRemoved,
+            Subject::Edge("e1".to_string()),
         ),
         round_trip_case(
             "reconnect edge",
@@ -1881,8 +1843,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 source: "A".to_string(),
                 target: "C".to_string(),
             },
-            MmdsDiffKind::EdgeReconnected,
-            MmdsDiffSubject::Edge("e0".to_string()),
+            ChangeKind::EdgeReconnected,
+            Subject::Edge("e0".to_string()),
         ),
         round_trip_case(
             "set edge endpoint intent",
@@ -1894,8 +1856,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 from_subgraph: Some("sg1".to_string()),
                 to_subgraph: Some("sg2".to_string()),
             },
-            MmdsDiffKind::EdgeEndpointIntentChanged,
-            MmdsDiffSubject::Edge("e0".to_string()),
+            ChangeKind::EdgeEndpointIntentChanged,
+            Subject::Edge("e0".to_string()),
         ),
         round_trip_case(
             "change edge label",
@@ -1904,8 +1866,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 edge: EdgeSelector::Id("e0".to_string()),
                 label: Some("much longer label".to_string()),
             },
-            MmdsDiffKind::EdgeLabelChanged,
-            MmdsDiffSubject::Edge("e0".to_string()),
+            ChangeKind::EdgeLabelChanged,
+            Subject::Edge("e0".to_string()),
         ),
         round_trip_case(
             "change edge style",
@@ -1917,8 +1879,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 arrow_end: Some("diamond".to_string()),
                 minlen: Some(2),
             },
-            MmdsDiffKind::EdgeStyleChanged,
-            MmdsDiffSubject::Edge("e0".to_string()),
+            ChangeKind::EdgeStyleChanged,
+            Subject::Edge("e0".to_string()),
         ),
         round_trip_case(
             "add subgraph",
@@ -1932,8 +1894,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 concurrent_regions: Vec::new(),
                 invisible: false,
             },
-            MmdsDiffKind::SubgraphAdded,
-            MmdsDiffSubject::Subgraph("sg1".to_string()),
+            ChangeKind::SubgraphAdded,
+            Subject::Subgraph("sg1".to_string()),
         ),
         round_trip_case(
             "remove subgraph",
@@ -1941,8 +1903,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
             Command::RemoveSubgraph {
                 id: "sg1".to_string(),
             },
-            MmdsDiffKind::SubgraphRemoved,
-            MmdsDiffSubject::Subgraph("sg1".to_string()),
+            ChangeKind::SubgraphRemoved,
+            Subject::Subgraph("sg1".to_string()),
         ),
         round_trip_case_no_geometry(
             "change subgraph title",
@@ -1951,8 +1913,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 subgraph: "sg1".to_string(),
                 title: Some("Pipeline".to_string()),
             },
-            MmdsDiffKind::SubgraphTitleChanged,
-            MmdsDiffSubject::Subgraph("sg1".to_string()),
+            ChangeKind::SubgraphTitleChanged,
+            Subject::Subgraph("sg1".to_string()),
         ),
         round_trip_case(
             "set subgraph direction",
@@ -1961,8 +1923,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 subgraph: "sg1".to_string(),
                 direction: Some("LR".to_string()),
             },
-            MmdsDiffKind::SubgraphDirectionChanged,
-            MmdsDiffSubject::Subgraph("sg1".to_string()),
+            ChangeKind::SubgraphDirectionChanged,
+            Subject::Subgraph("sg1".to_string()),
         ),
         round_trip_case(
             "set subgraph parent",
@@ -1973,8 +1935,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 subgraph: "sg1".to_string(),
                 parent: Some("outer".to_string()),
             },
-            MmdsDiffKind::SubgraphParentChanged,
-            MmdsDiffSubject::Subgraph("sg1".to_string()),
+            ChangeKind::SubgraphParentChanged,
+            Subject::Subgraph("sg1".to_string()),
         ),
         round_trip_case(
             "change subgraph membership",
@@ -1988,8 +1950,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 added_concurrent_regions: Vec::new(),
                 removed_concurrent_regions: Vec::new(),
             },
-            MmdsDiffKind::SubgraphMembershipChanged,
-            MmdsDiffSubject::Subgraph("sg1".to_string()),
+            ChangeKind::SubgraphMembershipChanged,
+            Subject::Subgraph("sg1".to_string()),
         ),
         round_trip_case(
             "set subgraph visibility",
@@ -1998,8 +1960,8 @@ fn apply_round_trip_cases() -> Vec<ApplyRoundTripCase> {
                 subgraph: "sg1".to_string(),
                 invisible: true,
             },
-            MmdsDiffKind::SubgraphVisibilityChanged,
-            MmdsDiffSubject::Subgraph("sg1".to_string()),
+            ChangeKind::SubgraphVisibilityChanged,
+            Subject::Subgraph("sg1".to_string()),
         ),
     ]
 }
@@ -2008,8 +1970,8 @@ fn round_trip_case(
     name: &'static str,
     before: crate::mmds::Document,
     command: Command,
-    expected_kind: MmdsDiffKind,
-    expected_subject: MmdsDiffSubject,
+    expected_kind: ChangeKind,
+    expected_subject: Subject,
 ) -> ApplyRoundTripCase {
     ApplyRoundTripCase {
         name,
@@ -2025,8 +1987,8 @@ fn round_trip_case_no_geometry(
     name: &'static str,
     before: crate::mmds::Document,
     command: Command,
-    expected_kind: MmdsDiffKind,
-    expected_subject: MmdsDiffSubject,
+    expected_kind: ChangeKind,
+    expected_subject: Subject,
 ) -> ApplyRoundTripCase {
     ApplyRoundTripCase {
         name,
@@ -2048,8 +2010,8 @@ fn tier_a_representative_command_cases() -> Vec<TierARepresentativeCommandCase> 
                 shape: "rectangle".to_string(),
                 parent: None,
             },
-            expected_kind: MmdsDiffKind::NodeAdded,
-            expected_subject: MmdsDiffSubject::Node("X".to_string()),
+            expected_kind: ChangeKind::NodeAdded,
+            expected_subject: Subject::Node("X".to_string()),
         },
         TierARepresentativeCommandCase {
             pair_id: "M05",
@@ -2057,8 +2019,8 @@ fn tier_a_representative_command_cases() -> Vec<TierARepresentativeCommandCase> 
                 node: "Lint".to_string(),
                 label: "Static Analysis".to_string(),
             },
-            expected_kind: MmdsDiffKind::NodeLabelChanged,
-            expected_subject: MmdsDiffSubject::Node("Lint".to_string()),
+            expected_kind: ChangeKind::NodeLabelChanged,
+            expected_subject: Subject::Node("Lint".to_string()),
         },
         TierARepresentativeCommandCase {
             pair_id: "M07",
@@ -2069,8 +2031,8 @@ fn tier_a_representative_command_cases() -> Vec<TierARepresentativeCommandCase> 
                 arrow_end: None,
                 minlen: None,
             },
-            expected_kind: MmdsDiffKind::EdgeStyleChanged,
-            expected_subject: MmdsDiffSubject::Edge("e0".to_string()),
+            expected_kind: ChangeKind::EdgeStyleChanged,
+            expected_subject: Subject::Edge("e0".to_string()),
         },
         TierARepresentativeCommandCase {
             pair_id: "M10",
@@ -2078,71 +2040,71 @@ fn tier_a_representative_command_cases() -> Vec<TierARepresentativeCommandCase> 
                 subgraph: "sg1".to_string(),
                 direction: Some("TD".to_string()),
             },
-            expected_kind: MmdsDiffKind::SubgraphDirectionChanged,
-            expected_subject: MmdsDiffSubject::Subgraph("sg1".to_string()),
+            expected_kind: ChangeKind::SubgraphDirectionChanged,
+            expected_subject: Subject::Subgraph("sg1".to_string()),
         },
     ]
 }
 
-fn all_diff_kinds() -> [MmdsDiffKind; 36] {
+fn all_diff_kinds() -> [ChangeKind; 36] {
     [
-        MmdsDiffKind::GeometryLevelChanged,
-        MmdsDiffKind::DirectionChanged,
-        MmdsDiffKind::EngineChanged,
-        MmdsDiffKind::NodeAdded,
-        MmdsDiffKind::NodeRemoved,
-        MmdsDiffKind::EdgeAdded,
-        MmdsDiffKind::EdgeRemoved,
-        MmdsDiffKind::SubgraphAdded,
-        MmdsDiffKind::SubgraphRemoved,
-        MmdsDiffKind::NodeLabelChanged,
-        MmdsDiffKind::NodeShapeChanged,
-        MmdsDiffKind::NodeParentChanged,
-        MmdsDiffKind::NodeStyleChanged,
-        MmdsDiffKind::EdgeReconnected,
-        MmdsDiffKind::EdgeEndpointIntentChanged,
-        MmdsDiffKind::EdgeLabelChanged,
-        MmdsDiffKind::EdgeStyleChanged,
-        MmdsDiffKind::SubgraphTitleChanged,
-        MmdsDiffKind::SubgraphDirectionChanged,
-        MmdsDiffKind::SubgraphParentChanged,
-        MmdsDiffKind::SubgraphMembershipChanged,
-        MmdsDiffKind::SubgraphVisibilityChanged,
-        MmdsDiffKind::ProfileChanged,
-        MmdsDiffKind::ExtensionChanged,
-        MmdsDiffKind::NodeMoved,
-        MmdsDiffKind::NodeResized,
-        MmdsDiffKind::CanvasResized,
-        MmdsDiffKind::SubgraphBoundsChanged,
-        MmdsDiffKind::EdgeRerouted,
-        MmdsDiffKind::EndpointFaceChanged,
-        MmdsDiffKind::PortIntentChanged,
-        MmdsDiffKind::LabelMoved,
-        MmdsDiffKind::LabelResized,
-        MmdsDiffKind::LabelSideChanged,
-        MmdsDiffKind::PathPortDivergenceChanged,
-        MmdsDiffKind::GlobalReflowDetected,
+        ChangeKind::GeometryLevelChanged,
+        ChangeKind::DirectionChanged,
+        ChangeKind::EngineChanged,
+        ChangeKind::NodeAdded,
+        ChangeKind::NodeRemoved,
+        ChangeKind::EdgeAdded,
+        ChangeKind::EdgeRemoved,
+        ChangeKind::SubgraphAdded,
+        ChangeKind::SubgraphRemoved,
+        ChangeKind::NodeLabelChanged,
+        ChangeKind::NodeShapeChanged,
+        ChangeKind::NodeParentChanged,
+        ChangeKind::NodeStyleChanged,
+        ChangeKind::EdgeReconnected,
+        ChangeKind::EdgeEndpointIntentChanged,
+        ChangeKind::EdgeLabelChanged,
+        ChangeKind::EdgeStyleChanged,
+        ChangeKind::SubgraphTitleChanged,
+        ChangeKind::SubgraphDirectionChanged,
+        ChangeKind::SubgraphParentChanged,
+        ChangeKind::SubgraphMembershipChanged,
+        ChangeKind::SubgraphVisibilityChanged,
+        ChangeKind::ProfileChanged,
+        ChangeKind::ExtensionChanged,
+        ChangeKind::NodeMoved,
+        ChangeKind::NodeResized,
+        ChangeKind::CanvasResized,
+        ChangeKind::SubgraphBoundsChanged,
+        ChangeKind::EdgeRerouted,
+        ChangeKind::EndpointFaceChanged,
+        ChangeKind::PortIntentChanged,
+        ChangeKind::LabelMoved,
+        ChangeKind::LabelResized,
+        ChangeKind::LabelSideChanged,
+        ChangeKind::PathPortDivergenceChanged,
+        ChangeKind::GlobalReflowDetected,
     ]
 }
 
-fn geometry_effect_kinds() -> [MmdsDiffKind; 12] {
+fn geometry_effect_kinds() -> [ChangeKind; 12] {
     [
-        MmdsDiffKind::NodeMoved,
-        MmdsDiffKind::NodeResized,
-        MmdsDiffKind::CanvasResized,
-        MmdsDiffKind::SubgraphBoundsChanged,
-        MmdsDiffKind::EdgeRerouted,
-        MmdsDiffKind::EndpointFaceChanged,
-        MmdsDiffKind::PortIntentChanged,
-        MmdsDiffKind::LabelMoved,
-        MmdsDiffKind::LabelResized,
-        MmdsDiffKind::LabelSideChanged,
-        MmdsDiffKind::PathPortDivergenceChanged,
-        MmdsDiffKind::GlobalReflowDetected,
+        ChangeKind::NodeMoved,
+        ChangeKind::NodeResized,
+        ChangeKind::CanvasResized,
+        ChangeKind::SubgraphBoundsChanged,
+        ChangeKind::EdgeRerouted,
+        ChangeKind::EndpointFaceChanged,
+        ChangeKind::PortIntentChanged,
+        ChangeKind::LabelMoved,
+        ChangeKind::LabelResized,
+        ChangeKind::LabelSideChanged,
+        ChangeKind::PathPortDivergenceChanged,
+        ChangeKind::GlobalReflowDetected,
     ]
 }
 
-fn assert_same_kinds(left: &[MmdsDiffKind], right: &[MmdsDiffKind]) {
+fn assert_same_kinds(left: &[ChangeKind], right: &[ChangeKind]) {
     assert_eq!(left.len(), right.len());
     for kind in left {
         assert!(contains_kind(right, *kind), "missing {kind:?}");
@@ -2152,7 +2114,7 @@ fn assert_same_kinds(left: &[MmdsDiffKind], right: &[MmdsDiffKind]) {
     }
 }
 
-fn contains_kind(kinds: &[MmdsDiffKind], needle: MmdsDiffKind) -> bool {
+fn contains_kind(kinds: &[ChangeKind], needle: ChangeKind) -> bool {
     kinds.contains(&needle)
 }
 
@@ -2219,20 +2181,16 @@ fn map_from_pairs<const N: usize>(
         .collect()
 }
 
-fn assert_primary_event(
-    events: &[crate::mmds::diff::MmdsDiffEvent],
-    kind: MmdsDiffKind,
-    subject_id: &str,
-) {
+fn assert_primary_event(events: &[ModelEvent], kind: ModelEventKind, subject_id: &str) {
     assert_eq!(events.len(), 1);
     assert_eq!(events[0].kind, kind);
     assert!(subject_matches(&events[0].subject, subject_id));
 }
 
-fn assert_has_event_pair(
-    events: &[crate::mmds::diff::MmdsDiffEvent],
-    kind: MmdsDiffKind,
-    subject: &MmdsDiffSubject,
+fn assert_has_change_pair(
+    events: &[crate::mmds::diff::Change],
+    kind: ChangeKind,
+    subject: &Subject,
 ) {
     assert!(
         events
@@ -2242,20 +2200,27 @@ fn assert_has_event_pair(
     );
 }
 
+fn assert_has_model_event_change_pair(events: &[ModelEvent], kind: ChangeKind, subject: &Subject) {
+    assert!(
+        events
+            .iter()
+            .any(|event| model_event_kind_to_change_kind(event.kind) == kind
+                && event.subject == *subject),
+        "missing ({kind:?}, {subject:?}) in {events:#?}"
+    );
+}
+
 fn assert_in_place_diff(
     before: &crate::mmds::Document,
     after: &crate::mmds::Document,
-    kind: MmdsDiffKind,
+    kind: ChangeKind,
     subject_id: &str,
 ) {
     assert_geometry_unchanged(before, after);
-    let diff = crate::mmds::diff::diff_outputs(before, after);
-    assert!(diff.has_event(kind, subject_id), "{diff:#?}");
+    let diff = crate::mmds::diff::diff_documents(before, after);
+    assert!(diff.has_change(kind, subject_id), "{diff:#?}");
     assert!(
-        !diff
-            .events
-            .iter()
-            .any(|event| event.kind.is_geometry_effect()),
+        !diff.changes.iter().any(|event| event.kind.is_geometry()),
         "{diff:#?}"
     );
 }
@@ -2315,12 +2280,12 @@ fn subgraph_geometry(output: &crate::mmds::Document) -> Vec<serde_json::Value> {
         .collect()
 }
 
-fn subject_matches(subject: &crate::mmds::diff::MmdsDiffSubject, subject_id: &str) -> bool {
+fn subject_matches(subject: &crate::mmds::Subject, subject_id: &str) -> bool {
     match subject {
-        crate::mmds::diff::MmdsDiffSubject::Document => subject_id.is_empty(),
-        crate::mmds::diff::MmdsDiffSubject::Node(id)
-        | crate::mmds::diff::MmdsDiffSubject::Edge(id)
-        | crate::mmds::diff::MmdsDiffSubject::Subgraph(id) => id == subject_id,
+        crate::mmds::Subject::Document => subject_id.is_empty(),
+        crate::mmds::Subject::Node(id)
+        | crate::mmds::Subject::Edge(id)
+        | crate::mmds::Subject::Subgraph(id) => id == subject_id,
     }
 }
 

--- a/src/internal_tests/mmds_diff.rs
+++ b/src/internal_tests/mmds_diff.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::layout_stability::mutations;
 use crate::graph::GeometryLevel;
-use crate::mmds::diff::{MmdsDiff, MmdsDiffKind};
+use crate::mmds::diff::{ChangeKind, Diff};
 use crate::{OutputFormat, RenderConfig};
 
 #[test]
@@ -12,13 +12,13 @@ fn mmds_diff_model_identical_outputs_have_no_events() {
     let before = parse_routed("graph TD; A --> B");
     let after = parse_routed("graph TD; A --> B");
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.events.is_empty(), "{diff:#?}");
+    assert!(diff.changes.is_empty(), "{diff:#?}");
     assert_eq!(diff.before_geometry_level, "routed");
     assert_eq!(diff.after_geometry_level, "routed");
 
-    assert!(!diff.has_event(crate::mmds::diff::MmdsDiffKind::GeometryLevelChanged, ""));
+    assert!(!diff.has_change(crate::mmds::diff::ChangeKind::GeometryLevelChanged, ""));
 }
 
 #[test]
@@ -26,10 +26,10 @@ fn mmds_diff_identity_reports_node_and_edge_additions() {
     let before = parse_routed("graph TD; A --> B");
     let after = parse_routed("graph TD; A --> B; B --> C");
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::NodeAdded, "C"));
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeAdded, "e1"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::NodeAdded, "C"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeAdded, "e1"));
 }
 
 #[test]
@@ -37,10 +37,10 @@ fn mmds_diff_identity_treats_id_change_as_remove_add() {
     let before = parse_routed("graph TD; Lint --> Build");
     let after = parse_routed("graph TD; Audit --> Build");
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::NodeRemoved, "Lint"));
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::NodeAdded, "Audit"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::NodeRemoved, "Lint"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::NodeAdded, "Audit"));
 }
 
 #[test]
@@ -48,10 +48,10 @@ fn mmds_diff_semantic_reports_node_label_and_shape_changes() {
     let before = parse_layout("graph TD; A[Build]");
     let after = parse_layout("graph TD; A{Deploy}");
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::NodeLabelChanged, "A"));
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::NodeShapeChanged, "A"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::NodeLabelChanged, "A"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::NodeShapeChanged, "A"));
 }
 
 #[test]
@@ -59,10 +59,10 @@ fn mmds_diff_semantic_reports_edge_label_and_style_changes() {
     let before = parse_routed("graph TD; A -->|ok| B");
     let after = parse_routed("graph TD; A -.->|warn| B");
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeLabelChanged, "e0"));
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeStyleChanged, "e0"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeLabelChanged, "e0"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeStyleChanged, "e0"));
 }
 
 #[test]
@@ -75,16 +75,16 @@ fn mmds_diff_edge_matching_shifted_id_reports_label_change_not_remove_add() {
     after.edges[1].label = Some("new".to_string());
     after.edges[2].id = "e3".to_string();
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeLabelChanged, "e2"));
-    assert!(!diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeRemoved, "e1"));
-    assert!(!diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeAdded, "e2"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeLabelChanged, "e2"));
+    assert!(!diff.has_change(crate::mmds::diff::ChangeKind::EdgeRemoved, "e1"));
+    assert!(!diff.has_change(crate::mmds::diff::ChangeKind::EdgeAdded, "e2"));
     assert!(
-        diff.events.iter().any(|event| {
+        diff.changes.iter().any(|event| {
             matches!(
                 &event.subject,
-                crate::mmds::diff::MmdsDiffSubject::Edge(id) if id == "e2"
+                crate::mmds::Subject::Edge(id) if id == "e2"
             ) && event.evidence_mentions("matched_by=fallback")
                 && event.evidence_mentions("before_id=e1")
                 && event.evidence_mentions("after_id=e2")
@@ -102,14 +102,14 @@ fn mmds_diff_edge_matching_shifted_id_uses_after_id_for_routed_evidence() {
     after.edges[1].id = "e2".to_string();
     after.edges[1].path = Some(vec![[0.0, 0.0], [40.0, 0.0], [40.0, 20.0]]);
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeRerouted, "e2"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeRerouted, "e2"));
     assert!(
-        diff.events.iter().any(|event| {
+        diff.changes.iter().any(|event| {
             matches!(
                 &event.subject,
-                crate::mmds::diff::MmdsDiffSubject::Edge(id) if id == "e2"
+                crate::mmds::Subject::Edge(id) if id == "e2"
             ) && event.evidence_mentions("matched_by=fallback")
                 && event.evidence_mentions("before_id=e1")
                 && event.evidence_mentions("after_id=e2")
@@ -127,13 +127,13 @@ fn mmds_diff_edge_matching_m01_preserves_split_and_matches_downstream_shift() {
 ",
     );
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::NodeAdded, "X"));
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeRemoved, "e1"));
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeAdded, "e1"));
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeAdded, "e2"));
-    assert!(!diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeAdded, "e3"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::NodeAdded, "X"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeRemoved, "e1"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeAdded, "e1"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeAdded, "e2"));
+    assert!(!diff.has_change(crate::mmds::diff::ChangeKind::EdgeAdded, "e3"));
 }
 
 #[test]
@@ -141,11 +141,11 @@ fn mmds_diff_edge_matching_keeps_existing_node_reconnect_as_reconnected() {
     let before = parse_routed("graph TD; A --> B; C[Alternative]");
     let after = parse_routed("graph TD; A --> C; B[Target]");
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeReconnected, "e0"));
-    assert!(!diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeRemoved, "e0"));
-    assert!(!diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeAdded, "e0"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeReconnected, "e0"));
+    assert!(!diff.has_change(crate::mmds::diff::ChangeKind::EdgeRemoved, "e0"));
+    assert!(!diff.has_change(crate::mmds::diff::ChangeKind::EdgeAdded, "e0"));
 }
 
 #[test]
@@ -158,15 +158,15 @@ fn mmds_diff_edge_matching_parallel_edges_prefers_label_tiebreaker() {
     after.edges[1].id = "e2".to_string();
     after.edges[1].label = Some("alpha changed".to_string());
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeLabelChanged, "e2"));
-    assert!(!diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeLabelChanged, "e1"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeLabelChanged, "e2"));
+    assert!(!diff.has_change(crate::mmds::diff::ChangeKind::EdgeLabelChanged, "e1"));
     assert!(
-        diff.events.iter().any(|event| {
+        diff.changes.iter().any(|event| {
             matches!(
                 &event.subject,
-                crate::mmds::diff::MmdsDiffSubject::Edge(id) if id == "e2"
+                crate::mmds::Subject::Edge(id) if id == "e2"
             ) && event.evidence_mentions("matched_by=fallback")
                 && event.evidence_mentions("before_id=e0")
                 && event.evidence_mentions("after_id=e2")
@@ -184,14 +184,14 @@ fn mmds_diff_edge_matching_parallel_edges_falls_back_to_declaration_order() {
     after.edges[0].path = Some(vec![[0.0, 0.0], [40.0, 0.0], [40.0, 20.0]]);
     after.edges[1].id = "e2".to_string();
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::EdgeRerouted, "e1"));
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::EdgeRerouted, "e1"));
     assert!(
-        diff.events.iter().any(|event| {
+        diff.changes.iter().any(|event| {
             matches!(
                 &event.subject,
-                crate::mmds::diff::MmdsDiffSubject::Edge(id) if id == "e1"
+                crate::mmds::Subject::Edge(id) if id == "e1"
             ) && event.evidence_mentions("matched_by=fallback")
                 && event.evidence_mentions("before_id=e0")
                 && event.evidence_mentions("after_id=e1")
@@ -218,15 +218,15 @@ fn mmds_diff_semantic_reports_subgraph_title_direction_and_membership_changes() 
         end",
     );
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_event(crate::mmds::diff::MmdsDiffKind::SubgraphTitleChanged, "sg"));
-    assert!(diff.has_event(
-        crate::mmds::diff::MmdsDiffKind::SubgraphDirectionChanged,
+    assert!(diff.has_change(crate::mmds::diff::ChangeKind::SubgraphTitleChanged, "sg"));
+    assert!(diff.has_change(
+        crate::mmds::diff::ChangeKind::SubgraphDirectionChanged,
         "sg"
     ));
-    assert!(diff.has_event(
-        crate::mmds::diff::MmdsDiffKind::SubgraphMembershipChanged,
+    assert!(diff.has_change(
+        crate::mmds::diff::ChangeKind::SubgraphMembershipChanged,
         "sg"
     ));
 }
@@ -236,12 +236,12 @@ fn mmds_diff_routed_separates_path_from_port_intent() {
     let before = parse_routed("graph TD; A --> B");
     let after = parse_routed("graph LR; A --> B");
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_kind(crate::mmds::diff::MmdsDiffKind::EdgeRerouted));
-    assert!(diff.has_kind(crate::mmds::diff::MmdsDiffKind::EndpointFaceChanged));
-    assert!(diff.events.iter().all(|event| {
-        event.kind != crate::mmds::diff::MmdsDiffKind::PortIntentChanged
+    assert!(diff.has_change_kind(crate::mmds::diff::ChangeKind::EdgeRerouted));
+    assert!(diff.has_change_kind(crate::mmds::diff::ChangeKind::EndpointFaceChanged));
+    assert!(diff.changes.iter().all(|event| {
+        event.kind != crate::mmds::diff::ChangeKind::PortIntentChanged
             || event.evidence_mentions("logical")
     }));
 }
@@ -251,9 +251,9 @@ fn mmds_diff_geometry_reports_label_rect_change() {
     let before = render_pair_before_routed("M14");
     let after = render_pair_after_routed("M14");
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_kind(crate::mmds::diff::MmdsDiffKind::LabelResized));
+    assert!(diff.has_change_kind(crate::mmds::diff::ChangeKind::LabelResized));
 }
 
 #[test]
@@ -261,10 +261,10 @@ fn mmds_diff_reflow_suppresses_tiny_unchanged_node_movement() {
     let before = parse_routed("graph TD; A --> B");
     let after = output_with_node_shift(&before, "A", 0.5, 0.0);
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(!diff.has_kind(crate::mmds::diff::MmdsDiffKind::NodeMoved));
-    assert!(!diff.has_kind(crate::mmds::diff::MmdsDiffKind::GlobalReflowDetected));
+    assert!(!diff.has_change_kind(crate::mmds::diff::ChangeKind::NodeMoved));
+    assert!(!diff.has_change_kind(crate::mmds::diff::ChangeKind::GlobalReflowDetected));
 }
 
 #[test]
@@ -272,12 +272,12 @@ fn mmds_diff_reflow_reports_many_unchanged_nodes_moving() {
     let before = render_pair_before_routed("M14");
     let after = render_pair_after_routed("M14");
 
-    let diff = crate::mmds::diff::diff_outputs(&before, &after);
+    let diff = crate::mmds::diff::diff_documents(&before, &after);
 
-    assert!(diff.has_kind(crate::mmds::diff::MmdsDiffKind::EdgeLabelChanged));
+    assert!(diff.has_change_kind(crate::mmds::diff::ChangeKind::EdgeLabelChanged));
     assert!(
         diff.has_related_geometry_for("e0")
-            || diff.has_kind(crate::mmds::diff::MmdsDiffKind::EdgeRerouted)
+            || diff.has_change_kind(crate::mmds::diff::ChangeKind::EdgeRerouted)
     );
 }
 
@@ -285,44 +285,44 @@ fn mmds_diff_reflow_reports_many_unchanged_nodes_moving() {
 fn mmds_diff_tier_a_reports_expected_event_families() {
     let summaries = run_tier_a_diff_summaries();
 
-    assert!(summaries["M01"].has_kind(MmdsDiffKind::NodeAdded));
-    assert!(summaries["M05"].has_kind(MmdsDiffKind::NodeLabelChanged));
-    assert!(summaries["M07"].has_kind(MmdsDiffKind::EdgeStyleChanged));
-    assert!(!summaries["M07"].has_kind(MmdsDiffKind::EdgeRerouted));
-    assert!(summaries["M10"].has_kind(MmdsDiffKind::SubgraphDirectionChanged));
+    assert!(summaries["M01"].has_change_kind(ChangeKind::NodeAdded));
+    assert!(summaries["M05"].has_change_kind(ChangeKind::NodeLabelChanged));
+    assert!(summaries["M07"].has_change_kind(ChangeKind::EdgeStyleChanged));
+    assert!(!summaries["M07"].has_change_kind(ChangeKind::EdgeRerouted));
+    assert!(summaries["M10"].has_change_kind(ChangeKind::SubgraphDirectionChanged));
 }
 
 #[test]
 fn mmds_diff_edge_matching_tier_a_controls_stay_calibrated() {
     let summaries = run_tier_a_diff_summaries();
 
-    assert!(summaries["M01"].has_event(MmdsDiffKind::NodeAdded, "X"));
-    assert!(summaries["M01"].has_event(MmdsDiffKind::EdgeRemoved, "e1"));
-    assert!(summaries["M01"].has_event(MmdsDiffKind::EdgeAdded, "e1"));
-    assert!(summaries["M01"].has_event(MmdsDiffKind::EdgeAdded, "e2"));
+    assert!(summaries["M01"].has_change(ChangeKind::NodeAdded, "X"));
+    assert!(summaries["M01"].has_change(ChangeKind::EdgeRemoved, "e1"));
+    assert!(summaries["M01"].has_change(ChangeKind::EdgeAdded, "e1"));
+    assert!(summaries["M01"].has_change(ChangeKind::EdgeAdded, "e2"));
 
     for pair_id in ["M04", "M11", "M19", "M20", "M21"] {
         assert!(
-            summaries[pair_id].has_kind(MmdsDiffKind::EdgeAdded),
+            summaries[pair_id].has_change_kind(ChangeKind::EdgeAdded),
             "{pair_id} should stay an edge-addition control"
         );
         assert!(
-            !summaries[pair_id].has_kind(MmdsDiffKind::EdgeRemoved),
+            !summaries[pair_id].has_change_kind(ChangeKind::EdgeRemoved),
             "{pair_id} should not report fallback-induced edge removals"
         );
     }
 
-    assert!(summaries["M05"].has_kind(MmdsDiffKind::NodeLabelChanged));
-    assert!(summaries["M07"].has_kind(MmdsDiffKind::EdgeStyleChanged));
-    assert!(!summaries["M07"].has_kind(MmdsDiffKind::EdgeRerouted));
-    assert!(summaries["S02"].has_kind(MmdsDiffKind::EdgeLabelChanged));
-    assert!(!summaries["S02"].has_kind(MmdsDiffKind::EdgeRerouted));
-    assert!(summaries["S03"].has_kind(MmdsDiffKind::EdgeStyleChanged));
-    assert!(!summaries["S03"].has_kind(MmdsDiffKind::EdgeRerouted));
+    assert!(summaries["M05"].has_change_kind(ChangeKind::NodeLabelChanged));
+    assert!(summaries["M07"].has_change_kind(ChangeKind::EdgeStyleChanged));
+    assert!(!summaries["M07"].has_change_kind(ChangeKind::EdgeRerouted));
+    assert!(summaries["S02"].has_change_kind(ChangeKind::EdgeLabelChanged));
+    assert!(!summaries["S02"].has_change_kind(ChangeKind::EdgeRerouted));
+    assert!(summaries["S03"].has_change_kind(ChangeKind::EdgeStyleChanged));
+    assert!(!summaries["S03"].has_change_kind(ChangeKind::EdgeRerouted));
 
-    assert!(summaries["M08"].has_kind(MmdsDiffKind::SubgraphAdded));
-    assert!(summaries["M09"].has_kind(MmdsDiffKind::SubgraphMembershipChanged));
-    assert!(summaries["M10"].has_kind(MmdsDiffKind::SubgraphDirectionChanged));
+    assert!(summaries["M08"].has_change_kind(ChangeKind::SubgraphAdded));
+    assert!(summaries["M09"].has_change_kind(ChangeKind::SubgraphMembershipChanged));
+    assert!(summaries["M10"].has_change_kind(ChangeKind::SubgraphDirectionChanged));
 }
 
 fn parse_layout(source: &str) -> crate::mmds::Document {
@@ -352,7 +352,7 @@ fn output_with_node_shift(
     shifted
 }
 
-fn run_tier_a_diff_summaries() -> BTreeMap<&'static str, MmdsDiff> {
+fn run_tier_a_diff_summaries() -> BTreeMap<&'static str, Diff> {
     mutations::tier_a_pairs()
         .iter()
         .map(|pair| {
@@ -361,7 +361,7 @@ fn run_tier_a_diff_summaries() -> BTreeMap<&'static str, MmdsDiff> {
 
             (
                 pair.id,
-                crate::mmds::diff::diff_outputs(&parse_routed(&before), &parse_routed(&after)),
+                crate::mmds::diff::diff_documents(&parse_routed(&before), &parse_routed(&after)),
             )
         })
         .collect()

--- a/src/internal_tests/mod.rs
+++ b/src/internal_tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod composition_probe;
 mod cross_pipeline;
+mod event_change_mapping;
 mod graph_routing_pipeline;
 mod grid_routing_regression;
 mod label_node_overlap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,20 @@
 //!
 //! Most consumers only need the facade functions and two config types:
 //!
-//! - [`render_diagram`] — detect, parse, and render in one call
-//! - [`materialize_diagram`] — materialize a graph-family [`mmds::Document`]
-//! - [`render_mmds_document`] — render an already-parsed graph-family MMDS document
+//! - [`render_diagram`] — render Mermaid source or MMDS JSON in one call
+//! - [`materialize_diagram`] — materialize Mermaid source or MMDS JSON as a
+//!   graph-family [`mmds::Document`]
+//! - [`render_document`] — render an already-parsed [`mmds::Document`]
 //! - [`detect_diagram`] — detect the diagram type without rendering
 //! - [`validate_diagram`] — parse and return structured JSON diagnostics
 //! - [`OutputFormat`] — `Text`, `Ascii`, `Svg`, or `Mmds`
 //! - [`RenderConfig`] — layout engine, routing, padding, color, and more
+//!
+//! Use [`render_diagram`] when you have text input. It auto-detects Mermaid
+//! source vs MMDS JSON because both represent the same abstract diagram. Use
+//! [`materialize_diagram`] when you want the typed [`mmds::Document`], and use
+//! [`render_document`] when you already have one, such as after
+//! [`views::project`].
 //!
 //! ```
 //! use mmdflux::{OutputFormat, RenderConfig, render_diagram};
@@ -32,6 +39,10 @@
 //! // Render as MMDS JSON (structured interchange format)
 //! let json = render_diagram(input, OutputFormat::Mmds, &RenderConfig::default()).unwrap();
 //! assert!(json.contains("\"diagram_type\""));
+//!
+//! // MMDS JSON is also accepted as text input.
+//! let replayed = render_diagram(&json, OutputFormat::Text, &RenderConfig::default()).unwrap();
+//! assert!(!replayed.trim().is_empty());
 //! ```
 //!
 //! ## Customizing output
@@ -167,6 +178,85 @@
 //! assert!(mermaid.contains("flowchart TD"));
 //! ```
 //!
+//! ## Commands, Diffs, and Views
+//!
+//! Public MMDS commands emit model events, while [`mmds::diff::diff_documents`]
+//! reports a snapshot diff between two document states. Model events and diff
+//! changes are related, but they are not interchangeable:
+//!
+//! ```
+//! use mmdflux::commands::{Command, apply};
+//! use mmdflux::mmds::Subject;
+//! use mmdflux::mmds::diff::{ChangeKind, diff_documents};
+//! use mmdflux::mmds::events::ModelEventKind;
+//! use mmdflux::views::{Selector, ViewSpec, ViewStatement, project};
+//! use mmdflux::{RenderConfig, materialize_diagram};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let initial = materialize_diagram(
+//!     "graph TD\n    A[Gateway] --> B[Billing]",
+//!     &RenderConfig::default(),
+//! )?;
+//! let mut current = initial.clone();
+//!
+//! apply(
+//!     &Command::AddNode {
+//!         id: "C".to_string(),
+//!         label: "Auth".to_string(),
+//!         shape: "rectangle".to_string(),
+//!         parent: None,
+//!     },
+//!     &mut current,
+//! )?;
+//! apply(
+//!     &Command::AddEdge {
+//!         id: None,
+//!         source: "A".to_string(),
+//!         target: "C".to_string(),
+//!         from_subgraph: None,
+//!         to_subgraph: None,
+//!         label: Some("routes".to_string()),
+//!         stroke: "solid".to_string(),
+//!         arrow_start: "none".to_string(),
+//!         arrow_end: "normal".to_string(),
+//!         minlen: 1,
+//!     },
+//!     &mut current,
+//! )?;
+//! let model_events = apply(
+//!     &Command::ChangeNodeLabel {
+//!         node: "C".to_string(),
+//!         label: "Auth Service".to_string(),
+//!     },
+//!     &mut current,
+//! )?;
+//!
+//! let snapshot_diff = diff_documents(&initial, &current);
+//! let (view, _view_events) = project(
+//!     &current,
+//!     &ViewSpec {
+//!         statements: vec![ViewStatement::Include(Selector::All)],
+//!         ..ViewSpec::default()
+//!     },
+//! )?;
+//!
+//! assert!(model_events.iter().any(|event| {
+//!     event.kind == ModelEventKind::NodeLabelChanged
+//!         && matches!(&event.subject, Subject::Node(id) if id == "C")
+//! }));
+//! assert!(snapshot_diff.changes.iter().any(|event| {
+//!     event.kind == ChangeKind::NodeAdded
+//!         && matches!(&event.subject, Subject::Node(id) if id == "C")
+//! }));
+//! assert!(!snapshot_diff.changes.iter().any(|event| {
+//!     event.kind == ChangeKind::NodeLabelChanged
+//!         && matches!(&event.subject, Subject::Node(id) if id == "C")
+//! }));
+//! assert_eq!(view.nodes.len(), current.nodes.len());
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! ## Materialized MMDS views
 //!
 //! Use [`views`] when an adapter needs a focused read model over a canonical
@@ -177,9 +267,9 @@
 //! ```
 //! use mmdflux::mmds::Document;
 //! use mmdflux::views::{
-//!     AnchorRef, Selector, TraversalDirection, ViewSpec, ViewStatement, apply_view,
+//!     AnchorRef, Selector, TraversalDirection, ViewSpec, ViewStatement, project,
 //! };
-//! use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_mmds_document};
+//! use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_document};
 //!
 //! let source = "\
 //! graph TD
@@ -197,8 +287,8 @@
 //!     ..ViewSpec::default()
 //! };
 //!
-//! let (view, events) = apply_view(&canonical, &spec).unwrap();
-//! let text = render_mmds_document(&view, OutputFormat::Text, &RenderConfig::default()).unwrap();
+//! let (view, events) = project(&canonical, &spec).unwrap();
+//! let text = render_document(&view, OutputFormat::Text, &RenderConfig::default()).unwrap();
 //! assert!(text.contains("Gateway"));
 //! assert_eq!(view.nodes.len(), 3);
 //! assert!(events.iter().any(|event| matches!(
@@ -208,6 +298,7 @@
 //! ```
 
 pub mod builtins;
+pub mod commands;
 mod diagrams;
 mod engines;
 pub mod errors;
@@ -250,12 +341,12 @@ pub use runtime::config_input::RuntimeConfigInput;
 pub use runtime::config_input::apply_svg_surface_defaults;
 /// Detect the diagram type from input text.
 pub use runtime::detect_diagram;
-/// Detect, parse, solve, and materialize a graph-family diagram as MMDS.
+/// Detect, parse, solve, and materialize Mermaid source or MMDS JSON as MMDS.
 pub use runtime::materialize_diagram;
-/// Detect, parse, and render a diagram in one call.
+/// Detect, parse, and render Mermaid source or MMDS JSON in one call.
 pub use runtime::render_diagram;
 /// Render a parsed graph-family MMDS document.
-pub use runtime::render_mmds_document;
+pub use runtime::render_document;
 /// Validate input and return structured JSON diagnostics.
 pub use runtime::validate_diagram;
 

--- a/src/mmds/diff.rs
+++ b/src/mmds/diff.rs
@@ -1,31 +1,63 @@
+//! Snapshot diff for MMDS documents.
+//!
+//! [`diff_documents`] compares two fully materialized MMDS [`Document`] values and returns a
+//! snapshot diff: the changes describe what differs between the two states, regardless of
+//! the command sequence or editing path that produced them.
+//!
+//! This is intentionally different from the model events returned by
+//! `mmdflux::commands::apply` and `mmdflux::commands::apply_with_config`. Model events
+//! describe accepted model mutations; a snapshot diff may collapse, reorder, or expand
+//! those headlines based only on the compared document states.
+//!
+//! The secondary semantic effects are returned as ordinary flat changes in [`Diff::changes`].
+//! For example, changing subgraph membership can also change a node's parent, and changing
+//! node style extensions can also change the document extension map. Geometry changes are
+//! not filtered out; callers can use [`ChangeKind::is_model`] and
+//! [`ChangeKind::is_geometry`] to separate model changes from geometry changes.
+//!
+//! [`Change::related_change_ids`] links geometry effects back to related semantic
+//! changes by index within the same [`Diff::changes`] vector. [`Change::evidence`]
+//! contains diagnostic and not format-stable strings intended for debugging and test output,
+//! not for long-lived parsing contracts.
+//!
+//! The diff is an output comparison. It can say that a route moved, a label moved, or a
+//! fallback edge match was used; it does not provide causal route attribution.
+
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::Value;
 
 use super::document::NODE_STYLE_EXTENSION_NAMESPACE;
-use super::{Bounds, Document, Edge, Node, Port, Position, Rect, Subgraph};
+use super::{Bounds, Document, Edge, Node, Port, Position, Rect, Subgraph, Subject};
 
 const COORD_EPS: f64 = 0.01;
 const DISPLAY_EPS: f64 = 1.0;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct MmdsDiff {
-    pub(crate) before_geometry_level: String,
-    pub(crate) after_geometry_level: String,
-    pub(crate) events: Vec<MmdsDiffEvent>,
+pub struct Diff {
+    /// Geometry level recorded on the `before` document.
+    pub before_geometry_level: String,
+    /// Geometry level recorded on the `after` document.
+    pub after_geometry_level: String,
+    /// Flat change list describing differences between the two documents.
+    pub changes: Vec<Change>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct MmdsDiffEvent {
-    pub(crate) kind: MmdsDiffKind,
-    pub(crate) subject: MmdsDiffSubject,
-    // Semantic events are the headlines; geometry events can be linked back as evidence.
-    pub(crate) evidence: Vec<String>,
-    pub(crate) related_event_ids: Vec<usize>,
+pub struct Change {
+    /// Change classification.
+    pub kind: ChangeKind,
+    /// Entity the change is about.
+    pub subject: Subject,
+    /// Diagnostic, not format-stable evidence strings.
+    pub evidence: Vec<String>,
+    /// Change indexes in the same `Diff::changes` vector that are related to this change.
+    pub related_change_ids: Vec<usize>,
 }
 
+/// Kind of change observed in an MMDS snapshot diff.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum MmdsDiffKind {
+pub enum ChangeKind {
     GeometryLevelChanged,
     DirectionChanged,
     EngineChanged,
@@ -64,8 +96,9 @@ pub(crate) enum MmdsDiffKind {
     GlobalReflowDetected,
 }
 
-impl MmdsDiffKind {
-    pub(crate) fn is_geometry_effect(self) -> bool {
+impl ChangeKind {
+    /// Returns true when this change describes geometry or routed output.
+    pub fn is_geometry(self) -> bool {
         matches!(
             self,
             Self::NodeMoved
@@ -83,34 +116,31 @@ impl MmdsDiffKind {
         )
     }
 
+    /// Returns true when this change describes model state rather than geometry.
+    pub fn is_model(self) -> bool {
+        !self.is_geometry()
+    }
+
     fn can_have_related_geometry(self) -> bool {
-        !self.is_geometry_effect()
+        !self.is_geometry()
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum MmdsDiffSubject {
-    Document,
-    Node(String),
-    Edge(String),
-    Subgraph(String),
-}
-
-pub(crate) fn diff_outputs(before: &Document, after: &Document) -> MmdsDiff {
-    let mut events = Vec::new();
+pub fn diff_documents(before: &Document, after: &Document) -> Diff {
+    let mut changes = Vec::new();
 
     if before.geometry_level != after.geometry_level {
-        events.push(document_event(MmdsDiffKind::GeometryLevelChanged));
+        changes.push(document_change(ChangeKind::GeometryLevelChanged));
     }
     if before.metadata.direction != after.metadata.direction {
-        events.push(document_event(MmdsDiffKind::DirectionChanged));
+        changes.push(document_change(ChangeKind::DirectionChanged));
     }
     if before.metadata.engine != after.metadata.engine {
-        events.push(document_event(MmdsDiffKind::EngineChanged));
+        changes.push(document_change(ChangeKind::EngineChanged));
     }
     if bounds_changed(&before.metadata.bounds, &after.metadata.bounds) {
-        events.push(document_event_with_evidence(
-            MmdsDiffKind::CanvasResized,
+        changes.push(document_change_with_evidence(
+            ChangeKind::CanvasResized,
             vec![bounds_evidence(
                 "canvas",
                 &before.metadata.bounds,
@@ -119,76 +149,78 @@ pub(crate) fn diff_outputs(before: &Document, after: &Document) -> MmdsDiff {
         ));
     }
     if before.profiles != after.profiles {
-        events.push(document_event(MmdsDiffKind::ProfileChanged));
+        changes.push(document_change(ChangeKind::ProfileChanged));
     }
     if before.extensions != after.extensions {
-        events.push(document_event(MmdsDiffKind::ExtensionChanged));
+        changes.push(document_change(ChangeKind::ExtensionChanged));
     }
 
     let before_nodes = nodes_by_id(before);
     let after_nodes = nodes_by_id(after);
     push_removed_added(
-        &mut events,
+        &mut changes,
         &before_nodes,
         &after_nodes,
-        MmdsDiffKind::NodeRemoved,
-        MmdsDiffKind::NodeAdded,
-        MmdsDiffSubject::Node,
+        ChangeKind::NodeRemoved,
+        ChangeKind::NodeAdded,
+        Subject::Node,
     );
-    push_node_semantic_events(&mut events, before, after, &before_nodes, &after_nodes);
-    push_node_geometry_events(&mut events, &before_nodes, &after_nodes);
-    push_global_reflow_event(&mut events, before, after, &before_nodes, &after_nodes);
+    push_node_semantic_events(&mut changes, before, after, &before_nodes, &after_nodes);
+    push_node_geometry_events(&mut changes, &before_nodes, &after_nodes);
+    push_global_reflow_event(&mut changes, before, after, &before_nodes, &after_nodes);
 
     let before_edges = edges_by_id(before);
     let after_edges = edges_by_id(after);
     let edge_matches =
         edge_correspondences(&before_edges, &after_edges, &before_nodes, &after_nodes);
-    push_edge_removed_added(&mut events, &edge_matches);
-    push_edge_semantic_events(&mut events, &edge_matches);
-    push_edge_geometry_events(&mut events, &edge_matches, &before_nodes, &after_nodes);
+    push_edge_removed_added(&mut changes, &edge_matches);
+    push_edge_semantic_events(&mut changes, &edge_matches);
+    push_edge_geometry_events(&mut changes, &edge_matches, &before_nodes, &after_nodes);
 
     let before_subgraphs = subgraphs_by_id(before);
     let after_subgraphs = subgraphs_by_id(after);
     push_removed_added(
-        &mut events,
+        &mut changes,
         &before_subgraphs,
         &after_subgraphs,
-        MmdsDiffKind::SubgraphRemoved,
-        MmdsDiffKind::SubgraphAdded,
-        MmdsDiffSubject::Subgraph,
+        ChangeKind::SubgraphRemoved,
+        ChangeKind::SubgraphAdded,
+        Subject::Subgraph,
     );
-    push_subgraph_semantic_events(&mut events, &before_subgraphs, &after_subgraphs);
-    push_subgraph_geometry_events(&mut events, &before_subgraphs, &after_subgraphs);
+    push_subgraph_semantic_events(&mut changes, &before_subgraphs, &after_subgraphs);
+    push_subgraph_geometry_events(&mut changes, &before_subgraphs, &after_subgraphs);
 
-    link_related_geometry(&mut events);
+    link_related_geometry(&mut changes);
 
-    MmdsDiff {
+    Diff {
         before_geometry_level: before.geometry_level.clone(),
         after_geometry_level: after.geometry_level.clone(),
-        events,
+        changes,
     }
 }
 
-impl MmdsDiff {
-    pub(crate) fn has_event(&self, kind: MmdsDiffKind, subject_id: &str) -> bool {
-        self.events
+#[cfg(test)]
+impl Diff {
+    pub(crate) fn has_change(&self, kind: ChangeKind, subject_id: &str) -> bool {
+        self.changes
             .iter()
-            .any(|event| event.kind == kind && event.subject.matches_id(subject_id))
+            .any(|change| change.kind == kind && change.subject.matches_id(subject_id))
     }
 
-    pub(crate) fn has_kind(&self, kind: MmdsDiffKind) -> bool {
-        self.events.iter().any(|event| event.kind == kind)
+    pub(crate) fn has_change_kind(&self, kind: ChangeKind) -> bool {
+        self.changes.iter().any(|change| change.kind == kind)
     }
 
     pub(crate) fn has_related_geometry_for(&self, subject_id: &str) -> bool {
-        self.events.iter().any(|event| {
-            event.subject.matches_id(subject_id)
-                && (event.kind.is_geometry_effect() || !event.related_event_ids.is_empty())
+        self.changes.iter().any(|change| {
+            change.subject.matches_id(subject_id)
+                && (change.kind.is_geometry() || !change.related_change_ids.is_empty())
         })
     }
 }
 
-impl MmdsDiffEvent {
+#[cfg(test)]
+impl Change {
     pub(crate) fn evidence_mentions(&self, needle: &str) -> bool {
         self.evidence
             .iter()
@@ -196,25 +228,16 @@ impl MmdsDiffEvent {
     }
 }
 
-impl MmdsDiffSubject {
-    fn matches_id(&self, subject_id: &str) -> bool {
-        match self {
-            Self::Document => subject_id.is_empty(),
-            Self::Node(id) | Self::Edge(id) | Self::Subgraph(id) => id == subject_id,
-        }
-    }
+fn document_change(kind: ChangeKind) -> Change {
+    document_change_with_evidence(kind, Vec::new())
 }
 
-fn document_event(kind: MmdsDiffKind) -> MmdsDiffEvent {
-    document_event_with_evidence(kind, Vec::new())
-}
-
-fn document_event_with_evidence(kind: MmdsDiffKind, evidence: Vec<String>) -> MmdsDiffEvent {
-    MmdsDiffEvent {
+fn document_change_with_evidence(kind: ChangeKind, evidence: Vec<String>) -> Change {
+    Change {
         kind,
-        subject: MmdsDiffSubject::Document,
+        subject: Subject::Document,
         evidence,
-        related_event_ids: Vec::new(),
+        related_change_ids: Vec::new(),
     }
 }
 
@@ -243,28 +266,28 @@ fn subgraphs_by_id(output: &Document) -> BTreeMap<String, &Subgraph> {
 }
 
 fn push_removed_added<T>(
-    events: &mut Vec<MmdsDiffEvent>,
+    events: &mut Vec<Change>,
     before: &BTreeMap<String, T>,
     after: &BTreeMap<String, T>,
-    removed_kind: MmdsDiffKind,
-    added_kind: MmdsDiffKind,
-    subject: fn(String) -> MmdsDiffSubject,
+    removed_kind: ChangeKind,
+    added_kind: ChangeKind,
+    subject: fn(String) -> Subject,
 ) {
     for id in before.keys().filter(|id| !after.contains_key(*id)) {
-        events.push(MmdsDiffEvent {
+        events.push(Change {
             kind: removed_kind,
             subject: subject(id.clone()),
             evidence: Vec::new(),
-            related_event_ids: Vec::new(),
+            related_change_ids: Vec::new(),
         });
     }
 
     for id in after.keys().filter(|id| !before.contains_key(*id)) {
-        events.push(MmdsDiffEvent {
+        events.push(Change {
             kind: added_kind,
             subject: subject(id.clone()),
             evidence: Vec::new(),
-            related_event_ids: Vec::new(),
+            related_change_ids: Vec::new(),
         });
     }
 }
@@ -592,16 +615,13 @@ fn edge_endpoints_exist_in_both_outputs(
     .all(|id| before_nodes.contains_key(id) && after_nodes.contains_key(id))
 }
 
-fn push_edge_removed_added(
-    events: &mut Vec<MmdsDiffEvent>,
-    correspondences: &EdgeCorrespondences<'_>,
-) {
+fn push_edge_removed_added(events: &mut Vec<Change>, correspondences: &EdgeCorrespondences<'_>) {
     for (id, _) in &correspondences.removed {
-        events.push(edge_event(MmdsDiffKind::EdgeRemoved, id));
+        events.push(edge_change(ChangeKind::EdgeRemoved, id));
     }
 
     for (id, _) in &correspondences.added {
-        events.push(edge_event(MmdsDiffKind::EdgeAdded, id));
+        events.push(edge_change(ChangeKind::EdgeAdded, id));
     }
 }
 
@@ -623,7 +643,7 @@ fn edge_match_evidence(edge_match: &EdgeMatch<'_>) -> Vec<String> {
 }
 
 fn push_node_semantic_events(
-    events: &mut Vec<MmdsDiffEvent>,
+    events: &mut Vec<Change>,
     before_output: &Document,
     after_output: &Document,
     before: &BTreeMap<String, &Node>,
@@ -635,31 +655,28 @@ fn push_node_semantic_events(
         };
 
         if before_node.label != after_node.label {
-            events.push(node_event(MmdsDiffKind::NodeLabelChanged, id));
+            events.push(node_change(ChangeKind::NodeLabelChanged, id));
         }
         if before_node.shape != after_node.shape {
-            events.push(node_event(MmdsDiffKind::NodeShapeChanged, id));
+            events.push(node_change(ChangeKind::NodeShapeChanged, id));
         }
         if before_node.parent != after_node.parent {
-            events.push(node_event(MmdsDiffKind::NodeParentChanged, id));
+            events.push(node_change(ChangeKind::NodeParentChanged, id));
         }
         if node_style_payload(before_output, id) != node_style_payload(after_output, id) {
-            events.push(node_event(MmdsDiffKind::NodeStyleChanged, id));
+            events.push(node_change(ChangeKind::NodeStyleChanged, id));
         }
     }
 }
 
-fn push_edge_semantic_events(
-    events: &mut Vec<MmdsDiffEvent>,
-    correspondences: &EdgeCorrespondences<'_>,
-) {
+fn push_edge_semantic_events(events: &mut Vec<Change>, correspondences: &EdgeCorrespondences<'_>) {
     for edge_match in &correspondences.matches {
         let before_edge = edge_match.before;
         let after_edge = edge_match.after;
 
         if before_edge.source != after_edge.source || before_edge.target != after_edge.target {
-            events.push(edge_event_for_match_with_evidence(
-                MmdsDiffKind::EdgeReconnected,
+            events.push(edge_change_for_match_with_evidence(
+                ChangeKind::EdgeReconnected,
                 edge_match,
                 Vec::new(),
             ));
@@ -667,22 +684,22 @@ fn push_edge_semantic_events(
         if before_edge.from_subgraph != after_edge.from_subgraph
             || before_edge.to_subgraph != after_edge.to_subgraph
         {
-            events.push(edge_event_for_match_with_evidence(
-                MmdsDiffKind::EdgeEndpointIntentChanged,
+            events.push(edge_change_for_match_with_evidence(
+                ChangeKind::EdgeEndpointIntentChanged,
                 edge_match,
                 Vec::new(),
             ));
         }
         if before_edge.label != after_edge.label {
-            events.push(edge_event_for_match_with_evidence(
-                MmdsDiffKind::EdgeLabelChanged,
+            events.push(edge_change_for_match_with_evidence(
+                ChangeKind::EdgeLabelChanged,
                 edge_match,
                 Vec::new(),
             ));
         }
         if edge_style_changed(before_edge, after_edge) {
-            events.push(edge_event_for_match_with_evidence(
-                MmdsDiffKind::EdgeStyleChanged,
+            events.push(edge_change_for_match_with_evidence(
+                ChangeKind::EdgeStyleChanged,
                 edge_match,
                 Vec::new(),
             ));
@@ -691,7 +708,7 @@ fn push_edge_semantic_events(
 }
 
 fn push_node_geometry_events(
-    events: &mut Vec<MmdsDiffEvent>,
+    events: &mut Vec<Change>,
     before: &BTreeMap<String, &Node>,
     after: &BTreeMap<String, &Node>,
 ) {
@@ -704,8 +721,8 @@ fn push_node_geometry_events(
         let dy = after_node.position.y - before_node.position.y;
         let distance = dx.hypot(dy);
         if distance > DISPLAY_EPS {
-            events.push(node_event_with_evidence(
-                MmdsDiffKind::NodeMoved,
+            events.push(node_change_with_evidence(
+                ChangeKind::NodeMoved,
                 id,
                 vec![format!(
                     "displacement dx={dx:.2}; dy={dy:.2}; distance={distance:.2}"
@@ -716,8 +733,8 @@ fn push_node_geometry_events(
         let width_delta = after_node.size.width - before_node.size.width;
         let height_delta = after_node.size.height - before_node.size.height;
         if width_delta.abs() > DISPLAY_EPS || height_delta.abs() > DISPLAY_EPS {
-            events.push(node_event_with_evidence(
-                MmdsDiffKind::NodeResized,
+            events.push(node_change_with_evidence(
+                ChangeKind::NodeResized,
                 id,
                 vec![format!(
                     "size width_delta={width_delta:.2}; height_delta={height_delta:.2}"
@@ -728,7 +745,7 @@ fn push_node_geometry_events(
 }
 
 fn push_global_reflow_event(
-    events: &mut Vec<MmdsDiffEvent>,
+    events: &mut Vec<Change>,
     before_output: &Document,
     after_output: &Document,
     before: &BTreeMap<String, &Node>,
@@ -754,8 +771,8 @@ fn push_global_reflow_event(
     }
 
     if moved_ids.len() >= 3 && moved_ids.len() * 5 >= unchanged_count.max(1) {
-        events.push(document_event_with_evidence(
-            MmdsDiffKind::GlobalReflowDetected,
+        events.push(document_change_with_evidence(
+            ChangeKind::GlobalReflowDetected,
             vec![format!(
                 "unchanged_nodes_moved={}/{}; threshold=min(3 nodes, 20 percent); sample={:?}",
                 moved_ids.len(),
@@ -780,7 +797,7 @@ fn node_semantics_same(
 }
 
 fn push_edge_geometry_events(
-    events: &mut Vec<MmdsDiffEvent>,
+    events: &mut Vec<Change>,
     correspondences: &EdgeCorrespondences<'_>,
     before_nodes: &BTreeMap<String, &Node>,
     after_nodes: &BTreeMap<String, &Node>,
@@ -791,8 +808,8 @@ fn push_edge_geometry_events(
 
         let path = path_delta(before_edge, after_edge);
         if path.changed {
-            events.push(edge_event_for_match_with_evidence(
-                MmdsDiffKind::EdgeRerouted,
+            events.push(edge_change_for_match_with_evidence(
+                ChangeKind::EdgeRerouted,
                 edge_match,
                 vec![format!(
                     "path point_count_delta={}; bend_count_delta={}; length_delta={:.2}; envelope_changed={}",
@@ -814,8 +831,8 @@ fn push_edge_geometry_events(
             ),
         ] {
             if before_face != after_face {
-                events.push(edge_event_for_match_with_evidence(
-                    MmdsDiffKind::EndpointFaceChanged,
+                events.push(edge_change_for_match_with_evidence(
+                    ChangeKind::EndpointFaceChanged,
                     edge_match,
                     vec![format!(
                         "visible {endpoint} endpoint face {before_face}->{after_face}"
@@ -837,8 +854,8 @@ fn push_edge_geometry_events(
             ),
         ] {
             if !same_port_intent(before_port, after_port) {
-                events.push(edge_event_for_match_with_evidence(
-                    MmdsDiffKind::PortIntentChanged,
+                events.push(edge_change_for_match_with_evidence(
+                    ChangeKind::PortIntentChanged,
                     edge_match,
                     vec![format!(
                         "logical {endpoint}_port {}->{}",
@@ -862,7 +879,7 @@ fn push_edge_geometry_events(
 }
 
 fn push_subgraph_semantic_events(
-    events: &mut Vec<MmdsDiffEvent>,
+    events: &mut Vec<Change>,
     before: &BTreeMap<String, &Subgraph>,
     after: &BTreeMap<String, &Subgraph>,
 ) {
@@ -872,28 +889,28 @@ fn push_subgraph_semantic_events(
         };
 
         if before_subgraph.title != after_subgraph.title {
-            events.push(subgraph_event(MmdsDiffKind::SubgraphTitleChanged, id));
+            events.push(subgraph_change(ChangeKind::SubgraphTitleChanged, id));
         }
         if before_subgraph.direction != after_subgraph.direction {
-            events.push(subgraph_event(MmdsDiffKind::SubgraphDirectionChanged, id));
+            events.push(subgraph_change(ChangeKind::SubgraphDirectionChanged, id));
         }
         if before_subgraph.parent != after_subgraph.parent {
-            events.push(subgraph_event(MmdsDiffKind::SubgraphParentChanged, id));
+            events.push(subgraph_change(ChangeKind::SubgraphParentChanged, id));
         }
         if string_set(&before_subgraph.children) != string_set(&after_subgraph.children)
             || string_set(&before_subgraph.concurrent_regions)
                 != string_set(&after_subgraph.concurrent_regions)
         {
-            events.push(subgraph_event(MmdsDiffKind::SubgraphMembershipChanged, id));
+            events.push(subgraph_change(ChangeKind::SubgraphMembershipChanged, id));
         }
         if before_subgraph.invisible != after_subgraph.invisible {
-            events.push(subgraph_event(MmdsDiffKind::SubgraphVisibilityChanged, id));
+            events.push(subgraph_change(ChangeKind::SubgraphVisibilityChanged, id));
         }
     }
 }
 
 fn push_subgraph_geometry_events(
-    events: &mut Vec<MmdsDiffEvent>,
+    events: &mut Vec<Change>,
     before: &BTreeMap<String, &Subgraph>,
     after: &BTreeMap<String, &Subgraph>,
 ) {
@@ -906,8 +923,8 @@ fn push_subgraph_geometry_events(
             before_subgraph.bounds.as_ref(),
             after_subgraph.bounds.as_ref(),
         ) {
-            events.push(subgraph_event_with_evidence(
-                MmdsDiffKind::SubgraphBoundsChanged,
+            events.push(subgraph_change_with_evidence(
+                ChangeKind::SubgraphBoundsChanged,
                 id,
                 vec![option_bounds_evidence(
                     "subgraph_bounds",
@@ -920,14 +937,14 @@ fn push_subgraph_geometry_events(
 }
 
 fn push_label_geometry_events(
-    events: &mut Vec<MmdsDiffEvent>,
+    events: &mut Vec<Change>,
     edge_match: &EdgeMatch<'_>,
     before: &Edge,
     after: &Edge,
 ) {
     if before.label_side != after.label_side {
-        events.push(edge_event_for_match_with_evidence(
-            MmdsDiffKind::LabelSideChanged,
+        events.push(edge_change_for_match_with_evidence(
+            ChangeKind::LabelSideChanged,
             edge_match,
             vec![format!(
                 "label_side {:?}->{:?}",
@@ -946,15 +963,15 @@ fn push_label_geometry_events(
             let height_delta = after_rect.height - before_rect.height;
 
             if dx.hypot(dy) > DISPLAY_EPS {
-                events.push(edge_event_for_match_with_evidence(
-                    MmdsDiffKind::LabelMoved,
+                events.push(edge_change_for_match_with_evidence(
+                    ChangeKind::LabelMoved,
                     edge_match,
                     vec![format!("label_rect center_dx={dx:.2}; center_dy={dy:.2}")],
                 ));
             }
             if width_delta.abs() > DISPLAY_EPS || height_delta.abs() > DISPLAY_EPS {
-                events.push(edge_event_for_match_with_evidence(
-                    MmdsDiffKind::LabelResized,
+                events.push(edge_change_for_match_with_evidence(
+                    ChangeKind::LabelResized,
                     edge_match,
                     vec![format!(
                         "label_rect width_delta={width_delta:.2}; height_delta={height_delta:.2}"
@@ -963,13 +980,13 @@ fn push_label_geometry_events(
             }
         }
         (None, Some(_)) | (Some(_), None) => {
-            events.push(edge_event_for_match_with_evidence(
-                MmdsDiffKind::LabelMoved,
+            events.push(edge_change_for_match_with_evidence(
+                ChangeKind::LabelMoved,
                 edge_match,
                 vec!["label_rect presence changed".to_string()],
             ));
-            events.push(edge_event_for_match_with_evidence(
-                MmdsDiffKind::LabelResized,
+            events.push(edge_change_for_match_with_evidence(
+                ChangeKind::LabelResized,
                 edge_match,
                 vec!["label_rect presence changed".to_string()],
             ));
@@ -978,8 +995,8 @@ fn push_label_geometry_events(
             let before_pos = before.label_position.as_ref();
             let after_pos = after.label_position.as_ref();
             if option_position_moved(before_pos, after_pos) {
-                events.push(edge_event_for_match_with_evidence(
-                    MmdsDiffKind::LabelMoved,
+                events.push(edge_change_for_match_with_evidence(
+                    ChangeKind::LabelMoved,
                     edge_match,
                     vec!["label_position changed without label_rect".to_string()],
                 ));
@@ -989,7 +1006,7 @@ fn push_label_geometry_events(
 }
 
 fn push_path_port_divergence_events(
-    events: &mut Vec<MmdsDiffEvent>,
+    events: &mut Vec<Change>,
     edge_match: &EdgeMatch<'_>,
     before_edge: &Edge,
     after_edge: &Edge,
@@ -1027,8 +1044,8 @@ fn push_path_port_divergence_events(
         let before_diverged = path_port_diverged(before_path_face.as_str(), before_port_face);
         let after_diverged = path_port_diverged(after_path_face.as_str(), after_port_face);
         if before_diverged != after_diverged {
-            events.push(edge_event_for_match_with_evidence(
-                MmdsDiffKind::PathPortDivergenceChanged,
+            events.push(edge_change_for_match_with_evidence(
+                ChangeKind::PathPortDivergenceChanged,
                 edge_match,
                 vec![format!(
                     "path_port_divergence {endpoint} {before_diverged}->{after_diverged}; visible {before_path_face}->{after_path_face}; logical {endpoint}_port {:?}->{:?}",
@@ -1294,11 +1311,11 @@ fn option_bounds_evidence(label: &str, before: Option<&Bounds>, after: Option<&B
     }
 }
 
-fn link_related_geometry(events: &mut [MmdsDiffEvent]) {
+fn link_related_geometry(events: &mut [Change]) {
     let geometry_events = events
         .iter()
         .enumerate()
-        .filter(|(_, event)| event.kind.is_geometry_effect())
+        .filter(|(_, event)| event.kind.is_geometry())
         .map(|(index, event)| (index, event.subject.clone(), event.kind))
         .collect::<Vec<_>>();
 
@@ -1309,10 +1326,10 @@ fn link_related_geometry(events: &mut [MmdsDiffEvent]) {
 
         for (index, subject, kind) in &geometry_events {
             if *subject == event.subject {
-                event.related_event_ids.push(*index);
+                event.related_change_ids.push(*index);
                 event
                     .evidence
-                    .push(format!("related_geometry event_id={index}; kind={kind:?}"));
+                    .push(format!("related_geometry change_id={index}; kind={kind:?}"));
             }
         }
     }
@@ -1338,54 +1355,50 @@ fn string_set(values: &[String]) -> BTreeSet<&str> {
     values.iter().map(String::as_str).collect()
 }
 
-fn node_event(kind: MmdsDiffKind, id: &str) -> MmdsDiffEvent {
-    node_event_with_evidence(kind, id, Vec::new())
+fn node_change(kind: ChangeKind, id: &str) -> Change {
+    node_change_with_evidence(kind, id, Vec::new())
 }
 
-fn node_event_with_evidence(kind: MmdsDiffKind, id: &str, evidence: Vec<String>) -> MmdsDiffEvent {
-    MmdsDiffEvent {
+fn node_change_with_evidence(kind: ChangeKind, id: &str, evidence: Vec<String>) -> Change {
+    Change {
         kind,
-        subject: MmdsDiffSubject::Node(id.to_string()),
+        subject: Subject::Node(id.to_string()),
         evidence,
-        related_event_ids: Vec::new(),
+        related_change_ids: Vec::new(),
     }
 }
 
-fn edge_event(kind: MmdsDiffKind, id: &str) -> MmdsDiffEvent {
-    edge_event_with_evidence(kind, id, Vec::new())
+fn edge_change(kind: ChangeKind, id: &str) -> Change {
+    edge_change_with_evidence(kind, id, Vec::new())
 }
 
-fn edge_event_with_evidence(kind: MmdsDiffKind, id: &str, evidence: Vec<String>) -> MmdsDiffEvent {
-    MmdsDiffEvent {
+fn edge_change_with_evidence(kind: ChangeKind, id: &str, evidence: Vec<String>) -> Change {
+    Change {
         kind,
-        subject: MmdsDiffSubject::Edge(id.to_string()),
+        subject: Subject::Edge(id.to_string()),
         evidence,
-        related_event_ids: Vec::new(),
+        related_change_ids: Vec::new(),
     }
 }
 
-fn edge_event_for_match_with_evidence(
-    kind: MmdsDiffKind,
+fn edge_change_for_match_with_evidence(
+    kind: ChangeKind,
     edge_match: &EdgeMatch<'_>,
     mut evidence: Vec<String>,
-) -> MmdsDiffEvent {
+) -> Change {
     evidence.extend(edge_match_evidence(edge_match));
-    edge_event_with_evidence(kind, edge_match.after_id.as_str(), evidence)
+    edge_change_with_evidence(kind, edge_match.after_id.as_str(), evidence)
 }
 
-fn subgraph_event(kind: MmdsDiffKind, id: &str) -> MmdsDiffEvent {
-    subgraph_event_with_evidence(kind, id, Vec::new())
+fn subgraph_change(kind: ChangeKind, id: &str) -> Change {
+    subgraph_change_with_evidence(kind, id, Vec::new())
 }
 
-fn subgraph_event_with_evidence(
-    kind: MmdsDiffKind,
-    id: &str,
-    evidence: Vec<String>,
-) -> MmdsDiffEvent {
-    MmdsDiffEvent {
+fn subgraph_change_with_evidence(kind: ChangeKind, id: &str, evidence: Vec<String>) -> Change {
+    Change {
         kind,
-        subject: MmdsDiffSubject::Subgraph(id.to_string()),
+        subject: Subject::Subgraph(id.to_string()),
         evidence,
-        related_event_ids: Vec::new(),
+        related_change_ids: Vec::new(),
     }
 }

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -169,7 +169,7 @@ pub(crate) fn to_document_typed(
 
 /// Serialize a graph-family diagram to MMDS JSON with fallback routing.
 #[deprecated(
-    note = "use materialize_diagram plus serde_json serialization for JSON output, or render_mmds_document for replay"
+    note = "use materialize_diagram plus serde_json serialization for JSON output, or render_document for replay"
 )]
 pub fn to_json_typed_with_routing(
     diagram_type: &str,

--- a/src/mmds/events.rs
+++ b/src/mmds/events.rs
@@ -1,0 +1,46 @@
+//! Model events emitted by accepted MMDS model mutations.
+//!
+//! Model events describe state transitions accepted by the MMDS model. They are not
+//! snapshot diffs. To compare two fully materialized document states, use
+//! [`crate::mmds::diff::diff_documents`] and inspect [`crate::mmds::diff::Change`]
+//! entries instead.
+
+use super::Subject;
+
+/// Event emitted for an accepted MMDS model state transition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelEvent {
+    /// Model event classification.
+    pub kind: ModelEventKind,
+    /// Entity the event is about.
+    pub subject: Subject,
+}
+
+/// Kind of state transition accepted by the MMDS model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelEventKind {
+    GeometryLevelChanged,
+    DirectionChanged,
+    EngineChanged,
+    NodeAdded,
+    NodeRemoved,
+    EdgeAdded,
+    EdgeRemoved,
+    SubgraphAdded,
+    SubgraphRemoved,
+    NodeLabelChanged,
+    NodeShapeChanged,
+    NodeParentChanged,
+    NodeStyleChanged,
+    EdgeReconnected,
+    EdgeEndpointIntentChanged,
+    EdgeLabelChanged,
+    EdgeStyleChanged,
+    SubgraphTitleChanged,
+    SubgraphDirectionChanged,
+    SubgraphParentChanged,
+    SubgraphMembershipChanged,
+    SubgraphVisibilityChanged,
+    ProfileChanged,
+    ExtensionChanged,
+}

--- a/src/mmds/mod.rs
+++ b/src/mmds/mod.rs
@@ -4,12 +4,10 @@
 //! Mermaid regeneration helpers, validation, and hydration to `Diagram` for
 //! adapter workflows. Replay rendering lives in `runtime::mmds`.
 
-#[cfg(test)]
-pub(crate) mod commands;
 pub(crate) mod detect;
-#[cfg(test)]
-pub(crate) mod diff;
+pub mod diff;
 pub(crate) mod document;
+pub mod events;
 pub(crate) mod hydrate;
 mod mermaid;
 pub(crate) mod parse;
@@ -54,6 +52,25 @@ use serde_json::{Map, Value};
 
 #[cfg(test)]
 mod regression_tests;
+
+/// Subject associated with an MMDS model event or snapshot diff change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Subject {
+    Document,
+    Node(String),
+    Edge(String),
+    Subgraph(String),
+}
+
+impl Subject {
+    #[cfg(test)]
+    pub(crate) fn matches_id(&self, subject_id: &str) -> bool {
+        match self {
+            Self::Document => subject_id.is_empty(),
+            Self::Node(id) | Self::Edge(id) | Self::Subgraph(id) => id == subject_id,
+        }
+    }
+}
 
 /// Parse-time error for MMDS input.
 #[derive(Debug, Clone)]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -34,11 +34,15 @@ pub fn detect_diagram(input: &str) -> Option<&'static str> {
     }
 }
 
-/// Detect, parse, and render a diagram in one call.
+/// Detect, parse, and render a diagram from text input in one call.
 ///
-/// This is the primary entrypoint for both CLI and WASM adapters.
-/// Adapter-specific policy (format defaults, color resolution) should be
-/// applied to `config` before calling this function.
+/// The input can be Mermaid source or MMDS JSON. The frontend is auto-detected
+/// before dispatch, so adapters can pass user-provided diagram text without
+/// pre-selecting the wire format.
+///
+/// Use [`render_document`] when you already hold a parsed [`crate::mmds::Document`],
+/// for example after [`materialize_diagram`] or [`crate::views::project`].
+/// Use [`render_diagram`] when you have text input.
 pub fn render_diagram(
     input: &str,
     format: OutputFormat,
@@ -104,13 +108,13 @@ pub fn render_diagram(
     payload::render_payload(payload, format, &effective_config)
 }
 
-/// Detect, parse, solve, and materialize a graph-family diagram as MMDS.
+/// Detect, parse, solve, and materialize graph-family text input as MMDS.
 ///
-/// This is the typed counterpart to `render_diagram(input,
-/// OutputFormat::Mmds, config)`. It returns a graph-family
-/// [`crate::mmds::Document`] directly instead of serializing to JSON first.
-/// For MMDS input, this is equivalent to [`crate::mmds::Document::try_from`]
-/// and `config` is unused.
+/// The input can be Mermaid source or MMDS JSON. This is the typed counterpart
+/// to `render_diagram(input, OutputFormat::Mmds, config)`: it returns a
+/// graph-family [`crate::mmds::Document`] directly instead of serializing to
+/// JSON first. For MMDS JSON input, this is equivalent to parsing the
+/// [`crate::mmds::Document`] and `config` is unused.
 pub fn materialize_diagram(
     input: &str,
     config: &RenderConfig,
@@ -147,11 +151,12 @@ pub fn materialize_diagram(
 
 /// Render a parsed graph-family MMDS document.
 ///
-/// This is the typed replay path for consumers that already hold
-/// [`crate::mmds::Document`], such as materialized view pipelines. It avoids
-/// serializing the document to JSON just to feed it back through
-/// [`render_diagram`].
-pub fn render_mmds_document(
+/// Use this when you already have a [`crate::mmds::Document`], for example
+/// after [`materialize_diagram`] or [`crate::views::project`]. Use
+/// [`render_diagram`] when you have text input, either Mermaid source or MMDS
+/// JSON. Rendering a document directly avoids serializing it to JSON just to
+/// feed it back through the text-input facade.
+pub fn render_document(
     document: &crate::mmds::Document,
     format: OutputFormat,
     config: &RenderConfig,

--- a/src/views/evaluate.rs
+++ b/src/views/evaluate.rs
@@ -14,7 +14,7 @@ pub(super) struct ViewEvaluation {
     /// Subgraph IDs explicitly retained by the evaluated view.
     ///
     /// Ancestor subgraphs required to contain retained nodes are added by
-    /// [`apply_view`](crate::views::apply_view) during materialization.
+    /// [`project`](crate::views::project) during materialization.
     pub(super) subgraphs: BTreeSet<String>,
 }
 
@@ -38,7 +38,7 @@ impl ViewEvaluation {
 ///
 /// This function resolves selectors only. It does not clone or prune the MMDS
 /// payload, preserve ancestor subgraphs, filter edges, or emit elision events;
-/// use [`apply_view`](crate::views::apply_view) for the full materialized view.
+/// use [`project`](crate::views::project) for the full materialized view.
 pub(super) fn evaluate_view(
     output: &Document,
     spec: &ViewSpec,

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -6,7 +6,7 @@
 //! The v1 surface is intentionally small: materialize a filtered MMDS payload
 //! from a `ViewSpec` and emit events for elements that leave the view.
 //! Rendering remains a runtime concern; pass the returned document to
-//! [`crate::render_mmds_document`] when a text, SVG, or MMDS rendering is
+//! [`crate::render_document`] when a text, SVG, or MMDS rendering is
 //! needed.
 //!
 //! # Example
@@ -14,9 +14,9 @@
 //! ```no_run
 //! use mmdflux::mmds::Document;
 //! use mmdflux::views::{
-//!     AnchorRef, Selector, TraversalDirection, ViewSpec, ViewStatement, apply_view,
+//!     AnchorRef, Selector, TraversalDirection, ViewSpec, ViewStatement, project,
 //! };
-//! use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_mmds_document};
+//! use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_document};
 //!
 //! let source = "\
 //! graph TD
@@ -37,27 +37,27 @@
 //!     ..ViewSpec::default()
 //! };
 //!
-//! let (view, events) = apply_view(&canonical, &spec)?;
+//! let (view, events) = project(&canonical, &spec)?;
 //! assert!(view.nodes.iter().any(|node| node.id == "service_c"));
 //! assert!(events.iter().any(|event| matches!(
 //!     event,
 //!     mmdflux::views::ViewEvent::NodeLeftView { id, .. } if id == "external"
 //! )));
 //!
-//! let text = render_mmds_document(&view, OutputFormat::Text, &RenderConfig::default())?;
+//! let text = render_document(&view, OutputFormat::Text, &RenderConfig::default())?;
 //! assert!(text.contains("Service A"));
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
-mod apply;
 mod error;
 mod evaluate;
 mod events;
+mod project;
 mod spec;
 
-pub use apply::{VIEW_EXTENSION_NAMESPACE, apply_view};
 pub use error::ViewError;
 pub use events::{ElisionReason, ViewEvent};
+pub use project::{VIEW_EXTENSION_NAMESPACE, project};
 pub use spec::{
     AnchorRef, BoundaryPolicy, CompoundPolicy, EdgeAnchor, LayoutMode, NodePredicate, Selector,
     TraversalDirection, ViewSpec, ViewStatement,

--- a/src/views/project.rs
+++ b/src/views/project.rs
@@ -19,7 +19,7 @@ const NODE_RANKS_KEY: &str = "node_ranks";
 const EDGE_WAYPOINTS_KEY: &str = "edge_waypoints";
 const LABEL_POSITIONS_KEY: &str = "label_positions";
 
-/// Apply a materialized view specification to a canonical MMDS payload.
+/// Project a materialized view specification over a canonical MMDS payload.
 ///
 /// The returned [`Document`] is a cloned and pruned payload:
 ///
@@ -32,7 +32,7 @@ const LABEL_POSITIONS_KEY: &str = "label_positions";
 /// The returned [`ViewEvent`] list describes canonical nodes, subgraphs, and
 /// edges that did not survive materialization. Unsupported v1 features return
 /// [`ViewError::NotImplementedYet`] before payload cloning.
-pub fn apply_view(
+pub fn project(
     canonical: &Document,
     spec: &ViewSpec,
 ) -> Result<(Document, Vec<ViewEvent>), ViewError> {
@@ -70,13 +70,13 @@ pub fn apply_view(
             subgraph
         })
         .collect();
-    apply_view_extensions(&mut output, &evaluation.nodes);
+    project_extensions(&mut output, &evaluation.nodes);
 
     let events = view_events(canonical, &evaluation.nodes, &retained_subgraphs);
     Ok((output, events))
 }
 
-fn apply_view_extensions(output: &mut Document, retained_nodes: &BTreeSet<String>) {
+fn project_extensions(output: &mut Document, retained_nodes: &BTreeSet<String>) {
     output.extensions.insert(
         VIEW_EXTENSION_NAMESPACE.to_string(),
         shared_coordinates_view_extension(),

--- a/tests/lib_exports.rs
+++ b/tests/lib_exports.rs
@@ -91,6 +91,7 @@ fn crate_root_only_exports_supported_public_modules() {
 
     for required in [
         "builtins",
+        "commands",
         "errors",
         "format",
         "graph",
@@ -138,7 +139,7 @@ fn views_module_is_public_low_level_api() {
 fn view_contract_types_compile() {
     use mmdflux::views::{
         AnchorRef, BoundaryPolicy, CompoundPolicy, EdgeAnchor, LayoutMode, NodePredicate, Selector,
-        TraversalDirection, ViewError, ViewEvent, ViewSpec, ViewStatement, apply_view,
+        TraversalDirection, ViewError, ViewEvent, ViewSpec, ViewStatement, project,
     };
 
     let spec = ViewSpec::default();
@@ -173,7 +174,7 @@ fn view_contract_types_compile() {
         ViewError::NotImplementedYet {
             feature: "edge anchors".to_string(),
         },
-        apply_view,
+        project,
     );
 }
 
@@ -317,6 +318,15 @@ fn mmds_module_keeps_supported_adapter_helpers_public() {
     let _ = std::any::type_name::<mmdflux::mmds::Document>();
     let _ = std::any::type_name::<mmdflux::mmds::HydrationError>();
     let _ = std::any::type_name::<mmdflux::mmds::GenerationError>();
+    let _ = std::any::type_name::<mmdflux::mmds::diff::Diff>();
+    let _ = std::any::type_name::<mmdflux::mmds::diff::Change>();
+    let _ = std::any::type_name::<mmdflux::mmds::diff::ChangeKind>();
+    let _ = std::any::type_name::<mmdflux::mmds::events::ModelEvent>();
+    let _ = std::any::type_name::<mmdflux::mmds::events::ModelEventKind>();
+    let _ = std::any::type_name::<mmdflux::mmds::Subject>();
+    let _ = std::any::type_name::<mmdflux::commands::Command>();
+    let _ = std::any::type_name::<mmdflux::commands::EdgeSelector>();
+    let _ = std::any::type_name::<mmdflux::commands::CommandApplyError>();
 
     let _parse_with_profiles: fn(
         &str,
@@ -340,11 +350,24 @@ fn mmds_module_keeps_supported_adapter_helpers_public() {
         &str,
         &mmdflux::RenderConfig,
     ) -> Result<mmdflux::mmds::Document, mmdflux::RenderError> = mmdflux::materialize_diagram;
-    let _render_mmds_document: fn(
+    let _render_document: fn(
         &mmdflux::mmds::Document,
         mmdflux::OutputFormat,
         &mmdflux::RenderConfig,
-    ) -> Result<String, mmdflux::RenderError> = mmdflux::render_mmds_document;
+    ) -> Result<String, mmdflux::RenderError> = mmdflux::render_document;
+    let _diff_documents: fn(
+        &mmdflux::mmds::Document,
+        &mmdflux::mmds::Document,
+    ) -> mmdflux::mmds::diff::Diff = mmdflux::mmds::diff::diff_documents;
+    assert!(mmdflux::mmds::diff::ChangeKind::NodeMoved.is_geometry());
+    assert!(!mmdflux::mmds::diff::ChangeKind::NodeMoved.is_model());
+    let _apply: fn(
+        &mmdflux::commands::Command,
+        &mut mmdflux::mmds::Document,
+    ) -> Result<
+        Vec<mmdflux::mmds::events::ModelEvent>,
+        mmdflux::commands::CommandApplyError,
+    > = mmdflux::commands::apply;
 }
 
 #[test]

--- a/tests/mmds_commands.rs
+++ b/tests/mmds_commands.rs
@@ -1,0 +1,182 @@
+use mmdflux::commands::{Command, CommandApplyError, EdgeSelector, apply, apply_with_config};
+use mmdflux::mmds::Subject;
+use mmdflux::mmds::diff::{ChangeKind, diff_documents};
+use mmdflux::mmds::events::ModelEventKind;
+use mmdflux::{EngineAlgorithmId, RenderConfig, materialize_diagram};
+
+fn materialize(source: &str) -> mmdflux::mmds::Document {
+    materialize_diagram(source, &RenderConfig::default()).expect("diagram should materialize")
+}
+
+fn add_gamma_command() -> Command {
+    Command::AddNode {
+        id: "C".to_string(),
+        label: "Gamma".to_string(),
+        shape: "rectangle".to_string(),
+        parent: None,
+    }
+}
+
+fn vertical_distance(document: &mmdflux::mmds::Document, source: &str, target: &str) -> f64 {
+    let source = document
+        .nodes
+        .iter()
+        .find(|node| node.id == source)
+        .expect("source node should exist");
+    let target = document
+        .nodes
+        .iter()
+        .find(|node| node.id == target)
+        .expect("target node should exist");
+    (target.position.y - source.position.y).abs()
+}
+
+#[test]
+fn public_mmds_commands_expose_apply_and_structured_errors() {
+    let mut document = materialize(
+        r#"
+graph TD
+    A[Alpha] --> B[Beta]
+"#,
+    );
+
+    let error = apply(
+        &Command::RemoveNode {
+            id: "missing".to_string(),
+        },
+        &mut document,
+    )
+    .expect_err("missing node should produce a structured error");
+
+    assert!(matches!(error, CommandApplyError::NodeNotFound { .. }));
+    let _: Box<dyn std::error::Error> = Box::new(error);
+
+    let _selector = EdgeSelector::Id("e0".to_string());
+}
+
+#[test]
+fn public_mmds_commands_apply_with_config_uses_caller_engine_when_document_has_none() {
+    let mut document = materialize(
+        r#"
+graph TD
+    A[Alpha] --> B[Beta]
+"#,
+    );
+    document.metadata.engine = None;
+
+    let config = RenderConfig {
+        layout_engine: Some(EngineAlgorithmId::parse("mermaid-layered").unwrap()),
+        ..RenderConfig::default()
+    };
+
+    apply_with_config(&add_gamma_command(), &mut document, &config)
+        .expect("add node should apply with caller config");
+
+    assert_eq!(document.metadata.engine.as_deref(), Some("mermaid-layered"));
+}
+
+#[test]
+fn public_mmds_commands_apply_with_config_document_engine_overrides_caller_engine() {
+    let mut document = materialize(
+        r#"
+graph TD
+    A[Alpha] --> B[Beta]
+"#,
+    );
+    document.metadata.engine = Some("flux-layered".to_string());
+
+    let config = RenderConfig {
+        layout_engine: Some(EngineAlgorithmId::parse("mermaid-layered").unwrap()),
+        ..RenderConfig::default()
+    };
+
+    apply_with_config(&add_gamma_command(), &mut document, &config)
+        .expect("add node should apply with caller config");
+
+    assert_eq!(document.metadata.engine.as_deref(), Some("flux-layered"));
+}
+
+#[test]
+fn public_mmds_commands_apply_with_config_preserves_non_engine_caller_config() {
+    let source = r#"
+graph TD
+    A[Alpha] --> B[Beta]
+"#;
+    let mut default_document = materialize(source);
+    let mut wide_document = materialize(source);
+
+    apply(&add_gamma_command(), &mut default_document).expect("default add node should apply");
+
+    let mut wide_config = RenderConfig::default();
+    wide_config.layout.rank_sep = 220.0;
+
+    apply_with_config(&add_gamma_command(), &mut wide_document, &wide_config)
+        .expect("add node should apply with caller config");
+
+    let default_distance = vertical_distance(&default_document, "A", "B");
+    let wide_distance = vertical_distance(&wide_document, "A", "B");
+
+    assert!(
+        wide_distance > default_distance + 100.0,
+        "caller rank_sep should flow through relayout: default={default_distance}, wide={wide_distance}"
+    );
+}
+
+#[test]
+fn public_mmds_commands_events_are_not_snapshot_diff_entries() {
+    let before = materialize(
+        r#"
+graph TD
+    A[Alpha] --> B[Beta]
+"#,
+    );
+    let mut document = before.clone();
+
+    apply(&add_gamma_command(), &mut document).expect("add node should apply");
+    let model_events = apply(
+        &Command::ChangeNodeLabel {
+            node: "C".to_string(),
+            label: "Gamma prime".to_string(),
+        },
+        &mut document,
+    )
+    .expect("label change should apply");
+    let snapshot_diff = diff_documents(&before, &document);
+
+    assert!(model_events.iter().any(|event| {
+        event.kind == ModelEventKind::NodeLabelChanged
+            && matches!(&event.subject, Subject::Node(id) if id == "C")
+    }));
+    assert!(snapshot_diff.changes.iter().any(|event| {
+        event.kind == ChangeKind::NodeAdded
+            && matches!(&event.subject, Subject::Node(id) if id == "C")
+    }));
+    assert!(!snapshot_diff.changes.iter().any(|event| {
+        event.kind == ChangeKind::NodeLabelChanged
+            && matches!(&event.subject, Subject::Node(id) if id == "C")
+    }));
+}
+
+#[test]
+fn public_mmds_commands_docs_name_event_snapshot_diff_contract() {
+    let source = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/commands.rs"),
+    )
+    .expect("commands source should be readable");
+
+    for required in [
+        "model events",
+        "snapshot diff",
+        "apply_with_config",
+        "document-owned",
+        "EdgeSelector::Semantic",
+        "AddEdge.id",
+        "wraps non-object",
+        "std::error::Error",
+    ] {
+        assert!(
+            source.contains(required),
+            "commands rustdoc should document: {required}"
+        );
+    }
+}

--- a/tests/mmds_diff.rs
+++ b/tests/mmds_diff.rs
@@ -1,0 +1,54 @@
+use mmdflux::mmds::Subject;
+use mmdflux::mmds::diff::{ChangeKind, diff_documents};
+use mmdflux::{RenderConfig, materialize_diagram};
+
+fn materialize(source: &str) -> mmdflux::mmds::Document {
+    materialize_diagram(source, &RenderConfig::default()).expect("diagram should materialize")
+}
+
+#[test]
+fn public_mmds_diff_exposes_changes_and_geometry_levels() {
+    let before = materialize(
+        r#"
+graph TD
+    A[Alpha] --> B[Beta]
+"#,
+    );
+    let after = materialize(
+        r#"
+graph TD
+    A[Alpine] --> B[Beta]
+"#,
+    );
+
+    let diff = diff_documents(&before, &after);
+
+    assert_eq!(diff.before_geometry_level, before.geometry_level);
+    assert_eq!(diff.after_geometry_level, after.geometry_level);
+    assert!(diff.changes.iter().any(|event| {
+        event.kind == ChangeKind::NodeLabelChanged
+            && matches!(&event.subject, Subject::Node(id) if id == "A")
+    }));
+    assert!(!ChangeKind::NodeLabelChanged.is_geometry());
+    assert!(ChangeKind::NodeLabelChanged.is_model());
+}
+
+#[test]
+fn public_mmds_diff_docs_name_snapshot_diff_contract() {
+    let source = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/mmds/diff.rs"),
+    )
+    .expect("diff source should be readable");
+
+    for required in [
+        "snapshot diff",
+        "diagnostic and not format-stable",
+        "secondary semantic effects",
+        "related_change_ids",
+    ] {
+        assert!(
+            source.contains(required),
+            "diff rustdoc should document: {required}"
+        );
+    }
+}

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -1168,7 +1168,7 @@ fn docs_and_schema_reference_view_extension_contract() {
     let docs = std::fs::read_to_string("docs/mmds.md").unwrap();
     assert!(docs.contains("mmdflux::views"));
     assert!(docs.contains("ViewSpec"));
-    assert!(docs.contains("apply_view"));
+    assert!(docs.contains("project"));
     assert!(docs.contains("ViewEvent"));
     assert!(docs.contains("org.mmdflux.view.v1"));
     assert!(docs.contains("[\"e0\", \"e2\", \"e4\"]"));

--- a/tests/mmds_views.rs
+++ b/tests/mmds_views.rs
@@ -6,9 +6,9 @@ use mmdflux::mmds::{
 };
 use mmdflux::views::{
     AnchorRef, ElisionReason, LayoutMode, NodePredicate, Selector, TraversalDirection,
-    VIEW_EXTENSION_NAMESPACE, ViewError, ViewEvent, ViewSpec, ViewStatement, apply_view,
+    VIEW_EXTENSION_NAMESPACE, ViewError, ViewEvent, ViewSpec, ViewStatement, project,
 };
-use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_mmds_document};
+use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_document};
 use serde_json::{Map, Value, json};
 
 const LEGACY_TEXT_EXTENSION_NAMESPACE: &str = "org.mmdflux.text.v1.projection";
@@ -167,7 +167,7 @@ fn view_replay_payloads() -> (Document, Document, Document) {
         hops: 1,
     })]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
     let mut plain_payload = view_payload.clone();
     plain_payload.extensions.remove(VIEW_EXTENSION_NAMESPACE);
     let mut no_projection_payload = plain_payload.clone();
@@ -186,7 +186,7 @@ fn canary_view_replay_payloads() -> (Document, Document) {
 }
 
 fn render_mmds_payload(payload: &Document, format: OutputFormat) -> String {
-    render_mmds_document(payload, format, &RenderConfig::default()).expect("payload should render")
+    render_document(payload, format, &RenderConfig::default()).expect("payload should render")
 }
 
 fn canary_canonical_output() -> Document {
@@ -204,7 +204,7 @@ fn canary_view_spec() -> ViewSpec {
 
 fn canary_view_payload() -> Document {
     let canonical = canary_canonical_output();
-    apply_view(&canonical, &canary_view_spec())
+    project(&canonical, &canary_view_spec())
         .expect("canary view should materialize")
         .0
 }
@@ -251,7 +251,7 @@ fn view_selector_downstream_hops_include_anchor() {
         hops: 2,
     })]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     assert_eq!(node_ids(&view_payload), ids(&["gateway", "auth", "db"]));
     assert!(view_payload.subgraphs.is_empty());
@@ -279,7 +279,7 @@ fn view_selector_upstream_hops_follow_incoming_edges() {
         hops: 1,
     })]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     assert_eq!(
         node_ids(&view_payload),
@@ -309,7 +309,7 @@ fn view_selector_neighbors_combines_directions() {
         hops: 1,
     })]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     assert_eq!(
         node_ids(&view_payload),
@@ -336,7 +336,7 @@ fn view_selector_subgraph_descendants_recurse() {
         "root".to_string(),
     ))]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     assert_eq!(node_ids(&view_payload), ids(&["auth", "charge", "gateway"]));
     assert_eq!(subgraph_ids(&view_payload), ids(&["payments", "root"]));
@@ -356,7 +356,7 @@ fn view_selector_subgraph_anchor_keeps_container_without_descendants() {
         AnchorRef::Subgraph("payments".to_string()),
     ))]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     assert!(view_payload.nodes.is_empty());
     assert_eq!(view_payload.subgraphs.len(), 1);
@@ -387,7 +387,7 @@ fn view_selector_parent_and_shape_predicates_filter_nodes() {
         ))),
     ]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     assert_eq!(node_ids(&view_payload), ids(&["db"]));
 }
@@ -401,7 +401,7 @@ fn view_selector_unknown_anchor_returns_error() {
         hops: 1,
     })]);
 
-    let error = apply_view(&payload, &spec).expect_err("missing anchor should fail");
+    let error = project(&payload, &spec).expect_err("missing anchor should fail");
 
     assert_eq!(
         error,
@@ -432,7 +432,7 @@ fn view_apply_keeps_node_positions_and_canonical_bounds() {
         AnchorRef::Node("gateway".to_string()),
     ))]);
 
-    let (view_payload, events) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, events) = project(&payload, &spec).expect("view should materialize");
 
     assert_eq!(
         view_payload.metadata.bounds.width,
@@ -476,7 +476,7 @@ fn view_apply_preserves_sparse_surviving_edge_ids() {
         hops: 2,
     })]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     let edge_ids: Vec<&str> = view_payload
         .edges
@@ -501,7 +501,7 @@ fn view_apply_drops_edges_with_elided_endpoints() {
         AnchorRef::Node("gateway".to_string()),
     ))]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     assert!(view_payload.edges.is_empty());
 }
@@ -525,7 +525,7 @@ fn view_apply_emits_node_and_edge_elision_events() {
         AnchorRef::Node("gateway".to_string()),
     ))]);
 
-    let (_, events) = apply_view(&payload, &spec).expect("view should materialize");
+    let (_, events) = project(&payload, &spec).expect("view should materialize");
 
     assert!(events.contains(&ViewEvent::NodeLeftView {
         id: "auth".to_string(),
@@ -572,7 +572,7 @@ fn view_apply_preserves_ancestor_subgraph_containers() {
         ViewStatement::Exclude(Selector::Anchor(AnchorRef::Node("charge".to_string()))),
     ]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     let node_ids: Vec<&str> = view_payload
         .nodes
@@ -602,7 +602,7 @@ fn view_apply_rejects_unimplemented_layout_modes() {
         ..ViewSpec::default()
     };
 
-    let error = apply_view(&payload, &spec).expect_err("compact mode is deferred");
+    let error = project(&payload, &spec).expect_err("compact mode is deferred");
 
     assert_eq!(
         error,
@@ -619,7 +619,7 @@ fn view_apply_marks_shared_coordinates_view_payload() {
         AnchorRef::Node("gateway".to_string()),
     ))]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     let marker = view_payload
         .extensions
@@ -655,7 +655,7 @@ fn view_apply_preserves_text_projection_under_render_namespace() {
         hops: 1,
     })]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     assert!(
         view_payload
@@ -688,7 +688,7 @@ fn view_apply_prunes_node_ranks_to_retained_nodes() {
         hops: 1,
     })]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     let node_ranks = projection(&view_payload, TEXT_EXTENSION_NAMESPACE)
         .get("node_ranks")
@@ -711,7 +711,7 @@ fn view_apply_does_not_emit_legacy_text_namespace() {
         AnchorRef::Node("gateway".to_string()),
     ))]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     assert!(
         !view_payload
@@ -741,7 +741,7 @@ fn view_apply_drops_edge_indexed_text_projection_keys() {
         hops: 1,
     })]);
 
-    let (view_payload, _) = apply_view(&payload, &spec).expect("view should materialize");
+    let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
 
     let projection = projection(&view_payload, TEXT_EXTENSION_NAMESPACE);
     assert!(!projection.contains_key("edge_waypoints"));
@@ -924,7 +924,7 @@ fn view_canary_deferred_primitives_return_not_implemented() {
     ];
 
     for (spec, feature) in cases {
-        let error = apply_view(&payload, &spec).expect_err("deferred feature should fail");
+        let error = project(&payload, &spec).expect_err("deferred feature should fail");
         assert_eq!(
             error,
             ViewError::NotImplementedYet {


### PR DESCRIPTION
## Summary

This lifts the MMDS diff and command primitives from test-only internals into the public Rust low-level API, and tightens the already-public views and document-rendering API before release.

The public snapshot diff entrypoint is `mmdflux::mmds::diff::diff_documents(before, after) -> Diff`. The diff surface exposes `Diff`, `Change`, `ChangeKind`, and the shared `mmds::Subject`; `Diff.changes` records what is different between two materialized documents, with diagnostic evidence, related change IDs, secondary model effects, and model/geometry layer filtering.

Commands are exposed as a top-level `mmdflux::commands` module rather than `mmdflux::mmds::commands`. That is intentional: command application owns synchronous mutation plus full relayout fallback, so it depends on runtime orchestration. Keeping it as a sibling preserves `mmds/` as the pure document/diff interchange boundary.

Command application returns model events through `mmdflux::mmds::events::{ModelEvent, ModelEventKind}`. These are intentionally separate from snapshot diff changes because model events say what model mutation was accepted, while snapshot diffs say what final-state differences are observable. Internal validation compares the two surfaces through test-only mapping helpers rather than a public conversion API.

The views entrypoint is renamed from `mmdflux::views::apply_view` to `mmdflux::views::project` before release. That keeps command-side mutation (`commands::apply`) distinct from read-side projection (`views::project`). The typed document render helper is also renamed from `render_mmds_document` to `render_document`, and the facade docs now spell out that `render_diagram` / `materialize_diagram` accept Mermaid source or MMDS JSON.

## What This Adds

- `mmdflux::mmds::diff::diff_documents` for MMDS document snapshot diffs.
- Public diff/change types: `Diff`, `Change`, `ChangeKind`, and shared `mmds::Subject`.
- Public `ChangeKind::{is_geometry, is_model}` for separating geometry changes from model changes.
- Public model-event types: `ModelEvent` and `ModelEventKind`.
- `mmdflux::commands::{apply, apply_with_config}` for synchronous command application.
- Public command vocabulary, `EdgeSelector`, and `CommandApplyError` with `std::error::Error` support.
- Config-aware command relayout through `apply_with_config`, with document-owned `geometry_level` and present `metadata.engine` remaining authoritative.
- `mmdflux::views::project` as the public read-side projection entrypoint.
- `mmdflux::render_document` for rendering an already-materialized `mmds::Document`.
- Crate-level rustdoc example showing commands, snapshot diff, and views composed together.

## Scope Boundaries

This does not add CLI surface, TypeScript bindings, wire protocol, MMDS schema changes, async processing, incremental layout, causal route attribution, match-confidence fields, or view API expansion beyond the pre-release entrypoint rename.

Command results remain model events. `diff_documents` remains a final-state snapshot diff. These are intentionally separate surfaces because model event streams and snapshot diff headlines are not interchangeable.

## Validation

- `cargo nextest run -E 'test(mmds_views) | test(lib_exports) | test(runtime_facade) | test(mmds_json)'` passed.
- `cargo test --doc` passed.
- `just check` passed after the final amendment: commit validation, fmt, lint/architecture, and full nextest (`2926 passed`, `8 skipped`).
