### PR TITLE
docs: add mmds API examples

### DIFF
--- a/examples/commands_events_views.rs
+++ b/examples/commands_events_views.rs
@@ -1,0 +1,90 @@
+use mmdflux::commands::{Command, apply};
+use mmdflux::graph::{Arrow, Shape, Stroke};
+use mmdflux::mmds::events::ModelEvent;
+use mmdflux::mmds::{Document, Subject};
+use mmdflux::views::{
+    AnchorRef, Selector, TraversalDirection, ViewEvent, ViewSpec, ViewStatement, project,
+};
+use mmdflux::{OutputFormat, RenderConfig, materialize_diagram, render_document};
+
+const SOURCE: &str = r#"graph TD
+api[API] --> auth[Auth]
+api --> billing[Billing]
+auth --> users[(Users)]
+billing --> ledger[(Ledger)]
+"#;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut document: Document = materialize_diagram(SOURCE, &RenderConfig::default())?;
+    let mut model_events = Vec::new();
+
+    for command in [
+        Command::AddNode {
+            id: "cache".to_string(),
+            label: "Cache".to_string(),
+            shape: Shape::Cylinder,
+            parent: None,
+        },
+        Command::AddEdge {
+            id: None,
+            source: "api".to_string(),
+            target: "cache".to_string(),
+            from_subgraph: None,
+            to_subgraph: None,
+            label: Some("warms".to_string()),
+            stroke: Stroke::Dashed,
+            arrow_start: Arrow::None,
+            arrow_end: Arrow::Normal,
+            minlen: 1,
+        },
+        Command::ChangeNodeLabel {
+            node: "billing".to_string(),
+            label: "Billing API".to_string(),
+        },
+    ] {
+        model_events.extend(apply(&command, &mut document)?);
+    }
+
+    println!("model events:");
+    for event in &model_events {
+        println!("- {}", describe_model_event(event));
+    }
+
+    let spec = ViewSpec {
+        statements: vec![ViewStatement::Include(Selector::Traversal {
+            anchor: AnchorRef::Node("api".to_string()),
+            direction: TraversalDirection::Downstream,
+            hops: 1,
+        })],
+        ..ViewSpec::default()
+    };
+    let (view, view_events) = project(&document, &spec)?;
+
+    println!("\nview nodes:");
+    for node in &view.nodes {
+        println!("- {}", node.id);
+    }
+
+    println!("\nview events:");
+    for event in &view_events {
+        if let ViewEvent::NodeLeftView { id, .. } = event {
+            println!("- node left view: {id}");
+        }
+    }
+
+    let text = render_document(&view, OutputFormat::Text, &RenderConfig::default())?;
+    println!("\n{text}");
+
+    Ok(())
+}
+
+fn describe_model_event(event: &ModelEvent) -> String {
+    let subject = match &event.subject {
+        Subject::Document => "document".to_string(),
+        Subject::Node(id) => format!("node {id}"),
+        Subject::Edge(id) => format!("edge {id}"),
+        Subject::Subgraph(id) => format!("subgraph {id}"),
+    };
+
+    format!("{:?} on {subject}", event.kind)
+}

--- a/examples/snapshot_diff.rs
+++ b/examples/snapshot_diff.rs
@@ -1,0 +1,68 @@
+use mmdflux::mmds::diff::{Change, ChangeKind, diff_documents};
+use mmdflux::mmds::{Document, Subject};
+use mmdflux::{RenderConfig, materialize_diagram};
+
+const BEFORE: &str = r#"graph TD
+api[API] --> auth[Auth]
+api --> billing[Billing]
+"#;
+
+const AFTER: &str = r#"graph TD
+api[Public API] --> auth[Auth]
+api --> billing[Billing API]
+billing --> ledger[(Ledger)]
+"#;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let before: Document = materialize_diagram(BEFORE, &RenderConfig::default())?;
+    let after: Document = materialize_diagram(AFTER, &RenderConfig::default())?;
+    let diff = diff_documents(&before, &after);
+
+    println!(
+        "geometry level: {} -> {}",
+        diff.before_geometry_level, diff.after_geometry_level
+    );
+
+    println!("\nmodel changes:");
+    for change in diff.changes.iter().filter(|change| change.kind.is_model()) {
+        println!("- {}", describe_change(change));
+    }
+
+    println!("\ngeometry changes:");
+    for change in diff
+        .changes
+        .iter()
+        .filter(|change| change.kind.is_geometry())
+    {
+        println!("- {}", describe_change(change));
+    }
+
+    if diff
+        .changes
+        .iter()
+        .any(|change| change.kind == ChangeKind::NodeLabelChanged)
+    {
+        println!("\nThe snapshot diff reports what differs, not which command produced it.");
+    }
+
+    Ok(())
+}
+
+fn describe_change(change: &Change) -> String {
+    let subject = match &change.subject {
+        Subject::Document => "document".to_string(),
+        Subject::Node(id) => format!("node {id}"),
+        Subject::Edge(id) => format!("edge {id}"),
+        Subject::Subgraph(id) => format!("subgraph {id}"),
+    };
+
+    if change.evidence.is_empty() {
+        format!("{:?} on {subject}", change.kind)
+    } else {
+        format!(
+            "{:?} on {subject} ({})",
+            change.kind,
+            change.evidence.join("; ")
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a Rust example that applies MMDS commands, inspects emitted model events, projects a view, and renders the projected document
- add a Rust example that compares two independently materialized documents with the snapshot diff API

## Validation
- cargo check --examples
- cargo run --example commands_events_views
- cargo run --example snapshot_diff
- just check
