### PR TITLE
docs: harden public Rust API pre-tag surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,10 @@ public contract.
   negotiation, replay, and Mermaid regeneration
 - [`examples/materialized_view.rs`](examples/materialized_view.rs) —
   materialize a focused MMDS view and replay it as text
+- [`examples/commands_events_views.rs`](examples/commands_events_views.rs) —
+  apply MMDS commands, inspect model events, project a view, and render it
+- [`examples/snapshot_diff.rs`](examples/snapshot_diff.rs) — compare two
+  materialized MMDS documents with the snapshot diff API
 
 Verify the examples compile with `cargo test --examples`.
 

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -33,8 +33,15 @@ Adapter-oriented workflows can use the low-level API:
   and Mermaid generation
 - `mmdflux::views` for materialized read-side views over canonical MMDS payloads
 
-The current Rust replay example lives at `examples/mmds_replay.rs`.
-The materialized-view example lives at `examples/materialized_view.rs`.
+Rust examples for MMDS-oriented adapter workflows:
+
+- `examples/mmds_replay.rs` — profile negotiation, replay, and Mermaid
+  regeneration from an MMDS document
+- `examples/materialized_view.rs` — focused read-side view projection and replay
+- `examples/commands_events_views.rs` — command application, model events, view
+  projection, and rendering
+- `examples/snapshot_diff.rs` — snapshot comparison between two materialized
+  MMDS documents
 
 Fixture-backed payloads used throughout the Rust contract tests live at:
 

--- a/examples/commands_events_views.rs
+++ b/examples/commands_events_views.rs
@@ -50,14 +50,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("- {}", describe_model_event(event));
     }
 
-    let spec = ViewSpec {
-        statements: vec![ViewStatement::Include(Selector::Traversal {
-            anchor: AnchorRef::Node("api".to_string()),
-            direction: TraversalDirection::Downstream,
-            hops: 1,
-        })],
-        ..ViewSpec::default()
-    };
+    let spec = ViewSpec::new(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("api".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 1,
+    })]);
     let (view, view_events) = project(&document, &spec)?;
 
     println!("\nview nodes:");
@@ -84,6 +81,7 @@ fn describe_model_event(event: &ModelEvent) -> String {
         Subject::Node(id) => format!("node {id}"),
         Subject::Edge(id) => format!("edge {id}"),
         Subject::Subgraph(id) => format!("subgraph {id}"),
+        _ => "<unknown>".to_string(),
     };
 
     format!("{:?} on {subject}", event.kind)

--- a/examples/materialized_view.rs
+++ b/examples/materialized_view.rs
@@ -14,14 +14,11 @@ service_a --> audit[Audit]
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let canonical: Document = materialize_diagram(SOURCE, &RenderConfig::default())?;
-    let spec = ViewSpec {
-        statements: vec![ViewStatement::Include(Selector::Traversal {
-            anchor: AnchorRef::Node("service_a".to_string()),
-            direction: TraversalDirection::Downstream,
-            hops: 2,
-        })],
-        ..ViewSpec::default()
-    };
+    let spec = ViewSpec::new(vec![ViewStatement::Include(Selector::Traversal {
+        anchor: AnchorRef::Node("service_a".to_string()),
+        direction: TraversalDirection::Downstream,
+        hops: 2,
+    })]);
 
     let (view, events) = project(&canonical, &spec)?;
     let text = render_document(&view, OutputFormat::Text, &RenderConfig::default())?;

--- a/examples/snapshot_diff.rs
+++ b/examples/snapshot_diff.rs
@@ -54,6 +54,7 @@ fn describe_change(change: &Change) -> String {
         Subject::Node(id) => format!("node {id}"),
         Subject::Edge(id) => format!("edge {id}"),
         Subject::Subgraph(id) => format!("subgraph {id}"),
+        _ => "<unknown>".to_string(),
     };
 
     if change.evidence.is_empty() {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,8 +1,11 @@
 //! Command vocabulary and synchronous MMDS command application.
 //!
+//! See the crate-level [Stability](crate#stability) section for the
+//! variant-addition and field-addition policy on the public types in this module.
+//!
 //! This module applies one [`Command`] to a fully materialized MMDS [`Document`] and
-//! returns model events. Model events describe accepted model mutations. They are
-//! intentionally different from the snapshot diff returned by
+//! returns model events, not snapshot diff changes. Model events describe accepted
+//! model mutations. They are intentionally different from the snapshot diff returned by
 //! [`crate::mmds::diff::diff_documents`], which compares two document states and can
 //! collapse, reorder, or expand command headlines.
 //!
@@ -95,6 +98,7 @@ const GEOMETRY_CHANGE_KINDS: &[ChangeKind] = &[
 /// Commands describe intent, not transport. Applying a command can update semantic
 /// fields directly or run a full relayout depending on the variant, but the returned
 /// events remain model events rather than snapshot diff changes.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum Command {
     SetGeometryLevel {
@@ -217,6 +221,7 @@ pub enum Command {
 /// [`EdgeSelector::Semantic`] when selecting by source, target, and optional edge
 /// attributes is acceptable. Semantic selectors intentionally return ambiguity errors
 /// instead of guessing when multiple parallel edges match.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EdgeSelector {
     Id(String),
@@ -242,6 +247,7 @@ pub(crate) enum ChangeKindLayer {
 ///
 /// Variants are part of the public command contract and can be matched directly.
 /// The type also implements [`std::error::Error`] through `thiserror`.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum CommandApplyError {
     #[error("node not found: {id}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! mmdflux — Mermaid diagrams to text, SVG, and MMDS
 //!
 //! mmdflux parses [Mermaid](https://mermaid.js.org/) diagram syntax and
-//! renders it as Unicode/ASCII text, SVG, or structured JSON ([MMDS](https://mmds.dev/)).
-//! Supported diagram types: **flowchart**, **class**, and **sequence**.
+//! renders it as Unicode/ASCII text, SVG, or structured JSON (MMDS).
+//! Supported diagram types: **flowchart**, **class**, **state**, and **sequence**.
 //!
 //! # High-Level API
 //!
@@ -22,6 +22,38 @@
 //! [`materialize_diagram`] when you want the typed [`mmds::Document`], and use
 //! [`render_document`] when you already have one, such as after
 //! [`views::project`].
+//! For document-level workflows, use `commands::apply` to mutate a document,
+//! `mmds::diff::diff_documents` to compare two snapshots, and
+//! `views::project` to produce a read-side view.
+//!
+//! # Stability
+//!
+//! The `commands`, `mmds::events`, `mmds::diff`, and `views` modules are early
+//! surfaces. The following kinds of changes will land in minor versions and are
+//! not considered breaking under this crate's SemVer policy:
+//!
+//! - new variants on the early-surface enums marked `#[non_exhaustive]`
+//!   (including `commands::Command`, `commands::EdgeSelector`,
+//!   `commands::CommandApplyError`, `mmds::events::ModelEventKind`,
+//!   `mmds::diff::ChangeKind`, `mmds::Subject`, `views::ViewStatement`,
+//!   `views::Selector`, `views::ViewEvent`, `views::ViewError`, and the
+//!   supporting view vocabulary)
+//! - new fields on early-surface structs marked `#[non_exhaustive]` (including
+//!   `mmds::events::ModelEvent`, `mmds::diff::Change`, `mmds::diff::Diff`,
+//!   `mmds::MmdsTokenError`, and `views::ViewSpec`)
+//!
+//! ## What is not covered
+//!
+//! - Renaming, removing, or changing the meaning of an existing variant or field
+//!   remains a breaking change.
+//! - Adding fields to existing struct-like enum variants
+//!   (for example, `Command::AddNode { ... }`) is still breaking; individual
+//!   variants are not currently marked `#[non_exhaustive]`.
+//! - The runtime facade (`render_diagram`, `materialize_diagram`,
+//!   `render_document`, `detect_diagram`, `validate_diagram`, `OutputFormat`,
+//!   `RenderConfig`, `RenderError`) follows standard SemVer.
+//! - `views::TraversalDirection` is intentionally exhaustive because its
+//!   vocabulary is closed.
 //!
 //! ```
 //! use mmdflux::{OutputFormat, RenderConfig, render_diagram};
@@ -139,7 +171,7 @@
 //!
 //! ## MMDS interchange
 //!
-//! [MMDS](https://mmds.dev/) is a structured JSON format for diagram geometry.
+//! MMDS is mmdflux's structured JSON format for diagram geometry.
 //! Use the [`mmds`] module to parse MMDS input, hydrate it to a
 //! [`graph::Graph`], or regenerate Mermaid source. To render MMDS input to
 //! text/SVG, pass it to [`render_diagram`] which auto-detects MMDS:
@@ -178,87 +210,74 @@
 //! assert!(mermaid.contains("flowchart TD"));
 //! ```
 //!
-//! ## Commands, Diffs, and Views
+//! ## Commands and Model Events
 //!
-//! Public MMDS commands emit model events, while [`mmds::diff::diff_documents`]
-//! reports a snapshot diff between two document states. Model events and diff
-//! changes are related, but they are not interchangeable:
+//! Public MMDS commands mutate a document and emit model events that describe
+//! the accepted state transition:
 //!
 //! ```
 //! use mmdflux::commands::{Command, apply};
-//! use mmdflux::graph::{Arrow, Shape, Stroke};
+//! use mmdflux::graph::Shape;
 //! use mmdflux::mmds::Subject;
-//! use mmdflux::mmds::diff::{ChangeKind, diff_documents};
 //! use mmdflux::mmds::events::ModelEventKind;
-//! use mmdflux::views::{Selector, ViewSpec, ViewStatement, project};
 //! use mmdflux::{RenderConfig, materialize_diagram};
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let initial = materialize_diagram(
+//! let mut document = materialize_diagram(
 //!     "graph TD\n    A[Gateway] --> B[Billing]",
 //!     &RenderConfig::default(),
 //! )?;
-//! let mut current = initial.clone();
 //!
-//! apply(
+//! let model_events = apply(
 //!     &Command::AddNode {
 //!         id: "C".to_string(),
 //!         label: "Auth".to_string(),
 //!         shape: Shape::Rectangle,
 //!         parent: None,
 //!     },
-//!     &mut current,
-//! )?;
-//! apply(
-//!     &Command::AddEdge {
-//!         id: None,
-//!         source: "A".to_string(),
-//!         target: "C".to_string(),
-//!         from_subgraph: None,
-//!         to_subgraph: None,
-//!         label: Some("routes".to_string()),
-//!         stroke: Stroke::Solid,
-//!         arrow_start: Arrow::None,
-//!         arrow_end: Arrow::Normal,
-//!         minlen: 1,
-//!     },
-//!     &mut current,
-//! )?;
-//! let model_events = apply(
-//!     &Command::ChangeNodeLabel {
-//!         node: "C".to_string(),
-//!         label: "Auth Service".to_string(),
-//!     },
-//!     &mut current,
-//! )?;
-//!
-//! let snapshot_diff = diff_documents(&initial, &current);
-//! let (view, _view_events) = project(
-//!     &current,
-//!     &ViewSpec {
-//!         statements: vec![ViewStatement::Include(Selector::All)],
-//!         ..ViewSpec::default()
-//!     },
+//!     &mut document,
 //! )?;
 //!
 //! assert!(model_events.iter().any(|event| {
-//!     event.kind == ModelEventKind::NodeLabelChanged
+//!     event.kind == ModelEventKind::NodeAdded
 //!         && matches!(&event.subject, Subject::Node(id) if id == "C")
 //! }));
-//! assert!(snapshot_diff.changes.iter().any(|event| {
-//!     event.kind == ChangeKind::NodeAdded
-//!         && matches!(&event.subject, Subject::Node(id) if id == "C")
-//! }));
-//! assert!(!snapshot_diff.changes.iter().any(|event| {
-//!     event.kind == ChangeKind::NodeLabelChanged
-//!         && matches!(&event.subject, Subject::Node(id) if id == "C")
-//! }));
-//! assert_eq!(view.nodes.len(), current.nodes.len());
+//! assert!(document.nodes.iter().any(|node| node.id == "C"));
 //! # Ok(())
 //! # }
 //! ```
 //!
-//! ## Materialized MMDS views
+//! ## Snapshot Diffs
+//!
+//! [`mmds::diff::diff_documents`] compares two document states and reports a
+//! snapshot diff. Diff changes describe what is different between snapshots;
+//! they do not describe edit intent or command history:
+//!
+//! ```
+//! use mmdflux::mmds::Subject;
+//! use mmdflux::mmds::diff::{ChangeKind, diff_documents};
+//! use mmdflux::{RenderConfig, materialize_diagram};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let before = materialize_diagram(
+//!     "graph TD\n    A[Gateway] --> B[Billing]",
+//!     &RenderConfig::default(),
+//! )?;
+//! let after = materialize_diagram(
+//!     "graph TD\n    A[Gateway] --> B[Billing]\n    A --> C[Auth]",
+//!     &RenderConfig::default(),
+//! )?;
+//!
+//! let diff = diff_documents(&before, &after);
+//! assert!(diff.changes.iter().any(|change| {
+//!     change.kind == ChangeKind::NodeAdded
+//!         && matches!(&change.subject, Subject::Node(id) if id == "C")
+//! }));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Views
 //!
 //! Use [`views`] when an adapter needs a focused read model over a canonical
 //! MMDS payload. V1 views preserve shared coordinates, keep surviving edge IDs
@@ -279,14 +298,11 @@
 //! A --> D[Audit]
 //! ";
 //! let canonical: Document = materialize_diagram(source, &RenderConfig::default()).unwrap();
-//! let spec = ViewSpec {
-//!     statements: vec![ViewStatement::Include(Selector::Traversal {
+//! let spec = ViewSpec::new(vec![ViewStatement::Include(Selector::Traversal {
 //!         anchor: AnchorRef::Node("A".to_string()),
 //!         direction: TraversalDirection::Downstream,
 //!         hops: 1,
-//!     })],
-//!     ..ViewSpec::default()
-//! };
+//!     })]);
 //!
 //! let (view, events) = project(&canonical, &spec).unwrap();
 //! let text = render_document(&view, OutputFormat::Text, &RenderConfig::default()).unwrap();

--- a/src/mmds/diff.rs
+++ b/src/mmds/diff.rs
@@ -1,5 +1,8 @@
 //! Snapshot diff for MMDS documents.
 //!
+//! See the crate-level [Stability](crate#stability) section for the
+//! variant-addition and field-addition policy on the public types in this module.
+//!
 //! [`diff_documents`] compares two fully materialized MMDS [`Document`] values and returns a
 //! snapshot diff: the changes describe what differs between the two states, regardless of
 //! the command sequence or editing path that produced them.
@@ -33,6 +36,7 @@ use super::{Bounds, Document, Edge, Node, Port, Position, Rect, Subgraph, Subjec
 const COORD_EPS: f64 = 0.01;
 const DISPLAY_EPS: f64 = 1.0;
 
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Diff {
     /// Geometry level recorded on the `before` document.
@@ -43,6 +47,7 @@ pub struct Diff {
     pub changes: Vec<Change>,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Change {
     /// Change classification.
@@ -56,6 +61,7 @@ pub struct Change {
 }
 
 /// Kind of change observed in an MMDS snapshot diff.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChangeKind {
     GeometryLevelChanged,

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -169,6 +169,7 @@ pub(crate) fn to_document_typed(
 }
 
 /// Serialize a graph-family diagram to MMDS JSON with fallback routing.
+#[doc(hidden)]
 #[deprecated(
     note = "use materialize_diagram plus serde_json serialization for JSON output, or render_document for replay"
 )]

--- a/src/mmds/events.rs
+++ b/src/mmds/events.rs
@@ -1,13 +1,17 @@
 //! Model events emitted by accepted MMDS model mutations.
 //!
-//! Model events describe state transitions accepted by the MMDS model. They are not
-//! snapshot diffs. To compare two fully materialized document states, use
+//! See the crate-level [Stability](crate#stability) section for the
+//! variant-addition and field-addition policy on the public types in this module.
+//!
+//! Model events describe state transitions accepted by the MMDS model. They are not snapshot diffs.
+//! To compare two fully materialized document states, use
 //! [`crate::mmds::diff::diff_documents`] and inspect [`crate::mmds::diff::Change`]
 //! entries instead.
 
 use super::Subject;
 
 /// Event emitted for an accepted MMDS model state transition.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModelEvent {
     /// Model event classification.
@@ -17,6 +21,7 @@ pub struct ModelEvent {
 }
 
 /// Kind of state transition accepted by the MMDS model.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModelEventKind {
     GeometryLevelChanged,

--- a/src/mmds/mod.rs
+++ b/src/mmds/mod.rs
@@ -1,5 +1,8 @@
 //! MMDS interchange contract and document-generation namespace.
 //!
+//! See the crate-level [Stability](crate#stability) section for the
+//! variant-addition and field-addition policy on the public types in this module.
+//!
 //! This module owns the typed graph-family MMDS document, profile vocabulary,
 //! Mermaid regeneration helpers, validation, and hydration to `Diagram` for
 //! adapter workflows. Replay rendering lives in `runtime::mmds`.
@@ -56,6 +59,7 @@ pub use token::{MmdsToken, MmdsTokenError};
 mod regression_tests;
 
 /// Subject associated with an MMDS model event or snapshot diff change.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Subject {
     Document,

--- a/src/mmds/token.rs
+++ b/src/mmds/token.rs
@@ -1,4 +1,7 @@
 //! Canonical MMDS string token contracts for graph-family enums.
+//!
+//! See the crate-level [Stability](crate#stability) section for the
+//! variant-addition and field-addition policy on the public types in this module.
 
 use std::error::Error;
 use std::fmt;
@@ -15,6 +18,7 @@ pub trait MmdsToken: Sized {
 }
 
 /// Error returned when an MMDS string token does not match a graph vocabulary.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MmdsTokenError {
     /// Vocabulary being parsed, such as `"shape"` or `"direction"`.

--- a/src/views/error.rs
+++ b/src/views/error.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter};
 use serde::{Deserialize, Serialize};
 
 /// Error returned while resolving or materializing a view.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ViewError {
     /// A requested view feature is reserved for a later slice.

--- a/src/views/events.rs
+++ b/src/views/events.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Reason an element is absent from a materialized view.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ElisionReason {
     /// The element did not match the active view selectors.
@@ -12,6 +13,7 @@ pub enum ElisionReason {
 }
 
 /// Diagnostic event emitted while materializing a view.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ViewEvent {
     /// A canonical node was omitted from the materialized view.

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -1,10 +1,13 @@
 //! Materialized diagram views over canonical MMDS payloads.
 //!
+//! See the crate-level [Stability](crate#stability) section for the
+//! variant-addition and field-addition policy on the public types in this module.
+//!
 //! This module owns the read-side `ViewSpec` contract. It intentionally works
 //! over `mmds::Document` rather than renderer or engine internals.
 //!
-//! The v1 surface is intentionally small: materialize a filtered MMDS payload
-//! from a `ViewSpec` and emit events for elements that leave the view.
+//! The v1 surface is intentionally small: project a filtered MMDS payload
+//! from a `ViewSpec` and emit projection events for elements that leave the view.
 //! Rendering remains a runtime concern; pass the returned document to
 //! [`crate::render_document`] when a text, SVG, or MMDS rendering is
 //! needed.
@@ -28,14 +31,11 @@
 //! ";
 //!
 //! let canonical: Document = materialize_diagram(source, &RenderConfig::default())?;
-//! let spec = ViewSpec {
-//!     statements: vec![ViewStatement::Include(Selector::Traversal {
+//! let spec = ViewSpec::new(vec![ViewStatement::Include(Selector::Traversal {
 //!         anchor: AnchorRef::Node("service_a".to_string()),
 //!         direction: TraversalDirection::Downstream,
 //!         hops: 2,
-//!     })],
-//!     ..ViewSpec::default()
-//! };
+//!     })]);
 //!
 //! let (view, events) = project(&canonical, &spec)?;
 //! assert!(view.nodes.iter().any(|node| node.id == "service_c"));

--- a/src/views/spec.rs
+++ b/src/views/spec.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Materialized view request over a canonical MMDS payload.
+#[non_exhaustive]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ViewSpec {
     /// Ordered include/exclude statements used to build the view keep-set.
@@ -27,7 +28,18 @@ pub struct ViewSpec {
     pub compound: CompoundPolicy,
 }
 
+impl ViewSpec {
+    /// Build a view spec from the ordered selector statements that define it.
+    pub fn new(statements: Vec<ViewStatement>) -> Self {
+        Self {
+            statements,
+            ..Self::default()
+        }
+    }
+}
+
 /// Include or exclude a selector from the view keep-set.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ViewStatement {
     /// Add the selector result to the current keep-set.
@@ -37,6 +49,7 @@ pub enum ViewStatement {
 }
 
 /// Selector expression for v1 and forward-compatible follow-up view slices.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Selector {
     /// Select every node and subgraph in the payload.
@@ -61,6 +74,7 @@ pub enum Selector {
 }
 
 /// Stable anchor reference used by view selectors.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AnchorRef {
     /// Anchor on a node ID.
@@ -75,6 +89,7 @@ pub enum AnchorRef {
 }
 
 /// Edge anchor shape reserved for a later edge-aware view slice.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EdgeAnchor {
     /// Source node ID.
@@ -100,6 +115,7 @@ pub enum TraversalDirection {
 }
 
 /// Node predicate for selector filters.
+#[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NodePredicate {
     /// Select nodes whose MMDS `shape` equals the supplied value.
@@ -113,6 +129,7 @@ pub enum NodePredicate {
 }
 
 /// Layout policy for the materialized view.
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LayoutMode {
     /// Preserve canonical coordinates and mark the payload as a shared-coordinate view.
@@ -133,6 +150,7 @@ pub enum LayoutMode {
 }
 
 /// Boundary policy for elements connected to elided endpoints.
+#[non_exhaustive]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BoundaryPolicy {
     /// Drop edges whose source or target node is outside the view.
@@ -148,6 +166,7 @@ pub enum BoundaryPolicy {
 }
 
 /// Compound/subgraph handling policy.
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CompoundPolicy {
     /// Preserve retained subgraphs and their ancestor chain.

--- a/tests/lib_exports.rs
+++ b/tests/lib_exports.rs
@@ -86,6 +86,39 @@ fn assert_exports_exclude(exports: &BTreeSet<String>, forbidden: &[&str], contex
     }
 }
 
+fn lines_before(source: &str, needle: &str, count: usize) -> String {
+    let index = source
+        .find(needle)
+        .unwrap_or_else(|| panic!("{needle} should exist"));
+    let mut lines: Vec<_> = source[..index].lines().rev().take(count).collect();
+    lines.reverse();
+    lines.join("\n")
+}
+
+fn assert_hidden_deprecated_item(source: &str, needle: &str, replacement: &str) {
+    let attrs = lines_before(source, needle, 8);
+    assert!(
+        attrs.contains("#[doc(hidden)]"),
+        "{needle} should be hidden from public docs"
+    );
+    assert!(
+        attrs.contains("#[deprecated("),
+        "{needle} should be deprecated"
+    );
+    assert!(
+        attrs.contains(replacement),
+        "{needle} should name replacement {replacement:?}"
+    );
+}
+
+fn assert_non_exhaustive(source: &str, needle: &str) {
+    let attrs = lines_before(source, needle, 8);
+    assert!(
+        attrs.contains("#[non_exhaustive]"),
+        "{needle} should be #[non_exhaustive]"
+    );
+}
+
 #[test]
 fn crate_root_only_exports_supported_public_modules() {
     let modules = public_modules_for_test();
@@ -149,12 +182,8 @@ fn view_contract_types_compile() {
         direction: TraversalDirection::Downstream,
         hops: 2,
     });
-    let edge_anchor = AnchorRef::Edge(EdgeAnchor {
-        source: "gateway".to_string(),
-        target: "auth".to_string(),
-        ordinal: 0,
-        label: Some("calls".to_string()),
-    });
+    let anchor = AnchorRef::Node("gateway".to_string());
+    let edge_anchor_type = std::any::type_name::<EdgeAnchor>();
     let stub_policy = BoundaryPolicy::Stub {
         aggregate_threshold: 4,
     };
@@ -163,7 +192,8 @@ fn view_contract_types_compile() {
     let _ = (
         spec,
         statement,
-        edge_anchor,
+        anchor,
+        edge_anchor_type,
         stub_policy,
         tag_predicate,
         LayoutMode::SharedCoordinates,
@@ -177,6 +207,236 @@ fn view_contract_types_compile() {
         },
         project,
     );
+}
+
+#[test]
+fn mmds_public_api_surface_is_explicit_before_2_4_0() {
+    let _ = mmdflux::render_diagram;
+    let _ = mmdflux::materialize_diagram;
+    let _ = mmdflux::render_document;
+    let _ = mmdflux::detect_diagram;
+    let _ = mmdflux::validate_diagram;
+
+    let _ = mmdflux::commands::apply;
+    let _ = mmdflux::commands::apply_with_config;
+    let _ = std::any::type_name::<mmdflux::commands::Command>();
+    let _ = std::any::type_name::<mmdflux::commands::EdgeSelector>();
+    let _ = std::any::type_name::<mmdflux::commands::CommandApplyError>();
+
+    let _ = std::any::type_name::<mmdflux::mmds::events::ModelEvent>();
+    let _ = std::any::type_name::<mmdflux::mmds::events::ModelEventKind>();
+    let _ = mmdflux::mmds::diff::diff_documents;
+    let _ = std::any::type_name::<mmdflux::mmds::diff::Diff>();
+    let _ = std::any::type_name::<mmdflux::mmds::diff::Change>();
+    let _ = std::any::type_name::<mmdflux::mmds::diff::ChangeKind>();
+    let _ = std::any::type_name::<mmdflux::mmds::Document>();
+    let _ = std::any::type_name::<mmdflux::mmds::Subject>();
+    let _ = std::any::type_name::<mmdflux::mmds::MmdsTokenError>();
+    let _parse_shape: fn(&str) -> Result<Shape, MmdsTokenError> = <Shape as MmdsToken>::parse_mmds;
+
+    let _ = mmdflux::views::project;
+    let _ = std::any::type_name::<mmdflux::views::ViewSpec>();
+    let _ = std::any::type_name::<mmdflux::views::ViewStatement>();
+    let _ = std::any::type_name::<mmdflux::views::Selector>();
+    let _ = std::any::type_name::<mmdflux::views::ViewEvent>();
+    let _ = std::any::type_name::<mmdflux::views::ViewError>();
+
+    let _render_document: fn(
+        &mmdflux::mmds::Document,
+        mmdflux::OutputFormat,
+        &mmdflux::RenderConfig,
+    ) -> Result<String, mmdflux::RenderError> = mmdflux::render_document;
+}
+
+#[test]
+fn early_mmds_surface_is_non_exhaustive() {
+    let commands = repo_file("src/commands.rs");
+    assert_non_exhaustive(&commands, "pub enum Command");
+    assert_non_exhaustive(&commands, "pub enum EdgeSelector");
+    assert_non_exhaustive(&commands, "pub enum CommandApplyError");
+
+    let events = repo_file("src/mmds/events.rs");
+    assert_non_exhaustive(&events, "pub struct ModelEvent");
+    assert_non_exhaustive(&events, "pub enum ModelEventKind");
+
+    let diff = repo_file("src/mmds/diff.rs");
+    assert_non_exhaustive(&diff, "pub struct Diff");
+    assert_non_exhaustive(&diff, "pub struct Change");
+    assert_non_exhaustive(&diff, "pub enum ChangeKind");
+
+    let mmds = repo_file("src/mmds/mod.rs");
+    assert_non_exhaustive(&mmds, "pub enum Subject");
+
+    let token = repo_file("src/mmds/token.rs");
+    assert_non_exhaustive(&token, "pub struct MmdsTokenError");
+
+    let view_spec = repo_file("src/views/spec.rs");
+    assert_non_exhaustive(&view_spec, "pub struct ViewSpec");
+    assert_non_exhaustive(&view_spec, "pub enum ViewStatement");
+    assert_non_exhaustive(&view_spec, "pub enum Selector");
+    assert_non_exhaustive(&view_spec, "pub enum AnchorRef");
+    assert_non_exhaustive(&view_spec, "pub struct EdgeAnchor");
+    assert_non_exhaustive(&view_spec, "pub enum NodePredicate");
+    assert_non_exhaustive(&view_spec, "pub enum LayoutMode");
+    assert_non_exhaustive(&view_spec, "pub enum BoundaryPolicy");
+    assert_non_exhaustive(&view_spec, "pub enum CompoundPolicy");
+
+    let view_events = repo_file("src/views/events.rs");
+    assert_non_exhaustive(&view_events, "pub enum ElisionReason");
+    assert_non_exhaustive(&view_events, "pub enum ViewEvent");
+
+    let view_error = repo_file("src/views/error.rs");
+    assert_non_exhaustive(&view_error, "pub enum ViewError");
+}
+
+#[test]
+fn crate_root_does_not_flatten_mmds_command_diff_event_or_view_types() {
+    let exports = public_exports_for_test();
+
+    assert_exports_exclude(
+        &exports,
+        &[
+            "Command",
+            "EdgeSelector",
+            "CommandApplyError",
+            "ModelEvent",
+            "ModelEventKind",
+            "Diff",
+            "Change",
+            "ChangeKind",
+            "Subject",
+            "MmdsToken",
+            "MmdsTokenError",
+            "ViewSpec",
+            "ViewStatement",
+            "Selector",
+            "ViewEvent",
+            "ViewError",
+        ],
+        "the crate-root export surface (MMDS commands, events, diffs, tokens, and views stay in home modules)",
+    );
+}
+
+#[test]
+fn deprecated_mmds_public_helpers_have_explicit_release_policy() {
+    let mmds_mod = repo_file("src/mmds/mod.rs");
+    let document = repo_file("src/mmds/document.rs");
+    let hydrate = repo_file("src/mmds/hydrate.rs");
+
+    let deprecated_count = [&mmds_mod, &document, &hydrate]
+        .iter()
+        .map(|source| source.matches("#[deprecated(").count())
+        .sum::<usize>();
+    assert_eq!(
+        deprecated_count, 6,
+        "the deprecated MMDS compatibility inventory should stay explicit"
+    );
+
+    assert_hidden_deprecated_item(&document, "pub type Output = Document;", "mmds::Document");
+    assert_hidden_deprecated_item(
+        &document,
+        "pub fn to_json_typed_with_routing(",
+        "materialize_diagram plus serde_json serialization",
+    );
+    assert_hidden_deprecated_item(
+        &mmds_mod,
+        "pub fn evaluate_profiles_for_output(",
+        "evaluate_profiles_for_document",
+    );
+    assert_hidden_deprecated_item(&hydrate, "pub fn from_output(", "from_document");
+    assert_hidden_deprecated_item(
+        &hydrate,
+        "pub fn hydrate_graph_geometry_from_output_with_diagram(",
+        "hydrate_graph_geometry_from_document_with_diagram",
+    );
+    assert_hidden_deprecated_item(
+        &hydrate,
+        "pub fn hydrate_routed_geometry_from_output(",
+        "hydrate_routed_geometry_from_document",
+    );
+}
+
+#[test]
+fn crate_root_rustdoc_names_public_workflows_without_unreleased_migration_guide() {
+    let source = lib_rs_source();
+
+    for required in [
+        "Supported diagram types: **flowchart**, **class**, **state**, and **sequence**.",
+        "# Stability",
+        "## What is not covered",
+        "render_diagram",
+        "materialize_diagram",
+        "render_document",
+        "commands::apply",
+        "mmds::diff::diff_documents",
+        "views::project",
+        "## Commands and Model Events",
+        "## Views",
+        "## Snapshot Diffs",
+    ] {
+        assert!(
+            source.contains(required),
+            "{required} should be named in crate docs"
+        );
+    }
+
+    assert!(
+        !source.contains("migration guide for views")
+            && !source.contains("migration guide for commands")
+            && !source.contains("migration guide for events"),
+        "unreleased APIs should not be documented as migration-guide changes"
+    );
+    assert!(
+        !source.contains("## Commands, Diffs, and Views")
+            && !source.contains("## Commands and Views"),
+        "command/event, view, and snapshot diff examples should stay separated"
+    );
+}
+
+#[test]
+fn public_module_rustdocs_name_contract_caveats() {
+    let commands = repo_file("src/commands.rs");
+    let diff = repo_file("src/mmds/diff.rs");
+    let events = repo_file("src/mmds/events.rs");
+    let mmds = repo_file("src/mmds/mod.rs");
+    let token = repo_file("src/mmds/token.rs");
+    let views = repo_file("src/views/mod.rs");
+
+    for source in [&commands, &diff, &events, &mmds, &token, &views] {
+        assert!(
+            source.contains("[Stability](crate#stability)"),
+            "early public modules should link to the crate-level stability policy"
+        );
+    }
+
+    assert!(commands.contains("model events"));
+    assert!(commands.contains("not snapshot diff"));
+    assert!(diff.contains("snapshot diff"));
+    assert!(events.contains("not snapshot diffs"));
+    assert!(token.contains("MMDS string token"));
+    assert!(views.contains("projection"));
+}
+
+#[test]
+fn readme_and_docs_list_public_rust_api_examples() {
+    let readme = repo_file("README.md");
+    let mmds_docs = repo_file("docs/mmds.md");
+
+    for example in [
+        "commands_events_views",
+        "snapshot_diff",
+        "materialized_view",
+        "mmds_replay",
+    ] {
+        assert!(
+            readme.contains(example),
+            "{example} should be discoverable from README"
+        );
+        assert!(
+            mmds_docs.contains(example),
+            "{example} should be discoverable from docs/mmds.md"
+        );
+    }
 }
 
 #[test]

--- a/tests/mmds_views.rs
+++ b/tests/mmds_views.rs
@@ -103,10 +103,7 @@ fn subgraph(id: &str, children: &[&str], parent: Option<&str>) -> Subgraph {
 }
 
 fn view(statements: Vec<ViewStatement>) -> ViewSpec {
-    ViewSpec {
-        statements,
-        ..ViewSpec::default()
-    }
+    ViewSpec::new(statements)
 }
 
 fn text_projection_extension() -> Map<String, Value> {
@@ -594,13 +591,10 @@ fn view_apply_preserves_ancestor_subgraph_containers() {
 #[test]
 fn view_apply_rejects_unimplemented_layout_modes() {
     let payload = output(vec![node("gateway", "rectangle", None)], vec![], vec![]);
-    let spec = ViewSpec {
-        layout: LayoutMode::Compact,
-        statements: vec![ViewStatement::Include(Selector::Anchor(AnchorRef::Node(
-            "gateway".to_string(),
-        )))],
-        ..ViewSpec::default()
-    };
+    let mut spec = ViewSpec::new(vec![ViewStatement::Include(Selector::Anchor(
+        AnchorRef::Node("gateway".to_string()),
+    ))]);
+    spec.layout = LayoutMode::Compact;
 
     let error = project(&payload, &spec).expect_err("compact mode is deferred");
 
@@ -882,11 +876,12 @@ fn view_canary_deferred_primitives_return_not_implemented() {
     let payload = canary_canonical_output();
     let cases = [
         (
-            ViewSpec {
-                boundary: mmdflux::views::BoundaryPolicy::Stub {
+            {
+                let mut spec = canary_view_spec();
+                spec.boundary = mmdflux::views::BoundaryPolicy::Stub {
                     aggregate_threshold: 3,
-                },
-                ..canary_view_spec()
+                };
+                spec
             },
             "boundary stubs",
         ),
@@ -897,27 +892,18 @@ fn view_canary_deferred_primitives_return_not_implemented() {
             "tag predicates",
         ),
         (
-            view(vec![ViewStatement::Include(Selector::Anchor(
-                AnchorRef::Edge(mmdflux::views::EdgeAnchor {
-                    source: "service_a".to_string(),
-                    target: "service_b".to_string(),
-                    ordinal: 0,
-                    label: None,
-                }),
-            ))]),
-            "edge anchors",
-        ),
-        (
-            ViewSpec {
-                layout: LayoutMode::Compact,
-                ..canary_view_spec()
+            {
+                let mut spec = canary_view_spec();
+                spec.layout = LayoutMode::Compact;
+                spec
             },
             "non-shared-coordinate layout modes",
         ),
         (
-            ViewSpec {
-                compound: mmdflux::views::CompoundPolicy::Flatten,
-                ..canary_view_spec()
+            {
+                let mut spec = canary_view_spec();
+                spec.compound = mmdflux::views::CompoundPolicy::Flatten;
+                spec
             },
             "compound flattening",
         ),


### PR DESCRIPTION
## Summary

- freeze the intended 2.4.0 Rust public API surface in `tests/lib_exports.rs`
- keep released deprecated MMDS helpers hidden and deprecated with replacement notes
- mark early MMDS surfaces `#[non_exhaustive]` and document the explicit minor-version stability carve-out
- tighten crate/module rustdoc contracts, example discovery, and supported diagram-type docs

## Notes

- separates command/model-event, view projection, and snapshot-diff rustdoc examples
- removes stale external MMDS documentation links from crate docs
- adds `ViewSpec::new(...)` as the construction path for the non-exhaustive view spec
- records the stability policy and remaining exclusions in Plan 0175 findings

## Validation

- `cargo nextest run --test lib_exports`
- `cargo test --doc`
- `cargo test --examples`
- `cargo test --no-default-features --lib`
- `cargo nextest run --test mmds_views --test mmds_commands --test mmds_diff`
- `just check`