### PR TITLE
fix: type MMDS node shapes

### DIFF
--- a/boundaries.toml
+++ b/boundaries.toml
@@ -168,7 +168,7 @@ id = "allow-views"
 type = "allow"
 [rules.config]
 source = "views"
-allowed = ["mmds"]
+allowed = ["graph", "mmds"]
 
 [[rules]]
 id = "allow-frontends"

--- a/docs/architecture/dependency-rules.md
+++ b/docs/architecture/dependency-rules.md
@@ -123,12 +123,14 @@ collapsed back into singleton roots:
    `mmds/` also owns the canonical MMDS string token contract for graph-family
    enums. The `MmdsToken` trait maps graph-owned typed vocabulary such as
    `Shape`, `Direction`, `Stroke`, `Arrow`, and `GeometryLevel` to and from
-   MMDS schema tokens via `parse_mmds` / `as_mmds_str`. `mmds::Document` fields
-   retain the string form for adapter-friendly interchange, while command inputs
-   use the typed form so Rust callers get vocabulary validation before relayout.
-   Engine IDs are the exception: they stay string-backed at the command boundary
-   because engine selector types live behind the runtime/engine facade, not in
-   graph-owned vocabulary.
+   MMDS schema tokens via `parse_mmds` / `as_mmds_str`. Rust fields use the
+   graph-owned typed form where the public `Document` contract can expose a
+   closed vocabulary without losing adapter-friendly JSON interchange (for
+   example node shapes and node shape defaults); remaining schema tokens stay
+   string-backed until they are promoted deliberately. Engine IDs are the
+   exception: they stay string-backed at the command boundary because engine
+   selector types live behind the runtime/engine facade, not in graph-owned
+   vocabulary.
 
 10. **MMDS is a frontend, not a logical diagram type** — MMDS input handling
     is detected through `src/frontends.rs`, while the MMDS parse, hydration,
@@ -138,11 +140,12 @@ collapsed back into singleton roots:
 11. **views/ owns read-side materialized diagram views** — `src/views/` owns
     the `ViewSpec`, selector, `ViewEvent`, and `project` contracts for
     filtering canonical `mmds::Document` payloads into materialized view
-    payloads. In the v1 view slice, `views` depends on `mmds` only and derives
-    any adjacency directly from `Document.edges`; it must not import `graph`,
-    `render`, `engines`, `runtime`, Mermaid parser modules, or command/diff
-    machinery. Runtime may consume `views` for replay hooks, but `views` does
-    not own rendering or orchestration.
+    payloads. In the v1 view slice, `views` depends on `mmds` plus graph-owned
+    typed vocabulary such as `Shape`, and derives any adjacency directly from
+    `Document.edges`; it must not import `render`, `engines`, `runtime`,
+    Mermaid parser modules, or command/diff machinery. Runtime may consume
+    `views` for replay hooks, but `views` does not own rendering or
+    orchestration.
 
 12. **commands.rs owns MMDS command application orchestration** —
     `src/commands.rs` owns the public `Command`, `EdgeSelector`,

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -82,7 +82,7 @@ The primary entry point is:
 - `Selector::Anchor(AnchorRef::Node(id))`
 - `Selector::Anchor(AnchorRef::Subgraph(id))` for the subgraph container only
 - `Selector::Traversal` from a node anchor with upstream, downstream, or neighbor hops
-- `Selector::Predicate(NodePredicate::Shape(value))`
+- `Selector::Predicate(NodePredicate::Shape(shape))` with `mmdflux::graph::Shape`
 - `Selector::Predicate(NodePredicate::Parent(subgraph_id))`
 - `Selector::SubgraphDescendants(id)` for recursive subgraph contents
 - ordered `Include` and `Exclude` statements

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -601,7 +601,7 @@ pub fn apply_with_config(
                     candidate.nodes.push(Node {
                         id: id.clone(),
                         label: label.clone(),
-                        shape: shape.as_mmds_str().to_string(),
+                        shape: *shape,
                         parent: parent.clone(),
                         position: Position { x: 0.0, y: 0.0 },
                         size: Size {
@@ -634,7 +634,7 @@ pub fn apply_with_config(
                 node_event(ModelEventKind::NodeShapeChanged, node.clone()),
                 |candidate| {
                     let index = node_index(candidate, node)?;
-                    candidate.nodes[index].shape = shape.as_mmds_str().to_string();
+                    candidate.nodes[index].shape = *shape;
                     Ok(())
                 },
             )

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -1,11 +1,11 @@
 //! Node types and shape definitions.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::style::NodeStyle;
 
 /// Shape of a node in the diagram.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Shape {
     // === Box-style shapes ===

--- a/src/internal_tests/mmds_commands.rs
+++ b/src/internal_tests/mmds_commands.rs
@@ -549,7 +549,7 @@ fn mmds_command_apply_relayout_changes_node_shape() {
     )
     .expect("change node shape should apply");
 
-    assert_eq!(node_shape(&output, "A"), "stadium");
+    assert_eq!(node_shape(&output, "A"), Shape::Stadium);
     assert_primary_event(&events, ModelEventKind::NodeShapeChanged, "A");
     assert!(
         crate::mmds::diff::diff_documents(&before, &output)
@@ -2140,14 +2140,13 @@ fn node_label(output: &crate::mmds::Document, id: &str) -> String {
         .clone()
 }
 
-fn node_shape(output: &crate::mmds::Document, id: &str) -> String {
+fn node_shape(output: &crate::mmds::Document, id: &str) -> Shape {
     output
         .nodes
         .iter()
         .find(|node| node.id == id)
         .unwrap_or_else(|| panic!("node {id} should exist"))
         .shape
-        .clone()
 }
 
 fn node_parent(output: &crate::mmds::Document, id: &str) -> Option<String> {

--- a/src/internal_tests/mmds_document_serialization.rs
+++ b/src/internal_tests/mmds_document_serialization.rs
@@ -9,7 +9,7 @@ use crate::engines::graph::contracts::MeasurementMode;
 use crate::graph::geometry::{GraphGeometry, RoutedGraphGeometry};
 use crate::graph::measure::default_proportional_text_metrics;
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
-use crate::graph::{GeometryLevel, Graph};
+use crate::graph::{GeometryLevel, Graph, Shape};
 use crate::mmds::document::{Document, to_json, to_layout, to_routed};
 use crate::simplification::PathSimplification;
 
@@ -48,7 +48,7 @@ fn layout_json_has_metadata() {
     let (diagram, geom) = layout_geometry("graph TD\nA-->B");
     let json = to_layout(&diagram, &geom);
     let output: Document = serde_json::from_str(&json).unwrap();
-    assert_eq!(output.defaults.node.shape, "rectangle");
+    assert_eq!(output.defaults.node.shape, Shape::Rectangle);
     assert_eq!(output.defaults.edge.stroke, "solid");
     assert_eq!(output.defaults.edge.arrow_start, "none");
     assert_eq!(output.defaults.edge.arrow_end, "normal");
@@ -68,7 +68,7 @@ fn layout_json_has_nodes_with_positions() {
     assert_eq!(output.nodes.len(), 2);
     let node_a = output.nodes.iter().find(|n| n.id == "A").unwrap();
     assert_eq!(node_a.label, "Start");
-    assert_eq!(node_a.shape, "rectangle");
+    assert_eq!(node_a.shape, Shape::Rectangle);
     assert!(node_a.size.width > 0.0);
     assert!(node_a.size.height > 0.0);
 }
@@ -190,7 +190,7 @@ fn layout_deserializes_with_defaults() {
     )
     .unwrap();
     let output: Document = serde_json::from_str(&json).unwrap();
-    assert_eq!(output.nodes[0].shape, "rectangle");
+    assert_eq!(output.nodes[0].shape, Shape::Rectangle);
     assert_eq!(output.edges[0].stroke, "solid");
     assert_eq!(output.edges[0].arrow_start, "none");
     assert_eq!(output.edges[0].arrow_end, "normal");

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -18,7 +18,7 @@ use crate::graph::measure::default_proportional_text_metrics;
 use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
 use crate::graph::style::NodeStyle;
-use crate::graph::{GeometryLevel, Graph};
+use crate::graph::{GeometryLevel, Graph, Shape};
 use crate::mmds::MmdsToken;
 use crate::simplification::PathSimplification;
 
@@ -647,7 +647,7 @@ fn node(pn: &PositionedNode) -> Node {
     Node {
         id: pn.id.clone(),
         label: pn.label.clone(),
-        shape: pn.shape.as_mmds_str().to_string(),
+        shape: pn.shape,
         parent: pn.parent.clone(),
         position: Position {
             x: pn.rect.x + pn.rect.width / 2.0,
@@ -712,7 +712,7 @@ pub struct Defaults {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeDefaults {
     #[serde(default = "default_node_shape")]
-    pub shape: String,
+    pub shape: Shape,
 }
 
 impl Default for NodeDefaults {
@@ -789,12 +789,12 @@ pub struct Node {
     pub id: String,
     /// Display label.
     pub label: String,
-    /// Shape name (snake_case).
+    /// Node shape.
     #[serde(
         default = "default_node_shape",
         skip_serializing_if = "is_default_node_shape"
     )]
-    pub shape: String,
+    pub shape: Shape,
     /// Parent subgraph ID, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -939,8 +939,8 @@ pub struct Subgraph {
     pub concurrent_regions: Vec<String>,
 }
 
-fn default_node_shape() -> String {
-    "rectangle".to_string()
+fn default_node_shape() -> Shape {
+    Shape::Rectangle
 }
 
 fn default_stroke() -> String {
@@ -959,8 +959,8 @@ fn default_minlen() -> i32 {
     1
 }
 
-fn is_default_node_shape(value: &String) -> bool {
-    value == "rectangle"
+fn is_default_node_shape(value: &Shape) -> bool {
+    *value == Shape::Rectangle
 }
 
 fn is_default_stroke(value: &String) -> bool {

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -17,7 +17,7 @@ use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
 use crate::graph::space::{FPoint, FRect};
 use crate::graph::style::{ColorToken, NodeStyle};
-use crate::graph::{Arrow, Direction, Edge as GraphEdge, Graph, Node, Shape, Stroke, Subgraph};
+use crate::graph::{Arrow, Direction, Edge as GraphEdge, Graph, Node, Stroke, Subgraph};
 use crate::mmds::{
     Document, Edge, MmdsToken, NODE_STYLE_EXTENSION_NAMESPACE, TEXT_EXTENSION_NAMESPACE,
     parse_input,
@@ -76,14 +76,9 @@ pub fn from_document(output: &Document) -> Result<Graph, HydrationError> {
         if node.id.trim().is_empty() {
             return Err(HydrationError::MissingNodeId { index });
         }
-        let shape = Shape::parse_mmds(&node.shape).map_err(|_| HydrationError::InvalidShape {
-            node_id: node.id.clone(),
-            value: node.shape.clone(),
-        })?;
-
         let mut hydrated = Node::new(node.id.clone())
             .with_label(node.label.clone())
-            .with_shape(shape);
+            .with_shape(node.shape);
         hydrated.parent = node.parent.clone();
         diagram.add_node(hydrated);
     }

--- a/src/mmds/mermaid.rs
+++ b/src/mmds/mermaid.rs
@@ -6,6 +6,8 @@ use std::error::Error;
 use std::fmt;
 
 use super::{Document, Edge, Node, Subgraph, parse_input};
+use crate::graph::Shape;
+use crate::mmds::MmdsToken;
 
 /// Error produced when MMDS-to-Mermaid regeneration fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -267,35 +269,36 @@ fn emit_edges(
 fn render_node(node_id: &str, node: &Node) -> Result<String, GenerationError> {
     let label = format_structural_label(&node.label);
 
-    match node.shape.as_str() {
-        "rectangle" => Ok(format!("{node_id}[{label}]")),
-        "round" => Ok(format!("{node_id}({label})")),
-        "diamond" => Ok(format!("{node_id}{{{label}}}")),
-        "stadium" => Ok(format!("{node_id}([{label}])")),
-        "subroutine" => Ok(format!("{node_id}[[{label}]]")),
-        "cylinder" => Ok(format!("{node_id}[({label})]")),
-        "circle" => Ok(format!("{node_id}(({label}))")),
-        "double_circle" => Ok(format!("{node_id}((({label})))")),
-        "hexagon" => Ok(format!("{node_id}{{{{{label}}}}}")),
-        "trapezoid" => Ok(format!(r#"{node_id}[/{label}\]"#)),
-        "inv_trapezoid" => Ok(format!(r#"{node_id}[\{label}/]"#)),
-        "asymmetric" => Ok(format!("{node_id}>{label}]")),
-        "document" => Ok(render_at_shape(node_id, "doc", &node.label)),
-        "documents" => Ok(render_at_shape(node_id, "docs", &node.label)),
-        "tagged_document" => Ok(render_at_shape(node_id, "tag-doc", &node.label)),
-        "card" => Ok(render_at_shape(node_id, "card", &node.label)),
-        "tagged_rect" => Ok(render_at_shape(node_id, "tag-rect", &node.label)),
-        "parallelogram" => Ok(render_at_shape(node_id, "lean-r", &node.label)),
-        "inv_parallelogram" => Ok(render_at_shape(node_id, "lean-l", &node.label)),
-        "manual_input" => Ok(render_at_shape(node_id, "sl-rect", &node.label)),
-        "small_circle" => Ok(render_at_shape(node_id, "sm-circ", &node.label)),
-        "framed_circle" => Ok(render_at_shape(node_id, "fr-circ", &node.label)),
-        "crossed_circle" => Ok(render_at_shape(node_id, "cross-circ", &node.label)),
-        "text_block" => Ok(render_at_shape(node_id, "text", &node.label)),
-        "fork_join" => Ok(render_at_shape(node_id, "fork", &node.label)),
-        value => Err(GenerationError::new(format!(
+    match node.shape {
+        Shape::Rectangle => Ok(format!("{node_id}[{label}]")),
+        Shape::Round => Ok(format!("{node_id}({label})")),
+        Shape::Diamond => Ok(format!("{node_id}{{{label}}}")),
+        Shape::Stadium => Ok(format!("{node_id}([{label}])")),
+        Shape::Subroutine => Ok(format!("{node_id}[[{label}]]")),
+        Shape::Cylinder => Ok(format!("{node_id}[({label})]")),
+        Shape::Circle => Ok(format!("{node_id}(({label}))")),
+        Shape::DoubleCircle => Ok(format!("{node_id}((({label})))")),
+        Shape::Hexagon => Ok(format!("{node_id}{{{{{label}}}}}")),
+        Shape::Trapezoid => Ok(format!(r#"{node_id}[/{label}\]"#)),
+        Shape::InvTrapezoid => Ok(format!(r#"{node_id}[\{label}/]"#)),
+        Shape::Asymmetric => Ok(format!("{node_id}>{label}]")),
+        Shape::Document => Ok(render_at_shape(node_id, "doc", &node.label)),
+        Shape::Documents => Ok(render_at_shape(node_id, "docs", &node.label)),
+        Shape::TaggedDocument => Ok(render_at_shape(node_id, "tag-doc", &node.label)),
+        Shape::Card => Ok(render_at_shape(node_id, "card", &node.label)),
+        Shape::TaggedRect => Ok(render_at_shape(node_id, "tag-rect", &node.label)),
+        Shape::Parallelogram => Ok(render_at_shape(node_id, "lean-r", &node.label)),
+        Shape::InvParallelogram => Ok(render_at_shape(node_id, "lean-l", &node.label)),
+        Shape::ManualInput => Ok(render_at_shape(node_id, "sl-rect", &node.label)),
+        Shape::SmallCircle => Ok(render_at_shape(node_id, "sm-circ", &node.label)),
+        Shape::FramedCircle => Ok(render_at_shape(node_id, "fr-circ", &node.label)),
+        Shape::CrossedCircle => Ok(render_at_shape(node_id, "cross-circ", &node.label)),
+        Shape::TextBlock => Ok(render_at_shape(node_id, "text", &node.label)),
+        Shape::ForkJoin => Ok(render_at_shape(node_id, "fork", &node.label)),
+        Shape::NoteRect => Err(GenerationError::new(format!(
             "unsupported node shape '{value}' for node '{}'",
-            node.id
+            node.id,
+            value = node.shape.as_mmds_str()
         ))),
     }
 }

--- a/src/mmds/regression_tests.rs
+++ b/src/mmds/regression_tests.rs
@@ -82,7 +82,11 @@ fn hydration_rejects_invalid_enum_value() {
     let payload = invalid_fixture("invalid-shape.json");
     let err = from_str(&payload).unwrap_err();
 
-    assert!(matches!(err, HydrationError::InvalidShape { .. }));
+    let HydrationError::Parse { message } = err else {
+        panic!("invalid shape should fail during typed MMDS parse");
+    };
+    assert!(message.contains("unknown variant"));
+    assert!(message.contains("triangle"));
 }
 
 #[test]

--- a/src/views/spec.rs
+++ b/src/views/spec.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::graph::Shape;
+
 /// Materialized view request over a canonical MMDS payload.
 #[non_exhaustive]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -118,8 +120,8 @@ pub enum TraversalDirection {
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NodePredicate {
-    /// Select nodes whose MMDS `shape` equals the supplied value.
-    Shape(String),
+    /// Select nodes whose MMDS `shape` equals the supplied graph shape.
+    Shape(Shape),
     /// Select nodes whose `parent` subgraph ID equals the supplied value.
     Parent(String),
     /// Select nodes by tag metadata.

--- a/tests/json_output.rs
+++ b/tests/json_output.rs
@@ -18,6 +18,12 @@ fn test_shape_serializes_as_snake_case() {
 }
 
 #[test]
+fn test_shape_deserializes_from_snake_case() {
+    let shape: Shape = serde_json::from_str("\"double_circle\"").unwrap();
+    assert_eq!(shape, Shape::DoubleCircle);
+}
+
+#[test]
 fn test_edge_serializes_to_json() {
     let edge = Edge::new("A", "B").with_label("yes");
     let json = serde_json::to_string(&edge).unwrap();

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -8,7 +8,7 @@ mod common;
 
 use std::path::Path;
 
-use mmdflux::graph::GeometryLevel;
+use mmdflux::graph::{GeometryLevel, Shape};
 use mmdflux::mmds::{
     Document, Edge as MmdsEdge, Port as MmdsPort, Position as MmdsPosition, Rect as MmdsRect,
     SUPPORTED_PROFILES, evaluate_profiles, hydrate_routed_geometry_from_document, parse_input,
@@ -387,7 +387,7 @@ fn mmds_layout_nodes_have_positions_and_sizes() {
 
     let node_a = output.nodes.iter().find(|n| n.id == "A").unwrap();
     assert_eq!(node_a.label, "Start");
-    assert_eq!(node_a.shape, "rectangle");
+    assert_eq!(node_a.shape, Shape::Rectangle);
     assert!(node_a.size.width > 0.0);
     assert!(node_a.size.height > 0.0);
 }
@@ -405,15 +405,15 @@ fn mmds_layout_node_shapes() {
     let json = render_json("graph TD\nA[Rect]\nB(Round)\nC{Diamond}\nD([Stadium])");
     let output: Document = serde_json::from_str(&json).unwrap();
 
-    let shapes: std::collections::HashMap<String, String> = output
+    let shapes: std::collections::HashMap<String, Shape> = output
         .nodes
         .iter()
-        .map(|n| (n.id.clone(), n.shape.clone()))
+        .map(|n| (n.id.clone(), n.shape))
         .collect();
-    assert_eq!(shapes["A"], "rectangle");
-    assert_eq!(shapes["B"], "round");
-    assert_eq!(shapes["C"], "diamond");
-    assert_eq!(shapes["D"], "stadium");
+    assert_eq!(shapes["A"], Shape::Rectangle);
+    assert_eq!(shapes["B"], Shape::Round);
+    assert_eq!(shapes["C"], Shape::Diamond);
+    assert_eq!(shapes["D"], Shape::Stadium);
 }
 
 #[test]
@@ -968,7 +968,7 @@ fn mmds_routed_still_includes_paths() {
 fn mmds_deserializes_with_defaults() {
     let json = render_json("graph TD\nA-->B");
     let output: Document = serde_json::from_str(&json).unwrap();
-    assert_eq!(output.nodes[0].shape, "rectangle");
+    assert_eq!(output.nodes[0].shape, Shape::Rectangle);
     assert_eq!(output.edges[0].stroke, "solid");
     assert_eq!(output.edges[0].arrow_start, "none");
     assert_eq!(output.edges[0].arrow_end, "normal");

--- a/tests/mmds_views.rs
+++ b/tests/mmds_views.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use mmdflux::graph::Shape;
 use mmdflux::mmds::{
     Bounds, Defaults, Document, Edge, Metadata, Node, Position, Size, Subgraph,
     TEXT_EXTENSION_NAMESPACE,
@@ -46,11 +47,11 @@ fn output(nodes: Vec<Node>, edges: Vec<Edge>, subgraphs: Vec<Subgraph>) -> Docum
     }
 }
 
-fn node(id: &str, shape: &str, parent: Option<&str>) -> Node {
+fn node(id: &str, shape: Shape, parent: Option<&str>) -> Node {
     Node {
         id: id.to_string(),
         label: id.to_string(),
-        shape: shape.to_string(),
+        shape,
         parent: parent.map(str::to_string),
         position: Position { x: 0.0, y: 0.0 },
         size: Size {
@@ -144,11 +145,11 @@ fn view_replay_payloads() -> (Document, Document, Document) {
         vec![
             Node {
                 position: Position { x: 0.0, y: 0.0 },
-                ..node("gateway", "rectangle", None)
+                ..node("gateway", Shape::Rectangle, None)
             },
             Node {
                 position: Position { x: 20.0, y: 10.0 },
-                ..node("auth", "rectangle", None)
+                ..node("auth", Shape::Rectangle, None)
             },
         ],
         vec![edge("e0", "gateway", "auth")],
@@ -230,10 +231,10 @@ fn subgraph_ids(payload: &Document) -> BTreeSet<String> {
 fn view_selector_downstream_hops_include_anchor() {
     let payload = output(
         vec![
-            node("gateway", "rectangle", None),
-            node("auth", "rectangle", None),
-            node("db", "cylinder", None),
-            node("monitor", "rectangle", None),
+            node("gateway", Shape::Rectangle, None),
+            node("auth", Shape::Rectangle, None),
+            node("db", Shape::Cylinder, None),
+            node("monitor", Shape::Rectangle, None),
         ],
         vec![
             edge("e0", "gateway", "auth"),
@@ -258,10 +259,10 @@ fn view_selector_downstream_hops_include_anchor() {
 fn view_selector_upstream_hops_follow_incoming_edges() {
     let payload = output(
         vec![
-            node("gateway", "rectangle", None),
-            node("auth", "rectangle", None),
-            node("client", "rectangle", None),
-            node("monitor", "rectangle", None),
+            node("gateway", Shape::Rectangle, None),
+            node("auth", Shape::Rectangle, None),
+            node("client", Shape::Rectangle, None),
+            node("monitor", Shape::Rectangle, None),
         ],
         vec![
             edge("e0", "client", "gateway"),
@@ -288,10 +289,10 @@ fn view_selector_upstream_hops_follow_incoming_edges() {
 fn view_selector_neighbors_combines_directions() {
     let payload = output(
         vec![
-            node("gateway", "rectangle", None),
-            node("auth", "rectangle", None),
-            node("client", "rectangle", None),
-            node("monitor", "rectangle", None),
+            node("gateway", Shape::Rectangle, None),
+            node("auth", Shape::Rectangle, None),
+            node("client", Shape::Rectangle, None),
+            node("monitor", Shape::Rectangle, None),
         ],
         vec![
             edge("e0", "client", "gateway"),
@@ -318,10 +319,10 @@ fn view_selector_neighbors_combines_directions() {
 fn view_selector_subgraph_descendants_recurse() {
     let payload = output(
         vec![
-            node("gateway", "rectangle", Some("root")),
-            node("auth", "rectangle", Some("payments")),
-            node("charge", "rectangle", Some("payments")),
-            node("unrelated", "rectangle", None),
+            node("gateway", Shape::Rectangle, Some("root")),
+            node("auth", Shape::Rectangle, Some("payments")),
+            node("charge", Shape::Rectangle, Some("payments")),
+            node("unrelated", Shape::Rectangle, None),
         ],
         vec![],
         vec![
@@ -343,8 +344,8 @@ fn view_selector_subgraph_descendants_recurse() {
 fn view_selector_subgraph_anchor_keeps_container_without_descendants() {
     let payload = output(
         vec![
-            node("auth", "rectangle", Some("payments")),
-            node("charge", "rectangle", Some("payments")),
+            node("auth", Shape::Rectangle, Some("payments")),
+            node("charge", Shape::Rectangle, Some("payments")),
         ],
         vec![],
         vec![subgraph("payments", &["auth", "charge"], None)],
@@ -365,9 +366,9 @@ fn view_selector_subgraph_anchor_keeps_container_without_descendants() {
 fn view_selector_parent_and_shape_predicates_filter_nodes() {
     let payload = output(
         vec![
-            node("auth", "rectangle", Some("payments")),
-            node("db", "cylinder", Some("payments")),
-            node("cache", "cylinder", Some("internal")),
+            node("auth", Shape::Rectangle, Some("payments")),
+            node("db", Shape::Cylinder, Some("payments")),
+            node("cache", Shape::Cylinder, Some("internal")),
         ],
         vec![],
         vec![
@@ -379,9 +380,7 @@ fn view_selector_parent_and_shape_predicates_filter_nodes() {
         ViewStatement::Include(Selector::Predicate(NodePredicate::Parent(
             "payments".to_string(),
         ))),
-        ViewStatement::Exclude(Selector::Predicate(NodePredicate::Shape(
-            "rectangle".to_string(),
-        ))),
+        ViewStatement::Exclude(Selector::Predicate(NodePredicate::Shape(Shape::Rectangle))),
     ]);
 
     let (view_payload, _) = project(&payload, &spec).expect("view should materialize");
@@ -390,8 +389,28 @@ fn view_selector_parent_and_shape_predicates_filter_nodes() {
 }
 
 #[test]
+fn view_shape_predicate_serializes_as_graph_shape_token() {
+    let spec = view(vec![ViewStatement::Include(Selector::Predicate(
+        NodePredicate::Shape(Shape::Cylinder),
+    ))]);
+    let json = serde_json::to_value(&spec).expect("view spec should serialize");
+
+    assert_eq!(
+        json["statements"][0]["Include"]["Predicate"]["Shape"],
+        "cylinder"
+    );
+
+    let round_trip: ViewSpec = serde_json::from_value(json).expect("view spec should deserialize");
+    assert_eq!(round_trip, spec);
+}
+
+#[test]
 fn view_selector_unknown_anchor_returns_error() {
-    let payload = output(vec![node("gateway", "rectangle", None)], vec![], vec![]);
+    let payload = output(
+        vec![node("gateway", Shape::Rectangle, None)],
+        vec![],
+        vec![],
+    );
     let spec = view(vec![ViewStatement::Include(Selector::Traversal {
         anchor: AnchorRef::Node("missing".to_string()),
         direction: TraversalDirection::Downstream,
@@ -418,9 +437,9 @@ fn view_apply_keeps_node_positions_and_canonical_bounds() {
                     width: 44.0,
                     height: 22.0,
                 },
-                ..node("gateway", "rectangle", None)
+                ..node("gateway", Shape::Rectangle, None)
             },
-            node("internal", "rectangle", None),
+            node("internal", Shape::Rectangle, None),
         ],
         vec![],
         vec![],
@@ -455,10 +474,10 @@ fn view_apply_keeps_node_positions_and_canonical_bounds() {
 fn view_apply_preserves_sparse_surviving_edge_ids() {
     let payload = output(
         vec![
-            node("external", "rectangle", None),
-            node("gateway", "rectangle", None),
-            node("auth", "rectangle", None),
-            node("db", "cylinder", None),
+            node("external", Shape::Rectangle, None),
+            node("gateway", Shape::Rectangle, None),
+            node("auth", Shape::Rectangle, None),
+            node("db", Shape::Cylinder, None),
         ],
         vec![
             edge("e0", "external", "gateway"),
@@ -487,9 +506,9 @@ fn view_apply_preserves_sparse_surviving_edge_ids() {
 fn view_apply_drops_edges_with_elided_endpoints() {
     let payload = output(
         vec![
-            node("gateway", "rectangle", None),
-            node("auth", "rectangle", None),
-            node("db", "cylinder", None),
+            node("gateway", Shape::Rectangle, None),
+            node("auth", Shape::Rectangle, None),
+            node("db", Shape::Cylinder, None),
         ],
         vec![edge("e0", "gateway", "auth"), edge("e1", "auth", "db")],
         vec![],
@@ -507,9 +526,9 @@ fn view_apply_drops_edges_with_elided_endpoints() {
 fn view_apply_emits_node_and_edge_elision_events() {
     let payload = output(
         vec![
-            node("gateway", "rectangle", None),
-            node("auth", "rectangle", None),
-            node("db", "cylinder", None),
+            node("gateway", Shape::Rectangle, None),
+            node("auth", Shape::Rectangle, None),
+            node("db", Shape::Cylinder, None),
         ],
         vec![
             edge_with_label("e0", "gateway", "auth", "first"),
@@ -552,9 +571,9 @@ fn view_apply_emits_node_and_edge_elision_events() {
 fn view_apply_preserves_ancestor_subgraph_containers() {
     let payload = output(
         vec![
-            node("gateway", "rectangle", Some("root")),
-            node("auth", "rectangle", Some("payments")),
-            node("charge", "rectangle", Some("payments")),
+            node("gateway", Shape::Rectangle, Some("root")),
+            node("auth", Shape::Rectangle, Some("payments")),
+            node("charge", Shape::Rectangle, Some("payments")),
         ],
         vec![],
         vec![
@@ -590,7 +609,11 @@ fn view_apply_preserves_ancestor_subgraph_containers() {
 
 #[test]
 fn view_apply_rejects_unimplemented_layout_modes() {
-    let payload = output(vec![node("gateway", "rectangle", None)], vec![], vec![]);
+    let payload = output(
+        vec![node("gateway", Shape::Rectangle, None)],
+        vec![],
+        vec![],
+    );
     let mut spec = ViewSpec::new(vec![ViewStatement::Include(Selector::Anchor(
         AnchorRef::Node("gateway".to_string()),
     ))]);
@@ -608,7 +631,11 @@ fn view_apply_rejects_unimplemented_layout_modes() {
 
 #[test]
 fn view_apply_marks_shared_coordinates_view_payload() {
-    let payload = output(vec![node("gateway", "rectangle", None)], vec![], vec![]);
+    let payload = output(
+        vec![node("gateway", Shape::Rectangle, None)],
+        vec![],
+        vec![],
+    );
     let spec = view(vec![ViewStatement::Include(Selector::Anchor(
         AnchorRef::Node("gateway".to_string()),
     ))]);
@@ -633,8 +660,8 @@ fn view_apply_marks_shared_coordinates_view_payload() {
 fn view_apply_preserves_text_projection_under_render_namespace() {
     let mut payload = output(
         vec![
-            node("gateway", "rectangle", None),
-            node("auth", "rectangle", None),
+            node("gateway", Shape::Rectangle, None),
+            node("auth", Shape::Rectangle, None),
         ],
         vec![edge("e0", "gateway", "auth")],
         vec![],
@@ -664,10 +691,10 @@ fn view_apply_preserves_text_projection_under_render_namespace() {
 fn view_apply_prunes_node_ranks_to_retained_nodes() {
     let mut payload = output(
         vec![
-            node("gateway", "rectangle", None),
-            node("auth", "rectangle", None),
-            node("db", "cylinder", None),
-            node("internal", "rectangle", None),
+            node("gateway", Shape::Rectangle, None),
+            node("auth", Shape::Rectangle, None),
+            node("db", Shape::Cylinder, None),
+            node("internal", Shape::Rectangle, None),
         ],
         vec![edge("e0", "gateway", "auth"), edge("e1", "auth", "db")],
         vec![],
@@ -696,7 +723,11 @@ fn view_apply_prunes_node_ranks_to_retained_nodes() {
 
 #[test]
 fn view_apply_does_not_emit_legacy_text_namespace() {
-    let mut payload = output(vec![node("gateway", "rectangle", None)], vec![], vec![]);
+    let mut payload = output(
+        vec![node("gateway", Shape::Rectangle, None)],
+        vec![],
+        vec![],
+    );
     payload.extensions.insert(
         TEXT_EXTENSION_NAMESPACE.to_string(),
         text_projection_extension(),
@@ -718,9 +749,9 @@ fn view_apply_does_not_emit_legacy_text_namespace() {
 fn view_apply_drops_edge_indexed_text_projection_keys() {
     let mut payload = output(
         vec![
-            node("gateway", "rectangle", None),
-            node("auth", "rectangle", None),
-            node("db", "cylinder", None),
+            node("gateway", Shape::Rectangle, None),
+            node("auth", Shape::Rectangle, None),
+            node("db", Shape::Cylinder, None),
         ],
         vec![edge("e0", "gateway", "auth"), edge("e1", "auth", "db")],
         vec![],


### PR DESCRIPTION
## Summary

- Use `graph::Shape` for MMDS node shape fields, node shape defaults, and view shape predicates.
- Preserve existing snake_case JSON interchange for shapes while making Rust callers use the closed graph shape vocabulary.
- Update hydration, MMDS-to-Mermaid generation, command application, docs, architecture boundary policy, and tests around the typed contract.

## Root Cause

The newly shipped view/MMDS shape surfaces exposed arbitrary strings in Rust APIs even though the supported shape vocabulary already lives in `graph::Shape` and serializes to the MMDS token strings.

## Validation

- `just check`