### PR TITLE
feat: add graph-family text metrics provider seam

### DIFF
--- a/src/engines/graph/algorithms/layered/float_layout.rs
+++ b/src/engines/graph/algorithms/layered/float_layout.rs
@@ -12,22 +12,25 @@ use super::{float_router, from_layered_layout};
 use crate::graph::direction_policy::build_node_directions;
 use crate::graph::geometry::{GraphGeometry, RoutedEdgeGeometry};
 use crate::graph::grid::GridLayoutConfig;
-use crate::graph::measure::{ProportionalTextMetrics, proportional_node_dimensions};
-use crate::graph::routing::{EdgeRouting, route_graph_geometry};
+use crate::graph::measure::{
+    TextMetricsProvider, edge_label_dimensions_for_provider,
+    edge_label_dimensions_wrapped_for_provider, proportional_node_dimensions_with_provider,
+};
+use crate::graph::routing::{EdgeRouting, route_graph_geometry_with_provider};
 use crate::graph::{Direction, Edge, Graph, Stroke};
 
 /// Edge-label sizing that honors the pre-engine wrap artifact when present.
 /// Falls back to single-line measurement otherwise.
 fn edge_label_dims_proportional(
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     edge: &Edge,
 ) -> Option<(f64, f64)> {
     if let Some(lines) = edge.wrapped_label_lines.as_deref() {
-        return Some(metrics.edge_label_dimensions_wrapped(lines));
+        return Some(edge_label_dimensions_wrapped_for_provider(metrics, lines));
     }
     edge.label
         .as_deref()
-        .map(|label| metrics.edge_label_dimensions(label))
+        .map(|label| edge_label_dimensions_for_provider(metrics, label))
 }
 
 /// Stroke thickness in layout units used for ELK label-dummy padding.
@@ -90,7 +93,7 @@ pub(super) fn pad_edge_label_dims_grid(
 pub(crate) fn build_float_layout_with_flags(
     diagram: &Graph,
     config: &GridLayoutConfig,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     edge_routing: EdgeRouting,
     skip_non_isolated_overrides: bool,
     engine_flags: Option<&LayoutConfig>,
@@ -116,7 +119,7 @@ pub(crate) fn build_float_layout_with_flags(
     let mut layout = build_layered_layout_with_config(
         diagram,
         &layered_config,
-        |node| proportional_node_dimensions(metrics, node, direction),
+        |node| proportional_node_dimensions_with_provider(metrics, node, direction),
         |edge| {
             edge_label_dims_proportional(metrics, edge).map(|dims| {
                 pad_edge_label_dims(dims, edge_label_spacing, edge_thickness(edge), direction)
@@ -126,7 +129,7 @@ pub(crate) fn build_float_layout_with_flags(
     let sublayouts = compute_sublayouts(
         diagram,
         &layered_config,
-        |node| proportional_node_dimensions(metrics, node, direction),
+        |node| proportional_node_dimensions_with_provider(metrics, node, direction),
         |edge| {
             edge_label_dims_proportional(metrics, edge).map(|dims| {
                 pad_edge_label_dims(dims, edge_label_spacing, edge_thickness(edge), direction)
@@ -134,8 +137,8 @@ pub(crate) fn build_float_layout_with_flags(
         },
         skip_non_isolated_overrides,
     );
-    let title_pad_y = metrics.font_size;
-    let content_pad_y = metrics.font_size * 0.3;
+    let title_pad_y = metrics.font_size();
+    let content_pad_y = metrics.font_size() * 0.3;
     reconcile_sublayouts(
         diagram,
         &mut layout,
@@ -145,14 +148,14 @@ pub(crate) fn build_float_layout_with_flags(
     );
 
     // Expand parent subgraph bounds to encompass repositioned children.
-    let child_margin = metrics.node_padding_x.max(metrics.node_padding_y);
-    let title_margin = metrics.font_size;
+    let child_margin = metrics.node_padding_x().max(metrics.node_padding_y());
+    let title_margin = metrics.font_size();
     expand_parent_bounds(diagram, &mut layout, child_margin, title_margin);
 
     // Push external nodes that now overlap with reconciled subgraph bounds.
     // Account for post-padding expansion (2 * node_padding_y for adjacent
     // subgraphs) plus visual breathing room (font_size).
-    let overlap_gap = metrics.node_padding_y * 2.0 + metrics.font_size;
+    let overlap_gap = metrics.node_padding_y() * 2.0 + metrics.font_size();
     resolve_sublayout_overlaps(diagram, &mut layout, overlap_gap);
 
     // Align sibling nodes with their cross-boundary edge targets on the
@@ -192,8 +195,8 @@ pub(crate) fn build_float_layout_with_flags(
     apply_subgraph_float_padding(
         diagram,
         &mut layout,
-        metrics.node_padding_x,
-        metrics.node_padding_y,
+        metrics.node_padding_x(),
+        metrics.node_padding_y(),
     );
 
     // Push external nodes away from subgraph borders so that subgraph-as-node
@@ -240,9 +243,9 @@ fn inject_routed_paths(
     diagram: &Graph,
     geom: &GraphGeometry,
     edge_routing: EdgeRouting,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
 ) -> GraphGeometry {
-    let routed = route_graph_geometry(diagram, geom, edge_routing, metrics);
+    let routed = route_graph_geometry_with_provider(diagram, geom, edge_routing, metrics);
     let mut updated = geom.clone();
     apply_routed_edge_paths(&mut updated, routed.edges);
     updated

--- a/src/engines/graph/algorithms/layered/measurement.rs
+++ b/src/engines/graph/algorithms/layered/measurement.rs
@@ -13,8 +13,10 @@ use crate::errors::RenderError;
 use crate::graph::geometry::GraphGeometry;
 use crate::graph::grid::{GridLayoutConfig, GridRanker};
 use crate::graph::measure::{
-    grid_edge_label_dimensions, grid_edge_label_dimensions_wrapped, grid_node_dimensions,
-    proportional_node_dimensions,
+    TextMetricsProvider, edge_label_dimensions_for_provider,
+    edge_label_dimensions_wrapped_for_provider, grid_edge_label_dimensions,
+    grid_edge_label_dimensions_wrapped, grid_node_dimensions,
+    proportional_node_dimensions_with_provider,
 };
 use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
 use crate::graph::{Direction, Edge, Graph, Node};
@@ -60,15 +62,15 @@ fn grid_node_layout_dimensions(node: &Node, direction: Direction) -> (f64, f64) 
 }
 
 fn edge_label_dims_proportional_for_run(
-    metrics: &crate::graph::measure::ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     edge: &Edge,
 ) -> Option<(f64, f64)> {
     if let Some(lines) = edge.wrapped_label_lines.as_deref() {
-        return Some(metrics.edge_label_dimensions_wrapped(lines));
+        return Some(edge_label_dimensions_wrapped_for_provider(metrics, lines));
     }
     edge.label
         .as_deref()
-        .map(|label| metrics.edge_label_dimensions(label))
+        .map(|label| edge_label_dimensions_for_provider(metrics, label))
 }
 
 fn grid_edge_label_layout_dimensions(edge: &Edge) -> Option<(f64, f64)> {
@@ -146,7 +148,10 @@ pub fn run_layered_layout(
 
     let direction = diagram.direction;
     let edge_label_spacing = lc.edge_label_spacing;
-    let mut result = match mode {
+    // This deref-match relies on `MeasurementMode` staying `Copy` (currently
+    // a unit variant or provider reference). If a future variant stores
+    // non-Copy data, switch the match arms to borrow patterns.
+    let mut result = match *mode {
         // Grid-mode label-dummy dims are padded in whole-cell increments
         // via `pad_edge_label_dims_grid` so the Text renderer honors
         // `edge_label_spacing`. Default spacing 2.0 + default thickness 1.0
@@ -172,7 +177,7 @@ pub fn run_layered_layout(
         MeasurementMode::Proportional(metrics) => build_layered_layout_with_config(
             diagram,
             &lc,
-            |node| proportional_node_dimensions(metrics, node, direction),
+            |node| proportional_node_dimensions_with_provider(metrics, node, direction),
             |edge| {
                 edge_label_dims_proportional_for_run(metrics, edge).map(|dims| {
                     super::float_layout::pad_edge_label_dims(

--- a/src/engines/graph/contracts.rs
+++ b/src/engines/graph/contracts.rs
@@ -9,15 +9,27 @@ use super::{EngineAlgorithmCapabilities, EngineAlgorithmId, LayoutConfig};
 use crate::errors::RenderError;
 use crate::format::RoutingStyle;
 use crate::graph::GeometryLevel;
+use crate::graph::measure::TextMetricsProvider;
 
 /// Measurement mode controls whether layout uses grid-cell dimensions or
 /// proportional float-space dimensions for node sizing.
-#[derive(Debug, Clone)]
-pub enum MeasurementMode {
+#[derive(Clone, Copy)]
+pub enum MeasurementMode<'a> {
     /// Grid-cell dimensions for discrete grid replay.
     Grid,
     /// Proportional dimensions for unitless float-space geometry.
-    Proportional(crate::graph::measure::ProportionalTextMetrics),
+    Proportional(&'a dyn TextMetricsProvider),
+}
+
+impl std::fmt::Debug for MeasurementMode<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Grid => f.write_str("Grid"),
+            // Keep provider details opaque so `TextMetricsProvider` does not
+            // need a `Debug` super-trait or extra object-safety constraints.
+            Self::Proportional(_) => f.write_str("Proportional(..)"),
+        }
+    }
 }
 
 /// Engine-specific configuration envelope.
@@ -46,9 +58,9 @@ pub enum SubgraphDirectionPolicy {
 
 /// Request parameters for a `GraphEngine::solve()` call.
 #[derive(Debug, Clone)]
-pub struct GraphSolveRequest {
+pub struct GraphSolveRequest<'a> {
     /// Measurement model used for node and edge label sizing.
-    pub measurement_mode: MeasurementMode,
+    pub measurement_mode: MeasurementMode<'a>,
     /// Float-geometry contract requested by the caller.
     pub geometry_contract: GraphGeometryContract,
     /// Geometry detail level requested by the caller.
@@ -68,10 +80,10 @@ pub enum GraphGeometryContract {
     Visual,
 }
 
-impl GraphSolveRequest {
+impl<'a> GraphSolveRequest<'a> {
     /// Build a solve request from explicit engine-owned solve instructions.
     pub fn new(
-        measurement_mode: MeasurementMode,
+        measurement_mode: MeasurementMode<'a>,
         geometry_contract: GraphGeometryContract,
         geometry_level: GeometryLevel,
         routing_style: Option<RoutingStyle>,
@@ -113,6 +125,6 @@ pub trait GraphEngine: Send + Sync {
         &self,
         diagram: &crate::graph::Graph,
         config: &EngineConfig,
-        request: &GraphSolveRequest,
+        request: &GraphSolveRequest<'_>,
     ) -> Result<GraphSolveResult, RenderError>;
 }

--- a/src/engines/graph/flux.rs
+++ b/src/engines/graph/flux.rs
@@ -15,8 +15,10 @@ use crate::engines::graph::{
 };
 use crate::errors::RenderError;
 use crate::graph::geometry::{GraphGeometry, RoutedGraphGeometry};
-use crate::graph::measure::default_proportional_text_metrics;
-use crate::graph::routing::{EdgeRouting, route_graph_geometry};
+use crate::graph::measure::{TextMetricsProvider, default_proportional_text_metrics};
+use crate::graph::routing::{
+    EdgeRouting, route_graph_geometry, route_graph_geometry_with_provider,
+};
 use crate::graph::{GeometryLevel, Graph};
 
 /// Flux-layered engine: native graph-family layout plus native routing.
@@ -192,7 +194,7 @@ fn edge_crowding_score(
 }
 
 pub(crate) fn adapt_flux_profile_for_reversed_chain_crowding(
-    mode: &MeasurementMode,
+    mode: &MeasurementMode<'_>,
     diagram: &Graph,
     edge_routing: EdgeRouting,
     profile: &LayoutConfig,
@@ -249,7 +251,7 @@ impl GraphEngine for FluxLayeredEngine {
         config: &EngineConfig,
         request: &GraphSolveRequest,
     ) -> Result<GraphSolveResult, RenderError> {
-        let mode = request.measurement_mode.clone();
+        let mode = request.measurement_mode;
 
         let EngineConfig::Layered(ref input_cfg) = *config;
         let edge_routing = self.id().edge_routing_for_style(request.routing_style);
@@ -270,7 +272,7 @@ impl GraphEngine for FluxLayeredEngine {
         let config = &enhanced_config;
 
         if matches!(request.geometry_contract, GraphGeometryContract::Visual) {
-            let MeasurementMode::Proportional(ref metrics) = mode else {
+            let MeasurementMode::Proportional(metrics) = mode else {
                 return Err(RenderError {
                     message: "internal: visual geometry requires proportional measurement mode"
                         .to_string(),
@@ -297,15 +299,19 @@ impl GraphEngine for FluxLayeredEngine {
         let geometry = run_layered_layout(&mode, diagram, config)?;
         let routed: Option<RoutedGraphGeometry> =
             if matches!(request.geometry_level, GeometryLevel::Routed) {
-                let solve_metrics = match &mode {
-                    MeasurementMode::Proportional(m) => m.clone(),
-                    MeasurementMode::Grid => default_proportional_text_metrics(),
+                let fallback_metrics;
+                let solve_metrics: &dyn TextMetricsProvider = match mode {
+                    MeasurementMode::Proportional(m) => m,
+                    MeasurementMode::Grid => {
+                        fallback_metrics = default_proportional_text_metrics();
+                        &fallback_metrics
+                    }
                 };
-                Some(route_graph_geometry(
+                Some(route_graph_geometry_with_provider(
                     diagram,
                     &geometry,
                     edge_routing,
-                    &solve_metrics,
+                    solve_metrics,
                 ))
             } else {
                 None

--- a/src/engines/graph/mermaid.rs
+++ b/src/engines/graph/mermaid.rs
@@ -17,7 +17,7 @@ use crate::engines::graph::{
 };
 use crate::errors::RenderError;
 use crate::graph::geometry::RoutedGraphGeometry;
-use crate::graph::routing::{EdgeRouting, route_graph_geometry};
+use crate::graph::routing::{EdgeRouting, route_graph_geometry_with_provider};
 use crate::graph::{GeometryLevel, Graph};
 
 /// Mermaid dagre default for isolated subgraphs without explicit direction:
@@ -165,9 +165,9 @@ impl GraphEngine for MermaidLayeredEngine {
         };
         let diagram = compat_diagram.as_ref().unwrap_or(diagram);
 
-        let mode = request.measurement_mode.clone();
+        let mode = request.measurement_mode;
 
-        let MeasurementMode::Proportional(ref metrics) = mode else {
+        let MeasurementMode::Proportional(metrics) = mode else {
             return Err(RenderError {
                 message: "internal: Mermaid float geometry requires proportional measurement mode"
                     .to_string(),
@@ -189,7 +189,7 @@ impl GraphEngine for MermaidLayeredEngine {
             (request.geometry_contract, request.geometry_level),
             (GraphGeometryContract::Canonical, GeometryLevel::Routed)
         ) {
-            Some(route_graph_geometry(
+            Some(route_graph_geometry_with_provider(
                 diagram,
                 &geometry,
                 EdgeRouting::PolylineRoute,

--- a/src/engines/graph/tests.rs
+++ b/src/engines/graph/tests.rs
@@ -13,9 +13,10 @@ use super::{
 };
 use crate::engines::graph::algorithms::layered::kernel::types::AcyclicPolicy;
 use crate::format::RoutingStyle;
-use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::measure::{ProportionalTextMetrics, default_proportional_text_metrics};
 use crate::graph::routing::EdgeRouting;
 use crate::graph::{GeometryLevel, Graph};
+use crate::internal_tests::stub_metrics::{NonCloneProvider, WideMProvider};
 
 fn build_simple_diagram() -> Graph {
     let flowchart = crate::mermaid::parse_flowchart("graph TD\nA-->B").unwrap();
@@ -38,8 +39,9 @@ fn solve_request_fields_round_trip() {
 
 #[test]
 fn solve_request_new_preserves_visual_proportional_fields() {
+    let metrics = ProportionalTextMetrics::new(16.0, 12.0, 10.0);
     let req = GraphSolveRequest::new(
-        MeasurementMode::Proportional(ProportionalTextMetrics::new(16.0, 12.0, 10.0)),
+        MeasurementMode::Proportional(&metrics),
         GraphGeometryContract::Visual,
         GeometryLevel::Routed,
         None,
@@ -56,8 +58,9 @@ fn solve_request_new_preserves_visual_proportional_fields() {
 
 #[test]
 fn solve_request_new_keeps_routing_style_independent_of_geometry_contract() {
+    let metrics = ProportionalTextMetrics::new(16.0, 15.0, 15.0);
     let req = GraphSolveRequest::new(
-        MeasurementMode::Proportional(ProportionalTextMetrics::new(16.0, 15.0, 15.0)),
+        MeasurementMode::Proportional(&metrics),
         GraphGeometryContract::Canonical,
         GeometryLevel::Routed,
         Some(RoutingStyle::Direct),
@@ -72,7 +75,54 @@ fn solve_request_new_keeps_routing_style_independent_of_geometry_contract() {
     assert_eq!(req.routing_style, Some(RoutingStyle::Direct));
 }
 
-fn grid_request(level: GeometryLevel, routing_style: Option<RoutingStyle>) -> GraphSolveRequest {
+#[test]
+fn graph_solve_request_borrows_non_clone_provider() {
+    let backing = NonCloneProvider::new(default_proportional_text_metrics());
+    let request = GraphSolveRequest::new(
+        MeasurementMode::Proportional(&backing),
+        GraphGeometryContract::Visual,
+        GeometryLevel::Layout,
+        None,
+        Default::default(),
+    );
+
+    assert!(matches!(
+        request.measurement_mode,
+        MeasurementMode::Proportional(_)
+    ));
+}
+
+#[test]
+fn layered_measurement_uses_provider_for_node_widths() {
+    let provider = WideMProvider;
+    let flowchart =
+        crate::mermaid::parse_flowchart("graph TD\nA[mmmm] --> B[iiii]\n").expect("fixture parses");
+    let diagram = crate::diagrams::flowchart::compile_to_graph(&flowchart);
+    let request = GraphSolveRequest::new(
+        MeasurementMode::Proportional(&provider),
+        GraphGeometryContract::Visual,
+        GeometryLevel::Layout,
+        None,
+        Default::default(),
+    );
+    let config = EngineConfig::Layered(LayoutConfig::default());
+
+    let result = FluxLayeredEngine::text()
+        .solve(&diagram, &config, &request)
+        .expect("solve should succeed");
+
+    let a_width = result.geometry.nodes["A"].rect.width;
+    let b_width = result.geometry.nodes["B"].rect.width;
+    assert!(
+        a_width > b_width + 100.0,
+        "provider should make m-label node wider than i-label node: A={a_width} B={b_width}"
+    );
+}
+
+fn grid_request(
+    level: GeometryLevel,
+    routing_style: Option<RoutingStyle>,
+) -> GraphSolveRequest<'static> {
     GraphSolveRequest::new(
         MeasurementMode::Grid,
         GraphGeometryContract::Canonical,
@@ -83,11 +133,11 @@ fn grid_request(level: GeometryLevel, routing_style: Option<RoutingStyle>) -> Gr
 }
 
 fn proportional_request(
-    metrics: ProportionalTextMetrics,
+    metrics: &ProportionalTextMetrics,
     geometry_contract: GraphGeometryContract,
     level: GeometryLevel,
     routing_style: Option<RoutingStyle>,
-) -> GraphSolveRequest {
+) -> GraphSolveRequest<'_> {
     GraphSolveRequest::new(
         MeasurementMode::Proportional(metrics),
         geometry_contract,
@@ -184,8 +234,9 @@ fn mermaid_layered_capabilities_are_hint_driven() {
 fn mermaid_layered_solve_layout_level_has_no_routed_geometry() {
     let diagram = build_simple_diagram();
     let engine = MermaidLayeredEngine::new();
+    let metrics = ProportionalTextMetrics::new(16.0, 15.0, 15.0);
     let request = proportional_request(
-        ProportionalTextMetrics::new(16.0, 15.0, 15.0),
+        &metrics,
         GraphGeometryContract::Canonical,
         GeometryLevel::Layout,
         None,
@@ -206,8 +257,9 @@ fn mermaid_layered_layout_matches_flux_layered_layout() {
     let diagram = build_simple_diagram();
     let config =
         EngineConfig::Layered(crate::engines::graph::algorithms::layered::LayoutConfig::default());
+    let metrics = ProportionalTextMetrics::new(16.0, 15.0, 15.0);
     let layout_req = proportional_request(
-        ProportionalTextMetrics::new(16.0, 15.0, 15.0),
+        &metrics,
         GraphGeometryContract::Canonical,
         GeometryLevel::Layout,
         None,
@@ -243,8 +295,9 @@ fn mermaid_layered_layout_matches_flux_layered_layout() {
 fn mermaid_layered_solve_routed_level_has_routed_geometry() {
     let diagram = build_simple_diagram();
     let engine = MermaidLayeredEngine::new();
+    let metrics = ProportionalTextMetrics::new(16.0, 15.0, 15.0);
     let request = proportional_request(
-        ProportionalTextMetrics::new(16.0, 15.0, 15.0),
+        &metrics,
         GraphGeometryContract::Canonical,
         GeometryLevel::Routed,
         None,
@@ -331,12 +384,9 @@ fn run_layered_layout_proportional_mode_produces_larger_dimensions() {
 
     let config = EngineConfig::Layered(LayoutConfig::default());
     let text_geom = run_layered_layout(&MeasurementMode::Grid, &diagram, &config).unwrap();
-    let proportional_geom = run_layered_layout(
-        &MeasurementMode::Proportional(ProportionalTextMetrics::new(16.0, 15.0, 15.0)),
-        &diagram,
-        &config,
-    )
-    .unwrap();
+    let metrics = ProportionalTextMetrics::new(16.0, 15.0, 15.0);
+    let proportional_geom =
+        run_layered_layout(&MeasurementMode::Proportional(&metrics), &diagram, &config).unwrap();
 
     let text_w = text_geom.nodes["A"].rect.width;
     let proportional_w = proportional_geom.nodes["A"].rect.width;
@@ -575,7 +625,8 @@ fn adaptive_reversed_chain_policy_relaxes_for_inline_label_crowding() {
     let input = include_str!("../../../tests/fixtures/flowchart/inline_label_flowchart.mmd");
     let flowchart = crate::mermaid::parse_flowchart(input).expect("fixture should parse");
     let diagram = crate::diagrams::flowchart::compile_to_graph(&flowchart);
-    let mode = MeasurementMode::Proportional(ProportionalTextMetrics::new(16.0, 15.0, 15.0));
+    let metrics = ProportionalTextMetrics::new(16.0, 15.0, 15.0);
+    let mode = MeasurementMode::Proportional(&metrics);
 
     let input_cfg = LayoutConfig {
         model_order_tiebreak: true,
@@ -616,7 +667,8 @@ fn adaptive_reversed_chain_policy_preserves_crossing_minimize_ordering() {
     let input = include_str!("../../../tests/fixtures/flowchart/crossing_minimize.mmd");
     let flowchart = crate::mermaid::parse_flowchart(input).expect("fixture should parse");
     let diagram = crate::diagrams::flowchart::compile_to_graph(&flowchart);
-    let mode = MeasurementMode::Proportional(ProportionalTextMetrics::new(16.0, 15.0, 15.0));
+    let metrics = ProportionalTextMetrics::new(16.0, 15.0, 15.0);
+    let mode = MeasurementMode::Proportional(&metrics);
 
     let input_cfg = LayoutConfig {
         model_order_tiebreak: true,
@@ -642,8 +694,9 @@ fn adaptive_reversed_chain_policy_preserves_crossing_minimize_ordering() {
 
 fn solve_visual_proportional(engine: &dyn GraphEngine, diagram: &Graph) -> GraphSolveResult {
     let config = EngineConfig::Layered(LayoutConfig::default());
+    let metrics = ProportionalTextMetrics::new(16.0, 15.0, 15.0);
     let request = proportional_request(
-        ProportionalTextMetrics::new(16.0, 15.0, 15.0),
+        &metrics,
         GraphGeometryContract::Visual,
         GeometryLevel::Layout,
         Some(RoutingStyle::Polyline),
@@ -656,8 +709,9 @@ fn solve_canonical_proportional_layout(
     diagram: &Graph,
 ) -> GraphSolveResult {
     let config = EngineConfig::Layered(LayoutConfig::default());
+    let metrics = ProportionalTextMetrics::new(16.0, 15.0, 15.0);
     let request = proportional_request(
-        ProportionalTextMetrics::new(16.0, 15.0, 15.0),
+        &metrics,
         GraphGeometryContract::Canonical,
         GeometryLevel::Layout,
         Some(RoutingStyle::Polyline),

--- a/src/graph/label_wrap.rs
+++ b/src/graph/label_wrap.rs
@@ -13,7 +13,9 @@
 //! so wrapping happens before engine sizing.
 
 use crate::graph::Edge;
-use crate::graph::measure::{ProportionalTextMetrics, wrap_lines};
+use crate::graph::measure::{
+    ProportionalTextMetrics, TextMetricsProvider, wrap_lines_with_provider,
+};
 
 /// Greedy-wrap every labeled edge's `label` against `max_width` using
 /// `metrics`, persisting the result as `edge.wrapped_label_lines`.
@@ -31,6 +33,14 @@ pub fn prepare_wrapped_labels(
     metrics: &ProportionalTextMetrics,
     max_width: Option<f64>,
 ) {
+    prepare_wrapped_labels_with_provider(edges, metrics, max_width);
+}
+
+pub(crate) fn prepare_wrapped_labels_with_provider(
+    edges: &mut [Edge],
+    provider: &dyn TextMetricsProvider,
+    max_width: Option<f64>,
+) {
     let Some(max_width) = max_width else {
         return;
     };
@@ -44,7 +54,7 @@ pub fn prepare_wrapped_labels(
         if label.is_empty() {
             continue;
         }
-        edge.wrapped_label_lines = Some(wrap_lines(metrics, label, max_width));
+        edge.wrapped_label_lines = Some(wrap_lines_with_provider(provider, label, max_width));
     }
 }
 

--- a/src/graph/measure.rs
+++ b/src/graph/measure.rs
@@ -61,6 +61,25 @@ pub struct ProportionalTextMetrics {
     width_model: ProportionalWidthModel,
 }
 
+/// Internal graph-family text measurement seam.
+///
+/// This is intentionally crate-local until browser/provider-backed measurement
+/// has a public API contract.
+pub(crate) trait TextMetricsProvider {
+    fn measure_line_width(&self, text: &str) -> f64;
+    fn measure_scalar_width(&self, ch: char) -> f64;
+    fn font_size(&self) -> f64;
+    fn line_height(&self) -> f64;
+    fn node_padding_x(&self) -> f64;
+    fn node_padding_y(&self) -> f64;
+    fn label_padding_x(&self) -> f64;
+    fn label_padding_y(&self) -> f64;
+
+    fn measure_space_width(&self) -> f64 {
+        self.measure_scalar_width(' ')
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 enum ProportionalWidthModel {
     CompatibilityHeuristic { scale: f64 },
@@ -130,19 +149,11 @@ impl ProportionalTextMetrics {
         padding_x: f64,
         padding_y: f64,
     ) -> (f64, f64) {
-        let lines: Vec<&str> = text.split('\n').collect();
-        let line_count = lines.len().max(1) as f64;
-        let max_width = lines
-            .iter()
-            .map(|line| self.measure_line_width(line))
-            .fold(0.0, f64::max);
-        let width = max_width + padding_x * 2.0;
-        let height = self.line_height * line_count + padding_y * 2.0;
-        (width, height)
+        measure_text_with_padding_for_provider(self, text, padding_x, padding_y)
     }
 
     pub fn edge_label_dimensions(&self, label: &str) -> (f64, f64) {
-        self.measure_text_with_padding(label, self.label_padding_x, self.label_padding_y)
+        edge_label_dimensions_for_provider(self, label)
     }
 
     /// Dimensions of an edge label that has already been wrapped into `lines`.
@@ -152,14 +163,7 @@ impl ProportionalTextMetrics {
     /// [`Self::edge_label_dimensions`] so the wrapped path is a drop-in
     /// replacement wherever `wrapped_label_lines` is populated.
     pub fn edge_label_dimensions_wrapped(&self, lines: &[String]) -> (f64, f64) {
-        let line_count = lines.len().max(1) as f64;
-        let max_width = lines
-            .iter()
-            .map(|line| self.measure_line_width(line))
-            .fold(0.0, f64::max);
-        let width = max_width + self.label_padding_x * 2.0;
-        let height = self.line_height * line_count + self.label_padding_y * 2.0;
-        (width, height)
+        edge_label_dimensions_wrapped_for_provider(self, lines)
     }
 
     pub(crate) fn measure_line_width(&self, text: &str) -> f64 {
@@ -176,6 +180,44 @@ impl ProportionalTextMetrics {
 
     pub(crate) fn char_width_ratio(&self, c: char) -> f64 {
         compatibility_char_width_ratio(c)
+    }
+}
+
+impl TextMetricsProvider for ProportionalTextMetrics {
+    fn measure_line_width(&self, text: &str) -> f64 {
+        // Use the inherent method explicitly; `self.measure_line_width(...)`
+        // would recurse into this trait method.
+        ProportionalTextMetrics::measure_line_width(self, text)
+    }
+
+    fn measure_scalar_width(&self, ch: char) -> f64 {
+        // Use the inherent method explicitly; `self.measure_scalar_width(...)`
+        // would recurse into this trait method.
+        ProportionalTextMetrics::measure_scalar_width(self, ch)
+    }
+
+    fn font_size(&self) -> f64 {
+        self.font_size
+    }
+
+    fn line_height(&self) -> f64 {
+        self.line_height
+    }
+
+    fn node_padding_x(&self) -> f64 {
+        self.node_padding_x
+    }
+
+    fn node_padding_y(&self) -> f64 {
+        self.node_padding_y
+    }
+
+    fn label_padding_x(&self) -> f64 {
+        self.label_padding_x
+    }
+
+    fn label_padding_y(&self) -> f64 {
+        self.label_padding_y
     }
 }
 
@@ -361,13 +403,64 @@ fn text_metrics_descriptor(
 /// variants to `'\n'` before calling this function. `wrap_lines` does not
 /// inspect the raw Mermaid source.
 pub fn wrap_lines(metrics: &ProportionalTextMetrics, text: &str, max_width: f64) -> Vec<String> {
-    let space_w = metrics.measure_space_width();
+    wrap_lines_with_provider(metrics, text, max_width)
+}
+
+pub(crate) fn measure_text_with_padding_for_provider(
+    provider: &dyn TextMetricsProvider,
+    text: &str,
+    padding_x: f64,
+    padding_y: f64,
+) -> (f64, f64) {
+    let lines: Vec<&str> = text.split('\n').collect();
+    let line_count = lines.len().max(1) as f64;
+    let max_width = lines
+        .iter()
+        .map(|line| provider.measure_line_width(line))
+        .fold(0.0, f64::max);
+    let width = max_width + padding_x * 2.0;
+    let height = provider.line_height() * line_count + padding_y * 2.0;
+    (width, height)
+}
+
+pub(crate) fn edge_label_dimensions_for_provider(
+    provider: &dyn TextMetricsProvider,
+    label: &str,
+) -> (f64, f64) {
+    measure_text_with_padding_for_provider(
+        provider,
+        label,
+        provider.label_padding_x(),
+        provider.label_padding_y(),
+    )
+}
+
+pub(crate) fn edge_label_dimensions_wrapped_for_provider(
+    provider: &dyn TextMetricsProvider,
+    lines: &[String],
+) -> (f64, f64) {
+    let line_count = lines.len().max(1) as f64;
+    let max_width = lines
+        .iter()
+        .map(|line| provider.measure_line_width(line))
+        .fold(0.0, f64::max);
+    let width = max_width + provider.label_padding_x() * 2.0;
+    let height = provider.line_height() * line_count + provider.label_padding_y() * 2.0;
+    (width, height)
+}
+
+pub(crate) fn wrap_lines_with_provider(
+    provider: &dyn TextMetricsProvider,
+    text: &str,
+    max_width: f64,
+) -> Vec<String> {
+    let space_w = provider.measure_space_width();
     let mut out = Vec::new();
     for segment in text.split('\n') {
         let mut current = String::new();
         let mut current_w = 0.0_f64;
         for word in segment.split_whitespace() {
-            let ww = metrics.measure_line_width(word);
+            let ww = provider.measure_line_width(word);
             if ww > max_width {
                 // Oversized word: fall back to per-character splits regardless
                 // of whether the word is first on the line. GPT-5.4 review of
@@ -379,7 +472,7 @@ pub fn wrap_lines(metrics: &ProportionalTextMetrics, text: &str, max_width: f64)
                     current_w = 0.0;
                 }
                 for ch in word.chars() {
-                    let cw = metrics.measure_scalar_width(ch);
+                    let cw = provider.measure_scalar_width(ch);
                     if current_w + cw > max_width && !current.is_empty() {
                         out.push(std::mem::take(&mut current));
                         current_w = 0.0;
@@ -421,6 +514,12 @@ pub fn default_proportional_text_metrics() -> ProportionalTextMetrics {
         DEFAULT_PROPORTIONAL_NODE_PADDING_X,
         DEFAULT_PROPORTIONAL_NODE_PADDING_Y,
     )
+}
+
+#[cfg(test)]
+pub(crate) fn default_proportional_text_metrics_provider() -> &'static ProportionalTextMetrics {
+    static METRICS: std::sync::OnceLock<ProportionalTextMetrics> = std::sync::OnceLock::new();
+    METRICS.get_or_init(default_proportional_text_metrics)
 }
 
 /// Calculate the grid dimensions needed to replay a node in the grid surface.
@@ -485,74 +584,83 @@ pub fn proportional_node_dimensions(
     node: &Node,
     direction: Direction,
 ) -> (f64, f64) {
-    let (label_w, label_h) = metrics.measure_text_with_padding(&node.label, 0.0, 0.0);
+    proportional_node_dimensions_with_provider(metrics, node, direction)
+}
+
+pub(crate) fn proportional_node_dimensions_with_provider(
+    provider: &dyn TextMetricsProvider,
+    node: &Node,
+    direction: Direction,
+) -> (f64, f64) {
+    let (label_w, label_h) =
+        measure_text_with_padding_for_provider(provider, &node.label, 0.0, 0.0);
 
     let (mut width, mut height) = match node.shape {
         Shape::Rectangle => (
-            label_w + metrics.node_padding_x * 4.0,
-            label_h + metrics.node_padding_y * 2.0,
+            label_w + provider.node_padding_x() * 4.0,
+            label_h + provider.node_padding_y() * 2.0,
         ),
         Shape::Diamond => {
-            let w = label_w + metrics.node_padding_x;
-            let h = label_h + metrics.node_padding_y;
+            let w = label_w + provider.node_padding_x();
+            let h = label_h + provider.node_padding_y();
             let size = w + h;
             (size, size)
         }
         Shape::Stadium => {
-            let h = label_h + metrics.node_padding_y * 2.0;
+            let h = label_h + provider.node_padding_y() * 2.0;
             let radius = h / 2.0;
-            (label_w + metrics.node_padding_x * 2.0 + radius, h)
+            (label_w + provider.node_padding_x() * 2.0 + radius, h)
         }
         Shape::Cylinder => {
-            let w = label_w + metrics.node_padding_x * 2.0;
+            let w = label_w + provider.node_padding_x() * 2.0;
             let rx = w / 2.0;
             let ry = rx / (2.5 + w / 50.0);
-            (w, label_h + metrics.node_padding_y * 2.0 + ry)
+            (w, label_h + provider.node_padding_y() * 2.0 + ry)
         }
         Shape::Document => {
-            let w = label_w + metrics.node_padding_x * 2.0;
-            let h = label_h + metrics.node_padding_y * 2.0;
+            let w = label_w + provider.node_padding_x() * 2.0;
+            let h = label_h + provider.node_padding_y() * 2.0;
             (w, h + h / 8.0)
         }
         Shape::Documents => {
-            let w = label_w + metrics.node_padding_x * 2.0;
-            let h = label_h + metrics.node_padding_y * 2.0;
+            let w = label_w + provider.node_padding_x() * 2.0;
+            let h = label_h + provider.node_padding_y() * 2.0;
             let offset = 5.0;
             (w + 2.0 * offset, h + h / 4.0 + 2.0 * offset)
         }
         Shape::TaggedDocument => {
-            let w = label_w + metrics.node_padding_x * 2.0;
-            let h = label_h + metrics.node_padding_y * 3.0;
+            let w = label_w + provider.node_padding_x() * 2.0;
+            let h = label_h + provider.node_padding_y() * 3.0;
             (w * 1.1, h + h / 4.0)
         }
         Shape::Card => {
-            let w = label_w + metrics.node_padding_x * 2.0;
-            let h = label_h + metrics.node_padding_y * 2.0;
+            let w = label_w + provider.node_padding_x() * 2.0;
+            let h = label_h + provider.node_padding_y() * 2.0;
             (w + 12.0, h)
         }
         Shape::TaggedRect => {
-            let w = label_w + metrics.node_padding_x * 2.0;
-            let h = label_h + metrics.node_padding_y * 2.0;
+            let w = label_w + provider.node_padding_x() * 2.0;
+            let h = label_h + provider.node_padding_y() * 2.0;
             (w + 0.2 * h, h)
         }
         Shape::Subroutine => {
-            let w = label_w + metrics.node_padding_x * 2.0;
-            let h = label_h + metrics.node_padding_y * 2.0;
+            let w = label_w + provider.node_padding_x() * 2.0;
+            let h = label_h + provider.node_padding_y() * 2.0;
             (w + 20.0, h)
         }
         Shape::Hexagon => {
-            let w = label_w + metrics.node_padding_x * 2.0;
-            let h = label_h + metrics.node_padding_y * 2.0;
+            let w = label_w + provider.node_padding_x() * 2.0;
+            let h = label_h + provider.node_padding_y() * 2.0;
             (w + h / 2.0, h)
         }
         Shape::Parallelogram | Shape::InvParallelogram | Shape::Trapezoid | Shape::InvTrapezoid => {
-            let w = label_w + metrics.node_padding_x * 2.0;
-            let h = label_h + metrics.node_padding_y * 2.0;
+            let w = label_w + provider.node_padding_x() * 2.0;
+            let h = label_h + provider.node_padding_y() * 2.0;
             (w + h / 3.0, h)
         }
         Shape::Asymmetric => {
-            let w = label_w + metrics.node_padding_x * 2.0;
-            let h = label_h + metrics.node_padding_y * 2.0;
+            let w = label_w + provider.node_padding_x() * 2.0;
+            let h = label_h + provider.node_padding_y() * 2.0;
             (w + h / 3.0, h)
         }
         Shape::SmallCircle => (14.0, 14.0),
@@ -561,8 +669,8 @@ pub fn proportional_node_dimensions(
         Shape::ForkJoin if node.label.trim().is_empty() => (70.0, 7.0),
         Shape::TextBlock => (label_w, label_h),
         _ => (
-            label_w + metrics.node_padding_x * 2.0,
-            label_h + metrics.node_padding_y * 2.0,
+            label_w + provider.node_padding_x() * 2.0,
+            label_h + provider.node_padding_y() * 2.0,
         ),
     };
 
@@ -596,6 +704,7 @@ pub fn proportional_node_dimensions(
 mod tests {
     use super::*;
     use crate::graph::Node;
+    use crate::internal_tests::stub_metrics::FixedWidthProvider;
 
     #[test]
     fn measure_text_uses_proportional_heuristic() {
@@ -632,6 +741,59 @@ mod tests {
         assert_eq!(
             resolved.descriptor.layout_text.edge_label_max_width,
             Some(200.0)
+        );
+    }
+
+    #[test]
+    fn proportional_text_metrics_implements_provider_contract() {
+        let metrics = resolve_text_metrics_profile(TextMetricsProfileConfig {
+            profile_id: Some(RECORDED_SANS_TEXT_METRICS_PROFILE_ID),
+            node_padding_x: 11.0,
+            node_padding_y: 7.0,
+            edge_label_max_width: Some(123.0),
+        })
+        .unwrap()
+        .metrics;
+
+        let provider: &dyn TextMetricsProvider = &metrics;
+
+        assert_eq!(provider.font_size(), metrics.font_size);
+        assert_eq!(provider.line_height(), metrics.line_height);
+        assert_eq!(provider.node_padding_x(), metrics.node_padding_x);
+        assert_eq!(provider.node_padding_y(), metrics.node_padding_y);
+        assert_eq!(provider.label_padding_x(), metrics.label_padding_x);
+        assert_eq!(provider.label_padding_y(), metrics.label_padding_y);
+        assert_eq!(
+            provider.measure_line_width("Abc"),
+            metrics.measure_line_width("Abc")
+        );
+        assert_eq!(
+            provider.measure_space_width(),
+            metrics.measure_space_width()
+        );
+    }
+
+    #[test]
+    fn wrap_lines_can_use_stub_provider_widths() {
+        let provider = FixedWidthProvider;
+
+        let lines = wrap_lines_with_provider(&provider, "mmmm iiii", 130.0);
+
+        assert_eq!(lines, vec!["mmmm", "iiii"]);
+    }
+
+    #[test]
+    fn proportional_node_dimensions_can_use_provider_padding_and_widths() {
+        let provider = FixedWidthProvider;
+        let node = Node::new("A").with_label("mmmm");
+
+        let (width, height) =
+            proportional_node_dimensions_with_provider(&provider, &node, Direction::TopDown);
+
+        assert_eq!(width, 30.0 * 4.0 + provider.node_padding_x() * 4.0);
+        assert_eq!(
+            height,
+            provider.line_height() + provider.node_padding_y() * 2.0
         );
     }
 

--- a/src/graph/routing/label_clamp.rs
+++ b/src/graph/routing/label_clamp.rs
@@ -15,7 +15,7 @@ use crate::graph::edge_marker::marker_avoidance_distance;
 use crate::graph::geometry::{
     EdgeLabelSide, FRect, PositionedNode, RoutedEdgeGeometry, UnfitOverlap,
 };
-use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::measure::TextMetricsProvider;
 use crate::graph::routing::label_gap::Axis;
 use crate::graph::{Direction, Graph};
 
@@ -30,10 +30,10 @@ pub(crate) fn clamp_label_geometry_to_node_bounds(
     nodes: &HashMap<String, PositionedNode>,
     diagram: &Graph,
     direction: Direction,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     unfit_overlaps: &mut Vec<UnfitOverlap>,
 ) {
-    let spacing = metrics.label_padding_y;
+    let spacing = metrics.label_padding_y();
 
     for edge in edges.iter_mut() {
         // Skip early when there's no label geometry to clamp.

--- a/src/graph/routing/label_gap.rs
+++ b/src/graph/routing/label_gap.rs
@@ -20,7 +20,7 @@
 use crate::graph::edge::{Arrow, Edge};
 use crate::graph::edge_marker::marker_avoidance_distance;
 use crate::graph::geometry::{RoutedEdgeGeometry, RoutedGraphGeometry};
-use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::measure::TextMetricsProvider;
 use crate::graph::{Direction, Graph};
 
 /// Edge-parallel axis along which the gap is measured.
@@ -103,7 +103,7 @@ pub(crate) fn compute_label_gap_and_span(
     routed: &RoutedGraphGeometry,
     diagram: &Graph,
     direction: Direction,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
 ) -> Option<LabelGapMeasurement> {
     let geom = edge.label_geometry.as_ref()?;
     let diagram_edge = diagram.edges.get(edge.index)?;
@@ -143,8 +143,8 @@ pub(crate) fn compute_label_gap_and_span(
 /// avoidance zone. We reuse `label_padding_y` as a proxy for "margin past
 /// the marker bbox" — it's the same scale (~2 px) and is already part of
 /// the metrics struct, so we don't need a separate constant.
-fn edge_label_spacing(metrics: &ProportionalTextMetrics) -> f64 {
-    metrics.label_padding_y
+fn edge_label_spacing(metrics: &dyn TextMetricsProvider) -> f64 {
+    metrics.label_padding_y()
 }
 
 #[cfg(test)]

--- a/src/graph/routing/label_lanes.rs
+++ b/src/graph/routing/label_lanes.rs
@@ -10,7 +10,10 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::graph::geometry::GraphGeometry;
-use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::measure::{
+    TextMetricsProvider, edge_label_dimensions_for_provider,
+    edge_label_dimensions_wrapped_for_provider,
+};
 use crate::graph::routing::labels::arc_length_midpoint;
 use crate::graph::space::{FPoint, FRect};
 use crate::graph::{Direction, Graph};
@@ -258,7 +261,7 @@ pub(super) fn assign_label_tracks(
     geometry: &GraphGeometry,
     paths: &HashMap<usize, Vec<FPoint>>,
     backward_flags: &HashMap<usize, bool>,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     direction: Direction,
 ) -> HashMap<usize, LabelTrackOutcome> {
     let descriptors = build_label_descriptors(diagram, geometry, paths, backward_flags, metrics);
@@ -511,7 +514,7 @@ pub(super) fn build_label_descriptors(
     geometry: &GraphGeometry,
     paths: &HashMap<usize, Vec<FPoint>>,
     backward_flags: &HashMap<usize, bool>,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
 ) -> Vec<LabelDescriptor> {
     let direction = diagram.direction;
     let mut out = Vec::new();
@@ -542,8 +545,8 @@ pub(super) fn build_label_descriptors(
         // to single-line measurement for edges that opted out of the
         // pre-engine wrap (dagre-parity mode).
         let (w, h) = match edge.wrapped_label_lines.as_deref() {
-            Some(lines) => metrics.edge_label_dimensions_wrapped(lines),
-            None => metrics.edge_label_dimensions(label_text),
+            Some(lines) => edge_label_dimensions_wrapped_for_provider(metrics, lines),
+            None => edge_label_dimensions_for_provider(metrics, label_text),
         };
 
         let direction_sign = if *backward_flags.get(&edge_index).unwrap_or(&false) {
@@ -831,6 +834,7 @@ fn label_lane_subcluster_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::graph::measure::ProportionalTextMetrics;
 
     fn make_descriptor(
         edge_index: usize,

--- a/src/graph/routing/label_rewrap.rs
+++ b/src/graph/routing/label_rewrap.rs
@@ -64,7 +64,9 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::graph::geometry::RoutedEdgeGeometry;
-use crate::graph::measure::{ProportionalTextMetrics, wrap_lines};
+use crate::graph::measure::{
+    TextMetricsProvider, edge_label_dimensions_wrapped_for_provider, wrap_lines_with_provider,
+};
 use crate::graph::routing::label_lanes::{LANE_GAP, LabelTrackOutcome, MIN_LABEL_LANE_STEP};
 use crate::graph::space::FPoint;
 use crate::graph::{Direction, Graph};
@@ -115,7 +117,7 @@ pub(super) fn re_wrap_labels_for_lane_fit(
     diagram: &Graph,
     edges: &mut [RoutedEdgeGeometry],
     lane_outcomes: &mut HashMap<usize, LabelTrackOutcome>,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     direction: Direction,
 ) -> usize {
     let mut total_rewraps: usize = 0;
@@ -181,8 +183,8 @@ pub(super) fn re_wrap_labels_for_lane_fit(
             }
 
             let target = (outcome.label_step * REWRAP_SAFETY).max(MIN_REWRAP_WIDTH);
-            let new_lines = wrap_lines(metrics, label_text, target);
-            let (new_w, new_h) = metrics.edge_label_dimensions_wrapped(&new_lines);
+            let new_lines = wrap_lines_with_provider(metrics, label_text, target);
+            let (new_w, new_h) = edge_label_dimensions_wrapped_for_provider(metrics, &new_lines);
 
             // Skip edges where the re-wrap would not actually narrow the
             // rect. Can happen with single oversized words where the

--- a/src/graph/routing/mod.rs
+++ b/src/graph/routing/mod.rs
@@ -24,6 +24,7 @@ pub use self::float_core::{
 };
 pub use self::labels::compute_end_label_positions;
 pub use self::orthogonal::{OrthogonalRoutingOptions, route_edges_orthogonal};
+pub(crate) use self::stage::route_graph_geometry_with_provider;
 pub use self::stage::{EdgeRouting, route_graph_geometry};
 #[cfg(test)]
 use crate::graph::Graph;
@@ -38,6 +39,7 @@ mod tests {
     use crate::graph::attachment::PortFace;
     use crate::graph::measure::default_proportional_text_metrics;
     use crate::graph::routing::EdgeRouting;
+    use crate::internal_tests::stub_metrics::WideMProvider;
 
     fn simple_geometry() -> (Graph, GraphGeometry) {
         let mut diagram = Graph::new(crate::graph::Direction::TopDown);
@@ -1612,6 +1614,79 @@ mod tests {
 
         // track: 0 — singleton compartment, no displacement needed.
         assert_eq!(lg.track, 0);
+    }
+
+    #[test]
+    fn routed_label_geometry_uses_provider_label_dimensions() {
+        let provider = WideMProvider;
+
+        let mut diagram = Graph::new(crate::graph::Direction::TopDown);
+        diagram.add_node(crate::graph::Node::new("A"));
+        diagram.add_node(crate::graph::Node::new("B"));
+        diagram.add_edge(crate::graph::Edge::new("A", "B").with_label("mmmm"));
+
+        let mut nodes = HashMap::new();
+        nodes.insert(
+            "A".into(),
+            PositionedNode {
+                id: "A".into(),
+                rect: FRect::new(50.0, 25.0, 40.0, 20.0),
+                shape: crate::graph::Shape::Rectangle,
+                label: "A".into(),
+                parent: None,
+            },
+        );
+        nodes.insert(
+            "B".into(),
+            PositionedNode {
+                id: "B".into(),
+                rect: FRect::new(50.0, 95.0, 40.0, 20.0),
+                shape: crate::graph::Shape::Rectangle,
+                label: "B".into(),
+                parent: None,
+            },
+        );
+
+        let geom = GraphGeometry {
+            nodes,
+            edges: vec![LayoutEdge {
+                index: 0,
+                from: "A".into(),
+                to: "B".into(),
+                waypoints: vec![],
+                label_position: Some(FPoint::new(70.0, 60.0)),
+                label_side: None,
+                from_subgraph: None,
+                to_subgraph: None,
+                layout_path_hint: Some(vec![FPoint::new(70.0, 35.0), FPoint::new(70.0, 105.0)]),
+                preserve_orthogonal_topology: false,
+                label_geometry: None,
+                effective_wrapped_lines: None,
+            }],
+            subgraphs: HashMap::new(),
+            self_edges: vec![],
+            direction: crate::graph::Direction::TopDown,
+            node_directions: HashMap::new(),
+            bounds: FRect::new(0.0, 0.0, 100.0, 140.0),
+            reversed_edges: vec![],
+            engine_hints: None,
+            grid_projection: None,
+            rerouted_edges: std::collections::HashSet::new(),
+            enhanced_backward_routing: false,
+        };
+
+        let routed = route_graph_geometry_with_provider(
+            &diagram,
+            &geom,
+            EdgeRouting::PolylineRoute,
+            &provider,
+        );
+
+        let label_rect = routed.edges[0].label_geometry.as_ref().unwrap().rect;
+        assert!(
+            label_rect.width > 160.0,
+            "provider label width should drive routed label rect, got {label_rect:?}"
+        );
     }
 
     /// Routed bounds must cover all edge path points, even when routing

--- a/src/graph/routing/stage.rs
+++ b/src/graph/routing/stage.rs
@@ -13,7 +13,10 @@ use crate::graph::geometry::{
     EdgeLabelGeometry, EdgeLabelSide, GraphGeometry, LayoutEdge, RoutedEdgeGeometry,
     RoutedGraphGeometry, RoutedSelfEdge,
 };
-use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::measure::{
+    ProportionalTextMetrics, TextMetricsProvider, edge_label_dimensions_for_provider,
+    edge_label_dimensions_wrapped_for_provider,
+};
 use crate::graph::space::{FPoint, FRect};
 use crate::graph::{Direction, Graph, Shape};
 
@@ -39,6 +42,15 @@ pub fn route_graph_geometry(
     geometry: &GraphGeometry,
     edge_routing: EdgeRouting,
     metrics: &ProportionalTextMetrics,
+) -> RoutedGraphGeometry {
+    route_graph_geometry_with_provider(diagram, geometry, edge_routing, metrics)
+}
+
+pub(crate) fn route_graph_geometry_with_provider(
+    diagram: &Graph,
+    geometry: &GraphGeometry,
+    edge_routing: EdgeRouting,
+    metrics: &dyn TextMetricsProvider,
 ) -> RoutedGraphGeometry {
     let port_attachments = compute_port_attachments_from_geometry(diagram, geometry);
     #[cfg(test)]
@@ -238,7 +250,7 @@ pub fn route_graph_geometry(
             .as_ref()
             .map(|g| (g.padding, g.side))
             .unwrap_or((
-                (metrics.label_padding_x, metrics.label_padding_y),
+                (metrics.label_padding_x(), metrics.label_padding_y()),
                 EdgeLabelSide::Center,
             ));
         routed_edge.label_position = Some(outcome.label_center);
@@ -923,7 +935,7 @@ fn snap_to_primary_face(
 fn populate_label_geometry(
     edges: &mut [RoutedEdgeGeometry],
     diagram: &Graph,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
 ) {
     for routed_edge in edges.iter_mut() {
         let Some(center) = routed_edge.label_position else {
@@ -939,14 +951,14 @@ fn populate_label_geometry(
         // Prefer the pre-engine wrap artifact when present so the reserved
         // rect matches what SVG text and the MMDS replay emit.
         let (w, h) = match diagram_edge.and_then(|e| e.wrapped_label_lines.as_deref()) {
-            Some(lines) => metrics.edge_label_dimensions_wrapped(lines),
-            None => metrics.edge_label_dimensions(label),
+            Some(lines) => edge_label_dimensions_wrapped_for_provider(metrics, lines),
+            None => edge_label_dimensions_for_provider(metrics, label),
         };
         let side = routed_edge.label_side.unwrap_or(EdgeLabelSide::Center);
         routed_edge.label_geometry = Some(EdgeLabelGeometry {
             center,
             rect: FRect::new(center.x - w / 2.0, center.y - h / 2.0, w, h),
-            padding: (metrics.label_padding_x, metrics.label_padding_y),
+            padding: (metrics.label_padding_x(), metrics.label_padding_y()),
             side,
             track: 0,
             compartment_size: 1,
@@ -973,7 +985,7 @@ fn populate_label_geometry(
 fn align_backward_side_offset_labels(
     edges: &mut [RoutedEdgeGeometry],
     diagram: &Graph,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     edge_routing: EdgeRouting,
 ) {
     if !matches!(edge_routing, EdgeRouting::OrthogonalRoute) {
@@ -1001,8 +1013,8 @@ fn align_backward_side_offset_labels(
             continue;
         }
         let (_, label_height) = match diagram_edge.wrapped_label_lines.as_deref() {
-            Some(lines) => metrics.edge_label_dimensions_wrapped(lines),
-            None => metrics.edge_label_dimensions(label),
+            Some(lines) => edge_label_dimensions_wrapped_for_provider(metrics, lines),
+            None => edge_label_dimensions_for_provider(metrics, label),
         };
         if let Some(aligned) = project_side_aware_anchor(&routed_edge.path, label_height, side) {
             routed_edge.label_position = Some(aligned);

--- a/src/graph/routing/trace.rs
+++ b/src/graph/routing/trace.rs
@@ -6,7 +6,10 @@ use crate::graph::attachment::EdgePort;
 use crate::graph::geometry::{
     EdgeLabelSide, GraphGeometry, RoutedEdgeGeometry, RoutedGraphGeometry,
 };
-use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::measure::{
+    TextMetricsProvider, edge_label_dimensions_for_provider,
+    edge_label_dimensions_wrapped_for_provider,
+};
 use crate::graph::space::{FPoint, FRect};
 use crate::graph::{Direction, Graph, Shape};
 
@@ -230,7 +233,7 @@ pub(crate) fn capture_route_input(
     geometry: &GraphGeometry,
     edge_routing: EdgeRouting,
     port_attachments: &HashMap<usize, (Option<EdgePort>, Option<EdgePort>)>,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
 ) {
     ACTIVE_TRACE.with(|trace| {
         let mut trace = trace.borrow_mut();
@@ -283,7 +286,7 @@ impl RouteInputSnapshot {
         geometry: &GraphGeometry,
         edge_routing: EdgeRouting,
         port_attachments: &HashMap<usize, (Option<EdgePort>, Option<EdgePort>)>,
-        metrics: &ProportionalTextMetrics,
+        metrics: &dyn TextMetricsProvider,
     ) -> Self {
         let mut nodes = geometry
             .nodes
@@ -338,8 +341,8 @@ impl RouteInputSnapshot {
                 }
                 let midpoint = edge.label_position?;
                 let (width, height) = match diagram_edge.wrapped_label_lines.as_deref() {
-                    Some(lines) => metrics.edge_label_dimensions_wrapped(lines),
-                    None => metrics.edge_label_dimensions(label),
+                    Some(lines) => edge_label_dimensions_wrapped_for_provider(metrics, lines),
+                    None => edge_label_dimensions_for_provider(metrics, label),
                 };
                 let (axis_dim, cross_dim, axis_center, cross_center) = match geometry.direction {
                     Direction::TopDown | Direction::BottomTop => {

--- a/src/internal_tests/cross_pipeline.rs
+++ b/src/internal_tests/cross_pipeline.rs
@@ -20,7 +20,9 @@ use crate::graph::geometry::{FPoint, RoutedGraphGeometry};
 use crate::graph::grid::{
     GridLayout, GridLayoutConfig, GridRanker, NodeBounds, geometry_to_grid_layout_with_routed,
 };
-use crate::graph::measure::default_proportional_text_metrics;
+use crate::graph::measure::{
+    default_proportional_text_metrics, default_proportional_text_metrics_provider,
+};
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
 use crate::graph::{Direction, GeometryLevel, Graph, Shape};
 use crate::mmds::from_str;
@@ -53,7 +55,7 @@ fn load_mmds_fixture(name: &str) -> String {
 fn default_grid_request(
     level: GeometryLevel,
     routing_style: Option<RoutingStyle>,
-) -> GraphSolveRequest {
+) -> GraphSolveRequest<'static> {
     GraphSolveRequest::new(
         MeasurementMode::Grid,
         GraphGeometryContract::Canonical,
@@ -63,15 +65,15 @@ fn default_grid_request(
     )
 }
 
-fn default_proportional_mode() -> MeasurementMode {
-    MeasurementMode::Proportional(default_proportional_text_metrics())
+fn default_proportional_mode() -> MeasurementMode<'static> {
+    MeasurementMode::Proportional(default_proportional_text_metrics_provider())
 }
 
 fn default_proportional_request(
     geometry_contract: GraphGeometryContract,
     level: GeometryLevel,
     routing_style: Option<RoutingStyle>,
-) -> GraphSolveRequest {
+) -> GraphSolveRequest<'static> {
     GraphSolveRequest::new(
         default_proportional_mode(),
         geometry_contract,

--- a/src/internal_tests/graph_routing_pipeline.rs
+++ b/src/internal_tests/graph_routing_pipeline.rs
@@ -12,7 +12,9 @@ use crate::engines::graph::EngineConfig;
 use crate::engines::graph::algorithms::layered::run_layered_layout;
 use crate::engines::graph::contracts::MeasurementMode;
 use crate::graph::geometry::*;
-use crate::graph::measure::default_proportional_text_metrics;
+use crate::graph::measure::{
+    default_proportional_text_metrics, default_proportional_text_metrics_provider,
+};
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
 use crate::mermaid::parse_flowchart;
 
@@ -73,8 +75,8 @@ fn layout_test_svg(input: &str) -> (crate::graph::Graph, GraphGeometry) {
     (diagram, geom)
 }
 
-fn default_proportional_mode() -> MeasurementMode {
-    MeasurementMode::Proportional(default_proportional_text_metrics())
+fn default_proportional_mode() -> MeasurementMode<'static> {
+    MeasurementMode::Proportional(default_proportional_text_metrics_provider())
 }
 
 fn layout_fixture_svg(name: &str) -> (crate::graph::Graph, GraphGeometry) {
@@ -5486,7 +5488,7 @@ mod plan_0145_q9_routed_red {
         let config = EngineConfig::Layered(
             crate::engines::graph::algorithms::layered::LayoutConfig::default(),
         );
-        let mode = MeasurementMode::Proportional(metrics.clone());
+        let mode = MeasurementMode::Proportional(&metrics);
         let geom = run_layered_layout(&mode, &diagram, &config).expect("layout should succeed");
         let routed = route_graph_geometry(&diagram, &geom, EdgeRouting::OrthogonalRoute, &metrics);
         (diagram, routed)
@@ -5664,7 +5666,7 @@ mod plan_0151_producer_alignment {
 
         let metrics = default_proportional_text_metrics();
         let request = GraphSolveRequest::new(
-            MeasurementMode::Proportional(metrics),
+            MeasurementMode::Proportional(&metrics),
             GraphGeometryContract::Canonical,
             GeometryLevel::Routed,
             None,
@@ -5693,7 +5695,7 @@ mod plan_0151_producer_alignment {
 
         let metrics = default_proportional_text_metrics();
         let request = GraphSolveRequest::new(
-            MeasurementMode::Proportional(metrics),
+            MeasurementMode::Proportional(&metrics),
             GraphGeometryContract::Canonical,
             GeometryLevel::Routed,
             None,

--- a/src/internal_tests/label_node_overlap.rs
+++ b/src/internal_tests/label_node_overlap.rs
@@ -150,7 +150,7 @@ fn flowchart_routed_for_fixture(path: &Path) -> (Graph, RoutedGraphGeometry) {
         .unwrap_or_else(|e| panic!("failed to parse {}: {e}", path.display()));
     let diagram = compile_to_graph(&fc);
     let metrics = default_proportional_text_metrics();
-    let mode = MeasurementMode::Proportional(metrics.clone());
+    let mode = MeasurementMode::Proportional(&metrics);
     let config = EngineConfig::Layered(crate::engines::graph::algorithms::layered::LayoutConfig {
         greedy_switch: true,
         model_order_tiebreak: true,

--- a/src/internal_tests/layered_kernel_bend.rs
+++ b/src/internal_tests/layered_kernel_bend.rs
@@ -275,7 +275,7 @@ fn canonical_proportional_solve_honors_edge_label_spacing_override() {
     let flowchart = parse_flowchart("graph TD\n    A -->|label| B\n").expect("fixture parses");
     let diagram = compile_to_graph(&flowchart);
     let metrics = default_proportional_text_metrics();
-    let mode = MeasurementMode::Proportional(metrics);
+    let mode = MeasurementMode::Proportional(&metrics);
 
     let baseline = LayoutConfig {
         label_dummy_placement: LabelDummyPlacement::WidestLayer,

--- a/src/internal_tests/mod.rs
+++ b/src/internal_tests/mod.rs
@@ -14,6 +14,7 @@ mod mmds_document_serialization;
 mod mmds_roundtrip;
 mod port_attachment_observation;
 mod singleton_centering_observation;
+pub(crate) mod stub_metrics;
 mod svg_render_pipeline;
 mod text_render_pipeline;
 

--- a/src/internal_tests/stub_metrics.rs
+++ b/src/internal_tests/stub_metrics.rs
@@ -1,0 +1,122 @@
+//! Shared text-metrics providers for crate-local canaries.
+
+use crate::graph::measure::{ProportionalTextMetrics, TextMetricsProvider};
+
+macro_rules! impl_stub_provider {
+    (
+        $provider:ty,
+        m_width: $m_width:expr,
+        other_width: $other_width:expr,
+        label_padding_x: $label_padding_x:expr,
+        label_padding_y: $label_padding_y:expr
+    ) => {
+        impl TextMetricsProvider for $provider {
+            fn measure_line_width(&self, text: &str) -> f64 {
+                text.chars().map(|ch| self.measure_scalar_width(ch)).sum()
+            }
+
+            fn measure_scalar_width(&self, ch: char) -> f64 {
+                if ch == 'm' { $m_width } else { $other_width }
+            }
+
+            fn font_size(&self) -> f64 {
+                16.0
+            }
+
+            fn line_height(&self) -> f64 {
+                20.0
+            }
+
+            fn node_padding_x(&self) -> f64 {
+                10.0
+            }
+
+            fn node_padding_y(&self) -> f64 {
+                6.0
+            }
+
+            fn label_padding_x(&self) -> f64 {
+                $label_padding_x
+            }
+
+            fn label_padding_y(&self) -> f64 {
+                $label_padding_y
+            }
+        }
+    };
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FixedWidthProvider;
+
+impl_stub_provider!(
+    FixedWidthProvider,
+    m_width: 30.0,
+    other_width: 5.0,
+    label_padding_x: 4.0,
+    label_padding_y: 2.0
+);
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct WideMProvider;
+
+impl_stub_provider!(
+    WideMProvider,
+    m_width: 40.0,
+    other_width: 5.0,
+    label_padding_x: 4.0,
+    label_padding_y: 2.0
+);
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PaddedProvider;
+
+impl_stub_provider!(
+    PaddedProvider,
+    m_width: 40.0,
+    other_width: 5.0,
+    label_padding_x: 11.0,
+    label_padding_y: 7.0
+);
+
+pub(crate) struct NonCloneProvider(ProportionalTextMetrics);
+
+impl NonCloneProvider {
+    pub(crate) fn new(metrics: ProportionalTextMetrics) -> Self {
+        Self(metrics)
+    }
+}
+
+impl TextMetricsProvider for NonCloneProvider {
+    fn measure_line_width(&self, text: &str) -> f64 {
+        ProportionalTextMetrics::measure_line_width(&self.0, text)
+    }
+
+    fn measure_scalar_width(&self, ch: char) -> f64 {
+        ProportionalTextMetrics::measure_scalar_width(&self.0, ch)
+    }
+
+    fn font_size(&self) -> f64 {
+        self.0.font_size
+    }
+
+    fn line_height(&self) -> f64 {
+        self.0.line_height
+    }
+
+    fn node_padding_x(&self) -> f64 {
+        self.0.node_padding_x
+    }
+
+    fn node_padding_y(&self) -> f64 {
+        self.0.node_padding_y
+    }
+
+    fn label_padding_x(&self) -> f64 {
+        self.0.label_padding_x
+    }
+
+    fn label_padding_y(&self) -> f64 {
+        self.0.label_padding_y
+    }
+}

--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -11,17 +11,25 @@ use crate::engines::graph::contracts::{
 use crate::engines::graph::flux::FluxLayeredEngine;
 use crate::format::{CornerStyle, Curve, RoutingStyle};
 use crate::graph::Stroke;
-use crate::graph::measure::default_proportional_text_metrics;
+use crate::graph::measure::{
+    TextMetricsProvider, default_proportional_text_metrics,
+    default_proportional_text_metrics_provider,
+};
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
+use crate::internal_tests::stub_metrics::WideMProvider;
 use crate::mermaid::parse_flowchart;
-use crate::render::graph::{render_svg_from_geometry, render_svg_from_routed_geometry};
+use crate::render::graph::{
+    SvgRenderOptions, render_svg_from_geometry,
+    render_svg_from_geometry_with_theme_routing_and_metrics, render_svg_from_routed_geometry,
+};
 use crate::simplification::PathSimplification;
-use crate::{OutputFormat, RenderConfig, SvgThemeConfig};
+use crate::{OutputFormat, RenderConfig, SvgThemeConfig, render_diagram};
 
 fn render_svg(diagram: &crate::graph::Graph, config: &RenderConfig) -> String {
     let engine = FluxLayeredEngine::text();
+    let metrics = default_proportional_text_metrics();
     let request = GraphSolveRequest::new(
-        MeasurementMode::Proportional(default_proportional_text_metrics()),
+        MeasurementMode::Proportional(&metrics),
         GraphGeometryContract::Visual,
         config.geometry_level,
         config
@@ -45,13 +53,76 @@ fn render_svg(diagram: &crate::graph::Graph, config: &RenderConfig) -> String {
     }
 }
 
+fn render_svg_with_provider_for_test(input: &str, provider: &dyn TextMetricsProvider) -> String {
+    let flowchart = parse_flowchart(input).expect("fixture parses");
+    let diagram = compile_to_graph(&flowchart);
+    let request = GraphSolveRequest::new(
+        MeasurementMode::Proportional(provider),
+        GraphGeometryContract::Visual,
+        crate::graph::GeometryLevel::Layout,
+        Some(RoutingStyle::Polyline),
+        Default::default(),
+    );
+    let result = FluxLayeredEngine::text()
+        .solve(
+            &diagram,
+            &EngineConfig::Layered(Default::default()),
+            &request,
+        )
+        .expect("provider-backed visual solve succeeds");
+
+    render_svg_from_geometry_with_theme_routing_and_metrics(
+        &diagram,
+        &result.geometry,
+        &SvgRenderOptions::default(),
+        EdgeRouting::PolylineRoute,
+        None,
+        provider,
+    )
+}
+
+#[test]
+fn internal_stub_provider_changes_svg_geometry_without_public_config() {
+    let input = "graph TD\nA[mmmm] --> B[iiii]\n";
+    let provider = WideMProvider;
+    let default_config = RenderConfig::default();
+    let default_svg = render_diagram(input, OutputFormat::Svg, &default_config)
+        .expect("default public SVG render should succeed");
+
+    let stub_svg = render_svg_with_provider_for_test(input, &provider);
+
+    assert_ne!(default_svg, stub_svg);
+    assert_eq!(
+        render_diagram(input, OutputFormat::Svg, &RenderConfig::default())
+            .expect("default public SVG render should still succeed"),
+        default_svg
+    );
+}
+
+#[test]
+fn svg_label_background_uses_provider_widths() {
+    let provider = WideMProvider;
+    let svg = render_svg_with_provider_for_test("graph TD\nA -->|mmmm| B\n", &provider);
+    let rects = extract_label_bg_rects(&svg);
+    let max_width = rects
+        .iter()
+        .map(|(_, _, width, _)| *width)
+        .fold(0.0, f64::max);
+
+    assert!(
+        max_width > 160.0,
+        "provider should drive SVG label background width; max={max_width}, svg={svg}"
+    );
+}
+
 fn solve_visual_geometry(
     diagram: &crate::graph::Graph,
     config: &RenderConfig,
 ) -> crate::graph::geometry::GraphGeometry {
     let engine = FluxLayeredEngine::text();
+    let metrics = default_proportional_text_metrics();
     let request = GraphSolveRequest::new(
-        MeasurementMode::Proportional(default_proportional_text_metrics()),
+        MeasurementMode::Proportional(&metrics),
         GraphGeometryContract::Visual,
         config.geometry_level,
         config
@@ -69,8 +140,8 @@ fn solve_visual_geometry(
         .geometry
 }
 
-fn default_proportional_mode() -> MeasurementMode {
-    MeasurementMode::Proportional(default_proportional_text_metrics())
+fn default_proportional_mode() -> MeasurementMode<'static> {
+    MeasurementMode::Proportional(default_proportional_text_metrics_provider())
 }
 
 fn routing_style_for(edge_routing: EdgeRouting) -> RoutingStyle {
@@ -5754,8 +5825,9 @@ fn render_svg_from_routed_geometry_preserves_label_geometry_rect() {
     let engine = FluxLayeredEngine::text();
     let config =
         EngineConfig::Layered(crate::engines::graph::algorithms::layered::LayoutConfig::default());
+    let metrics = default_proportional_text_metrics();
     let request = GraphSolveRequest::new(
-        MeasurementMode::Proportional(default_proportional_text_metrics()),
+        MeasurementMode::Proportional(&metrics),
         GraphGeometryContract::Canonical,
         GeometryLevel::Routed,
         Some(RoutingStyle::Polyline),

--- a/src/internal_tests/text_render_pipeline.rs
+++ b/src/internal_tests/text_render_pipeline.rs
@@ -683,7 +683,9 @@ mod edge_rendering_regression {
         AttachDirection, GridLayout, GridLayoutConfig, NodeBounds, SubgraphBounds,
         geometry_to_grid_layout_with_routed, route_all_edges, route_edge, route_edge_with_probe,
     };
-    use crate::graph::measure::default_proportional_text_metrics;
+    use crate::graph::measure::{
+        default_proportional_text_metrics, default_proportional_text_metrics_provider,
+    };
     use crate::graph::routing::{EdgeRouting, route_graph_geometry};
     use crate::graph::{Arrow, Direction, Edge, Graph, Node, Stroke};
     use crate::mermaid::parse_flowchart;
@@ -909,7 +911,7 @@ mod edge_rendering_regression {
     fn compute_layout_with_mode(
         diagram: &Graph,
         config: &GridLayoutConfig,
-        measurement_mode: MeasurementMode,
+        measurement_mode: MeasurementMode<'_>,
     ) -> (crate::graph::geometry::RoutedGraphGeometry, GridLayout) {
         let engine = FluxLayeredEngine::text();
         let request = GraphSolveRequest::new(
@@ -941,8 +943,9 @@ mod edge_rendering_regression {
         name: &str,
     ) -> (Graph, crate::graph::geometry::RoutedGraphGeometry) {
         let diagram = flowchart_fixture_diagram(name);
+        let metrics = default_proportional_text_metrics_provider();
         let geom = run_layered_layout(
-            &MeasurementMode::Proportional(default_proportional_text_metrics()),
+            &MeasurementMode::Proportional(metrics),
             &diagram,
             &flux_layout_config(),
         )

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -14,9 +14,13 @@ use crate::graph::attachment::{EdgePort, PortFace};
 use crate::graph::geometry::{
     EdgeLabelSide, GraphGeometry, PositionedNode, RoutedEdgeGeometry, RoutedGraphGeometry,
 };
-use crate::graph::measure::{TextMetricsProfileDescriptor, default_proportional_text_metrics};
+use crate::graph::measure::{
+    TextMetricsProfileDescriptor, TextMetricsProvider, default_proportional_text_metrics,
+};
 use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
-use crate::graph::routing::{EdgeRouting, route_graph_geometry};
+use crate::graph::routing::{
+    EdgeRouting, route_graph_geometry, route_graph_geometry_with_provider,
+};
 use crate::graph::style::NodeStyle;
 use crate::graph::{Arrow, Direction, GeometryLevel, Graph, Shape, Stroke};
 use crate::simplification::PathSimplification;
@@ -244,6 +248,7 @@ pub(crate) fn to_document_typed_with_routing(
         path_simplification,
         engine_id,
         None,
+        None,
     )
 }
 
@@ -257,12 +262,24 @@ pub(crate) fn to_document_typed_with_routing_and_text_metrics(
     path_simplification: PathSimplification,
     engine_id: Option<&str>,
     text_metrics_descriptor: Option<&TextMetricsProfileDescriptor>,
+    text_metrics_provider: Option<&dyn TextMetricsProvider>,
 ) -> Result<Document, RenderError> {
-    // MMDS fallback routing: default metrics are sufficient since this path
-    // only fires when no pre-routed geometry was provided (design §6.3).
-    let metrics = default_proportional_text_metrics();
-    let routed_owned = (routed.is_none() && matches!(level, GeometryLevel::Routed))
-        .then(|| route_graph_geometry(diagram, geometry, EdgeRouting::OrthogonalRoute, &metrics));
+    let routed_owned = (routed.is_none() && matches!(level, GeometryLevel::Routed)).then(|| {
+        match text_metrics_provider {
+            Some(metrics) => route_graph_geometry_with_provider(
+                diagram,
+                geometry,
+                EdgeRouting::OrthogonalRoute,
+                metrics,
+            ),
+            None => {
+                // Static MMDS fallback routing for legacy adapter callers that
+                // request routed output without already carrying resolved metrics.
+                let metrics = default_proportional_text_metrics();
+                route_graph_geometry(diagram, geometry, EdgeRouting::OrthogonalRoute, &metrics)
+            }
+        }
+    });
     let routed = routed.or(routed_owned.as_ref());
 
     to_document_typed_with_text_metrics(
@@ -1119,7 +1136,101 @@ fn is_default_minlen(value: &i32) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{HashMap, HashSet};
+
     use super::*;
+    use crate::graph::geometry::LayoutEdge;
+    use crate::graph::space::{FPoint, FRect};
+    use crate::graph::{Edge as GraphEdge, Node as GraphNode};
+    use crate::internal_tests::stub_metrics::WideMProvider;
+
+    fn labeled_graph_geometry() -> (Graph, GraphGeometry) {
+        let mut diagram = Graph::new(Direction::TopDown);
+        diagram.add_node(GraphNode::new("A"));
+        diagram.add_node(GraphNode::new("B"));
+        diagram.add_edge(GraphEdge::new("A", "B").with_label("mmmm"));
+
+        let mut nodes = HashMap::new();
+        nodes.insert(
+            "A".to_string(),
+            PositionedNode {
+                id: "A".to_string(),
+                rect: FRect::new(40.0, 20.0, 50.0, 30.0),
+                shape: Shape::Rectangle,
+                label: "A".to_string(),
+                parent: None,
+            },
+        );
+        nodes.insert(
+            "B".to_string(),
+            PositionedNode {
+                id: "B".to_string(),
+                rect: FRect::new(40.0, 110.0, 50.0, 30.0),
+                shape: Shape::Rectangle,
+                label: "B".to_string(),
+                parent: None,
+            },
+        );
+
+        let geometry = GraphGeometry {
+            nodes,
+            edges: vec![LayoutEdge {
+                index: 0,
+                from: "A".to_string(),
+                to: "B".to_string(),
+                waypoints: vec![],
+                label_position: Some(FPoint::new(65.0, 80.0)),
+                label_side: None,
+                from_subgraph: None,
+                to_subgraph: None,
+                layout_path_hint: Some(vec![FPoint::new(65.0, 50.0), FPoint::new(65.0, 110.0)]),
+                preserve_orthogonal_topology: false,
+                label_geometry: None,
+                effective_wrapped_lines: None,
+            }],
+            subgraphs: HashMap::new(),
+            self_edges: vec![],
+            direction: Direction::TopDown,
+            node_directions: HashMap::new(),
+            bounds: FRect::new(0.0, 0.0, 130.0, 160.0),
+            reversed_edges: vec![],
+            engine_hints: None,
+            grid_projection: None,
+            rerouted_edges: HashSet::new(),
+            enhanced_backward_routing: false,
+        };
+
+        (diagram, geometry)
+    }
+
+    #[test]
+    fn mmds_fallback_routing_uses_supplied_provider_when_available() {
+        let provider = WideMProvider;
+        let (diagram, geometry) = labeled_graph_geometry();
+
+        let document = to_document_typed_with_routing_and_text_metrics(
+            "flowchart",
+            &diagram,
+            &geometry,
+            None,
+            GeometryLevel::Routed,
+            PathSimplification::None,
+            None,
+            None,
+            Some(&provider),
+        )
+        .expect("fallback routed document should serialize");
+
+        let label_rect = document.edges[0]
+            .label_rect
+            .as_ref()
+            .expect("fallback routing should populate label_rect");
+        assert!(
+            label_rect.width > 160.0,
+            "label_rect width should come from supplied provider, got {}",
+            label_rect.width
+        );
+    }
 
     #[test]
     fn mmds_port_serializes_correctly() {

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -14,9 +14,9 @@ use crate::graph::geometry::{
     EdgeLabelGeometry, EdgeLabelSide, GraphGeometry, LayoutEdge, PositionedNode,
     RoutedGraphGeometry, SelfEdgeGeometry, SubgraphGeometry,
 };
-use crate::graph::measure::default_proportional_text_metrics;
+use crate::graph::measure::{TextMetricsProvider, default_proportional_text_metrics};
 use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
-use crate::graph::routing::{EdgeRouting, route_graph_geometry};
+use crate::graph::routing::{EdgeRouting, route_graph_geometry_with_provider};
 use crate::graph::space::{FPoint, FRect};
 use crate::graph::style::{ColorToken, NodeStyle};
 use crate::graph::{Edge as GraphEdge, GeometryLevel, Graph, Node, Subgraph};
@@ -352,16 +352,22 @@ pub(crate) fn hydrate_routed_geometry_from_mmds(
 pub fn hydrate_routed_geometry_from_document(
     output: &Document,
 ) -> Result<RoutedGraphGeometry, HydrationError> {
+    let metrics = default_proportional_text_metrics();
+    hydrate_routed_geometry_from_document_with_provider(output, &metrics)
+}
+
+/// Hydrate routed geometry IR from a parsed MMDS document with caller-supplied metrics.
+pub(crate) fn hydrate_routed_geometry_from_document_with_provider(
+    output: &Document,
+    metrics: &dyn TextMetricsProvider,
+) -> Result<RoutedGraphGeometry, HydrationError> {
     let (diagram, geometry) = hydrate_geometry_parts(output)?;
     let edge_routing = if output.geometry_level == GeometryLevel::Routed {
         EdgeRouting::EngineProvided
     } else {
         EdgeRouting::PolylineRoute
     };
-    // MMDS replay hydration: default metrics are sufficient since the MMDS
-    // replay path does not carry a request-specific metrics handle (design §6.3).
-    let metrics = default_proportional_text_metrics();
-    let mut routed = route_graph_geometry(&diagram, &geometry, edge_routing, &metrics);
+    let mut routed = route_graph_geometry_with_provider(&diagram, &geometry, edge_routing, metrics);
 
     // Preserve authoritative routed label geometry by overwriting
     // `label_geometry` on routed edges with the semantics carried by the MMDS
@@ -370,7 +376,7 @@ pub fn hydrate_routed_geometry_from_document(
     // lose the authoritative `label_rect` whenever `label_position` and
     // `label_rect` disagree.
     if output.geometry_level == GeometryLevel::Routed {
-        overlay_authoritative_label_geometry(&mut routed, output, &metrics);
+        overlay_authoritative_label_geometry(&mut routed, output, metrics);
     }
 
     Ok(routed)
@@ -391,7 +397,7 @@ pub fn hydrate_routed_geometry_from_output(
 fn overlay_authoritative_label_geometry(
     routed: &mut RoutedGraphGeometry,
     output: &Document,
-    metrics: &crate::graph::measure::ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
 ) {
     let edges = sorted_output_edges(output);
     for (routed_index, (_, mmds_edge)) in edges.into_iter().enumerate() {
@@ -420,7 +426,7 @@ fn overlay_authoritative_label_geometry(
         routed_edge.label_geometry = Some(EdgeLabelGeometry {
             center,
             rect,
-            padding: (metrics.label_padding_x, metrics.label_padding_y),
+            padding: (metrics.label_padding_x(), metrics.label_padding_y()),
             side,
             // Synthesized trust markers: replay consumers that gate on
             // `track != 0 || compartment_size > 1` treat the hydrated
@@ -994,6 +1000,92 @@ impl Error for HydrationError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::graph::{Arrow, Shape, Stroke};
+    use crate::internal_tests::stub_metrics::PaddedProvider;
+
+    fn routed_document_with_authoritative_label_rect() -> Document {
+        Document {
+            version: 1,
+            profiles: vec![],
+            extensions: Default::default(),
+            defaults: crate::mmds::Defaults::default(),
+            geometry_level: GeometryLevel::Routed,
+            metadata: crate::mmds::Metadata {
+                diagram_type: "flowchart".to_string(),
+                direction: Direction::TopDown,
+                bounds: crate::mmds::Bounds {
+                    width: 130.0,
+                    height: 160.0,
+                },
+                engine: None,
+            },
+            nodes: vec![
+                crate::mmds::Node {
+                    id: "A".to_string(),
+                    label: "A".to_string(),
+                    shape: Shape::Rectangle,
+                    parent: None,
+                    position: crate::mmds::Position { x: 65.0, y: 35.0 },
+                    size: crate::mmds::Size {
+                        width: 50.0,
+                        height: 30.0,
+                    },
+                },
+                crate::mmds::Node {
+                    id: "B".to_string(),
+                    label: "B".to_string(),
+                    shape: Shape::Rectangle,
+                    parent: None,
+                    position: crate::mmds::Position { x: 65.0, y: 125.0 },
+                    size: crate::mmds::Size {
+                        width: 50.0,
+                        height: 30.0,
+                    },
+                },
+            ],
+            edges: vec![crate::mmds::Edge {
+                id: "e0".to_string(),
+                source: "A".to_string(),
+                target: "B".to_string(),
+                from_subgraph: None,
+                to_subgraph: None,
+                label: Some("mmmm".to_string()),
+                stroke: Stroke::Solid,
+                arrow_start: Arrow::None,
+                arrow_end: Arrow::Normal,
+                minlen: 1,
+                path: Some(vec![[65.0, 50.0], [65.0, 110.0]]),
+                label_position: Some(crate::mmds::Position { x: 65.0, y: 80.0 }),
+                is_backward: Some(false),
+                source_port: None,
+                target_port: None,
+                label_side: Some(EdgeLabelSide::Center),
+                label_rect: Some(crate::mmds::Rect {
+                    x: 40.0,
+                    y: 70.0,
+                    width: 50.0,
+                    height: 20.0,
+                }),
+            }],
+            subgraphs: vec![],
+        }
+    }
+
+    #[test]
+    fn routed_hydration_uses_supplied_provider_for_authoritative_label_padding() {
+        let output = routed_document_with_authoritative_label_rect();
+        let provider = PaddedProvider;
+
+        let routed = hydrate_routed_geometry_from_document_with_provider(&output, &provider)
+            .expect("routed geometry should hydrate");
+
+        let label_geometry = routed.edges[0]
+            .label_geometry
+            .as_ref()
+            .expect("authoritative label geometry should overlay");
+        assert_eq!(label_geometry.padding, (11.0, 7.0));
+        assert_eq!(label_geometry.rect.width, 50.0);
+    }
 
     #[test]
     fn reconstruct_compound_membership_includes_descendants_for_ancestors() {

--- a/src/mmds/mod.rs
+++ b/src/mmds/mod.rs
@@ -41,6 +41,7 @@ pub use document::{
     SVG_PROFILE, TEXT_EXTENSION_NAMESPACE, TEXT_METRICS_EXTENSION_NAMESPACE, TEXT_METRICS_PROFILE,
     TEXT_PROFILE,
 };
+pub(crate) use hydrate::hydrate_routed_geometry_from_document_with_provider;
 pub use hydrate::{
     HydrationError, from_document, from_str, hydrate_graph_geometry_from_document_with_diagram,
     hydrate_routed_geometry_from_document,

--- a/src/render/graph/mod.rs
+++ b/src/render/graph/mod.rs
@@ -16,7 +16,7 @@ pub use self::svg::SvgRenderOptions;
 use crate::format::{OutputFormat, RoutingStyle, TextColorMode};
 use crate::graph::direction_policy::build_node_directions;
 use crate::graph::geometry::{GraphGeometry, LayoutEdge, RoutedGraphGeometry, SelfEdgeGeometry};
-use crate::graph::measure::{ProportionalTextMetrics, default_proportional_text_metrics};
+use crate::graph::measure::{TextMetricsProvider, default_proportional_text_metrics};
 use crate::graph::routing::{self, EdgeRouting};
 use crate::graph::{Direction, Graph};
 use crate::render::svg::theme::ResolvedSvgTheme;
@@ -102,7 +102,7 @@ pub(crate) fn render_svg_from_geometry_with_theme_routing_and_metrics(
     options: &SvgRenderOptions,
     edge_routing: EdgeRouting,
     theme: Option<&ResolvedSvgTheme>,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
 ) -> String {
     svg::render_svg_from_geometry_with_theme(
         diagram,
@@ -119,7 +119,7 @@ pub(crate) fn render_svg_from_routed_geometry_with_theme_and_metrics(
     routed: &RoutedGraphGeometry,
     options: &SvgRenderOptions,
     theme: Option<&ResolvedSvgTheme>,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
 ) -> String {
     let geometry = geometry_for_routed_svg(diagram, routed);
     render_svg_from_geometry_with_theme_routing_and_metrics(

--- a/src/render/graph/svg/bounds.rs
+++ b/src/render/graph/svg/bounds.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use super::labels::{fallback_label_position, precomputed_label_positions};
 use super::{Point, Rect};
 use crate::graph::geometry::GraphGeometry;
-use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::measure::{TextMetricsProvider, edge_label_dimensions_for_provider};
 use crate::graph::{Graph, Stroke};
 
 pub(super) struct SvgBounds {
@@ -52,7 +52,7 @@ impl SvgBounds {
 pub(super) fn compute_svg_bounds(
     diagram: &Graph,
     geom: &GraphGeometry,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     self_edge_paths: &HashMap<usize, Vec<Point>>,
     rendered_edge_paths: &HashMap<usize, Vec<Point>>,
 ) -> SvgBounds {
@@ -147,7 +147,7 @@ pub(super) fn compute_svg_bounds(
         let Some(point) = position else {
             continue;
         };
-        let (w, h) = metrics.edge_label_dimensions(label);
+        let (w, h) = edge_label_dimensions_for_provider(metrics, label);
         let rect = Rect {
             x: point.x - w / 2.0,
             y: point.y - h / 2.0,

--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -7,7 +7,7 @@ use super::text::{
 };
 use super::{GraphSvgPalette, Point, dynamic_css_attrs};
 use crate::graph::geometry::GraphGeometry;
-use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::measure::TextMetricsProvider;
 use crate::graph::routing::compute_end_label_positions;
 use crate::graph::{Graph, Stroke};
 use crate::render::svg::SvgWriter;
@@ -106,7 +106,7 @@ pub(super) fn render_edge_labels(
     self_edge_paths: &HashMap<usize, Vec<Point>>,
     rendered_edge_paths: &HashMap<usize, Vec<Point>>,
     override_nodes: &HashMap<String, String>,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     scale: f64,
     palette: &GraphSvgPalette,
 ) {

--- a/src/render/graph/svg/mod.rs
+++ b/src/render/graph/svg/mod.rs
@@ -22,6 +22,7 @@ use crate::graph::direction_policy::build_override_node_map;
 use crate::graph::geometry::{FPoint, FRect, GraphGeometry};
 use crate::graph::measure::{
     DEFAULT_GRAPH_FONT_FAMILY, DEFAULT_PROPORTIONAL_FONT_SIZE, ProportionalTextMetrics,
+    TextMetricsProvider,
 };
 use crate::graph::routing::EdgeRouting;
 use crate::graph::{Graph, Stroke};
@@ -156,7 +157,7 @@ pub(crate) fn render_svg_from_geometry_with_theme(
     geom: &GraphGeometry,
     edge_routing: EdgeRouting,
     theme: Option<&ResolvedSvgTheme>,
-    resolved_metrics: Option<&ProportionalTextMetrics>,
+    resolved_metrics: Option<&dyn TextMetricsProvider>,
 ) -> String {
     // Merge mode-derived rerouted edges with any engine-provided rerouted edges
     // (e.g., direction-override subgraph edges set by build_float_layout).
@@ -207,7 +208,7 @@ fn render_svg_with_geometry_context(
     geom: &GraphGeometry,
     context: GeometryContext<'_>,
     theme: Option<&ResolvedSvgTheme>,
-    resolved_metrics: Option<&ProportionalTextMetrics>,
+    resolved_metrics: Option<&dyn TextMetricsProvider>,
 ) -> String {
     let scale = options.scale;
     let owned_metrics;

--- a/src/render/graph/svg/nodes.rs
+++ b/src/render/graph/svg/nodes.rs
@@ -7,7 +7,7 @@ use super::edges::{document_svg_path, polygon_points};
 use super::text::{TextRenderStyle, render_text_centered};
 use super::{GraphSvgPalette, Point, Rect, dynamic_css_attrs};
 use crate::graph::geometry::{FRect, GraphGeometry};
-use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::measure::TextMetricsProvider;
 use crate::graph::routing::hexagon_vertices;
 use crate::graph::{Direction, Graph, Node, Shape};
 use crate::render::svg::{SvgWriter, escape_text, fmt_f64};
@@ -67,7 +67,7 @@ impl<'a> ResolvedSvgNodeStyle<'a> {
 struct NodeLabelRenderContext<'a> {
     rect: &'a Rect,
     style: ResolvedSvgNodeStyle<'a>,
-    metrics: &'a ProportionalTextMetrics,
+    metrics: &'a dyn TextMetricsProvider,
     scale: f64,
     palette: &'a GraphSvgPalette,
 }
@@ -76,7 +76,7 @@ pub(super) fn render_subgraphs(
     writer: &mut SvgWriter,
     diagram: &Graph,
     geom: &GraphGeometry,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     scale: f64,
     palette: &GraphSvgPalette,
 ) {
@@ -121,7 +121,7 @@ pub(super) fn render_subgraphs(
 
         if !sg_geom.title.trim().is_empty() {
             let title_x = rect.x + rect.width / 2.0;
-            let title_y = rect.y + metrics.font_size * 0.25;
+            let title_y = rect.y + metrics.font_size() * 0.25;
             let dynamic_attrs = dynamic_css_attrs(
                 palette.dynamic_css,
                 "graph-subgraph-text",
@@ -199,7 +199,7 @@ pub(super) fn render_nodes(
     writer: &mut SvgWriter,
     diagram: &Graph,
     geom: &GraphGeometry,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     scale: f64,
     palette: &GraphSvgPalette,
 ) {
@@ -314,13 +314,13 @@ fn render_node_label(
         return;
     }
 
-    let line_height = context.metrics.line_height * context.scale;
+    let line_height = context.metrics.line_height() * context.scale;
     let total_height = line_height * (lines.len().saturating_sub(1) as f64);
     let start_y = center.y - total_height / 2.0;
     let x1 = context.rect.x * context.scale;
     let x2 = (context.rect.x + context.rect.width) * context.scale;
     // Left-align x: node left edge + padding (matches text renderer's x+2 convention)
-    let left_x = x1 + context.metrics.node_padding_x * context.scale;
+    let left_x = x1 + context.metrics.node_padding_x() * context.scale;
     let mut past_separator = false;
 
     for (idx, line_text) in lines.iter().enumerate() {

--- a/src/render/graph/svg/self_edges.rs
+++ b/src/render/graph/svg/self_edges.rs
@@ -4,15 +4,18 @@ use std::collections::HashMap;
 
 use super::{Point, Rect};
 use crate::graph::geometry::GraphGeometry;
-use crate::graph::measure::ProportionalTextMetrics;
+use crate::graph::measure::TextMetricsProvider;
 use crate::graph::{Direction, Graph, Shape};
 
 pub(super) fn compute_self_edge_paths(
     diagram: &Graph,
     geom: &GraphGeometry,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
 ) -> HashMap<usize, Vec<Point>> {
-    let pad = metrics.node_padding_x.max(metrics.node_padding_y).max(4.0);
+    let pad = metrics
+        .node_padding_x()
+        .max(metrics.node_padding_y())
+        .max(4.0);
     let mut paths = HashMap::new();
 
     for se in &geom.self_edges {

--- a/src/render/graph/svg/text.rs
+++ b/src/render/graph/svg/text.rs
@@ -2,7 +2,8 @@
 
 use crate::graph::geometry::FPoint;
 use crate::graph::measure::{
-    DEFAULT_LABEL_PADDING_X, DEFAULT_LABEL_PADDING_Y, ProportionalTextMetrics,
+    DEFAULT_LABEL_PADDING_X, DEFAULT_LABEL_PADDING_Y, TextMetricsProvider,
+    edge_label_dimensions_wrapped_for_provider, measure_text_with_padding_for_provider,
 };
 use crate::render::svg::{SvgWriter, escape_text, fmt_f64};
 
@@ -26,7 +27,7 @@ pub(super) fn render_text_centered(
     writer: &mut SvgWriter,
     center: FPoint,
     text: &str,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     scale: f64,
     style: TextRenderStyle<'_>,
 ) {
@@ -42,7 +43,7 @@ pub(super) fn render_text_centered_with_wrap(
     center: FPoint,
     text: &str,
     wrapped_lines: Option<&[String]>,
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     scale: f64,
     style: TextRenderStyle<'_>,
 ) {
@@ -51,7 +52,12 @@ pub(super) fn render_text_centered_with_wrap(
             Some(lines) => {
                 measure_wrapped_with_padding(metrics, lines, LABEL_BG_PAD_X, LABEL_BG_PAD_Y)
             }
-            None => metrics.measure_text_with_padding(text, LABEL_BG_PAD_X, LABEL_BG_PAD_Y),
+            None => measure_text_with_padding_for_provider(
+                metrics,
+                text,
+                LABEL_BG_PAD_X,
+                LABEL_BG_PAD_Y,
+            ),
         };
         let rect_w = w * scale;
         let rect_h = h * scale;
@@ -94,7 +100,7 @@ pub(super) fn render_text_centered_with_wrap(
         return;
     }
 
-    let line_height = metrics.line_height * scale;
+    let line_height = metrics.line_height() * scale;
     let total_height = line_height * (lines.len().saturating_sub(1) as f64);
     let start_y = center.y - total_height / 2.0;
 
@@ -113,18 +119,18 @@ pub(super) fn render_text_centered_with_wrap(
 }
 
 fn measure_wrapped_with_padding(
-    metrics: &ProportionalTextMetrics,
+    metrics: &dyn TextMetricsProvider,
     lines: &[String],
     padding_x: f64,
     padding_y: f64,
 ) -> (f64, f64) {
     // Mirrors ProportionalTextMetrics::measure_text_with_padding but sources
     // the line vector from the caller's pre-wrapped artifact.
-    let (w, h) = metrics.edge_label_dimensions_wrapped(lines);
+    let (w, h) = edge_label_dimensions_wrapped_for_provider(metrics, lines);
     // `edge_label_dimensions_wrapped` bakes in `metrics.label_padding_*`; peel
     // those off and add the caller-requested padding to match the untreated
     // `measure_text_with_padding` behavior.
-    let raw_w = w - 2.0 * metrics.label_padding_x;
-    let raw_h = h - 2.0 * metrics.label_padding_y;
+    let raw_w = w - 2.0 * metrics.label_padding_x();
+    let raw_h = h - 2.0 * metrics.label_padding_y();
     (raw_w + 2.0 * padding_x, raw_h + 2.0 * padding_y)
 }

--- a/src/runtime/graph_family.rs
+++ b/src/runtime/graph_family.rs
@@ -7,11 +7,12 @@ use crate::engines::graph::{
 };
 use crate::errors::RenderError;
 use crate::format::OutputFormat;
-use crate::graph::label_wrap::prepare_wrapped_labels;
+use crate::graph::label_wrap::prepare_wrapped_labels_with_provider;
 use crate::graph::measure::{
     COMPATIBILITY_TEXT_METRICS_PROFILE_ID, DEFAULT_PROPORTIONAL_NODE_PADDING_X,
     DEFAULT_PROPORTIONAL_NODE_PADDING_Y, ProportionalTextMetrics, ResolvedTextMetrics,
-    TextMetricsProfileConfig, TextMetricsProfileDescriptor, resolve_text_metrics_profile,
+    TextMetricsProfileConfig, TextMetricsProfileDescriptor, TextMetricsProvider,
+    resolve_text_metrics_profile,
 };
 use crate::graph::{GeometryLevel, Graph};
 use crate::mmds::Document;
@@ -37,6 +38,7 @@ pub(crate) fn render_graph_family(
             diagram,
             &render_result.solve,
             &render_result.text_metrics.descriptor,
+            &render_result.text_metrics.metrics,
             config.geometry_level,
             config.path_simplification,
         ),
@@ -77,6 +79,7 @@ pub(crate) fn materialize_graph_family(
         diagram,
         &render_result.solve,
         &render_result.text_metrics.descriptor,
+        &render_result.text_metrics.metrics,
         config.geometry_level,
         config.path_simplification,
     )
@@ -112,7 +115,7 @@ fn solve_graph_family_for_render(
     // user-facing LayoutConfig default is `Some(200.0)` so wrap is on by
     // default. Explicit `None` disables wrap (dagre-parity fallback).
     let text_metrics = resolve_text_metrics_for_config(format, config)?;
-    prepare_wrapped_labels(
+    prepare_wrapped_labels_with_provider(
         &mut diagram.edges,
         &text_metrics.metrics,
         config.layout.edge_label_max_width,
@@ -136,12 +139,12 @@ fn subgraph_direction_policy_for(diagram_id: &str) -> SubgraphDirectionPolicy {
     }
 }
 
-fn graph_solve_request_for(
+fn graph_solve_request_for<'a>(
     format: OutputFormat,
     config: &RenderConfig,
     diagram_id: &str,
-    text_metrics: &ProportionalTextMetrics,
-) -> GraphSolveRequest {
+    text_metrics: &'a ProportionalTextMetrics,
+) -> GraphSolveRequest<'a> {
     let routing_style = config
         .routing_style
         .or_else(|| config.edge_preset.map(|preset| preset.expand().0));
@@ -157,11 +160,9 @@ fn graph_solve_request_for(
 fn measurement_mode_for_format(
     format: OutputFormat,
     text_metrics: &ProportionalTextMetrics,
-) -> MeasurementMode {
+) -> MeasurementMode<'_> {
     match format {
-        OutputFormat::Svg | OutputFormat::Mmds => {
-            MeasurementMode::Proportional(text_metrics.clone())
-        }
+        OutputFormat::Svg | OutputFormat::Mmds => MeasurementMode::Proportional(text_metrics),
         _ => MeasurementMode::Grid,
     }
 }
@@ -249,6 +250,7 @@ fn render_mmds_from_solve_result(
     diagram: &Graph,
     result: &GraphSolveResult,
     text_metrics_descriptor: &TextMetricsProfileDescriptor,
+    text_metrics: &dyn TextMetricsProvider,
     level: GeometryLevel,
     path_simplification: PathSimplification,
 ) -> Result<String, RenderError> {
@@ -257,6 +259,7 @@ fn render_mmds_from_solve_result(
         diagram,
         result,
         text_metrics_descriptor,
+        text_metrics,
         level,
         path_simplification,
     )?;
@@ -270,6 +273,7 @@ fn mmds_document_from_solve_result(
     diagram: &Graph,
     result: &GraphSolveResult,
     text_metrics_descriptor: &TextMetricsProfileDescriptor,
+    text_metrics: &dyn TextMetricsProvider,
     level: GeometryLevel,
     path_simplification: PathSimplification,
 ) -> Result<Document, RenderError> {
@@ -283,6 +287,7 @@ fn mmds_document_from_solve_result(
         path_simplification,
         Some(engine_id.as_str()),
         Some(text_metrics_descriptor),
+        Some(text_metrics),
     )
 }
 
@@ -369,6 +374,7 @@ mod tests {
             &diagram,
             &result,
             &text_metrics.descriptor,
+            &text_metrics.metrics,
             GeometryLevel::Routed,
             PathSimplification::default(),
         )

--- a/src/runtime/mmds.rs
+++ b/src/runtime/mmds.rs
@@ -17,8 +17,8 @@ use crate::graph::measure::{
 };
 use crate::mmds::{
     Document, TEXT_METRICS_EXTENSION_NAMESPACE, from_document, generate_mermaid,
-    hydrate_graph_geometry_from_document_with_diagram, hydrate_routed_geometry_from_document,
-    parse_input, resolve_logical_diagram_id,
+    hydrate_graph_geometry_from_document_with_diagram,
+    hydrate_routed_geometry_from_document_with_provider, parse_input, resolve_logical_diagram_id,
 };
 use crate::render::graph::{
     SvgRenderOptions, TextRenderOptions, edge_routing_from_style,
@@ -91,7 +91,7 @@ pub(crate) fn render_document(
     // the direct runtime render. New MMDS payloads persist the metrics
     // identity and layout-time values under the text-metrics extension; older
     // payloads fall back to the compatibility profile.
-    crate::graph::label_wrap::prepare_wrapped_labels(
+    crate::graph::label_wrap::prepare_wrapped_labels_with_provider(
         &mut diagram.edges,
         &text_metrics.metrics,
         text_metrics.descriptor.layout_text.edge_label_max_width,
@@ -100,7 +100,9 @@ pub(crate) fn render_document(
     let geometry = hydrate_graph_geometry_from_document_with_diagram(payload, &diagram)
         .map_err(display_error)?;
     let routed = has_routed_geometry
-        .then(|| hydrate_routed_geometry_from_document(payload))
+        .then(|| {
+            hydrate_routed_geometry_from_document_with_provider(payload, &text_metrics.metrics)
+        })
         .transpose()
         .map_err(display_error)?;
 

--- a/tests/wasm_cli_contract.rs
+++ b/tests/wasm_cli_contract.rs
@@ -234,6 +234,29 @@ fn runtime_config_input_rejects_unsupported_font_metrics_profile() {
 }
 
 #[test]
+fn runtime_config_input_rejects_dynamic_font_config_fields() {
+    use mmdflux::RuntimeConfigInput;
+
+    for (json, field) in [
+        (
+            r#"{"fontFamily":"Inter","fontMetricsProfile":"browser-dynamic-v1"}"#,
+            "fontFamily",
+        ),
+        (
+            r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"18px"}}"#,
+            "themeVariables",
+        ),
+    ] {
+        let err = serde_json::from_str::<RuntimeConfigInput>(json).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains(&format!("unknown field `{field}`")),
+            "{err}"
+        );
+    }
+}
+
+#[test]
 fn runtime_config_input_rejects_cli_only_svg_theme_auto_field() {
     use mmdflux::RuntimeConfigInput;
 


### PR DESCRIPTION
## Summary

- add a crate-local `TextMetricsProvider` seam for graph-family measurement
- thread borrowed providers through graph solves, routing, SVG rendering, and MMDS hydration/replay
- preserve existing public static metrics APIs and keep dynamic font config rejected at the public runtime config boundary
- add canaries proving the internal seam affects graph geometry, routed labels, SVG label backgrounds, and MMDS fallback/hydration paths

## Notes

This is the internal provider seam needed before browser-supplied dynamic metrics. It does not expose a public dynamic metrics API and does not emit `metricsProfile.source = "dynamic"`.

## Validation

- `just check`
- `cog check "origin/main..HEAD"`
