### PR TITLE
fix: stabilize sibling subgraph label placement

### DIFF
--- a/src/engines/graph/algorithms/layered/kernel/support.rs
+++ b/src/engines/graph/algorithms/layered/kernel/support.rs
@@ -50,30 +50,19 @@ pub(crate) fn switch_label_dummies(lg: &mut LayoutGraph, placement: LabelDummyPl
         *rank_widths.entry(rank).or_default() += lg.dimensions[idx].0;
     }
 
-    for chain in &mut lg.dummy_chains {
-        let Some(label_idx) = chain.label_dummy_index else {
+    for chain_idx in 0..lg.dummy_chains.len() {
+        let Some(label_idx) = lg.dummy_chains[chain_idx].label_dummy_index else {
             continue;
         };
 
-        // Find the widest layer among all dummies in this chain
-        let best_idx = chain
-            .dummy_ids
-            .iter()
-            .enumerate()
-            .max_by(|(_, a_id), (_, b_id)| {
-                let a_rank = lg.node_index.get(a_id).map(|&i| lg.ranks[i]).unwrap_or(0);
-                let b_rank = lg.node_index.get(b_id).map(|&i| lg.ranks[i]).unwrap_or(0);
-                let a_w = rank_widths.get(&a_rank).copied().unwrap_or(0.0);
-                let b_w = rank_widths.get(&b_rank).copied().unwrap_or(0.0);
-                a_w.partial_cmp(&b_w).unwrap_or(std::cmp::Ordering::Equal)
-            })
-            .map(|(i, _)| i)
+        let best_idx = preferred_sibling_compound_boundary_label_index(lg, chain_idx)
+            .or_else(|| widest_label_index(lg, chain_idx, &rank_widths))
             .unwrap_or(label_idx);
 
         if best_idx != label_idx {
             // Swap: label dummy becomes Edge dummy, target becomes EdgeLabel dummy
-            let label_id = chain.dummy_ids[label_idx].clone();
-            let target_id = chain.dummy_ids[best_idx].clone();
+            let label_id = lg.dummy_chains[chain_idx].dummy_ids[label_idx].clone();
+            let target_id = lg.dummy_chains[chain_idx].dummy_ids[best_idx].clone();
 
             if let (Some(label_dummy), Some(_target_dummy)) = (
                 lg.dummy_nodes.get(&label_id).cloned(),
@@ -102,10 +91,84 @@ pub(crate) fn switch_label_dummies(lg: &mut LayoutGraph, placement: LabelDummyPl
                 lg.dimensions[label_graph_idx] = (0.0, 0.0);
                 lg.dimensions[target_graph_idx] = (label_w, label_h);
 
-                chain.label_dummy_index = Some(best_idx);
+                lg.dummy_chains[chain_idx].label_dummy_index = Some(best_idx);
             }
         }
     }
+}
+
+fn widest_label_index(
+    lg: &LayoutGraph,
+    chain_idx: usize,
+    rank_widths: &HashMap<i32, f64>,
+) -> Option<usize> {
+    lg.dummy_chains[chain_idx]
+        .dummy_ids
+        .iter()
+        .enumerate()
+        .max_by(|(_, a_id), (_, b_id)| {
+            let a_rank = lg.node_index.get(a_id).map(|&i| lg.ranks[i]).unwrap_or(0);
+            let b_rank = lg.node_index.get(b_id).map(|&i| lg.ranks[i]).unwrap_or(0);
+            let a_w = rank_widths.get(&a_rank).copied().unwrap_or(0.0);
+            let b_w = rank_widths.get(&b_rank).copied().unwrap_or(0.0);
+            a_w.partial_cmp(&b_w).unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|(i, _)| i)
+}
+
+fn preferred_sibling_compound_boundary_label_index(
+    lg: &LayoutGraph,
+    chain_idx: usize,
+) -> Option<usize> {
+    let chain = &lg.dummy_chains[chain_idx];
+    let &(source_idx, target_idx) = lg.original_edge_endpoints.get(chain.edge_index)?;
+    let source_parent = lg.parents[source_idx]?;
+    let target_parent = lg.parents[target_idx]?;
+
+    let shared_parent = lg.parents[source_parent]?;
+    if source_parent == target_parent || lg.parents[target_parent] != Some(shared_parent) {
+        return None;
+    }
+
+    let source_rank = lg.ranks[source_idx];
+    let target_rank = lg.ranks[target_idx];
+    let source_min = node_min_rank(lg, source_parent);
+    let source_max = node_max_rank(lg, source_parent);
+    let target_min = node_min_rank(lg, target_parent);
+    let target_max = node_max_rank(lg, target_parent);
+
+    // For direct sibling-compound crossings, the visually stable slot is the
+    // first dummy rank on the target side of the source compound. Downstream
+    // side selection and SVG rendering then use that dummy geometry, keeping
+    // labels in the inter-sibling gap instead of on the source boundary.
+    chain.dummy_ids.iter().enumerate().find_map(|(idx, id)| {
+        let dummy_idx = *lg.node_index.get(id)?;
+        let rank = lg.ranks[dummy_idx];
+        let inside_target = target_min <= rank && rank <= target_max;
+        let crossed_from_source = if source_rank < target_rank {
+            rank > source_max
+        } else if source_rank > target_rank {
+            rank < source_min
+        } else {
+            false
+        };
+
+        (inside_target && crossed_from_source).then_some(idx)
+    })
+}
+
+fn node_min_rank(lg: &LayoutGraph, node_idx: usize) -> i32 {
+    lg.min_rank
+        .get(&node_idx)
+        .copied()
+        .unwrap_or(lg.ranks[node_idx])
+}
+
+fn node_max_rank(lg: &LayoutGraph, node_idx: usize) -> i32 {
+    lg.max_rank
+        .get(&node_idx)
+        .copied()
+        .unwrap_or(lg.ranks[node_idx])
 }
 
 /// Assign Above/Below sides to label dummies using positional strategy.

--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -6173,6 +6173,180 @@ mod plan_0145_q9_red {
     }
 }
 
+mod sibling_subgraph_label_placement {
+    use std::collections::HashMap;
+
+    use super::{
+        extract_edge_label_positions, parse_attr_f64, parse_flowchart_diagram_for_test,
+        parse_svg_text_position_and_value,
+    };
+    use crate::graph::measure::COMPATIBILITY_TEXT_METRICS_PROFILE_ID;
+    use crate::{OutputFormat, RenderConfig};
+
+    #[derive(Clone, Copy)]
+    struct SvgRect {
+        y: f64,
+        height: f64,
+    }
+
+    impl SvgRect {
+        fn bottom(self) -> f64 {
+            self.y + self.height
+        }
+    }
+
+    #[test]
+    fn nested_subgraph_parallel_labels_keep_cross_labels_centered_in_inter_region_gap() {
+        struct Case<'a> {
+            label: &'a str,
+            input: &'a str,
+            profile: Option<&'a str>,
+        }
+
+        let cases = [
+            Case {
+                label: "recorded default",
+                input: include_str!(
+                    "../../tests/fixtures/flowchart/nested_subgraph_parallel_labels.mmd"
+                ),
+                profile: None,
+            },
+            Case {
+                label: "compatibility with widened A1",
+                input: r#"graph TD
+    subgraph outer [Outer region]
+        subgraph inner_a [A region]
+            A1[Alpha One Wide] --> A2
+        end
+        subgraph inner_b [B region]
+            B1 --> B2
+        end
+    end
+    A1 -->|cross edge one| B1
+    A2 -->|cross edge two| B2
+"#,
+                profile: Some(COMPATIBILITY_TEXT_METRICS_PROFILE_ID),
+            },
+            Case {
+                label: "compatibility with widened A2",
+                input: r#"graph TD
+    subgraph outer [Outer region]
+        subgraph inner_a [A region]
+            A1 --> A2[Alpha Two Wide]
+        end
+        subgraph inner_b [B region]
+            B1 --> B2
+        end
+    end
+    A1 -->|cross edge one| B1
+    A2 -->|cross edge two| B2
+"#,
+                profile: Some(COMPATIBILITY_TEXT_METRICS_PROFILE_ID),
+            },
+            Case {
+                label: "compatibility with widened B1",
+                input: r#"graph TD
+    subgraph outer [Outer region]
+        subgraph inner_a [A region]
+            A1 --> A2
+        end
+        subgraph inner_b [B region]
+            B1[Beta One Wide] --> B2
+        end
+    end
+    A1 -->|cross edge one| B1
+    A2 -->|cross edge two| B2
+"#,
+                profile: Some(COMPATIBILITY_TEXT_METRICS_PROFILE_ID),
+            },
+            Case {
+                label: "compatibility with widened B2",
+                input: r#"graph TD
+    subgraph outer [Outer region]
+        subgraph inner_a [A region]
+            A1 --> A2
+        end
+        subgraph inner_b [B region]
+            B1 --> B2[Beta Two Wide]
+        end
+    end
+    A1 -->|cross edge one| B1
+    A2 -->|cross edge two| B2
+"#,
+                profile: Some(COMPATIBILITY_TEXT_METRICS_PROFILE_ID),
+            },
+        ];
+
+        for case in cases {
+            let diagram = parse_flowchart_diagram_for_test(case.input);
+            let svg = crate::render_diagram(
+                case.input,
+                OutputFormat::Svg,
+                &RenderConfig {
+                    font_metrics_profile: case.profile.map(str::to_string),
+                    ..RenderConfig::default()
+                },
+            )
+            .unwrap_or_else(|err| panic!("{} should render: {err}", case.label));
+            let positions: HashMap<_, _> = extract_edge_label_positions(&svg, &diagram)
+                .into_iter()
+                .collect();
+            let one_y = positions
+                .get("cross edge one")
+                .unwrap_or_else(|| panic!("{} should render cross edge one", case.label))
+                .1;
+            let two_y = positions
+                .get("cross edge two")
+                .unwrap_or_else(|| panic!("{} should render cross edge two", case.label))
+                .1;
+            let a_region = named_subgraph_rect(&svg, "A region")
+                .unwrap_or_else(|| panic!("{} should render A region rect", case.label));
+            let b_region = named_subgraph_rect(&svg, "B region")
+                .unwrap_or_else(|| panic!("{} should render B region rect", case.label));
+            let gap_top = a_region.bottom();
+            let gap_bottom = b_region.y;
+            let gap_mid = (gap_top + gap_bottom) / 2.0;
+            let mid_tolerance = ((gap_bottom - gap_top) * 0.2).max(8.0);
+
+            assert!(
+                (one_y - two_y).abs() <= 1.0,
+                "{} should keep both cross labels in the same inter-region band; \
+                 got cross edge one y={one_y}, cross edge two y={two_y}\nSVG:\n{svg}",
+                case.label
+            );
+            for (label, y) in [("cross edge one", one_y), ("cross edge two", two_y)] {
+                assert!(
+                    gap_top < y && y < gap_bottom && (y - gap_mid).abs() <= mid_tolerance,
+                    "{} should center {label} in the inter-region gap; \
+                     got y={y}, gap=({gap_top}, {gap_bottom}), midpoint={gap_mid}, \
+                     tolerance={mid_tolerance}\nSVG:\n{svg}",
+                    case.label
+                );
+            }
+        }
+    }
+
+    fn named_subgraph_rect(svg: &str, label: &str) -> Option<SvgRect> {
+        let mut pending_rect = None;
+        for line in svg.lines().map(str::trim) {
+            if line.starts_with("<rect class=\"subgraph\"") {
+                pending_rect = Some(SvgRect {
+                    y: parse_attr_f64(line, "y")?,
+                    height: parse_attr_f64(line, "height")?,
+                });
+                continue;
+            }
+            let Some((_, _, value)) = parse_svg_text_position_and_value(line) else {
+                continue;
+            };
+            if value == label {
+                return pending_rect;
+            }
+        }
+        None
+    }
+}
+
 // -- Plan 0147 Task 4.1: user RL repro edges bow around peer label rects --
 
 // -- Plan 0147 Task 4.2: long_reciprocal_labels wraps + bends --

--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -170,10 +170,18 @@ pub(super) fn render_edge_labels(
         // engine-supplied label_position, which can be off-path due to
         // upstream side-adjustment passes; keep the revalidation fallback
         // so those labels render attached to their edge.
+        //
+        // Exception: labels crossing between sibling subgraphs intentionally
+        // use the compound label-dummy slot, even when they are not lane-
+        // shifted. Re-validating those against a rendered direct path can snap
+        // them from the inter-sibling gap back to a child boundary.
+        let sibling_compound_center = label_geom
+            .filter(|_| edge_crosses_sibling_subgraphs(diagram, geom, edge))
+            .map(|g| g.center);
         let lane_shifted_center = label_geom
             .filter(|g| (g.track != 0 || g.compartment_size > 1) && use_precomputed)
             .map(|g| g.center);
-        let position = if let Some(center) = lane_shifted_center {
+        let position = if let Some(center) = sibling_compound_center.or(lane_shifted_center) {
             Some(center)
         } else {
             let candidate = if use_precomputed {
@@ -293,6 +301,47 @@ pub(super) fn render_edge_labels(
     }
 
     writer.end_group();
+}
+
+fn edge_crosses_sibling_subgraphs(
+    diagram: &Graph,
+    geom: &GraphGeometry,
+    edge: &crate::graph::Edge,
+) -> bool {
+    let Some(from_parent) = node_parent_id(diagram, geom, &edge.from) else {
+        return false;
+    };
+    let Some(to_parent) = node_parent_id(diagram, geom, &edge.to) else {
+        return false;
+    };
+    if from_parent == to_parent {
+        return false;
+    }
+
+    let from_grandparent = diagram
+        .subgraphs
+        .get(&from_parent)
+        .and_then(|sg| sg.parent.as_deref());
+    let to_grandparent = diagram
+        .subgraphs
+        .get(&to_parent)
+        .and_then(|sg| sg.parent.as_deref());
+    from_grandparent.is_some() && from_grandparent == to_grandparent
+}
+
+fn node_parent_id(diagram: &Graph, geom: &GraphGeometry, node_id: &str) -> Option<String> {
+    if let Some(parent) = geom
+        .nodes
+        .get(node_id)
+        .and_then(|node| node.parent.as_deref())
+    {
+        return Some(parent.to_string());
+    }
+    diagram
+        .subgraphs
+        .values()
+        .find(|subgraph| subgraph.nodes.iter().any(|member| member == node_id))
+        .map(|subgraph| subgraph.id.clone())
 }
 
 pub(super) fn fallback_label_position(

--- a/tests/svg-snapshots/flowchart-basis/nested_subgraph_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-basis/nested_subgraph_parallel_labels.svg
@@ -16,8 +16,8 @@
     <g class="edgePaths">
       <path d="M212.68,162.00 L212.68,164.78 C212.68,167.56 212.68,173.11 218.15,178.67 C223.61,184.22 234.55,189.78 240.02,194.67 C245.49,199.56 245.49,203.78 245.49,205.89 L245.49,208.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M144.42,476.00 L144.42,478.78 C144.42,481.56 144.42,487.11 149.89,492.67 C155.36,498.22 166.30,503.78 171.77,508.67 C177.24,513.56 177.24,517.78 177.24,519.89 L177.24,522.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M171.02,162.00 L165.72,167.99 L159.21,175.32 C152.71,182.66 139.71,197.33 133.21,217.83 C126.70,238.33 126.70,264.67 126.70,283.00 C126.70,301.33 126.70,311.67 126.70,325.17 C126.70,338.67 126.70,355.33 126.70,370.00 C126.70,384.67 126.70,397.33 126.70,403.67 L126.70,410.00 L126.70,418.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M263.21,266.00 L263.21,274.00 L263.21,276.83 C263.21,279.67 263.21,285.33 263.21,293.33 C263.21,301.33 263.21,311.67 263.21,325.17 C263.21,338.67 263.21,355.33 263.21,372.00 C263.21,388.67 263.21,405.33 255.10,429.23 C247.00,453.12 230.78,484.24 222.68,499.80 L214.57,515.36 L210.87,522.45" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M171.02,162.00 L165.72,167.99 L159.21,175.32 C152.71,182.66 139.71,197.33 133.21,222.00 C126.70,246.67 126.70,281.33 126.70,302.83 C126.70,324.33 126.70,332.67 126.70,342.00 C126.70,351.33 126.70,361.67 126.70,373.17 C126.70,384.67 126.70,397.33 126.70,403.67 L126.70,410.00 L126.70,418.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M263.21,266.00 L263.21,274.00 L263.21,281.00 C263.21,288.00 263.21,302.00 263.21,313.17 C263.21,324.33 263.21,332.67 263.21,342.00 C263.21,351.33 263.21,361.67 263.21,375.17 C263.21,388.67 263.21,405.33 255.10,429.23 C247.00,453.12 230.78,484.24 222.68,499.80 L214.57,515.36 L210.87,522.45" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="155.17" y="108.00" width="79.57" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
@@ -30,10 +30,10 @@
       <text x="194.96" y="553.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B2</text>
     </g>
     <g class="edgeLabels">
-      <rect x="68.00" y="274.50" width="117.41" height="28.00" fill="white" />
-      <text x="126.70" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
-      <rect x="205.41" y="274.50" width="115.61" height="28.00" fill="white" />
-      <text x="263.21" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
+      <rect x="68.00" y="324.50" width="117.41" height="28.00" fill="white" />
+      <text x="126.70" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
+      <rect x="205.41" y="324.50" width="115.61" height="28.00" fill="white" />
+      <text x="263.21" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/nested_subgraph_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/nested_subgraph_parallel_labels.svg
@@ -30,10 +30,10 @@
       <text x="194.96" y="553.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B2</text>
     </g>
     <g class="edgeLabels">
-      <rect x="86.23" y="276.00" width="117.41" height="28.00" fill="white" />
-      <text x="144.94" y="290.00" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
-      <rect x="205.41" y="274.50" width="115.61" height="28.00" fill="white" />
-      <text x="263.21" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
+      <rect x="68.00" y="324.50" width="117.41" height="28.00" fill="white" />
+      <text x="126.70" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
+      <rect x="205.41" y="324.50" width="115.61" height="28.00" fill="white" />
+      <text x="263.21" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/nested_subgraph_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-polyline/nested_subgraph_parallel_labels.svg
@@ -16,8 +16,8 @@
     <g class="edgePaths">
       <path d="M212.68,162.00 L243.30,208.66" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M144.42,476.00 L175.04,522.66" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M171.02,162.00 L126.70,212.00 L126.70,291.00 L126.70,322.00 L126.70,372.00 L126.70,418.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
-      <path d="M263.21,266.00 L263.21,291.00 L263.21,322.00 L263.21,372.00 L263.21,422.00 L210.87,522.45" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M171.02,162.00 L126.70,212.00 L126.70,316.00 L126.70,341.00 L126.70,372.00 L126.70,418.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M263.21,266.00 L263.21,316.00 L263.21,341.00 L263.21,372.00 L263.21,422.00 L210.87,522.45" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
     </g>
     <g class="nodes">
       <rect x="155.17" y="108.00" width="79.57" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
@@ -30,10 +30,10 @@
       <text x="194.96" y="553.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B2</text>
     </g>
     <g class="edgeLabels">
-      <rect x="68.00" y="274.50" width="117.41" height="28.00" fill="white" />
-      <text x="126.70" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
-      <rect x="205.41" y="274.50" width="115.61" height="28.00" fill="white" />
-      <text x="263.21" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
+      <rect x="68.00" y="324.50" width="117.41" height="28.00" fill="white" />
+      <text x="126.70" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
+      <rect x="205.41" y="324.50" width="115.61" height="28.00" fill="white" />
+      <text x="263.21" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/nested_subgraph_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/nested_subgraph_parallel_labels.svg
@@ -30,10 +30,10 @@
       <text x="194.96" y="553.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B2</text>
     </g>
     <g class="edgeLabels">
-      <rect x="68.00" y="274.50" width="117.41" height="28.00" fill="white" />
-      <text x="126.70" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
-      <rect x="205.41" y="274.50" width="115.61" height="28.00" fill="white" />
-      <text x="263.21" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
+      <rect x="68.00" y="324.50" width="117.41" height="28.00" fill="white" />
+      <text x="126.70" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
+      <rect x="205.41" y="324.50" width="115.61" height="28.00" fill="white" />
+      <text x="263.21" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/nested_subgraph_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-step/nested_subgraph_parallel_labels.svg
@@ -30,10 +30,10 @@
       <text x="194.96" y="553.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B2</text>
     </g>
     <g class="edgeLabels">
-      <rect x="68.00" y="274.50" width="117.41" height="28.00" fill="white" />
-      <text x="126.70" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
-      <rect x="205.41" y="274.50" width="115.61" height="28.00" fill="white" />
-      <text x="263.21" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
+      <rect x="68.00" y="324.50" width="117.41" height="28.00" fill="white" />
+      <text x="126.70" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
+      <rect x="205.41" y="324.50" width="115.61" height="28.00" fill="white" />
+      <text x="263.21" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/nested_subgraph_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart/nested_subgraph_parallel_labels.svg
@@ -30,10 +30,10 @@
       <text x="194.96" y="553.00" text-anchor="middle" dominant-baseline="middle" fill="#333">B2</text>
     </g>
     <g class="edgeLabels">
-      <rect x="68.00" y="274.50" width="117.41" height="28.00" fill="white" />
-      <text x="126.70" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
-      <rect x="205.41" y="274.50" width="115.61" height="28.00" fill="white" />
-      <text x="263.21" y="288.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
+      <rect x="68.00" y="324.50" width="117.41" height="28.00" fill="white" />
+      <text x="126.70" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge one</text>
+      <rect x="205.41" y="324.50" width="115.61" height="28.00" fill="white" />
+      <text x="263.21" y="338.50" text-anchor="middle" dominant-baseline="middle" fill="#333">cross edge two</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- prefer target-side compound label dummy slots for edges crossing nested sibling subgraphs
- let SVG rendering trust that sibling-compound label geometry instead of snapping back to the rendered path midpoint
- add regression coverage for recorded default and widened-label compatibility-profile variants; refresh only nested_subgraph_parallel_labels SVG snapshots

## Validation
- cargo +stable nextest run -E 'test(nested_subgraph_parallel_labels_keep_cross_labels_centered_in_inter_region_gap) or test(svg_orthogonal_orthogonal_route_labeled_edges_labels_remain_attached_to_active_segments) or test(svg_orthogonal_orthogonal_route_inline_label_flowchart_labels_remain_attached_to_active_segments) or test(render_svg_from_routed_geometry_preserves_label_geometry_rect)'\n- cargo +stable nextest run -E 'test(svg_snapshot_all_fixtures)'\n- just check\n\nCloses #302