### PR TITLE
fix: keep fan-in overflow routes on perimeter

### DIFF
--- a/src/graph/routing/orthogonal/forward.rs
+++ b/src/graph/routing/orthogonal/forward.rs
@@ -119,6 +119,7 @@ pub(super) fn avoid_forward_node_intrusions(
     path: &mut Vec<FPoint>,
     edge: &LayoutEdge,
     geometry: &GraphGeometry,
+    direction: Direction,
 ) {
     // Margin 0.0 means only segments strictly inside the node rect interior
     // trigger avoidance.  -0.5 was too aggressive and caught boundary-touching
@@ -233,38 +234,58 @@ pub(super) fn avoid_forward_node_intrusions(
             // Vertical segment at x = a.x crosses blockers.
             let left_x = env_min_x - NODE_CLEARANCE;
             let right_x = env_max_x + NODE_CLEARANCE;
-            let safe_x = if (a.x - left_x).abs() <= (a.x - right_x).abs() {
-                left_x
+            let preferred_safe_x = preferred_lr_source_perimeter_x(
+                path,
+                seg_idx,
+                edge,
+                geometry,
+                direction,
+                INTRUSION_MARGIN,
+                EPS,
+            );
+            let (safe_x, safe_x_validated_clear) = if let Some(preferred_safe_x) = preferred_safe_x
+            {
+                (preferred_safe_x, true)
+            } else if (a.x - left_x).abs() <= (a.x - right_x).abs() {
+                (left_x, false)
             } else {
-                right_x
+                (right_x, false)
             };
 
             let ja = FPoint::new(safe_x, a.y);
             let jb = FPoint::new(safe_x, b.y);
-            let detour_clear = !geometry.nodes.iter().any(|(nid, node)| {
-                nid != &edge.from
-                    && nid != &edge.to
-                    && super::collision::axis_aligned_segment_crosses_rect_interior(
+            let detour_clear = if safe_x_validated_clear {
+                debug_assert!(
+                    !super::collision::segment_crosses_any_other_node_interior(
+                        edge,
+                        geometry,
                         ja,
                         jb,
-                        node.rect,
                         INTRUSION_MARGIN,
-                    )
-            });
+                    ),
+                    "preferred LR perimeter detour must be node-clear"
+                );
+                true
+            } else {
+                !super::collision::segment_crosses_any_other_node_interior(
+                    edge,
+                    geometry,
+                    ja,
+                    jb,
+                    INTRUSION_MARGIN,
+                )
+            };
             if !detour_clear {
                 let alt_x = if safe_x == left_x { right_x } else { left_x };
                 let ja2 = FPoint::new(alt_x, a.y);
                 let jb2 = FPoint::new(alt_x, b.y);
-                let alt_clear = !geometry.nodes.iter().any(|(nid, node)| {
-                    nid != &edge.from
-                        && nid != &edge.to
-                        && super::collision::axis_aligned_segment_crosses_rect_interior(
-                            ja2,
-                            jb2,
-                            node.rect,
-                            INTRUSION_MARGIN,
-                        )
-                });
+                let alt_clear = !super::collision::segment_crosses_any_other_node_interior(
+                    edge,
+                    geometry,
+                    ja2,
+                    jb2,
+                    INTRUSION_MARGIN,
+                );
                 if !alt_clear {
                     continue;
                 }
@@ -277,6 +298,65 @@ pub(super) fn avoid_forward_node_intrusions(
         // scanning from the top.
         collapse_collinear_interior_points(path);
     }
+}
+
+fn preferred_lr_source_perimeter_x(
+    path: &[FPoint],
+    seg_idx: usize,
+    edge: &LayoutEdge,
+    geometry: &GraphGeometry,
+    direction: Direction,
+    intrusion_margin: f64,
+    eps: f64,
+) -> Option<f64> {
+    if !matches!(direction, Direction::LeftRight | Direction::RightLeft) || seg_idx != 0 {
+        return None;
+    }
+
+    let a = path[seg_idx];
+    let b = path[seg_idx + 1];
+    if (a.x - b.x).abs() > eps {
+        return None;
+    }
+
+    let next = *path.get(seg_idx + 2)?;
+    if (b.y - next.y).abs() > eps {
+        return None;
+    }
+
+    let candidate_x = next.x;
+    let advances_with_flow = match direction {
+        Direction::LeftRight => candidate_x > a.x + eps,
+        Direction::RightLeft => candidate_x < a.x - eps,
+        _ => false,
+    };
+    if !advances_with_flow {
+        return None;
+    }
+
+    // When a source-side vertical fan-in leg crosses a peer source node, the
+    // local nearest-clear detour can thread through peer approach lanes. If the
+    // route already has a downstream perimeter column and the two replacement
+    // segments are node-clear, use that column instead.
+    let jog_start = FPoint::new(candidate_x, a.y);
+    let jog_end = FPoint::new(candidate_x, b.y);
+    if super::collision::segment_crosses_any_other_node_interior(
+        edge,
+        geometry,
+        a,
+        jog_start,
+        intrusion_margin,
+    ) || super::collision::segment_crosses_any_other_node_interior(
+        edge,
+        geometry,
+        jog_start,
+        jog_end,
+        intrusion_margin,
+    ) {
+        return None;
+    }
+
+    Some(candidate_x)
 }
 
 /// Prevent forward edges from transiting through their own target node

--- a/src/graph/routing/orthogonal/mod.rs
+++ b/src/graph/routing/orthogonal/mod.rs
@@ -325,7 +325,7 @@ fn build_orthogonal_path(
             direction,
             target_primary_channel_depth,
         );
-        forward::avoid_forward_node_intrusions(&mut finalized, edge, geometry);
+        forward::avoid_forward_node_intrusions(&mut finalized, edge, geometry, direction);
         forward::prefer_secondary_axis_departure_for_angular_sources(
             &mut finalized,
             edge,

--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -12,7 +12,7 @@ use crate::engines::graph::flux::FluxLayeredEngine;
 use crate::format::{CornerStyle, Curve, RoutingStyle};
 use crate::graph::Stroke;
 use crate::graph::measure::{
-    TextMetricsProvider, default_proportional_text_metrics,
+    COMPATIBILITY_TEXT_METRICS_PROFILE_ID, TextMetricsProvider, default_proportional_text_metrics,
     default_proportional_text_metrics_provider,
 };
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
@@ -1551,6 +1551,11 @@ fn load_flowchart_fixture_diagram(name: &str) -> crate::graph::Graph {
         .join(name);
     let input = fs::read_to_string(fixture).expect("fixture should load");
     let flowchart = parse_flowchart(&input).expect("fixture should parse");
+    compile_to_graph(&flowchart)
+}
+
+fn parse_flowchart_diagram_for_test(input: &str) -> crate::graph::Graph {
+    let flowchart = parse_flowchart(input).expect("input should parse");
     compile_to_graph(&flowchart)
 }
 
@@ -4017,6 +4022,73 @@ fn svg_curved_orthogonal_route_five_fan_in_keeps_mirrored_pairs_visually_symmetr
         (a_prev.1 - e_prev.1).abs() <= 1.0,
         "curved A->Target and E->Target should have mirrored terminal approach depth after fan-in channel collapse: A_prev={a_prev:?}, E_prev={e_prev:?}, A={a_points:?}, E={e_points:?}"
     );
+}
+
+#[test]
+fn svg_five_fan_in_lr_bottom_overflow_avoids_peer_approach_crossing() {
+    struct FanInCase<'a> {
+        label: &'a str,
+        input: &'a str,
+        profile: Option<&'a str>,
+        e_from: &'a str,
+        peer_froms: &'a [&'a str],
+    }
+
+    let cases = [
+        FanInCase {
+            label: "recorded default fixture",
+            input: include_str!("../../tests/fixtures/flowchart/five_fan_in_lr.mmd"),
+            profile: None,
+            e_from: "E",
+            peer_froms: &["A", "B", "C", "D"],
+        },
+        FanInCase {
+            label: "compatibility bare labels",
+            input: include_str!("../../tests/fixtures/flowchart/five_fan_in_lr.mmd"),
+            profile: Some(COMPATIBILITY_TEXT_METRICS_PROFILE_ID),
+            e_from: "E",
+            peer_froms: &["A", "B", "C", "D"],
+        },
+        FanInCase {
+            label: "compatibility widened labels",
+            input: r#"graph LR
+    A1[Alpha] --> F[Target]
+    B1[Bravo] --> F
+    C1[Char] --> F
+    D1[Delta] --> F
+    E1[Echo] --> F
+"#,
+            profile: Some(COMPATIBILITY_TEXT_METRICS_PROFILE_ID),
+            e_from: "E1",
+            peer_froms: &["A1", "B1", "C1", "D1"],
+        },
+    ];
+
+    for case in cases {
+        let diagram = parse_flowchart_diagram_for_test(case.input);
+        let svg = crate::render_diagram(
+            case.input,
+            OutputFormat::Svg,
+            &RenderConfig {
+                font_metrics_profile: case.profile.map(str::to_string),
+                ..RenderConfig::default()
+            },
+        )
+        .unwrap_or_else(|err| panic!("{}: SVG render should succeed: {err}", case.label));
+
+        let e_path =
+            edge_path_for_svg_order(&diagram, &svg, edge_index(&diagram, case.e_from, "F"));
+        for peer_from in case.peer_froms {
+            let peer_path =
+                edge_path_for_svg_order(&diagram, &svg, edge_index(&diagram, peer_from, "F"));
+            assert!(
+                !paths_have_strict_interior_crossing(&peer_path, &e_path),
+                "{}: lower fan-in overflow edge should use the clean perimeter route instead of crossing a peer approach; {peer_from}->F={peer_path:?}, {}->F={e_path:?}",
+                case.label,
+                case.e_from,
+            );
+        }
+    }
 }
 
 #[test]

--- a/tests/svg-snapshots/flowchart-smooth-step/five_fan_in_lr.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/five_fan_in_lr.svg
@@ -10,7 +10,7 @@
       <path d="M78.67,158.00 L86.47,158.00 Q90.16,158.00 90.16,161.69 L90.16,165.37 L90.16,238.00 Q90.16,243.00 95.16,243.00 L125.55,243.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M79.55,243.00 L79.55,257.00 Q79.55,262.00 84.55,262.00 L125.55,262.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M79.55,328.00 L132.55,328.00 Q137.55,328.00 137.55,323.00 L137.55,278.00 L137.55,274.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M78.67,432.00 L83.11,432.00 Q87.55,432.00 87.55,427.56 L87.55,283.00 Q87.55,278.00 92.55,278.00 L225.80,278.00 Q227.80,278.00 227.80,276.00 L227.80,274.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M78.67,432.00 L222.80,432.00 Q227.80,432.00 227.80,427.00 L227.80,274.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="8.00" y="8.00" width="70.67" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />

--- a/tests/svg-snapshots/flowchart-step/five_fan_in_lr.svg
+++ b/tests/svg-snapshots/flowchart-step/five_fan_in_lr.svg
@@ -10,7 +10,7 @@
       <path d="M78.67,158.00 L90.16,158.00 L90.16,165.37 L90.16,243.00 L125.55,243.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M79.55,243.00 L79.55,262.00 L125.55,262.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M79.55,328.00 L137.55,328.00 L137.55,274.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M78.67,432.00 L87.55,432.00 L227.80,432.00 L227.80,274.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M78.67,432.00 L227.80,432.00 L227.80,274.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="8.00" y="8.00" width="70.67" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />

--- a/tests/svg-snapshots/flowchart/five_fan_in_lr.svg
+++ b/tests/svg-snapshots/flowchart/five_fan_in_lr.svg
@@ -10,7 +10,7 @@
       <path d="M78.67,158.00 L86.47,158.00 Q90.16,158.00 90.16,161.69 L90.16,165.37 L90.16,238.00 Q90.16,243.00 95.16,243.00 L125.55,243.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M79.55,243.00 L79.55,257.00 Q79.55,262.00 84.55,262.00 L125.55,262.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M79.55,328.00 L132.55,328.00 Q137.55,328.00 137.55,323.00 L137.55,278.00 L137.55,274.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M78.67,432.00 L83.11,432.00 Q87.55,432.00 87.55,427.56 L87.55,283.00 Q87.55,278.00 92.55,278.00 L225.80,278.00 Q227.80,278.00 227.80,276.00 L227.80,274.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M78.67,432.00 L222.80,432.00 Q227.80,432.00 227.80,427.00 L227.80,274.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="8.00" y="8.00" width="70.67" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />


### PR DESCRIPTION
## Summary

- preserve the existing LR/RL source-side perimeter column for clean fan-in overflow routes
- avoid replacing that clean perimeter route with a local detour through peer approach lanes
- add regression coverage for recorded defaults, compatibility-profile bare labels, and widened compatibility labels
- update the affected `five_fan_in_lr` SVG snapshots

## Root Cause

`avoid_forward_node_intrusions` treated the first source-side vertical segment as a local node-intrusion problem. For `E -> F` in `five_fan_in_lr`, the route already had a valid downstream perimeter column on the target's right side, but the local detour logic chose a nearer clearance lane. That lane avoided the source node interior while crossing peer approach paths.

## Validation

- `cargo fmt && cargo nextest run -E 'test(svg_five_fan_in_lr_bottom_overflow_avoids_peer_approach_crossing)'`
- `just check` (2992 passed, 8 skipped)
- `git diff --check`
- `cog check origin/main..HEAD`

Closes #303
