### PR TITLE
fix: strengthen MMDS vocabulary types

### DIFF
--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -292,7 +292,7 @@ mmdflux --format mmds --geometry-level routed diagram.mmd
 | `defaults`              | object                   | Document-level defaults for omitted node/edge fields                                                                                 |
 | `geometry_level`        | `"layout"` or `"routed"` | Geometry detail level                                                                                                                |
 | `metadata.diagram_type` | string                   | `"flowchart"`, `"class"`, `"state"`, or `"sequence"`                                                                                 |
-| `metadata.direction`    | string                   | `"TD"`, `"BT"`, `"LR"`, or `"RL"`                                                                                                    |
+| `metadata.direction`    | string                   | `"TD"`, `"TB"`, `"BT"`, `"LR"`, or `"RL"`; `"TB"` deserializes as canonical `"TD"`                                                   |
 | `metadata.bounds`       | object                   | Overall diagram canvas extents (`width`, `height`) in unitless MMDS coordinate space (currently SVG-pixel-aligned in mmdflux output) |
 | `metadata.engine`       | string?                  | Engine+algorithm that produced this output (e.g., `"flux-layered"`). Omitted when not produced via the solve pipeline.               |
 | `subgraphs`             | array                    | Subgraph inventory (omitted when empty)                                                                                              |
@@ -418,7 +418,7 @@ the routed path.
 | `title`     | string            | both   | Display title                                         |
 | `children`  | string[]          | both   | Direct child node IDs                                 |
 | `parent`    | string?           | both   | Parent subgraph ID                                    |
-| `direction` | string?           | both   | Direction override: `"TD"`, `"BT"`, `"LR"`, or `"RL"` |
+| `direction` | string?           | both   | Direction override: `"TD"`, `"TB"`, `"BT"`, `"LR"`, or `"RL"`; `"TB"` deserializes as canonical `"TD"` |
 | `bounds`    | `{width, height}` | routed | Bounding box dimensions                               |
 
 ## Schema
@@ -540,7 +540,7 @@ Positions come from the proportional SVG layout engine and are in the same unitl
 | `from`       | number | Source participant index                           |
 | `to`         | number | Target participant index (same as `from` for self) |
 | `line_style` | string | `"solid"` or `"dashed"`                            |
-| `arrow_head` | string | `"filled"`, `"open"`, `"cross"`, or `"async"`      |
+| `arrow_head` | string | `"filled"`, `"none"`, `"cross"`, or `"async"`      |
 | `text`       | string | Message label text                                 |
 | `y`          | number | Vertical position of the arrow                     |
 

--- a/docs/mmds.schema.json
+++ b/docs/mmds.schema.json
@@ -191,7 +191,7 @@
           "description": "Diagram type identifier (e.g., 'flowchart', 'class')."
         },
         "direction": {
-          "enum": ["TD", "BT", "LR", "RL"],
+          "enum": ["TD", "TB", "BT", "LR", "RL"],
           "description": "Layout direction."
         },
         "bounds": {
@@ -361,7 +361,7 @@
           "description": "Parent subgraph ID, if nested."
         },
         "direction": {
-          "enum": ["TD", "BT", "LR", "RL"],
+          "enum": ["TD", "TB", "BT", "LR", "RL"],
           "description": "Subgraph direction override."
         },
         "bounds": {
@@ -535,7 +535,7 @@
         "from": { "type": "integer", "minimum": 0, "description": "Source participant index." },
         "to": { "type": "integer", "minimum": 0, "description": "Target participant index." },
         "line_style": { "enum": ["solid", "dashed"], "description": "Line style." },
-        "arrow_head": { "enum": ["filled", "open", "cross", "async"], "description": "Arrowhead shape." },
+        "arrow_head": { "enum": ["filled", "none", "cross", "async"], "description": "Arrowhead shape." },
         "text": { "type": "string", "description": "Message label text." },
         "y": { "type": "number", "description": "Vertical position of the arrow." }
       }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,7 +12,7 @@
 //! Use [`apply`] when default relayout configuration is acceptable. Use
 //! [`apply_with_config`] when layout-affecting commands should preserve caller-owned
 //! [`RenderConfig`] fields. In both cases, document-owned fields remain authoritative:
-//! the document `geometry_level` is parsed into the effective relayout config, and
+//! the document `geometry_level` replaces the effective relayout config, and
 //! `metadata.engine` overrides the caller engine when it is present.
 //!
 //! Edge commands can use [`EdgeSelector::Id`] for exact edge identity or
@@ -44,8 +44,7 @@ use crate::graph::{Arrow, Direction, GeometryLevel, Shape, Stroke};
 use crate::mmds::diff::ChangeKind;
 use crate::mmds::events::{ModelEvent, ModelEventKind};
 use crate::mmds::{
-    Document, Edge, MmdsToken, NODE_STYLE_EXTENSION_NAMESPACE, Node, Position, Size, Subgraph,
-    Subject,
+    Document, Edge, NODE_STYLE_EXTENSION_NAMESPACE, Node, Position, Size, Subgraph, Subject,
 };
 use crate::runtime::config::RenderConfig;
 
@@ -449,9 +448,9 @@ pub fn apply_with_config(
                         from_subgraph: from_subgraph.clone(),
                         to_subgraph: to_subgraph.clone(),
                         label: label.clone(),
-                        stroke: stroke.as_mmds_str().to_string(),
-                        arrow_start: arrow_start.as_mmds_str().to_string(),
-                        arrow_end: arrow_end.as_mmds_str().to_string(),
+                        stroke: *stroke,
+                        arrow_start: *arrow_start,
+                        arrow_end: *arrow_end,
                         minlen: *minlen,
                         path: None,
                         label_position: None,
@@ -541,14 +540,13 @@ pub fn apply_with_config(
                 |candidate| {
                     let edge_index = resolve_edge_index(candidate, edge)?;
                     if let Some(stroke) = stroke {
-                        candidate.edges[edge_index].stroke = stroke.as_mmds_str().to_string();
+                        candidate.edges[edge_index].stroke = *stroke;
                     }
                     if let Some(arrow_start) = arrow_start {
-                        candidate.edges[edge_index].arrow_start =
-                            arrow_start.as_mmds_str().to_string();
+                        candidate.edges[edge_index].arrow_start = *arrow_start;
                     }
                     if let Some(arrow_end) = arrow_end {
-                        candidate.edges[edge_index].arrow_end = arrow_end.as_mmds_str().to_string();
+                        candidate.edges[edge_index].arrow_end = *arrow_end;
                     }
                     if let Some(minlen) = minlen {
                         candidate.edges[edge_index].minlen = *minlen;
@@ -562,7 +560,7 @@ pub fn apply_with_config(
             config,
             ModelEventKind::GeometryLevelChanged,
             |candidate| {
-                candidate.geometry_level = level.as_mmds_str().to_string();
+                candidate.geometry_level = *level;
                 Ok(())
             },
         ),
@@ -571,7 +569,7 @@ pub fn apply_with_config(
             config,
             ModelEventKind::DirectionChanged,
             |candidate| {
-                candidate.metadata.direction = direction.as_mmds_str().to_string();
+                candidate.metadata.direction = *direction;
                 Ok(())
             },
         ),
@@ -728,9 +726,7 @@ pub fn apply_with_config(
                         title: title.clone().unwrap_or_else(|| id.clone()),
                         children: Vec::new(),
                         parent: parent.clone(),
-                        direction: direction
-                            .as_ref()
-                            .map(|direction| direction.as_mmds_str().to_string()),
+                        direction: *direction,
                         bounds: None,
                         invisible: *invisible,
                         concurrent_regions: concurrent_regions.clone(),
@@ -783,9 +779,7 @@ pub fn apply_with_config(
                 subgraph_event(ModelEventKind::SubgraphDirectionChanged, subgraph.clone()),
                 |candidate| {
                     let subgraph_index = subgraph_index(candidate, subgraph)?;
-                    candidate.subgraphs[subgraph_index].direction = direction
-                        .as_ref()
-                        .map(|direction| direction.as_mmds_str().to_string());
+                    candidate.subgraphs[subgraph_index].direction = *direction;
                     Ok(())
                 },
             )
@@ -1075,13 +1069,13 @@ fn semantic_selector_matches(edge: &Edge, selector: &EdgeSelector) -> bool {
             .is_none_or(|expected| edge.label.as_ref() == Some(expected))
         && stroke
             .as_ref()
-            .is_none_or(|expected| edge.stroke == expected.as_mmds_str())
+            .is_none_or(|expected| edge.stroke == *expected)
         && arrow_start
             .as_ref()
-            .is_none_or(|expected| edge.arrow_start == expected.as_mmds_str())
+            .is_none_or(|expected| edge.arrow_start == *expected)
         && arrow_end
             .as_ref()
-            .is_none_or(|expected| edge.arrow_end == expected.as_mmds_str())
+            .is_none_or(|expected| edge.arrow_end == *expected)
         && minlen.is_none_or(|expected| edge.minlen == expected)
 }
 
@@ -1098,12 +1092,8 @@ fn relayout_output_for_command_apply_with_config(
 ) -> Result<Document, CommandApplyError> {
     let mut diagram = crate::mmds::from_document(output)
         .map_err(|err| relayout_failed("hydrate", err.to_string()))?;
-    let geometry_level = output
-        .geometry_level
-        .parse::<GeometryLevel>()
-        .map_err(|err| relayout_failed("config", err.to_string()))?;
     let mut config = config.clone();
-    config.geometry_level = geometry_level;
+    config.geometry_level = output.geometry_level;
     if let Some(engine) = output.metadata.engine.as_deref() {
         config.layout_engine =
             Some(engine.parse().map_err(|err: crate::errors::RenderError| {

--- a/src/graph/attachment.rs
+++ b/src/graph/attachment.rs
@@ -7,11 +7,14 @@
 
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::graph::Direction;
 use crate::graph::space::{FPoint, FRect};
 
 /// Which face of a node boundary an edge port attaches to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum PortFace {
     Top,
     Bottom,

--- a/src/graph/diagram.rs
+++ b/src/graph/diagram.rs
@@ -2,23 +2,27 @@
 
 use std::collections::{HashMap, HashSet};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::edge::{Edge, Stroke};
 use super::node::Node;
 
 /// Direction of the diagram layout.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum Direction {
     /// Top to bottom (vertical, downward).
+    #[serde(rename = "TD")]
+    #[serde(alias = "TB")]
     #[default]
     TopDown,
     /// Bottom to top (vertical, upward).
+    #[serde(rename = "BT")]
     BottomTop,
     /// Left to right (horizontal, rightward).
+    #[serde(rename = "LR")]
     LeftRight,
     /// Right to left (horizontal, leftward).
+    #[serde(rename = "RL")]
     RightLeft,
 }
 

--- a/src/graph/edge.rs
+++ b/src/graph/edge.rs
@@ -1,11 +1,11 @@
 //! Edge types including stroke styles and arrow heads.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::style::EdgeStyle;
 
 /// Style of the edge line.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Stroke {
     /// Normal solid line: --
@@ -22,7 +22,7 @@ pub enum Stroke {
 }
 
 /// Type of arrow head.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Arrow {
     /// Arrow head pointing to target: >

--- a/src/graph/geometry.rs
+++ b/src/graph/geometry.rs
@@ -8,6 +8,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use serde::{Deserialize, Serialize};
+
 use crate::errors::RenderError;
 use crate::format::normalize_enum_token;
 pub use crate::graph::attachment::EdgePort;
@@ -16,7 +18,8 @@ pub use crate::graph::space::{FPoint, FRect};
 use crate::graph::{Direction, Shape};
 
 /// Requested graph-geometry detail level for downstream emitters and exports.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum GeometryLevel {
     /// Node geometry + edge topology only (no edge paths).
     #[default]
@@ -162,7 +165,8 @@ pub struct SelfEdgeGeometry {
 }
 
 /// Label side for positioned and routed edges.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum EdgeLabelSide {
     Above,
     Below,

--- a/src/internal_tests/layout_stability/mmds_metrics.rs
+++ b/src/internal_tests/layout_stability/mmds_metrics.rs
@@ -1,7 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::{geometry_metrics, mutations};
-use crate::graph::geometry::{FPoint, FRect};
+use crate::graph::Direction;
+use crate::graph::attachment::PortFace;
+use crate::graph::geometry::{EdgeLabelSide, FPoint, FRect};
 use crate::mmds;
 
 pub(crate) const COORD_EPS: f64 = 0.01;
@@ -89,15 +91,15 @@ pub(crate) struct SubgraphMembershipDelta {
     pub(crate) after_children: Vec<String>,
     pub(crate) before_parent: Option<String>,
     pub(crate) after_parent: Option<String>,
-    pub(crate) before_direction: Option<String>,
-    pub(crate) after_direction: Option<String>,
+    pub(crate) before_direction: Option<Direction>,
+    pub(crate) after_direction: Option<Direction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct LabelSideDelta {
     pub(crate) edge_id: String,
-    pub(crate) before: Option<String>,
-    pub(crate) after: Option<String>,
+    pub(crate) before: Option<EdgeLabelSide>,
+    pub(crate) after: Option<EdgeLabelSide>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -139,8 +141,8 @@ pub(crate) struct LabelRectDelta {
 pub(crate) struct PortIntentDelta {
     pub(crate) edge_id: String,
     pub(crate) endpoint: Endpoint,
-    pub(crate) before_face: Option<String>,
-    pub(crate) after_face: Option<String>,
+    pub(crate) before_face: Option<PortFace>,
+    pub(crate) after_face: Option<PortFace>,
     pub(crate) before_fraction: Option<f64>,
     pub(crate) after_fraction: Option<f64>,
     pub(crate) before_group_size: Option<usize>,
@@ -162,7 +164,7 @@ pub(crate) struct PathPortDivergence {
     pub(crate) edge_id: String,
     pub(crate) endpoint: Endpoint,
     pub(crate) path_face: DerivedEndpointFace,
-    pub(crate) port_face: Option<String>,
+    pub(crate) port_face: Option<PortFace>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -434,8 +436,8 @@ fn subgraph_membership_changes(
             .unwrap_or_default();
         let before_parent = before.and_then(|subgraph| subgraph.parent.clone());
         let after_parent = after.and_then(|subgraph| subgraph.parent.clone());
-        let before_direction = before.and_then(|subgraph| subgraph.direction.clone());
-        let after_direction = after.and_then(|subgraph| subgraph.direction.clone());
+        let before_direction = before.and_then(|subgraph| subgraph.direction);
+        let after_direction = after.and_then(|subgraph| subgraph.direction);
 
         if before_children != after_children
             || before_parent != after_parent
@@ -482,8 +484,8 @@ fn label_side_changes(before: &mmds::Document, after: &mmds::Document) -> Vec<La
         if before_edge.label_side != after_edge.label_side {
             changes.push(LabelSideDelta {
                 edge_id: id,
-                before: before_edge.label_side.clone(),
-                after: after_edge.label_side.clone(),
+                before: before_edge.label_side,
+                after: after_edge.label_side,
             });
         }
     }
@@ -674,8 +676,8 @@ fn port_intent_deltas(
         Some(PortIntentDelta {
             edge_id: edge_id.to_string(),
             endpoint,
-            before_face: before.map(|port| port.face.clone()),
-            after_face: after.map(|port| port.face.clone()),
+            before_face: before.map(|port| port.face),
+            after_face: after.map(|port| port.face),
             before_fraction: before.map(|port| port.fraction),
             after_fraction: after.map(|port| port.fraction),
             before_group_size: before.map(|port| port.group_size),
@@ -741,18 +743,18 @@ fn path_port_divergence(
         (
             Endpoint::Source,
             endpoint_face(edge, nodes, Endpoint::Source),
-            edge.source_port.as_ref().map(|port| port.face.clone()),
+            edge.source_port.as_ref().map(|port| port.face),
         ),
         (
             Endpoint::Target,
             endpoint_face(edge, nodes, Endpoint::Target),
-            edge.target_port.as_ref().map(|port| port.face.clone()),
+            edge.target_port.as_ref().map(|port| port.face),
         ),
     ]
     .into_iter()
     .filter_map(|(endpoint, path_face, port_face)| {
         let diverged = match (&path_face, &port_face) {
-            (DerivedEndpointFace::Face(path), Some(port)) => path != port,
+            (DerivedEndpointFace::Face(path), Some(port)) => path != port.as_str(),
             (DerivedEndpointFace::Ambiguous, Some(_)) => true,
             _ => false,
         };

--- a/src/internal_tests/layout_stability/mod.rs
+++ b/src/internal_tests/layout_stability/mod.rs
@@ -16,6 +16,7 @@ use crate::engines::graph::algorithms::layered::kernel::trace::{
     DummyTraceKey, DummyTraceRole, LayeredPhaseTrace, TraceDummySnapshot, TraceNodeSnapshot,
     TraceStage, TraceStageSnapshot,
 };
+use crate::graph::GeometryLevel;
 
 #[test]
 fn input_magnitude_keeps_incompatible_axes_separate() {
@@ -1458,10 +1459,22 @@ fn render_surfaces_include_text_svg_layout_and_routed_mmds() {
     assert!(!rendered.after.text.is_empty());
     assert!(rendered.before.svg.contains("<svg"));
     assert!(rendered.after.svg.contains("<svg"));
-    assert_eq!(rendered.before.layout_mmds.geometry_level, "layout");
-    assert_eq!(rendered.before.routed_mmds.geometry_level, "routed");
-    assert_eq!(rendered.after.layout_mmds.geometry_level, "layout");
-    assert_eq!(rendered.after.routed_mmds.geometry_level, "routed");
+    assert_eq!(
+        rendered.before.layout_mmds.geometry_level,
+        GeometryLevel::Layout
+    );
+    assert_eq!(
+        rendered.before.routed_mmds.geometry_level,
+        GeometryLevel::Routed
+    );
+    assert_eq!(
+        rendered.after.layout_mmds.geometry_level,
+        GeometryLevel::Layout
+    );
+    assert_eq!(
+        rendered.after.routed_mmds.geometry_level,
+        GeometryLevel::Routed
+    );
 }
 
 #[test]
@@ -1471,8 +1484,11 @@ fn render_surfaces_allow_lossless_routed_mmds_for_style_canaries() {
     let (_, lossless) =
         render_surfaces::render_lossless_routed_mmds(&rendered.after.source).unwrap();
 
-    assert_eq!(rendered.after.routed_mmds.geometry_level, "routed");
-    assert_eq!(lossless.geometry_level, "routed");
+    assert_eq!(
+        rendered.after.routed_mmds.geometry_level,
+        GeometryLevel::Routed
+    );
+    assert_eq!(lossless.geometry_level, GeometryLevel::Routed);
 }
 
 #[test]

--- a/src/internal_tests/layout_stability/route_diagnostics.rs
+++ b/src/internal_tests/layout_stability/route_diagnostics.rs
@@ -491,11 +491,11 @@ fn route_decision_input_from_metrics(
                 endpoint: delta.endpoint,
                 before_face: delta
                     .before_face
-                    .clone()
+                    .map(|face| face.as_str().to_string())
                     .unwrap_or_else(|| "none".to_string()),
                 after_face: delta
                     .after_face
-                    .clone()
+                    .map(|face| face.as_str().to_string())
                     .unwrap_or_else(|| "none".to_string()),
             });
     }

--- a/src/internal_tests/mmds_commands.rs
+++ b/src/internal_tests/mmds_commands.rs
@@ -380,7 +380,7 @@ fn mmds_command_apply_relayout_sets_geometry_level() {
     )
     .expect("set geometry level should apply");
 
-    assert_eq!(output.geometry_level, "layout");
+    assert_eq!(output.geometry_level, GeometryLevel::Layout);
     assert_primary_event(&events, ModelEventKind::GeometryLevelChanged, "");
     assert!(
         crate::mmds::diff::diff_documents(&before, &output)
@@ -401,7 +401,7 @@ fn mmds_command_apply_relayout_sets_direction() {
     )
     .expect("set direction should apply");
 
-    assert_eq!(output.metadata.direction, "LR");
+    assert_eq!(output.metadata.direction, Direction::LeftRight);
     assert_primary_event(&events, ModelEventKind::DirectionChanged, "");
     assert!(
         crate::mmds::diff::diff_documents(&before, &output)
@@ -433,7 +433,7 @@ fn mmds_command_apply_relayout_sets_engine() {
 #[test]
 fn mmds_command_apply_relayout_invalid_document_config_rolls_back() {
     let mut output = parse_routed_for_command_apply("graph TD\n    A --> B\n");
-    output.metadata.direction = "SIDEWAYS".to_string();
+    output.metadata.engine = Some("not-a-real-engine".to_string());
     let before = output.clone();
 
     let result = apply(
@@ -758,9 +758,9 @@ fn mmds_command_apply_relayout_changes_edge_style() {
     .expect("change edge style should apply");
 
     let edge = edge_by_id(&output, "e0");
-    assert_eq!(edge.stroke, "dotted");
-    assert_eq!(edge.arrow_start, "circle");
-    assert_eq!(edge.arrow_end, "diamond");
+    assert_eq!(edge.stroke, Stroke::Dotted);
+    assert_eq!(edge.arrow_start, Arrow::Circle);
+    assert_eq!(edge.arrow_end, Arrow::Diamond);
     assert_eq!(edge.minlen, 2);
     assert_primary_event(&events, ModelEventKind::EdgeStyleChanged, "e0");
     assert!(
@@ -805,9 +805,9 @@ fn mmds_command_apply_relayout_reconnect_preserves_edge_fields() {
             .iter_mut()
             .find(|edge| edge.id == "e0")
             .expect("edge e0 should exist");
-        edge.stroke = "dashed".to_string();
-        edge.arrow_start = "circle".to_string();
-        edge.arrow_end = "diamond".to_string();
+        edge.stroke = Stroke::Dashed;
+        edge.arrow_start = Arrow::Circle;
+        edge.arrow_end = Arrow::Diamond;
         edge.minlen = 2;
     }
 
@@ -825,9 +825,9 @@ fn mmds_command_apply_relayout_reconnect_preserves_edge_fields() {
     assert_eq!(edge.source, "A");
     assert_eq!(edge.target, "C");
     assert_eq!(edge.label.as_deref(), Some("calls"));
-    assert_eq!(edge.stroke, "dashed");
-    assert_eq!(edge.arrow_start, "circle");
-    assert_eq!(edge.arrow_end, "diamond");
+    assert_eq!(edge.stroke, Stroke::Dashed);
+    assert_eq!(edge.arrow_start, Arrow::Circle);
+    assert_eq!(edge.arrow_end, Arrow::Diamond);
     assert_eq!(edge.minlen, 2);
 }
 
@@ -898,8 +898,8 @@ fn mmds_command_apply_relayout_sets_subgraph_direction() {
     .expect("set subgraph direction should apply");
 
     assert_eq!(
-        subgraph_by_id(&output, "sg1").direction.as_deref(),
-        Some("LR")
+        subgraph_by_id(&output, "sg1").direction,
+        Some(Direction::LeftRight)
     );
     assert_primary_event(&events, ModelEventKind::SubgraphDirectionChanged, "sg1");
     assert!(
@@ -1169,14 +1169,14 @@ fn mmds_command_apply_failure_modes_are_structured() {
         },
         |error| matches!(error, CommandApplyError::SubjectAlreadyExists { id } if id == "A"),
     );
-    output.metadata.direction = "SIDEWAYS".to_string();
+    output.metadata.engine = Some("not-a-real-engine".to_string());
     assert_apply_error_preserves_output(
         &mut output,
         Command::ChangeNodeLabel {
             node: "A".to_string(),
             label: "Alpha".to_string(),
         },
-        |error| matches!(error, CommandApplyError::RelayoutFailed { stage, .. } if stage == "hydrate"),
+        |error| matches!(error, CommandApplyError::RelayoutFailed { stage, .. } if stage == "config"),
     );
 }
 

--- a/src/internal_tests/mmds_diff.rs
+++ b/src/internal_tests/mmds_diff.rs
@@ -15,8 +15,8 @@ fn mmds_diff_model_identical_outputs_have_no_events() {
     let diff = crate::mmds::diff::diff_documents(&before, &after);
 
     assert!(diff.changes.is_empty(), "{diff:#?}");
-    assert_eq!(diff.before_geometry_level, "routed");
-    assert_eq!(diff.after_geometry_level, "routed");
+    assert_eq!(diff.before_geometry_level, GeometryLevel::Routed);
+    assert_eq!(diff.after_geometry_level, GeometryLevel::Routed);
 
     assert!(!diff.has_change(crate::mmds::diff::ChangeKind::GeometryLevelChanged, ""));
 }

--- a/src/internal_tests/mmds_document_serialization.rs
+++ b/src/internal_tests/mmds_document_serialization.rs
@@ -6,10 +6,11 @@
 use crate::engines::graph::EngineConfig;
 use crate::engines::graph::algorithms::layered::run_layered_layout;
 use crate::engines::graph::contracts::MeasurementMode;
+use crate::graph::attachment::PortFace;
 use crate::graph::geometry::{GraphGeometry, RoutedGraphGeometry};
 use crate::graph::measure::default_proportional_text_metrics;
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
-use crate::graph::{GeometryLevel, Graph, Shape};
+use crate::graph::{Arrow, Direction, GeometryLevel, Graph, Shape, Stroke};
 use crate::mmds::document::{Document, to_json, to_layout, to_routed};
 use crate::simplification::PathSimplification;
 
@@ -40,7 +41,7 @@ fn layout_json_has_version_and_level() {
     let json = to_layout(&diagram, &geom);
     let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.version, 1);
-    assert_eq!(output.geometry_level, "layout");
+    assert_eq!(output.geometry_level, GeometryLevel::Layout);
 }
 
 #[test]
@@ -49,12 +50,12 @@ fn layout_json_has_metadata() {
     let json = to_layout(&diagram, &geom);
     let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.defaults.node.shape, Shape::Rectangle);
-    assert_eq!(output.defaults.edge.stroke, "solid");
-    assert_eq!(output.defaults.edge.arrow_start, "none");
-    assert_eq!(output.defaults.edge.arrow_end, "normal");
+    assert_eq!(output.defaults.edge.stroke, Stroke::Solid);
+    assert_eq!(output.defaults.edge.arrow_start, Arrow::None);
+    assert_eq!(output.defaults.edge.arrow_end, Arrow::Normal);
     assert_eq!(output.defaults.edge.minlen, 1);
     assert_eq!(output.metadata.diagram_type, "flowchart");
-    assert_eq!(output.metadata.direction, "TD");
+    assert_eq!(output.metadata.direction, Direction::TopDown);
     assert!(output.metadata.bounds.width > 0.0);
     assert!(output.metadata.bounds.height > 0.0);
 }
@@ -98,9 +99,9 @@ fn layout_json_edge_semantics() {
 
     let edge = &output.edges[0];
     assert_eq!(edge.id, "e0");
-    assert_eq!(edge.stroke, "dotted");
+    assert_eq!(edge.stroke, Stroke::Dotted);
     assert_eq!(edge.label, Some("label".to_string()));
-    assert_eq!(edge.arrow_end, "normal");
+    assert_eq!(edge.arrow_end, Arrow::Normal);
     assert_eq!(edge.minlen, 1);
 }
 
@@ -191,9 +192,9 @@ fn layout_deserializes_with_defaults() {
     .unwrap();
     let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.nodes[0].shape, Shape::Rectangle);
-    assert_eq!(output.edges[0].stroke, "solid");
-    assert_eq!(output.edges[0].arrow_start, "none");
-    assert_eq!(output.edges[0].arrow_end, "normal");
+    assert_eq!(output.edges[0].stroke, Stroke::Solid);
+    assert_eq!(output.edges[0].arrow_start, Arrow::None);
+    assert_eq!(output.edges[0].arrow_end, Arrow::Normal);
     assert_eq!(output.edges[0].minlen, 1);
     assert!(output.subgraphs.is_empty());
 }
@@ -217,7 +218,7 @@ fn layout_json_subgraph_direction_override() {
         layout_geometry("graph TD\nsubgraph sg1[Group]\ndirection LR\nA-->B\nend");
     let json = to_layout(&diagram, &geom);
     let output: Document = serde_json::from_str(&json).unwrap();
-    assert_eq!(output.subgraphs[0].direction.as_deref(), Some("LR"));
+    assert_eq!(output.subgraphs[0].direction, Some(Direction::LeftRight));
 }
 
 #[test]
@@ -232,7 +233,12 @@ fn layout_json_nodes_sorted_by_id() {
 
 #[test]
 fn layout_json_direction_variants() {
-    for (dir_str, expected) in [("TD", "TD"), ("LR", "LR"), ("BT", "BT"), ("RL", "RL")] {
+    for (dir_str, expected) in [
+        ("TD", Direction::TopDown),
+        ("LR", Direction::LeftRight),
+        ("BT", Direction::BottomTop),
+        ("RL", Direction::RightLeft),
+    ] {
         let input = format!("graph {dir_str}\nA-->B");
         let (diagram, geom) = layout_geometry(&input);
         let json = to_layout(&diagram, &geom);
@@ -248,7 +254,7 @@ fn routed_json_has_version_and_level() {
     let json = to_routed(&diagram, &geom, &routed);
     let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.version, 1);
-    assert_eq!(output.geometry_level, "routed");
+    assert_eq!(output.geometry_level, GeometryLevel::Routed);
 }
 
 #[test]
@@ -331,8 +337,8 @@ fn routed_json_includes_port_metadata() {
     assert!(edge.target_port.is_some());
     let sp = edge.source_port.as_ref().unwrap();
     let tp = edge.target_port.as_ref().unwrap();
-    assert_eq!(sp.face, "bottom");
-    assert_eq!(tp.face, "top");
+    assert_eq!(sp.face, PortFace::Bottom);
+    assert_eq!(tp.face, PortFace::Top);
     assert_eq!(sp.group_size, 1);
     assert_eq!(tp.group_size, 1);
 }

--- a/src/internal_tests/port_attachment_observation.rs
+++ b/src/internal_tests/port_attachment_observation.rs
@@ -544,7 +544,7 @@ fn assert_endpoint_available(
 
 fn port_observation(port: &Port) -> EndpointObservation {
     EndpointObservation {
-        face: Some(port.face.clone()),
+        face: Some(port.face.as_str().to_string()),
         fraction: Some(port.fraction),
         position: Some((port.position.x, port.position.y)),
     }

--- a/src/mmds/diff.rs
+++ b/src/mmds/diff.rs
@@ -32,6 +32,8 @@ use serde_json::Value;
 
 use super::document::NODE_STYLE_EXTENSION_NAMESPACE;
 use super::{Bounds, Document, Edge, Node, Port, Position, Rect, Subgraph, Subject};
+use crate::graph::GeometryLevel;
+use crate::mmds::MmdsToken;
 
 const COORD_EPS: f64 = 0.01;
 const DISPLAY_EPS: f64 = 1.0;
@@ -40,9 +42,9 @@ const DISPLAY_EPS: f64 = 1.0;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Diff {
     /// Geometry level recorded on the `before` document.
-    pub before_geometry_level: String,
+    pub before_geometry_level: GeometryLevel,
     /// Geometry level recorded on the `after` document.
-    pub after_geometry_level: String,
+    pub after_geometry_level: GeometryLevel,
     /// Flat change list describing differences between the two documents.
     pub changes: Vec<Change>,
 }
@@ -199,8 +201,8 @@ pub fn diff_documents(before: &Document, after: &Document) -> Diff {
     link_related_geometry(&mut changes);
 
     Diff {
-        before_geometry_level: before.geometry_level.clone(),
-        after_geometry_level: after.geometry_level.clone(),
+        before_geometry_level: before.geometry_level,
+        after_geometry_level: after.geometry_level,
         changes,
     }
 }
@@ -601,7 +603,10 @@ fn edge_label_key(edge: &Edge) -> String {
 fn edge_style_key(edge: &Edge) -> String {
     format!(
         "{}|{}|{}|{}",
-        edge.stroke, edge.arrow_start, edge.arrow_end, edge.minlen
+        edge.stroke.as_mmds_str(),
+        edge.arrow_start.as_mmds_str(),
+        edge.arrow_end.as_mmds_str(),
+        edge.minlen
     )
 }
 
@@ -1249,8 +1254,15 @@ fn same_port_intent(before: Option<&Port>, after: Option<&Port>) -> bool {
 }
 
 fn port_summary(port: Option<&Port>) -> String {
-    port.map(|port| format!("{}@{:.3}/{}", port.face, port.fraction, port.group_size))
-        .unwrap_or_else(|| "none".to_string())
+    port.map(|port| {
+        format!(
+            "{}@{:.3}/{}",
+            port.face.as_str(),
+            port.fraction,
+            port.group_size
+        )
+    })
+    .unwrap_or_else(|| "none".to_string())
 }
 
 fn path_port_diverged(path_face: &str, port_face: Option<&str>) -> bool {

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Number, Value};
 
 use crate::errors::RenderError;
-use crate::graph::attachment::EdgePort;
+use crate::graph::attachment::{EdgePort, PortFace};
 use crate::graph::geometry::{
     EdgeLabelSide, GraphGeometry, PositionedNode, RoutedEdgeGeometry, RoutedGraphGeometry,
 };
@@ -18,8 +18,7 @@ use crate::graph::measure::default_proportional_text_metrics;
 use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
 use crate::graph::style::NodeStyle;
-use crate::graph::{GeometryLevel, Graph, Shape};
-use crate::mmds::MmdsToken;
+use crate::graph::{Arrow, Direction, GeometryLevel, Graph, Shape, Stroke};
 use crate::simplification::PathSimplification;
 
 pub const CORE_PROFILE: &str = "mmds-core-v1";
@@ -247,7 +246,7 @@ fn serialize_document(document: &Document) -> String {
 
 fn edge_port_to_mmds(port: &EdgePort) -> Port {
     Port {
-        face: port.face.as_str().to_string(),
+        face: port.face,
         fraction: port.fraction,
         position: Position {
             x: port.position.x,
@@ -257,28 +256,15 @@ fn edge_port_to_mmds(port: &EdgePort) -> Port {
     }
 }
 
-/// Map an `EdgeLabelSide` enum variant to its MMDS JSON string.
-fn edge_label_side_to_mmds_string(side: EdgeLabelSide) -> String {
-    match side {
-        EdgeLabelSide::Above => "above".into(),
-        EdgeLabelSide::Below => "below".into(),
-        EdgeLabelSide::Center => "center".into(),
-    }
-}
-
 /// Resolve `label_side` for an MMDS edge using the fallback chain:
 ///   `label_geometry.side` → `layout_edge.label_side`
 ///
 /// Returns `None` when no side has been assigned at either layer.
 fn mmds_edge_label_side(
     layout_edge: Option<&crate::graph::geometry::LayoutEdge>,
-) -> Option<String> {
+) -> Option<EdgeLabelSide> {
     let le = layout_edge?;
-    le.label_geometry
-        .as_ref()
-        .map(|g| g.side)
-        .or(le.label_side)
-        .map(edge_label_side_to_mmds_string)
+    le.label_geometry.as_ref().map(|g| g.side).or(le.label_side)
 }
 
 /// Resolve `label_rect` for an MMDS edge (routed level only).
@@ -305,7 +291,11 @@ fn build_document(
     path_simplification: PathSimplification,
     engine_id: Option<&str>,
 ) -> Document {
-    let level = if routed.is_some() { "routed" } else { "layout" };
+    let level = if routed.is_some() {
+        GeometryLevel::Routed
+    } else {
+        GeometryLevel::Layout
+    };
     let styled_nodes = collect_styled_nodes(diagram);
 
     // At routed level, use the recomputed routed bounds (which cover all
@@ -313,7 +303,7 @@ fn build_document(
     let effective_bounds = routed.map_or(geometry.bounds, |r| r.bounds);
     let metadata = Metadata {
         diagram_type: diagram_type.to_string(),
-        direction: diagram.direction.as_mmds_str().to_string(),
+        direction: diagram.direction,
         bounds: Bounds {
             width: effective_bounds.width,
             height: effective_bounds.height,
@@ -342,9 +332,9 @@ fn build_document(
                 from_subgraph: edge.from_subgraph.clone(),
                 to_subgraph: edge.to_subgraph.clone(),
                 label: edge.label.clone(),
-                stroke: edge.stroke.as_mmds_str().to_string(),
-                arrow_start: edge.arrow_start.as_mmds_str().to_string(),
-                arrow_end: edge.arrow_end.as_mmds_str().to_string(),
+                stroke: edge.stroke,
+                arrow_start: edge.arrow_start,
+                arrow_end: edge.arrow_end,
                 minlen: edge.minlen,
                 path: None,
                 label_position: None,
@@ -413,7 +403,7 @@ fn build_document(
                 title: sg.title.clone(),
                 children: direct_children,
                 parent: sg.parent.clone(),
-                direction: sg.dir.map(|d| d.as_mmds_str().to_string()),
+                direction: sg.dir,
                 bounds,
                 invisible: sg.invisible,
                 concurrent_regions: sg.concurrent_regions.clone(),
@@ -446,7 +436,7 @@ fn build_document(
         profiles,
         extensions,
         defaults: Defaults::default(),
-        geometry_level: level.to_string(),
+        geometry_level: level,
         metadata,
         nodes,
         edges,
@@ -680,8 +670,8 @@ pub struct Document {
     pub extensions: BTreeMap<String, Map<String, Value>>,
     /// Document-level default values for omitted node/edge fields.
     pub defaults: Defaults,
-    /// Geometry level: "layout" or "routed".
-    pub geometry_level: String,
+    /// Geometry level: `layout` or `routed`.
+    pub geometry_level: GeometryLevel,
     /// Diagram metadata.
     pub metadata: Metadata,
     /// Node inventory with positions.
@@ -727,11 +717,11 @@ impl Default for NodeDefaults {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EdgeDefaults {
     #[serde(default = "default_stroke")]
-    pub stroke: String,
+    pub stroke: Stroke,
     #[serde(default = "default_arrow_start")]
-    pub arrow_start: String,
+    pub arrow_start: Arrow,
     #[serde(default = "default_arrow_end")]
-    pub arrow_end: String,
+    pub arrow_end: Arrow,
     #[serde(default = "default_minlen")]
     pub minlen: i32,
 }
@@ -752,8 +742,8 @@ impl Default for EdgeDefaults {
 pub struct Metadata {
     /// Diagram type (e.g., "flowchart", "class").
     pub diagram_type: String,
-    /// Layout direction: "TD", "BT", "LR", or "RL".
-    pub direction: String,
+    /// Layout direction: `TD`, `BT`, `LR`, or `RL`.
+    pub direction: Direction,
     /// Overall diagram bounds in MMDS layout space.
     pub bounds: Bounds,
     /// Engine+algorithm identifier that produced this output (e.g., "flux-layered").
@@ -822,8 +812,8 @@ pub struct Size {
 /// Port attachment metadata for an edge endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Port {
-    /// Which face of the node the edge attaches to ("top", "bottom", "left", "right").
-    pub face: String,
+    /// Which face of the node the edge attaches to.
+    pub face: PortFace,
     /// Position within the face (0.0 = start, 1.0 = end).
     pub fraction: f64,
     /// Absolute position of the attachment point.
@@ -855,19 +845,19 @@ pub struct Edge {
     pub label: Option<String>,
     /// Stroke style.
     #[serde(default = "default_stroke", skip_serializing_if = "is_default_stroke")]
-    pub stroke: String,
+    pub stroke: Stroke,
     /// Arrow at source end.
     #[serde(
         default = "default_arrow_start",
         skip_serializing_if = "is_default_arrow_start"
     )]
-    pub arrow_start: String,
+    pub arrow_start: Arrow,
     /// Arrow at target end.
     #[serde(
         default = "default_arrow_end",
         skip_serializing_if = "is_default_arrow_end"
     )]
-    pub arrow_end: String,
+    pub arrow_end: Arrow,
     /// Minimum rank separation.
     #[serde(default = "default_minlen", skip_serializing_if = "is_default_minlen")]
     pub minlen: i32,
@@ -898,7 +888,7 @@ pub struct Edge {
     /// Populated from `EdgeLabelGeometry` when label-side assignment runs.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub label_side: Option<String>,
+    pub label_side: Option<EdgeLabelSide>,
     /// Padded label rectangle in MMDS coordinate space (routed level only).
     ///
     /// Includes `label_padding_x` / `label_padding_y` padding on each side.
@@ -923,10 +913,10 @@ pub struct Subgraph {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub parent: Option<String>,
-    /// Subgraph direction override ("TD", "BT", "LR", "RL"), if any.
+    /// Subgraph direction override, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub direction: Option<String>,
+    pub direction: Option<Direction>,
     /// Subgraph bounding box (routed level only).
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -943,16 +933,16 @@ fn default_node_shape() -> Shape {
     Shape::Rectangle
 }
 
-fn default_stroke() -> String {
-    "solid".to_string()
+fn default_stroke() -> Stroke {
+    Stroke::Solid
 }
 
-fn default_arrow_start() -> String {
-    "none".to_string()
+fn default_arrow_start() -> Arrow {
+    Arrow::None
 }
 
-fn default_arrow_end() -> String {
-    "normal".to_string()
+fn default_arrow_end() -> Arrow {
+    Arrow::Normal
 }
 
 fn default_minlen() -> i32 {
@@ -963,16 +953,16 @@ fn is_default_node_shape(value: &Shape) -> bool {
     *value == Shape::Rectangle
 }
 
-fn is_default_stroke(value: &String) -> bool {
-    value == "solid"
+fn is_default_stroke(value: &Stroke) -> bool {
+    *value == Stroke::Solid
 }
 
-fn is_default_arrow_start(value: &String) -> bool {
-    value == "none"
+fn is_default_arrow_start(value: &Arrow) -> bool {
+    *value == Arrow::None
 }
 
-fn is_default_arrow_end(value: &String) -> bool {
-    value == "normal"
+fn is_default_arrow_end(value: &Arrow) -> bool {
+    *value == Arrow::Normal
 }
 
 fn is_default_minlen(value: &i32) -> bool {
@@ -986,7 +976,7 @@ mod tests {
     #[test]
     fn mmds_port_serializes_correctly() {
         let port = Port {
-            face: "bottom".to_string(),
+            face: PortFace::Bottom,
             fraction: 0.5,
             position: Position { x: 50.0, y: 35.0 },
             group_size: 1,
@@ -1006,9 +996,9 @@ mod tests {
             from_subgraph: None,
             to_subgraph: None,
             label: None,
-            stroke: "solid".into(),
-            arrow_start: "none".into(),
-            arrow_end: "normal".into(),
+            stroke: Stroke::Solid,
+            arrow_start: Arrow::None,
+            arrow_end: Arrow::Normal,
             minlen: 1,
             path: None,
             label_position: None,
@@ -1026,7 +1016,7 @@ mod tests {
     #[test]
     fn mmds_edge_source_port_round_trips() {
         let port = Port {
-            face: "right".to_string(),
+            face: PortFace::Right,
             fraction: 0.3,
             position: Position { x: 100.0, y: 30.0 },
             group_size: 2,
@@ -1038,9 +1028,9 @@ mod tests {
             from_subgraph: None,
             to_subgraph: None,
             label: None,
-            stroke: "solid".into(),
-            arrow_start: "none".into(),
-            arrow_end: "normal".into(),
+            stroke: Stroke::Solid,
+            arrow_start: Arrow::None,
+            arrow_end: Arrow::Normal,
             minlen: 1,
             path: None,
             label_position: None,
@@ -1053,7 +1043,7 @@ mod tests {
         let json = serde_json::to_string(&edge).unwrap();
         let deserialized: Edge = serde_json::from_str(&json).unwrap();
         let sp = deserialized.source_port.unwrap();
-        assert_eq!(sp.face, "right");
+        assert_eq!(sp.face, PortFace::Right);
         assert!((sp.fraction - 0.3).abs() < 1e-9);
         assert!((sp.position.x - 100.0).abs() < 1e-9);
         assert_eq!(sp.group_size, 2);

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -7,6 +7,8 @@ use std::fmt;
 
 use serde_json::{Map, Value};
 
+#[cfg(test)]
+use crate::graph::Direction;
 use crate::graph::direction_policy::build_node_directions;
 use crate::graph::geometry::{
     EdgeLabelGeometry, EdgeLabelSide, GraphGeometry, LayoutEdge, PositionedNode,
@@ -17,10 +19,9 @@ use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
 use crate::graph::space::{FPoint, FRect};
 use crate::graph::style::{ColorToken, NodeStyle};
-use crate::graph::{Arrow, Direction, Edge as GraphEdge, Graph, Node, Stroke, Subgraph};
+use crate::graph::{Edge as GraphEdge, GeometryLevel, Graph, Node, Subgraph};
 use crate::mmds::{
-    Document, Edge, MmdsToken, NODE_STYLE_EXTENSION_NAMESPACE, TEXT_EXTENSION_NAMESPACE,
-    parse_input,
+    Document, Edge, NODE_STYLE_EXTENSION_NAMESPACE, TEXT_EXTENSION_NAMESPACE, parse_input,
 };
 
 /// Hydrate a graph `Diagram` from MMDS JSON text.
@@ -35,28 +36,13 @@ pub fn from_str(input: &str) -> Result<Graph, HydrationError> {
 pub fn from_document(output: &Document) -> Result<Graph, HydrationError> {
     validate_output(output)?;
 
-    let direction = Direction::parse_mmds(&output.metadata.direction).map_err(|_| {
-        HydrationError::InvalidDirection {
-            context: "metadata.direction".to_string(),
-            value: output.metadata.direction.clone(),
-        }
-    })?;
+    let direction = output.metadata.direction;
     let mut diagram = Graph::new(direction);
 
     for (index, subgraph) in output.subgraphs.iter().enumerate() {
         if subgraph.id.trim().is_empty() {
             return Err(HydrationError::MissingSubgraphId { index });
         }
-        let dir = if let Some(direction) = &subgraph.direction {
-            Some(Direction::parse_mmds(direction).map_err(|_| {
-                HydrationError::InvalidDirection {
-                    context: format!("subgraph {} direction", subgraph.id),
-                    value: direction.to_string(),
-                }
-            })?)
-        } else {
-            None
-        };
         diagram.subgraphs.insert(
             subgraph.id.clone(),
             Subgraph {
@@ -64,7 +50,7 @@ pub fn from_document(output: &Document) -> Result<Graph, HydrationError> {
                 title: subgraph.title.clone(),
                 nodes: subgraph.children.clone(),
                 parent: subgraph.parent.clone(),
-                dir,
+                dir: subgraph.direction,
                 invisible: subgraph.invisible,
                 concurrent_regions: subgraph.concurrent_regions.clone(),
             },
@@ -181,27 +167,9 @@ pub fn from_document(output: &Document) -> Result<Graph, HydrationError> {
             });
         }
 
-        let stroke =
-            Stroke::parse_mmds(&edge.stroke).map_err(|_| HydrationError::InvalidStroke {
-                edge_id: edge.id.clone(),
-                value: edge.stroke.clone(),
-            })?;
-        let arrow_start =
-            Arrow::parse_mmds(&edge.arrow_start).map_err(|_| HydrationError::InvalidArrow {
-                edge_id: edge.id.clone(),
-                endpoint: "start".to_string(),
-                value: edge.arrow_start.clone(),
-            })?;
-        let arrow_end =
-            Arrow::parse_mmds(&edge.arrow_end).map_err(|_| HydrationError::InvalidArrow {
-                edge_id: edge.id.clone(),
-                endpoint: "end".to_string(),
-                value: edge.arrow_end.clone(),
-            })?;
-
         let mut hydrated = GraphEdge::new(edge.source.clone(), edge.target.clone())
-            .with_stroke(stroke)
-            .with_arrows(arrow_start, arrow_end)
+            .with_stroke(edge.stroke)
+            .with_arrows(edge.arrow_start, edge.arrow_end)
             .with_minlen(edge.minlen);
         if let Some(label) = &edge.label {
             hydrated = hydrated.with_label(label.clone());
@@ -360,7 +328,7 @@ pub fn hydrate_routed_geometry_from_document(
     output: &Document,
 ) -> Result<RoutedGraphGeometry, HydrationError> {
     let (diagram, geometry) = hydrate_geometry_parts(output)?;
-    let edge_routing = if output.geometry_level == "routed" {
+    let edge_routing = if output.geometry_level == GeometryLevel::Routed {
         EdgeRouting::EngineProvided
     } else {
         EdgeRouting::PolylineRoute
@@ -376,7 +344,7 @@ pub fn hydrate_routed_geometry_from_document(
     // `label_position` inside `populate_label_geometry`, which would silently
     // lose the authoritative `label_rect` whenever `label_position` and
     // `label_rect` disagree.
-    if output.geometry_level == "routed" {
+    if output.geometry_level == GeometryLevel::Routed {
         overlay_authoritative_label_geometry(&mut routed, output, &metrics);
     }
 
@@ -412,7 +380,8 @@ fn overlay_authoritative_label_geometry(
         else {
             continue;
         };
-        let side = parse_mmds_label_side(mmds_edge.label_side.as_deref())
+        let side = mmds_edge
+            .label_side
             .or(routed_edge.label_side)
             .unwrap_or(EdgeLabelSide::Center);
         let rect = FRect::new(mmds_rect.x, mmds_rect.y, mmds_rect.width, mmds_rect.height);
@@ -435,15 +404,6 @@ fn overlay_authoritative_label_geometry(
             track: 0,
             compartment_size: 2,
         });
-    }
-}
-
-fn parse_mmds_label_side(value: Option<&str>) -> Option<EdgeLabelSide> {
-    match value? {
-        "above" => Some(EdgeLabelSide::Above),
-        "below" => Some(EdgeLabelSide::Below),
-        "center" => Some(EdgeLabelSide::Center),
-        _ => None,
     }
 }
 
@@ -635,7 +595,7 @@ fn build_positioned_nodes(
 }
 
 fn build_layout_edges(output: &Document) -> (Vec<LayoutEdge>, Vec<SelfEdgeGeometry>, Vec<usize>) {
-    let routed_level = output.geometry_level == "routed";
+    let routed_level = output.geometry_level == GeometryLevel::Routed;
     let edges = sorted_output_edges(output);
 
     let mut layout_edges = Vec::with_capacity(edges.len());
@@ -667,7 +627,7 @@ fn build_layout_edges(output: &Document) -> (Vec<LayoutEdge>, Vec<SelfEdgeGeomet
         } else {
             None
         };
-        let label_side = parse_mmds_label_side(edge.label_side.as_deref());
+        let label_side = edge.label_side;
 
         layout_edges.push(LayoutEdge {
             index,
@@ -790,12 +750,6 @@ fn validate_output(output: &Document) -> Result<(), HydrationError> {
     if output.version != 1 {
         return Err(HydrationError::UnsupportedVersion {
             version: output.version,
-        });
-    }
-
-    if !matches!(output.geometry_level.as_str(), "layout" | "routed") {
-        return Err(HydrationError::InvalidGeometryLevel {
-            value: output.geometry_level.clone(),
         });
     }
 

--- a/src/mmds/mermaid.rs
+++ b/src/mmds/mermaid.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use std::fmt;
 
 use super::{Document, Edge, Node, Subgraph, parse_input};
-use crate::graph::Shape;
+use crate::graph::{Arrow, Shape, Stroke};
 use crate::mmds::MmdsToken;
 
 /// Error produced when MMDS-to-Mermaid regeneration fails.
@@ -43,7 +43,10 @@ pub fn generate_mermaid(output: &Document) -> Result<String, GenerationError> {
     let identifiers = build_identifier_maps(output);
 
     let mut lines = Vec::with_capacity(1 + output.nodes.len() + output.edges.len());
-    lines.push(format!("flowchart {}", output.metadata.direction));
+    lines.push(format!(
+        "flowchart {}",
+        output.metadata.direction.as_mmds_str()
+    ));
 
     emit_nodes(output, &identifiers, &mut lines)?;
     emit_edges(output, &identifiers, &mut lines)?;
@@ -206,7 +209,10 @@ fn emit_subgraph(
 
     if let Some(direction) = &subgraph.direction {
         let child_padding = " ".repeat(indent + 4);
-        lines.push(format!("{child_padding}direction {direction}"));
+        lines.push(format!(
+            "{child_padding}direction {}",
+            direction.as_mmds_str()
+        ));
     }
 
     if let Some(children) = subgraphs_by_parent.get(subgraph.id.as_str()) {
@@ -375,33 +381,32 @@ fn format_edge_label(label: &str) -> String {
 
 fn connector_for(edge: &Edge) -> Result<String, GenerationError> {
     let minlen = edge.minlen.max(1) as usize;
-    let connector = match (
-        edge.stroke.as_str(),
-        edge.arrow_start.as_str(),
-        edge.arrow_end.as_str(),
-    ) {
-        ("solid", "none", "normal") => format!("{}>", "-".repeat(minlen + 1)),
-        ("solid", "none", "none") => "-".repeat(minlen + 2),
-        ("solid", "normal", "normal") => format!("<{}>", "-".repeat(minlen + 1)),
-        ("solid", "none", "cross") => format!("{}x", "-".repeat(minlen + 1)),
-        ("solid", "cross", "cross") => format!("x{}x", "-".repeat(minlen + 1)),
-        ("solid", "none", "circle") => format!("{}o", "-".repeat(minlen + 1)),
-        ("solid", "circle", "circle") => format!("o{}o", "-".repeat(minlen + 1)),
-        ("dotted", "none", "normal") => format!("-{}->", ".".repeat(minlen)),
-        ("dotted", "none", "none") => format!("-{}-", ".".repeat(minlen)),
-        ("dotted", "normal", "normal") => format!("<-{}->", ".".repeat(minlen)),
-        ("dotted", "none", "cross") => format!("-{}-x", ".".repeat(minlen)),
-        ("dotted", "none", "circle") => format!("-{}-o", ".".repeat(minlen)),
-        ("thick", "none", "normal") => format!("{}>", "=".repeat(minlen + 1)),
-        ("thick", "none", "none") => "=".repeat(minlen + 2),
-        ("thick", "normal", "normal") => format!("<{}>", "=".repeat(minlen + 1)),
-        ("thick", "none", "cross") => format!("{}x", "=".repeat(minlen + 1)),
-        ("thick", "none", "circle") => format!("{}o", "=".repeat(minlen + 1)),
-        ("invisible", "none", "none") => "~".repeat(minlen + 2),
+    let connector = match (edge.stroke, edge.arrow_start, edge.arrow_end) {
+        (Stroke::Solid, Arrow::None, Arrow::Normal) => format!("{}>", "-".repeat(minlen + 1)),
+        (Stroke::Solid, Arrow::None, Arrow::None) => "-".repeat(minlen + 2),
+        (Stroke::Solid, Arrow::Normal, Arrow::Normal) => format!("<{}>", "-".repeat(minlen + 1)),
+        (Stroke::Solid, Arrow::None, Arrow::Cross) => format!("{}x", "-".repeat(minlen + 1)),
+        (Stroke::Solid, Arrow::Cross, Arrow::Cross) => format!("x{}x", "-".repeat(minlen + 1)),
+        (Stroke::Solid, Arrow::None, Arrow::Circle) => format!("{}o", "-".repeat(minlen + 1)),
+        (Stroke::Solid, Arrow::Circle, Arrow::Circle) => format!("o{}o", "-".repeat(minlen + 1)),
+        (Stroke::Dotted, Arrow::None, Arrow::Normal) => format!("-{}->", ".".repeat(minlen)),
+        (Stroke::Dotted, Arrow::None, Arrow::None) => format!("-{}-", ".".repeat(minlen)),
+        (Stroke::Dotted, Arrow::Normal, Arrow::Normal) => format!("<-{}->", ".".repeat(minlen)),
+        (Stroke::Dotted, Arrow::None, Arrow::Cross) => format!("-{}-x", ".".repeat(minlen)),
+        (Stroke::Dotted, Arrow::None, Arrow::Circle) => format!("-{}-o", ".".repeat(minlen)),
+        (Stroke::Thick, Arrow::None, Arrow::Normal) => format!("{}>", "=".repeat(minlen + 1)),
+        (Stroke::Thick, Arrow::None, Arrow::None) => "=".repeat(minlen + 2),
+        (Stroke::Thick, Arrow::Normal, Arrow::Normal) => format!("<{}>", "=".repeat(minlen + 1)),
+        (Stroke::Thick, Arrow::None, Arrow::Cross) => format!("{}x", "=".repeat(minlen + 1)),
+        (Stroke::Thick, Arrow::None, Arrow::Circle) => format!("{}o", "=".repeat(minlen + 1)),
+        (Stroke::Invisible, Arrow::None, Arrow::None) => "~".repeat(minlen + 2),
         _ => {
             return Err(GenerationError::new(format!(
                 "unsupported edge connector combination stroke='{}' arrow_start='{}' arrow_end='{}' on edge '{}'",
-                edge.stroke, edge.arrow_start, edge.arrow_end, edge.id
+                edge.stroke.as_mmds_str(),
+                edge.arrow_start.as_mmds_str(),
+                edge.arrow_end.as_mmds_str(),
+                edge.id
             )));
         }
     };

--- a/src/mmds/sequence.rs
+++ b/src/mmds/sequence.rs
@@ -6,6 +6,69 @@
 
 use serde::Serialize;
 
+use crate::graph::GeometryLevel;
+
+// ---------------------------------------------------------------------------
+// Sequence MMDS vocabulary
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SequenceDiagramType {
+    Sequence,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MmdsParticipantKind {
+    Participant,
+    Actor,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MmdsLineStyle {
+    Solid,
+    Dashed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MmdsArrowHead {
+    None,
+    Filled,
+    Cross,
+    Async,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MmdsNotePlacement {
+    LeftOf,
+    RightOf,
+    Over,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MmdsBlockKind {
+    Loop,
+    Alt,
+    Opt,
+    Par,
+    Critical,
+    Break,
+    Rect,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum MmdsBlockDividerKind {
+    Else,
+    And,
+    Option,
+}
+
 // ---------------------------------------------------------------------------
 // Document types
 // ---------------------------------------------------------------------------
@@ -13,7 +76,7 @@ use serde::Serialize;
 #[derive(Serialize)]
 pub(crate) struct SequenceDocument {
     pub version: u32,
-    pub geometry_level: String,
+    pub geometry_level: GeometryLevel,
     pub metadata: SequenceMetadata,
     // Envelope compat — always empty for sequence diagrams.
     pub nodes: Vec<()>,
@@ -33,7 +96,7 @@ pub(crate) struct SequenceDocument {
 
 #[derive(Serialize)]
 pub(crate) struct SequenceMetadata {
-    pub diagram_type: String,
+    pub diagram_type: SequenceDiagramType,
     pub bounds: MmdsBounds,
 }
 
@@ -67,7 +130,7 @@ pub(crate) struct MmdsRect {
 pub(crate) struct MmdsParticipant {
     pub id: String,
     pub label: String,
-    pub kind: String,
+    pub kind: MmdsParticipantKind,
     pub position: MmdsPosition,
     pub size: MmdsSize,
     pub lifeline_x: f64,
@@ -78,15 +141,15 @@ pub(crate) struct MmdsMessage {
     pub id: String,
     pub from: usize,
     pub to: usize,
-    pub line_style: String,
-    pub arrow_head: String,
+    pub line_style: MmdsLineStyle,
+    pub arrow_head: MmdsArrowHead,
     pub text: String,
     pub y: f64,
 }
 
 #[derive(Serialize)]
 pub(crate) struct MmdsNote {
-    pub placement: String,
+    pub placement: MmdsNotePlacement,
     pub participants: Vec<usize>,
     pub text: String,
     pub position: MmdsPosition,
@@ -104,13 +167,13 @@ pub(crate) struct MmdsActivation {
 #[derive(Serialize)]
 pub(crate) struct MmdsBlockDivider {
     pub y: f64,
-    pub kind: String,
+    pub kind: MmdsBlockDividerKind,
     pub label: String,
 }
 
 #[derive(Serialize)]
 pub(crate) struct MmdsBlock {
-    pub kind: String,
+    pub kind: MmdsBlockKind,
     pub label: String,
     pub rect: MmdsRect,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/src/mmds/token.rs
+++ b/src/mmds/token.rs
@@ -6,6 +6,8 @@
 use std::error::Error;
 use std::fmt;
 
+use crate::graph::attachment::PortFace;
+use crate::graph::geometry::EdgeLabelSide;
 use crate::graph::{Arrow, Direction, GeometryLevel, Shape, Stroke};
 
 /// Conversion contract between graph-family Rust enums and MMDS schema tokens.
@@ -112,7 +114,7 @@ impl MmdsToken for Shape {
 impl MmdsToken for Direction {
     fn parse_mmds(value: &str) -> Result<Self, MmdsTokenError> {
         match value {
-            "TD" => Ok(Direction::TopDown),
+            "TD" | "TB" => Ok(Direction::TopDown),
             "BT" => Ok(Direction::BottomTop),
             "LR" => Ok(Direction::LeftRight),
             "RL" => Ok(Direction::RightLeft),
@@ -197,6 +199,41 @@ impl MmdsToken for GeometryLevel {
     }
 }
 
+impl MmdsToken for PortFace {
+    fn parse_mmds(value: &str) -> Result<Self, MmdsTokenError> {
+        match value {
+            "top" => Ok(PortFace::Top),
+            "bottom" => Ok(PortFace::Bottom),
+            "left" => Ok(PortFace::Left),
+            "right" => Ok(PortFace::Right),
+            _ => Err(MmdsTokenError::new("port face", value)),
+        }
+    }
+
+    fn as_mmds_str(&self) -> &'static str {
+        self.as_str()
+    }
+}
+
+impl MmdsToken for EdgeLabelSide {
+    fn parse_mmds(value: &str) -> Result<Self, MmdsTokenError> {
+        match value {
+            "above" => Ok(EdgeLabelSide::Above),
+            "below" => Ok(EdgeLabelSide::Below),
+            "center" => Ok(EdgeLabelSide::Center),
+            _ => Err(MmdsTokenError::new("edge label side", value)),
+        }
+    }
+
+    fn as_mmds_str(&self) -> &'static str {
+        match self {
+            EdgeLabelSide::Above => "above",
+            EdgeLabelSide::Below => "below",
+            EdgeLabelSide::Center => "center",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -226,6 +263,8 @@ mod tests {
             assert_eq!(Direction::parse_mmds(token), Ok(direction));
             assert_eq!(direction.as_mmds_str(), token);
         }
+        assert_eq!(Direction::parse_mmds("TB"), Ok(Direction::TopDown));
+        assert_eq!(Direction::parse_mmds("TB").unwrap().as_mmds_str(), "TD");
         assert_eq!(
             Direction::parse_mmds("top_down").unwrap_err().kind,
             "direction"
@@ -273,6 +312,36 @@ mod tests {
         assert_eq!(
             GeometryLevel::parse_mmds("full").unwrap_err().kind,
             "geometry level"
+        );
+    }
+
+    #[test]
+    fn port_face_mmds_tokens_round_trip() {
+        for (token, face) in [
+            ("top", PortFace::Top),
+            ("bottom", PortFace::Bottom),
+            ("left", PortFace::Left),
+            ("right", PortFace::Right),
+        ] {
+            assert_eq!(PortFace::parse_mmds(token), Ok(face));
+            assert_eq!(face.as_mmds_str(), token);
+        }
+        assert_eq!(PortFace::parse_mmds("north").unwrap_err().kind, "port face");
+    }
+
+    #[test]
+    fn edge_label_side_mmds_tokens_round_trip() {
+        for (token, side) in [
+            ("above", EdgeLabelSide::Above),
+            ("below", EdgeLabelSide::Below),
+            ("center", EdgeLabelSide::Center),
+        ] {
+            assert_eq!(EdgeLabelSide::parse_mmds(token), Ok(side));
+            assert_eq!(side.as_mmds_str(), token);
+        }
+        assert_eq!(
+            EdgeLabelSide::parse_mmds("sideways").unwrap_err().kind,
+            "edge label side"
         );
     }
 }

--- a/src/runtime/mmds.rs
+++ b/src/runtime/mmds.rs
@@ -51,16 +51,7 @@ pub(crate) fn render_document(
     svg_theme: Option<&ResolvedSvgTheme>,
 ) -> Result<String, RenderError> {
     let diagram_id = resolve_logical_diagram_id(payload)?;
-    let has_routed_geometry = payload.geometry_level == "routed";
-
-    if !matches!(payload.geometry_level.as_str(), "layout" | "routed") {
-        return Err(RenderError {
-            message: format!(
-                "MMDS validation error: invalid geometry_level '{}'",
-                payload.geometry_level
-            ),
-        });
-    }
+    let has_routed_geometry = payload.geometry_level == GeometryLevel::Routed;
 
     if matches!(format, OutputFormat::Mmds) {
         let output = if has_routed_geometry && geometry_level == GeometryLevel::Layout {
@@ -156,7 +147,7 @@ fn prefixed_display_error(prefix: &str, error: impl Display) -> RenderError {
 
 fn strip_routed_fields(payload: &Document) -> Document {
     let mut output = payload.clone();
-    output.geometry_level = "layout".to_string();
+    output.geometry_level = crate::graph::GeometryLevel::Layout;
     for edge in &mut output.edges {
         edge.path = None;
         edge.label_position = None;

--- a/src/runtime/timeline_family.rs
+++ b/src/runtime/timeline_family.rs
@@ -3,11 +3,13 @@
 //! Parallel to `graph_family` — computes SVG layout and serializes to MMDS
 //! JSON via the types defined in `mmds::sequence`.
 
+use crate::graph::GeometryLevel;
 use crate::graph::measure::ProportionalTextMetrics;
 use crate::mmds::sequence::{
-    self, MmdsActivation, MmdsBlock, MmdsBlockDivider, MmdsBounds, MmdsMessage, MmdsNote,
-    MmdsParticipant, MmdsParticipantBox, MmdsPosition, MmdsRect, MmdsSize, SequenceDocument,
-    SequenceMetadata,
+    self, MmdsActivation, MmdsArrowHead, MmdsBlock, MmdsBlockDivider, MmdsBlockDividerKind,
+    MmdsBlockKind, MmdsBounds, MmdsLineStyle, MmdsMessage, MmdsNote, MmdsNotePlacement,
+    MmdsParticipant, MmdsParticipantBox, MmdsParticipantKind, MmdsPosition, MmdsRect, MmdsSize,
+    SequenceDiagramType, SequenceDocument, SequenceMetadata,
 };
 use crate::render::timeline::svg_layout::{
     self as svg_layout, SvgBlock, SvgRow, SvgSequenceLayout,
@@ -17,49 +19,49 @@ use crate::timeline::sequence::model::{
 };
 
 // ---------------------------------------------------------------------------
-// String helpers
+// MMDS vocabulary conversion helpers
 // ---------------------------------------------------------------------------
 
-fn line_style_str(s: LineStyle) -> &'static str {
+fn mmds_line_style(s: LineStyle) -> MmdsLineStyle {
     match s {
-        LineStyle::Solid => "solid",
-        LineStyle::Dashed => "dashed",
+        LineStyle::Solid => MmdsLineStyle::Solid,
+        LineStyle::Dashed => MmdsLineStyle::Dashed,
     }
 }
 
-fn arrow_head_str(a: ArrowHead) -> &'static str {
+fn mmds_arrow_head(a: ArrowHead) -> MmdsArrowHead {
     match a {
-        ArrowHead::None => "none",
-        ArrowHead::Filled => "filled",
-        ArrowHead::Cross => "cross",
-        ArrowHead::Async => "async",
+        ArrowHead::None => MmdsArrowHead::None,
+        ArrowHead::Filled => MmdsArrowHead::Filled,
+        ArrowHead::Cross => MmdsArrowHead::Cross,
+        ArrowHead::Async => MmdsArrowHead::Async,
     }
 }
 
-fn participant_kind_str(k: &ParticipantKind) -> &'static str {
+fn mmds_participant_kind(k: &ParticipantKind) -> MmdsParticipantKind {
     match k {
-        ParticipantKind::Participant => "participant",
-        ParticipantKind::Actor => "actor",
+        ParticipantKind::Participant => MmdsParticipantKind::Participant,
+        ParticipantKind::Actor => MmdsParticipantKind::Actor,
     }
 }
 
-fn block_kind_str(k: BlockKind) -> &'static str {
+fn mmds_block_kind(k: BlockKind) -> MmdsBlockKind {
     match k {
-        BlockKind::Loop => "loop",
-        BlockKind::Alt => "alt",
-        BlockKind::Opt => "opt",
-        BlockKind::Par => "par",
-        BlockKind::Critical => "critical",
-        BlockKind::Break => "break",
-        BlockKind::Rect => "rect",
+        BlockKind::Loop => MmdsBlockKind::Loop,
+        BlockKind::Alt => MmdsBlockKind::Alt,
+        BlockKind::Opt => MmdsBlockKind::Opt,
+        BlockKind::Par => MmdsBlockKind::Par,
+        BlockKind::Critical => MmdsBlockKind::Critical,
+        BlockKind::Break => MmdsBlockKind::Break,
+        BlockKind::Rect => MmdsBlockKind::Rect,
     }
 }
 
-fn block_divider_kind_str(k: BlockDividerKind) -> &'static str {
+fn mmds_block_divider_kind(k: BlockDividerKind) -> MmdsBlockDividerKind {
     match k {
-        BlockDividerKind::Else => "else",
-        BlockDividerKind::And => "and",
-        BlockDividerKind::Option => "option",
+        BlockDividerKind::Else => MmdsBlockDividerKind::Else,
+        BlockDividerKind::And => MmdsBlockDividerKind::And,
+        BlockDividerKind::Option => MmdsBlockDividerKind::Option,
     }
 }
 
@@ -84,9 +86,9 @@ fn build_document(model: &Sequence, svg: &SvgSequenceLayout) -> SequenceDocument
 
     SequenceDocument {
         version: 1,
-        geometry_level: "layout".to_string(),
+        geometry_level: GeometryLevel::Layout,
         metadata: SequenceMetadata {
-            diagram_type: "sequence".to_string(),
+            diagram_type: SequenceDiagramType::Sequence,
             bounds: MmdsBounds {
                 width: svg.width,
                 height: svg.height,
@@ -111,7 +113,7 @@ fn build_participants(model: &Sequence, svg: &SvgSequenceLayout) -> Vec<MmdsPart
         .map(|(p, sp)| MmdsParticipant {
             id: p.id.clone(),
             label: p.label.clone(),
-            kind: participant_kind_str(&p.kind).to_string(),
+            kind: mmds_participant_kind(&p.kind),
             position: MmdsPosition {
                 x: sp.rect.x,
                 y: sp.rect.y,
@@ -141,8 +143,8 @@ fn build_messages_and_notes(svg: &SvgSequenceLayout) -> (Vec<MmdsMessage>, Vec<M
                     id: format!("m{msg_idx}"),
                     from,
                     to,
-                    line_style: line_style_str(m.line_style).to_string(),
-                    arrow_head: arrow_head_str(m.arrow_head).to_string(),
+                    line_style: mmds_line_style(m.line_style),
+                    arrow_head: mmds_arrow_head(m.arrow_head),
                     text: m.label.clone(),
                     y: m.y,
                 });
@@ -154,8 +156,8 @@ fn build_messages_and_notes(svg: &SvgSequenceLayout) -> (Vec<MmdsMessage>, Vec<M
                     id: format!("m{msg_idx}"),
                     from,
                     to: from,
-                    line_style: line_style_str(sm.line_style).to_string(),
-                    arrow_head: arrow_head_str(sm.arrow_head).to_string(),
+                    line_style: mmds_line_style(sm.line_style),
+                    arrow_head: mmds_arrow_head(sm.arrow_head),
                     text: sm.label.clone(),
                     y: sm.y,
                 });
@@ -165,7 +167,7 @@ fn build_messages_and_notes(svg: &SvgSequenceLayout) -> (Vec<MmdsMessage>, Vec<M
                 let participants = participants_for_note(&lifeline_xs, n);
                 let placement = placement_for_note(&lifeline_xs, n, &participants);
                 notes.push(MmdsNote {
-                    placement: placement.to_string(),
+                    placement,
                     participants,
                     text: n.text.clone(),
                     position: MmdsPosition {
@@ -220,19 +222,19 @@ fn placement_for_note(
     lifeline_xs: &[f64],
     note: &svg_layout::SvgNote,
     participants: &[usize],
-) -> &'static str {
+) -> MmdsNotePlacement {
     if participants.len() > 1 {
-        return "over";
+        return MmdsNotePlacement::Over;
     }
     let p_idx = participants[0];
     let lx = lifeline_xs[p_idx];
     let note_center = note.rect.x + note.rect.width / 2.0;
     if note_center < lx {
-        "left_of"
+        MmdsNotePlacement::LeftOf
     } else if note_center > lx {
-        "right_of"
+        MmdsNotePlacement::RightOf
     } else {
-        "over"
+        MmdsNotePlacement::Over
     }
 }
 
@@ -256,7 +258,7 @@ fn build_blocks(svg: &SvgSequenceLayout) -> Vec<MmdsBlock> {
     svg.blocks
         .iter()
         .map(|b: &SvgBlock| MmdsBlock {
-            kind: block_kind_str(b.kind).to_string(),
+            kind: mmds_block_kind(b.kind),
             label: b.label.clone(),
             rect: MmdsRect {
                 x: b.rect.x,
@@ -269,7 +271,7 @@ fn build_blocks(svg: &SvgSequenceLayout) -> Vec<MmdsBlock> {
                 .iter()
                 .map(|d| MmdsBlockDivider {
                     y: d.y,
-                    kind: block_divider_kind_str(d.kind).to_string(),
+                    kind: mmds_block_divider_kind(d.kind),
                     label: d.label.clone(),
                 })
                 .collect(),

--- a/tests/mmds_conformance.rs
+++ b/tests/mmds_conformance.rs
@@ -18,8 +18,8 @@ use std::path::Path;
 use mmdflux::builtins::default_registry;
 use mmdflux::graph::Graph;
 use mmdflux::mmds::{
-    Bounds, Document, Edge, Node, Port, Position, Subgraph, from_str, generate_mermaid_from_str,
-    parse_input,
+    Bounds, Document, Edge, MmdsToken, Node, Port, Position, Subgraph, from_str,
+    generate_mermaid_from_str, parse_input,
 };
 use mmdflux::payload::Diagram as Payload;
 use mmdflux::{OutputFormat, RenderConfig, render_diagram};
@@ -306,7 +306,8 @@ fn compare_layout_payloads(direct: &Document, roundtrip: &Document) -> Vec<Strin
     if direct.metadata.direction != roundtrip.metadata.direction {
         mismatches.push(format!(
             "direction: {} vs {}",
-            direct.metadata.direction, roundtrip.metadata.direction
+            direct.metadata.direction.as_mmds_str(),
+            roundtrip.metadata.direction.as_mmds_str()
         ));
     }
     if direct.geometry_level != roundtrip.geometry_level {

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -8,10 +8,13 @@ mod common;
 
 use std::path::Path;
 
-use mmdflux::graph::{GeometryLevel, Shape};
+use mmdflux::graph::attachment::PortFace;
+use mmdflux::graph::geometry::EdgeLabelSide;
+use mmdflux::graph::{Arrow, Direction, GeometryLevel, Shape, Stroke};
 use mmdflux::mmds::{
-    Document, Edge as MmdsEdge, Port as MmdsPort, Position as MmdsPosition, Rect as MmdsRect,
-    SUPPORTED_PROFILES, evaluate_profiles, hydrate_routed_geometry_from_document, parse_input,
+    Document, Edge as MmdsEdge, MmdsToken, Port as MmdsPort, Position as MmdsPosition,
+    Rect as MmdsRect, SUPPORTED_PROFILES, evaluate_profiles, hydrate_routed_geometry_from_document,
+    parse_input,
 };
 use mmdflux::simplification::PathSimplification;
 use mmdflux::{EngineAlgorithmId, OutputFormat, RenderConfig, TextColorMode, materialize_diagram};
@@ -244,7 +247,7 @@ fn mmds_default_has_version_1() {
 fn mmds_default_geometry_level_is_layout() {
     let json = render_json("graph TD\nA-->B");
     let output: Document = serde_json::from_str(&json).unwrap();
-    assert_eq!(output.geometry_level, "layout");
+    assert_eq!(output.geometry_level, GeometryLevel::Layout);
 }
 
 #[test]
@@ -252,7 +255,7 @@ fn mmds_has_metadata_with_direction() {
     let json = render_json("graph LR\nA-->B");
     let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.metadata.diagram_type, "flowchart");
-    assert_eq!(output.metadata.direction, "LR");
+    assert_eq!(output.metadata.direction, Direction::LeftRight);
 }
 
 #[test]
@@ -771,10 +774,10 @@ fn mmds_layout_edges_have_topology() {
     assert_eq!(edge.id, "e0");
     assert_eq!(edge.source, "A");
     assert_eq!(edge.target, "B");
-    assert_eq!(edge.stroke, "dotted");
+    assert_eq!(edge.stroke, Stroke::Dotted);
     assert_eq!(edge.label, Some("label".to_string()));
-    assert_eq!(edge.arrow_start, "none");
-    assert_eq!(edge.arrow_end, "normal");
+    assert_eq!(edge.arrow_start, Arrow::None);
+    assert_eq!(edge.arrow_end, Arrow::Normal);
 }
 
 #[test]
@@ -840,7 +843,7 @@ fn mmds_layout_subgraphs() {
 fn mmds_layout_subgraph_direction_override() {
     let json = render_json("graph TD\nsubgraph sg1[Group]\ndirection LR\nA-->B\nend");
     let output: Document = serde_json::from_str(&json).unwrap();
-    assert_eq!(output.subgraphs[0].direction.as_deref(), Some("LR"));
+    assert_eq!(output.subgraphs[0].direction, Some(Direction::LeftRight));
 }
 
 // -----------------------------------------------------------------------
@@ -851,7 +854,7 @@ fn mmds_layout_subgraph_direction_override() {
 fn mmds_routed_has_geometry_level_routed() {
     let json = render_json_with_level("graph TD\nA-->B", GeometryLevel::Routed);
     let output: Document = serde_json::from_str(&json).unwrap();
-    assert_eq!(output.geometry_level, "routed");
+    assert_eq!(output.geometry_level, GeometryLevel::Routed);
 }
 
 #[test]
@@ -969,9 +972,9 @@ fn mmds_deserializes_with_defaults() {
     let json = render_json("graph TD\nA-->B");
     let output: Document = serde_json::from_str(&json).unwrap();
     assert_eq!(output.nodes[0].shape, Shape::Rectangle);
-    assert_eq!(output.edges[0].stroke, "solid");
-    assert_eq!(output.edges[0].arrow_start, "none");
-    assert_eq!(output.edges[0].arrow_end, "normal");
+    assert_eq!(output.edges[0].stroke, Stroke::Solid);
+    assert_eq!(output.edges[0].arrow_start, Arrow::None);
+    assert_eq!(output.edges[0].arrow_end, Arrow::Normal);
     assert_eq!(output.edges[0].minlen, 1);
     assert!(output.edges[0].from_subgraph.is_none());
     assert!(output.edges[0].to_subgraph.is_none());
@@ -984,12 +987,27 @@ fn mmds_deserializes_with_defaults() {
 
 #[test]
 fn mmds_direction_variants() {
-    for (dir_str, expected) in [("TD", "TD"), ("LR", "LR"), ("BT", "BT"), ("RL", "RL")] {
+    for (dir_str, expected) in [
+        ("TD", Direction::TopDown),
+        ("LR", Direction::LeftRight),
+        ("BT", Direction::BottomTop),
+        ("RL", Direction::RightLeft),
+    ] {
         let input = format!("graph {dir_str}\nA-->B");
         let json = render_json(&input);
         let output: Document = serde_json::from_str(&json).unwrap();
         assert_eq!(output.metadata.direction, expected);
     }
+}
+
+#[test]
+fn mmds_direction_tb_deserializes_to_canonical_top_down() {
+    let input = STYLED_MMDS_LAYOUT.replace(r#""direction": "TD""#, r#""direction": "TB""#);
+    let output = parse_input(&input).unwrap();
+    assert_eq!(output.metadata.direction, Direction::TopDown);
+
+    let value = serde_json::to_value(&output).unwrap();
+    assert_eq!(value["metadata"]["direction"], "TD");
 }
 
 // -----------------------------------------------------------------------
@@ -1003,7 +1021,7 @@ fn mmds_class_diagram_produces_json() {
     let parsed: Document = serde_json::from_str(&output).unwrap();
 
     assert_eq!(parsed.version, 1);
-    assert_eq!(parsed.geometry_level, "layout");
+    assert_eq!(parsed.geometry_level, GeometryLevel::Layout);
     assert_eq!(parsed.metadata.diagram_type, "class");
     assert!(!output.contains("\"path\""));
 }
@@ -1017,7 +1035,7 @@ fn mmds_class_diagram_routed_level() {
     let output = render_json_with_config("classDiagram\nA --> B", &config);
     let parsed: Document = serde_json::from_str(&output).unwrap();
 
-    assert_eq!(parsed.geometry_level, "routed");
+    assert_eq!(parsed.geometry_level, GeometryLevel::Routed);
     assert!(output.contains("\"path\""));
 }
 
@@ -1245,8 +1263,8 @@ fn mmds_routed_port_faces_correct_td() {
     let edge = &output.edges[0];
     let sp = edge.source_port.as_ref().unwrap();
     let tp = edge.target_port.as_ref().unwrap();
-    assert_eq!(sp.face, "bottom", "TD source should exit bottom");
-    assert_eq!(tp.face, "top", "TD target should enter top");
+    assert_eq!(sp.face, PortFace::Bottom, "TD source should exit bottom");
+    assert_eq!(tp.face, PortFace::Top, "TD target should enter top");
 }
 
 #[test]
@@ -1620,9 +1638,9 @@ fn plan_0145_edge_contract_stub() -> MmdsEdge {
         from_subgraph: None,
         to_subgraph: None,
         label: Some("x".into()),
-        stroke: "solid".into(),
-        arrow_start: "none".into(),
-        arrow_end: "normal".into(),
+        stroke: Stroke::Solid,
+        arrow_start: Arrow::None,
+        arrow_end: Arrow::Normal,
         minlen: 1,
         path: None,
         label_position: None,
@@ -1637,7 +1655,7 @@ fn plan_0145_edge_contract_stub() -> MmdsEdge {
 #[test]
 fn mmds_edge_supports_label_side_and_label_rect_fields() {
     let edge = MmdsEdge {
-        label_side: Some("above".into()),
+        label_side: Some(EdgeLabelSide::Above),
         label_rect: Some(MmdsRect {
             x: 10.0,
             y: 20.0,
@@ -1655,7 +1673,7 @@ fn mmds_edge_supports_label_side_and_label_rect_fields() {
     assert_eq!(json["label_rect"]["height"], 10.0);
 
     let roundtrip: MmdsEdge = serde_json::from_value(json).unwrap();
-    assert_eq!(roundtrip.label_side.as_deref(), Some("above"));
+    assert_eq!(roundtrip.label_side, Some(EdgeLabelSide::Above));
     let rect = roundtrip.label_rect.expect("label_rect should round-trip");
     assert_eq!(rect.x, 10.0);
     assert_eq!(rect.y, 20.0);
@@ -1743,12 +1761,13 @@ fn mmds_output_populates_label_side_at_layout_level() {
             .collect::<Vec<_>>()
     );
 
-    // Each label_side value must be a recognized string.
+    // Each label_side value must serialize to a recognized string.
     for edge in &output.edges {
         if let Some(side) = &edge.label_side {
             assert!(
-                ["above", "below", "center"].contains(&side.as_str()),
-                "unexpected label_side value: {side}"
+                ["above", "below", "center"].contains(&side.as_mmds_str()),
+                "unexpected label_side value: {}",
+                side.as_mmds_str()
             );
         }
     }
@@ -1853,7 +1872,7 @@ fn mmds_routed_to_layout_down_conversion_strips_routed_only_edge_fields() {
         },
     );
     let parsed: Document = serde_json::from_str(&layout_output).unwrap();
-    assert_eq!(parsed.geometry_level, "layout");
+    assert_eq!(parsed.geometry_level, GeometryLevel::Layout);
     for edge in &parsed.edges {
         assert!(edge.path.is_none(), "path must be stripped at layout level");
         assert!(

--- a/tests/mmds_roundtrip.rs
+++ b/tests/mmds_roundtrip.rs
@@ -2,8 +2,8 @@ use std::fs;
 use std::path::Path;
 
 use mmdflux::builtins::default_registry;
-use mmdflux::graph::{Direction, Graph, Shape};
-use mmdflux::mmds::{from_str, generate_mermaid_from_str};
+use mmdflux::graph::{Arrow, Direction, Graph, Shape, Stroke};
+use mmdflux::mmds::{MmdsToken, from_str, generate_mermaid_from_str};
 use mmdflux::payload::Diagram as Payload;
 
 fn fixture(name: &str) -> String {
@@ -36,9 +36,9 @@ struct SemanticEdge {
     source: String,
     target: String,
     label: Option<String>,
-    stroke: String,
-    arrow_start: String,
-    arrow_end: String,
+    stroke: Stroke,
+    arrow_start: Arrow,
+    arrow_end: Arrow,
     minlen: i32,
     from_subgraph: Option<String>,
     to_subgraph: Option<String>,
@@ -123,9 +123,9 @@ fn semantic_diagram(diagram: &Graph) -> SemanticDiagram {
             source: edge.from.clone(),
             target: edge.to.clone(),
             label: edge.label.clone(),
-            stroke: format!("{:?}", edge.stroke),
-            arrow_start: format!("{:?}", edge.arrow_start),
-            arrow_end: format!("{:?}", edge.arrow_end),
+            stroke: edge.stroke,
+            arrow_start: edge.arrow_start,
+            arrow_end: edge.arrow_end,
             minlen: edge.minlen,
             from_subgraph: edge.from_subgraph.clone(),
             to_subgraph: edge.to_subgraph.clone(),
@@ -136,9 +136,17 @@ fn semantic_diagram(diagram: &Graph) -> SemanticDiagram {
             .cmp(&right.source)
             .then(left.target.cmp(&right.target))
             .then(left.label.cmp(&right.label))
-            .then(left.stroke.cmp(&right.stroke))
-            .then(left.arrow_start.cmp(&right.arrow_start))
-            .then(left.arrow_end.cmp(&right.arrow_end))
+            .then(left.stroke.as_mmds_str().cmp(right.stroke.as_mmds_str()))
+            .then(
+                left.arrow_start
+                    .as_mmds_str()
+                    .cmp(right.arrow_start.as_mmds_str()),
+            )
+            .then(
+                left.arrow_end
+                    .as_mmds_str()
+                    .cmp(right.arrow_end.as_mmds_str()),
+            )
             .then(left.minlen.cmp(&right.minlen))
             .then(left.from_subgraph.cmp(&right.from_subgraph))
             .then(left.to_subgraph.cmp(&right.to_subgraph))

--- a/tests/mmds_views.rs
+++ b/tests/mmds_views.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use mmdflux::graph::Shape;
+use mmdflux::graph::{Arrow, Direction, GeometryLevel, Shape, Stroke};
 use mmdflux::mmds::{
     Bounds, Defaults, Document, Edge, Metadata, Node, Position, Size, Subgraph,
     TEXT_EXTENSION_NAMESPACE,
@@ -31,10 +31,10 @@ fn output(nodes: Vec<Node>, edges: Vec<Edge>, subgraphs: Vec<Subgraph>) -> Docum
         profiles: Vec::new(),
         extensions: BTreeMap::new(),
         defaults: Defaults::default(),
-        geometry_level: "layout".to_string(),
+        geometry_level: GeometryLevel::Layout,
         metadata: Metadata {
             diagram_type: "flowchart".to_string(),
-            direction: "TD".to_string(),
+            direction: Direction::TopDown,
             bounds: Bounds {
                 width: 200.0,
                 height: 200.0,
@@ -69,9 +69,9 @@ fn edge(id: &str, source: &str, target: &str) -> Edge {
         from_subgraph: None,
         to_subgraph: None,
         label: None,
-        stroke: "solid".to_string(),
-        arrow_start: "none".to_string(),
-        arrow_end: "normal".to_string(),
+        stroke: Stroke::Solid,
+        arrow_start: Arrow::None,
+        arrow_end: Arrow::Normal,
         minlen: 1,
         path: None,
         label_position: None,


### PR DESCRIPTION
## Summary

- Strongly type graph-family MMDS finite vocabulary fields for geometry level, direction, edge style, port face, and label side
- Add typed sequence MMDS vocabulary enums and align docs/schema with the emitted sequence arrow-head token set
- Accept `TB` as a deserialization alias for `TopDown` while continuing to serialize canonical `TD`

## Root Cause

MMDS document structs carried several finite token fields as `String`, so invalid values could be constructed in Rust and only fail later during hydration or replay.

## Validation

- `just check`
- `just architecture-check`