### PR TITLE
feat: add opt-in browser text metrics adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,7 @@ dependencies = [
 name = "mmdflux-wasm"
 version = "2.4.2"
 dependencies = [
+ "js-sys",
  "mmdflux",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ default = ["cli"]
 # CLI-only dependency surface.
 cli = ["dep:clap", "dep:libc", "dep:tracing-subscriber", "dep:windows-sys"]
 engine-elk = []
+# Experimental bridge for callback-backed browser text measurement. This is
+# intentionally disabled by default and only consumed by mmdflux-wasm.
+unstable-text-metrics-provider = []
 
 [[bin]]
 name = "mmdflux"

--- a/crates/mmdflux-wasm/Cargo.toml
+++ b/crates/mmdflux-wasm/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/kevinswiber/mmdflux"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-mmdflux = { path = "../..", default-features = false }
+js-sys = "0.3"
+mmdflux = { path = "../..", default-features = false, features = ["unstable-text-metrics-provider"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 wasm-bindgen = "0.2"

--- a/crates/mmdflux-wasm/src/lib.rs
+++ b/crates/mmdflux-wasm/src/lib.rs
@@ -1,10 +1,21 @@
+use std::cell::Cell;
+
+use mmdflux::dynamic_text_metrics::{
+    DynamicMetricsInput, DynamicTextMetricsError, render_graph_family_with_dynamic_text_metrics,
+};
 use mmdflux::errors::RenderError;
 use mmdflux::format::OutputFormat;
 use mmdflux::{
     RenderConfig, RuntimeConfigInput, apply_svg_surface_defaults, detect_diagram, render_diagram,
     validate_diagram,
 };
+use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
+
+thread_local! {
+    static DYNAMIC_RENDER_DEPTH: Cell<u32> = const { Cell::new(0) };
+    static DYNAMIC_RENDER_REENTERED: Cell<bool> = const { Cell::new(false) };
+}
 
 #[wasm_bindgen]
 pub fn render(input: &str, format: &str, config_json: &str) -> Result<String, JsError> {
@@ -12,6 +23,35 @@ pub fn render(input: &str, format: &str, config_json: &str) -> Result<String, Js
     let config = parse_render_config(format, config_json)?;
 
     render_diagram(input, format, &config).map_err(|err| js_error(err.message))
+}
+
+#[wasm_bindgen(js_name = renderWithBrowserTextMetrics)]
+pub fn render_with_browser_text_metrics(
+    input: &str,
+    format: &str,
+    config_json: &str,
+    metrics_json: &str,
+    measure_text: &js_sys::Function,
+) -> Result<String, JsError> {
+    let reentry_guard = DynamicRenderGuard::enter()?;
+    let format = parse_output_format(format)?;
+    let config = parse_dynamic_render_config(config_json)?;
+    let metrics = parse_dynamic_metrics_input(metrics_json).map_err(|err| js_error(err.message))?;
+
+    let rendered = render_graph_family_with_dynamic_text_metrics(
+        input,
+        format,
+        &config,
+        metrics,
+        |text, css_font| measure_text_width(measure_text, text, css_font),
+    )
+    .map_err(|err| js_error(err.message));
+
+    if reentry_guard.reentered() {
+        return Err(js_error("renderWithBrowserTextMetrics re-entered"));
+    }
+
+    rendered
 }
 
 #[wasm_bindgen]
@@ -52,6 +92,64 @@ fn parse_render_config(format: OutputFormat, config_json: &str) -> Result<Render
     Ok(config)
 }
 
+fn parse_dynamic_render_config(config_json: &str) -> Result<RenderConfig, JsError> {
+    if config_json.trim().is_empty() {
+        return Ok(RenderConfig::default());
+    }
+
+    let input: RuntimeConfigInput = serde_json::from_str(config_json)
+        .map_err(|error| js_error(format!("invalid config_json: {error}")))?;
+    input
+        .into_render_config()
+        .map_err(|err| js_error(err.message))
+}
+
+fn parse_dynamic_metrics_input(metrics_json: &str) -> Result<DynamicMetricsInput, RenderError> {
+    let input: DynamicMetricsInput =
+        serde_json::from_str(metrics_json).map_err(|error| RenderError {
+            message: format!("invalid metrics_json: {error}"),
+        })?;
+    input.validate()?;
+    Ok(input)
+}
+
+fn measure_text_width(
+    measure_text: &js_sys::Function,
+    text: &str,
+    css_font: &str,
+) -> Result<f64, DynamicTextMetricsError> {
+    let value = measure_text
+        .call2(
+            &JsValue::UNDEFINED,
+            &JsValue::from_str(text),
+            &JsValue::from_str(css_font),
+        )
+        .map_err(|error| {
+            DynamicTextMetricsError::new(format!(
+                "measureText callback threw: {}",
+                js_value_message(&error)
+            ))
+        })?;
+
+    if value.is_instance_of::<js_sys::Promise>() {
+        return Err(DynamicTextMetricsError::new(
+            "measureText callback must be synchronous",
+        ));
+    }
+
+    let Some(width) = value.as_f64() else {
+        return Err(DynamicTextMetricsError::new(
+            "measureText callback must return a number",
+        ));
+    };
+    if !width.is_finite() || width < 0.0 {
+        return Err(DynamicTextMetricsError::new(
+            "measureText callback must return a finite non-negative number",
+        ));
+    }
+    Ok(width)
+}
+
 fn parse_output_format(value: &str) -> Result<OutputFormat, JsError> {
     value
         .parse::<OutputFormat>()
@@ -60,6 +158,52 @@ fn parse_output_format(value: &str) -> Result<OutputFormat, JsError> {
 
 fn js_error(message: impl Into<String>) -> JsError {
     JsError::new(&message.into())
+}
+
+fn js_value_message(value: &JsValue) -> String {
+    if let Some(message) = value.as_string() {
+        return message;
+    }
+
+    js_sys::Reflect::get(value, &JsValue::from_str("message"))
+        .ok()
+        .and_then(|message| message.as_string())
+        .unwrap_or_else(|| format!("{value:?}"))
+}
+
+struct DynamicRenderGuard;
+
+impl DynamicRenderGuard {
+    fn enter() -> Result<Self, JsError> {
+        let already_rendering = DYNAMIC_RENDER_DEPTH.with(|depth| {
+            let current = depth.get();
+            if current > 0 {
+                true
+            } else {
+                depth.set(1);
+                false
+            }
+        });
+
+        if already_rendering {
+            DYNAMIC_RENDER_REENTERED.with(|reentered| reentered.set(true));
+            return Err(js_error("renderWithBrowserTextMetrics re-entered"));
+        }
+
+        DYNAMIC_RENDER_REENTERED.with(|reentered| reentered.set(false));
+        Ok(Self)
+    }
+
+    fn reentered(&self) -> bool {
+        DYNAMIC_RENDER_REENTERED.with(Cell::get)
+    }
+}
+
+impl Drop for DynamicRenderGuard {
+    fn drop(&mut self) {
+        DYNAMIC_RENDER_DEPTH.with(|depth| depth.set(0));
+        DYNAMIC_RENDER_REENTERED.with(|reentered| reentered.set(false));
+    }
 }
 
 #[cfg(test)]
@@ -74,8 +218,69 @@ mod tests {
     #[test]
     fn wasm_export_signatures_are_stable() {
         let _render: fn(&str, &str, &str) -> Result<String, JsError> = render;
+        let _render_dynamic: fn(
+            &str,
+            &str,
+            &str,
+            &str,
+            &js_sys::Function,
+        ) -> Result<String, JsError> = render_with_browser_text_metrics;
         let _detect: fn(&str) -> Option<String> = detect;
         let _version: fn() -> String = version;
+    }
+
+    #[test]
+    fn parse_dynamic_metrics_input_accepts_strict_contract() {
+        let input = parse_dynamic_metrics_input(
+            r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24}"#,
+        )
+        .expect("dynamic metrics input should parse");
+
+        assert_eq!(input.css_font, "16px Inter");
+        assert_eq!(input.font_family, "Inter");
+        assert_eq!(input.font_size_px, 16.0);
+        assert_eq!(input.line_height_px, 24.0);
+    }
+
+    #[test]
+    fn parse_dynamic_metrics_input_rejects_invalid_json() {
+        let err = parse_dynamic_metrics_input("{").expect_err("invalid metrics JSON should fail");
+        assert!(err.message.contains("invalid metrics_json"), "{err}");
+    }
+
+    #[test]
+    fn parse_dynamic_metrics_input_rejects_unknown_fields() {
+        let err = parse_dynamic_metrics_input(
+            r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"extra":true}"#,
+        )
+        .expect_err("unknown field should fail");
+        assert!(err.message.contains("unknown field"), "{err}");
+        assert!(err.message.contains("extra"), "{err}");
+    }
+
+    #[test]
+    fn parse_dynamic_metrics_input_validates_required_fields() {
+        for (field, json) in [
+            (
+                "cssFont",
+                r#"{"cssFont":"","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24}"#,
+            ),
+            (
+                "fontFamily",
+                r#"{"cssFont":"16px Inter","fontFamily":"","fontSizePx":16,"lineHeightPx":24}"#,
+            ),
+            (
+                "fontSizePx",
+                r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":0,"lineHeightPx":24}"#,
+            ),
+            (
+                "lineHeightPx",
+                r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":-1}"#,
+            ),
+        ] {
+            let err = parse_dynamic_metrics_input(json).expect_err("invalid field should fail");
+            assert!(err.message.contains(field), "{err}");
+        }
     }
 
     #[test]

--- a/crates/mmdflux-wasm/tests/web.rs
+++ b/crates/mmdflux-wasm/tests/web.rs
@@ -1,4 +1,5 @@
-use mmdflux_wasm::{detect, render, version};
+use mmdflux_wasm::{detect, render, render_with_browser_text_metrics, validate, version};
+use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -26,6 +27,14 @@ fn strip_ansi(input: &str) -> String {
     }
 
     stripped
+}
+
+fn dynamic_metrics_json_fixture() -> &'static str {
+    r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24}"#
+}
+
+fn callback(body: &str) -> js_sys::Function {
+    js_sys::Function::new_with_args("text, cssFont", body)
 }
 
 #[wasm_bindgen_test]
@@ -57,6 +66,187 @@ fn renders_flowchart_text_with_color_policy_config() {
 fn renders_flowchart_svg() {
     let output = render("graph TD\nA-->B", "svg", "{}").expect("svg render should succeed");
     assert!(output.contains("<svg"));
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_callback_changes_svg_geometry() {
+    let input = "graph TD\nA -->|mmmm| B";
+    let static_output = render(input, "svg", "{}").expect("static svg should render");
+    let measure = callback("return text.includes('m') ? 100 : 8;");
+    let dynamic_output = render_with_browser_text_metrics(
+        input,
+        "svg",
+        "{}",
+        dynamic_metrics_json_fixture(),
+        &measure,
+    )
+    .expect("dynamic svg should render");
+
+    assert_ne!(dynamic_output, static_output);
+    assert!(dynamic_output.contains("<svg"));
+    assert!(dynamic_output.contains("width=\"108.00\""));
+}
+
+#[wasm_bindgen_test]
+fn static_render_export_stays_byte_stable_after_dynamic_render() {
+    let input = include_str!("../../../tests/fixtures/flowchart/labeled_edges.mmd");
+    let before = render(input, "svg", "{}").expect("static svg should render before dynamic");
+    let measure = callback("return text.length * 9;");
+    let dynamic = render_with_browser_text_metrics(
+        "graph TD\nA -->|mmmm| B",
+        "svg",
+        "{}",
+        dynamic_metrics_json_fixture(),
+        &measure,
+    )
+    .expect("dynamic svg should render");
+    assert!(dynamic.contains("<svg"));
+    let after = render(input, "svg", "{}").expect("static svg should render after dynamic");
+
+    assert_eq!(after, before);
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_callback_throw_errors() {
+    let measure = callback("throw new Error('canvas failed');");
+    let err = render_with_browser_text_metrics(
+        "graph TD\nA-->B",
+        "svg",
+        "{}",
+        dynamic_metrics_json_fixture(),
+        &measure,
+    )
+    .expect_err("callback throw should fail");
+
+    assert!(error_debug(err).contains("canvas failed"));
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_callback_rejects_non_number_returns() {
+    for (body, expected) in [
+        ("return Promise.resolve(12);", "synchronous"),
+        ("return { width: 12 };", "return a number"),
+        ("return '12';", "return a number"),
+        ("return null;", "return a number"),
+        ("return undefined;", "return a number"),
+    ] {
+        let measure = callback(body);
+        let err = render_with_browser_text_metrics(
+            "graph TD\nA-->B",
+            "svg",
+            "{}",
+            dynamic_metrics_json_fixture(),
+            &measure,
+        )
+        .expect_err("non-number callback return should fail");
+
+        let message = error_debug(err);
+        assert!(message.contains(expected), "{message}");
+    }
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_callback_rejects_invalid_widths() {
+    for body in ["return Number.NaN;", "return Infinity;", "return -1;"] {
+        let measure = callback(body);
+        let err = render_with_browser_text_metrics(
+            "graph TD\nA-->B",
+            "svg",
+            "{}",
+            dynamic_metrics_json_fixture(),
+            &measure,
+        )
+        .expect_err("invalid width should fail");
+
+        let message = error_debug(err);
+        assert!(message.contains("finite non-negative"), "{message}");
+    }
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_callback_failure_does_not_fallback_to_static_metrics() {
+    let measure = callback(
+        "if (text === 'mmmm') { throw new Error('missing glyph mmmm'); } return text.length * 8;",
+    );
+    let err = render_with_browser_text_metrics(
+        "graph TD\nA -->|mmmm| B",
+        "svg",
+        "{}",
+        dynamic_metrics_json_fixture(),
+        &measure,
+    )
+    .expect_err("callback failure should fail the dynamic render");
+
+    let message = error_debug(err);
+    assert!(message.contains("missing glyph mmmm"), "{message}");
+    assert!(message.contains("mmmm"), "{message}");
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_callback_reentry_errors_cleanly() {
+    let inner = callback("return 8;");
+    let closure = wasm_bindgen::closure::Closure::<dyn FnMut(String, String) -> f64>::new(
+        move |_text, _css_font| {
+            let _ = render_with_browser_text_metrics(
+                "graph TD\nA-->B",
+                "svg",
+                "{}",
+                dynamic_metrics_json_fixture(),
+                &inner,
+            );
+            8.0
+        },
+    );
+    let measure = closure.as_ref().unchecked_ref::<js_sys::Function>();
+    let err = render_with_browser_text_metrics(
+        "graph TD\nA-->B",
+        "svg",
+        "{}",
+        dynamic_metrics_json_fixture(),
+        measure,
+    )
+    .expect_err("dynamic render re-entry should fail");
+
+    let message = error_debug(err);
+    assert!(message.contains("re-entered"), "{message}");
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_callback_can_call_validate_without_corruption() {
+    let closure = wasm_bindgen::closure::Closure::<dyn FnMut(String, String) -> f64>::new(
+        move |_text, _css_font| {
+            let result = validate("graph TD\nA-->B");
+            assert!(result.contains("\"valid\":true"));
+            8.0
+        },
+    );
+    let measure = closure.as_ref().unchecked_ref::<js_sys::Function>();
+    let output = render_with_browser_text_metrics(
+        "graph TD\nA-->B",
+        "svg",
+        "{}",
+        dynamic_metrics_json_fixture(),
+        measure,
+    )
+    .expect("validate re-entry should not corrupt dynamic render");
+
+    assert!(output.contains("<svg"));
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_rejects_mmds_output() {
+    let measure = callback("return text.length * 8;");
+    let err = render_with_browser_text_metrics(
+        "graph TD\nA-->B",
+        "mmds",
+        "{}",
+        dynamic_metrics_json_fixture(),
+        &measure,
+    )
+    .expect_err("dynamic browser metrics should remain SVG-only");
+
+    let message = error_debug(err);
+    assert!(message.contains("only supports SVG output"), "{message}");
 }
 
 #[wasm_bindgen_test]

--- a/docs/development/wasm.md
+++ b/docs/development/wasm.md
@@ -40,6 +40,7 @@ just wasm-size
 `mmdflux-wasm` exports:
 
 - `render(input, format, configJson)`
+- `renderWithBrowserTextMetrics(input, format, configJson, metricsJson, measureText)`
 - `detect(input)`
 - `version()`
 
@@ -87,11 +88,47 @@ Notes:
   default recorded profile uses Liberation Sans Regular advances, while emitted
   SVG continues to use the existing Mermaid-style font stack. Exposing SVG
   `fontFamily` remains future work.
-- Dynamic/browser font measurement remains out of scope.
 - Release wasm artifacts use a size-optimized Cargo profile:
   `opt-level=z`, `codegen-units=1`, `lto=fat`, `panic=abort`.
 - Legacy keys such as `edgeRouting`, `edgeStyle`, `svgEdgeCurve`, and
   `svgEdgeCurveRadius` are rejected.
+
+## Experimental Browser Text Metrics
+
+The existing `render` export remains static and deterministic. It never calls
+browser measurement APIs, and importing the browser metrics export does not
+change `render` output.
+
+`renderWithBrowserTextMetrics(input, format, configJson, metricsJson, measureText)`
+is a separate experimental export for browser-owned font measurement. It only
+supports SVG graph-family Mermaid input. Text, ASCII, MMDS output, MMDS input,
+and sequence-family diagrams are rejected instead of silently falling back to a
+static profile.
+
+`metricsJson` is intentionally separate from `configJson`:
+
+```json
+{
+  "cssFont": "normal 400 16px \"Inter\"",
+  "fontFamily": "Inter",
+  "fontSizePx": 16,
+  "lineHeightPx": 24
+}
+```
+
+The JavaScript adapter must complete async font preflight before Rust layout
+starts. The v1 worker path requires `OffscreenCanvas` and a worker
+`FontFaceSet`: call `fonts.load(cssFont)`, await `fonts.ready`, and then use a
+post-load `fonts.check(cssFont)` validity gate before invoking Rust. The
+`measureText` callback itself is synchronous from Rust's perspective and must
+return a finite non-negative width number for each `(text, cssFont)` request.
+Promises, objects, `NaN`, `Infinity`, negative values, and thrown errors fail
+the render.
+
+The dynamic path does not fall back to `mmdflux-sans-v1` or
+`mmdflux-heuristic-proportional-v1` after a measurement failure. It also does
+not emit or replay MMDS and does not use `metricsProfile.source = "dynamic"` in
+this slice; provider-bound dynamic MMDS replay remains future work.
 
 ## Tracing and Diagnostics
 

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -421,7 +421,8 @@ Rules:
   browser font claim.
 - SVG font-family and metrics profile are intentionally decoupled for now: the default recorded profile uses Liberation Sans Regular advances, while emitted SVG continues to use the existing Mermaid-style font stack.
 - Exposing SVG `fontFamily` remains future work.
-- Dynamic/browser font measurement remains out of scope for this static profile.
+- The experimental browser dynamic metrics export is SVG-only and does not emit
+  or replay MMDS; provider-bound dynamic MMDS replay remains future work.
 - Replay uses `metricsProfile.id` plus `layoutText` node padding and edge-label wrap width when the extension is present.
 - Replay is document-owned: a caller-supplied `fontMetricsProfile` must match the replay profile, and the replay profile plus persisted `layoutText` values override SVG font and node-padding config.
 - Older MMDS documents without the extension replay with the `mmdflux-heuristic-proportional-v1` compatibility defaults.

--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -6456,7 +6456,194 @@ mod issue_301_backward_route_stability {
     }
 
     fn starts_with_rightward_outer_channel(points: &[(f64, f64)]) -> bool {
-        let Some([start, support, rest @ ..]) = points.get(0..) else {
+        let [start, support, rest @ ..] = points else {
+            return false;
+        };
+        let first_segment_is_rightward =
+            (support.1 - start.1).abs() <= 1.0 && support.0 > start.0 + 8.0;
+        let vertical_channel_span = rest
+            .windows(2)
+            .filter(|segment| (segment[0].0 - segment[1].0).abs() <= 1.0)
+            .map(|segment| (segment[0].1 - segment[1].1).abs())
+            .fold(0.0, f64::max);
+
+        first_segment_is_rightward && vertical_channel_span > 250.0
+    }
+}
+
+#[cfg(feature = "unstable-text-metrics-provider")]
+mod dynamic_text_metrics_topology_smoke_tests {
+    use std::collections::HashMap;
+
+    use super::{
+        edge_index, edge_path_for_svg_order, extract_edge_label_positions, parse_attr_f64,
+        parse_flowchart_diagram_for_test, parse_svg_text_position_and_value,
+        paths_have_strict_interior_crossing,
+    };
+    use crate::graph::measure::{
+        DEFAULT_GRAPH_FONT_FAMILY, TextMetricsProfileConfig, TextMetricsProvider,
+        resolve_text_metrics_profile,
+    };
+    use crate::runtime::config::RenderConfig;
+    use crate::runtime::dynamic_text_metrics::{
+        DynamicMetricsInput, render_graph_family_svg_with_dynamic_text_metrics,
+    };
+
+    #[derive(Clone, Copy)]
+    struct SvgRect {
+        y: f64,
+        height: f64,
+    }
+
+    impl SvgRect {
+        fn bottom(self) -> f64 {
+            self.y + self.height
+        }
+    }
+
+    #[test]
+    fn dynamic_backward_port_spread_keeps_same_source_fanout_outer_channel() {
+        let input = include_str!("../../tests/fixtures/flowchart/backward_port_spread.mmd");
+        let diagram = parse_flowchart_diagram_for_test(input);
+        let svg = dynamic_svg_with_width_scales(
+            input,
+            &[("A", 1.2), ("B", 1.2), ("C", 1.2), ("D", 1.2), ("E", 1.2)],
+        );
+        let path = edge_path_for_svg_order(&diagram, &svg, edge_index(&diagram, "E", "A"));
+
+        assert!(
+            starts_with_rightward_outer_channel(&path),
+            "dynamic #301 smoke should preserve the outer-channel E -> A topology; \
+             points={path:?}\nSVG:\n{svg}"
+        );
+    }
+
+    #[test]
+    fn dynamic_nested_subgraph_parallel_labels_stay_in_inter_region_gap() {
+        let input =
+            include_str!("../../tests/fixtures/flowchart/nested_subgraph_parallel_labels.mmd");
+        let diagram = parse_flowchart_diagram_for_test(input);
+        let svg = dynamic_svg_with_width_scales(
+            input,
+            &[
+                ("cross edge one", 1.2),
+                ("cross edge two", 1.2),
+                ("A1", 0.8),
+                ("B2", 1.2),
+            ],
+        );
+        let positions: HashMap<_, _> = extract_edge_label_positions(&svg, &diagram)
+            .into_iter()
+            .collect();
+        let one_y = positions
+            .get("cross edge one")
+            .expect("dynamic #302 smoke should render cross edge one")
+            .1;
+        let two_y = positions
+            .get("cross edge two")
+            .expect("dynamic #302 smoke should render cross edge two")
+            .1;
+        let a_region = named_subgraph_rect(&svg, "A region")
+            .expect("dynamic #302 smoke should render A region");
+        let b_region = named_subgraph_rect(&svg, "B region")
+            .expect("dynamic #302 smoke should render B region");
+        let gap_top = a_region.bottom();
+        let gap_bottom = b_region.y;
+        let gap_mid = (gap_top + gap_bottom) / 2.0;
+        let mid_tolerance = ((gap_bottom - gap_top) * 0.2).max(8.0);
+
+        assert!(
+            (one_y - two_y).abs() <= 1.0,
+            "dynamic #302 smoke should keep sibling cross labels in one band; \
+             cross edge one y={one_y}, cross edge two y={two_y}\nSVG:\n{svg}"
+        );
+        for (label, y) in [("cross edge one", one_y), ("cross edge two", two_y)] {
+            assert!(
+                gap_top < y && y < gap_bottom && (y - gap_mid).abs() <= mid_tolerance,
+                "dynamic #302 smoke should center {label} in the inter-region gap; \
+                 got y={y}, gap=({gap_top}, {gap_bottom}), midpoint={gap_mid}, \
+                 tolerance={mid_tolerance}\nSVG:\n{svg}"
+            );
+        }
+    }
+
+    #[test]
+    fn dynamic_five_fan_in_lr_bottom_overflow_avoids_peer_approach_crossings() {
+        let input = include_str!("../../tests/fixtures/flowchart/five_fan_in_lr.mmd");
+        let diagram = parse_flowchart_diagram_for_test(input);
+        let svg = dynamic_svg_with_width_scales(
+            input,
+            &[
+                ("A", 1.2),
+                ("B", 0.8),
+                ("C", 1.2),
+                ("D", 0.8),
+                ("E", 1.2),
+                ("Target", 1.2),
+            ],
+        );
+        let e_path = edge_path_for_svg_order(&diagram, &svg, edge_index(&diagram, "E", "F"));
+
+        for peer_from in ["A", "B", "C", "D"] {
+            let peer_path =
+                edge_path_for_svg_order(&diagram, &svg, edge_index(&diagram, peer_from, "F"));
+            assert!(
+                !paths_have_strict_interior_crossing(&peer_path, &e_path),
+                "dynamic #303 smoke should keep lower fan-in overflow edge from crossing \
+                 {peer_from}->F peer approach; {peer_from}->F={peer_path:?}, E->F={e_path:?}\nSVG:\n{svg}"
+            );
+        }
+    }
+
+    fn dynamic_svg_with_width_scales(input: &str, text_scales: &[(&str, f64)]) -> String {
+        let resolved = resolve_text_metrics_profile(TextMetricsProfileConfig::default())
+            .expect("default recorded text metrics should resolve");
+        let metrics = resolved.metrics;
+        let dynamic_input = DynamicMetricsInput {
+            css_font: format!("{}px {}", metrics.font_size(), DEFAULT_GRAPH_FONT_FAMILY),
+            font_family: DEFAULT_GRAPH_FONT_FAMILY.to_string(),
+            font_size_px: metrics.font_size(),
+            line_height_px: metrics.line_height(),
+        };
+        let text_scales = text_scales
+            .iter()
+            .map(|(text, scale)| ((*text).to_string(), *scale))
+            .collect::<HashMap<_, _>>();
+
+        render_graph_family_svg_with_dynamic_text_metrics(
+            input,
+            &RenderConfig::default(),
+            dynamic_input,
+            move |text, _css_font| {
+                let scale = text_scales.get(text).copied().unwrap_or(1.0);
+                Ok(metrics.measure_line_width(text) * scale)
+            },
+        )
+        .unwrap_or_else(|err| panic!("dynamic SVG render should succeed: {err}"))
+    }
+
+    fn named_subgraph_rect(svg: &str, label: &str) -> Option<SvgRect> {
+        let mut pending_rect = None;
+        for line in svg.lines().map(str::trim) {
+            if line.starts_with("<rect class=\"subgraph\"") {
+                pending_rect = Some(SvgRect {
+                    y: parse_attr_f64(line, "y")?,
+                    height: parse_attr_f64(line, "height")?,
+                });
+                continue;
+            }
+            let Some((_, _, value)) = parse_svg_text_position_and_value(line) else {
+                continue;
+            };
+            if value == label {
+                return pending_rect;
+            }
+        }
+        None
+    }
+
+    fn starts_with_rightward_outer_channel(points: &[(f64, f64)]) -> bool {
+        let [start, support, rest @ ..] = points else {
             return false;
         };
         let first_segment_is_rightward =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,11 @@ pub use runtime::config_input::RuntimeConfigInput;
 pub use runtime::config_input::apply_svg_surface_defaults;
 /// Detect the diagram type from input text.
 pub use runtime::detect_diagram;
+// Keep this re-export gate in lockstep with the runtime module gate so the
+// experimental dynamic metrics bridge stays opt-in and doc-hidden.
+#[cfg(feature = "unstable-text-metrics-provider")]
+#[doc(hidden)]
+pub use runtime::dynamic_text_metrics;
 /// Detect, parse, solve, and materialize Mermaid source or MMDS JSON as MMDS.
 pub use runtime::materialize_diagram;
 /// Detect, parse, and render Mermaid source or MMDS JSON in one call.

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -1,0 +1,702 @@
+//! Experimental dynamic text metrics contract for browser/WASM adapters.
+//!
+//! This module is feature-gated and doc-hidden because its callback-backed
+//! provider API is not part of the stable Rust facade.
+
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::fmt;
+
+use serde::Deserialize;
+
+use crate::builtins::default_registry;
+use crate::errors::RenderError;
+use crate::format::OutputFormat;
+use crate::frontends::{InputFrontend, detect_input_frontend};
+use crate::graph::measure::{
+    DEFAULT_LABEL_PADDING_X, DEFAULT_LABEL_PADDING_Y, DEFAULT_PROPORTIONAL_NODE_PADDING_X,
+    DEFAULT_PROPORTIONAL_NODE_PADDING_Y, TextMetricsProvider,
+};
+use crate::payload::Diagram;
+use crate::registry::DiagramFamily;
+use crate::runtime::config::RenderConfig;
+use crate::runtime::config_input::apply_svg_surface_defaults;
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DynamicMetricsInput {
+    pub css_font: String,
+    pub font_family: String,
+    pub font_size_px: f64,
+    pub line_height_px: f64,
+}
+
+impl DynamicMetricsInput {
+    pub fn validate(&self) -> Result<(), RenderError> {
+        validate_non_empty("cssFont", &self.css_font)?;
+        validate_non_empty("fontFamily", &self.font_family)?;
+        validate_positive_finite("fontSizePx", self.font_size_px)?;
+        validate_positive_finite("lineHeightPx", self.line_height_px)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DynamicTextMetricsError {
+    message: String,
+}
+
+impl DynamicTextMetricsError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for DynamicTextMetricsError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for DynamicTextMetricsError {}
+
+pub struct CallbackTextMetricsProvider<F>
+where
+    F: FnMut(&str, &str) -> Result<f64, DynamicTextMetricsError>,
+{
+    input: DynamicMetricsInput,
+    callback: RefCell<F>,
+    cache: RefCell<HashMap<String, f64>>,
+    first_error: RefCell<Option<DynamicTextMetricsError>>,
+    in_callback: Cell<bool>,
+    node_padding_x: f64,
+    node_padding_y: f64,
+}
+
+impl<F> CallbackTextMetricsProvider<F>
+where
+    F: FnMut(&str, &str) -> Result<f64, DynamicTextMetricsError>,
+{
+    pub fn new(input: DynamicMetricsInput, callback: F) -> Self {
+        Self::with_node_padding(
+            input,
+            DEFAULT_PROPORTIONAL_NODE_PADDING_X,
+            DEFAULT_PROPORTIONAL_NODE_PADDING_Y,
+            callback,
+        )
+    }
+
+    pub(crate) fn with_node_padding(
+        input: DynamicMetricsInput,
+        node_padding_x: f64,
+        node_padding_y: f64,
+        callback: F,
+    ) -> Self {
+        Self {
+            input,
+            callback: RefCell::new(callback),
+            cache: RefCell::new(HashMap::new()),
+            first_error: RefCell::new(None),
+            in_callback: Cell::new(false),
+            node_padding_x,
+            node_padding_y,
+        }
+    }
+
+    pub fn finish(&self) -> Result<(), RenderError> {
+        match self.first_error.borrow().clone() {
+            Some(error) => Err(RenderError {
+                message: error.to_string(),
+            }),
+            None => Ok(()),
+        }
+    }
+
+    fn measure_text(&self, text: &str) -> f64 {
+        if let Some(width) = self.cache.borrow().get(text).copied() {
+            return width;
+        }
+
+        if self.in_callback.get() {
+            self.record_error(DynamicTextMetricsError::new(format!(
+                "dynamic text measurement callback re-entered while measuring {text:?} with font {:?}",
+                self.input.css_font
+            )));
+            return 0.0;
+        }
+
+        self.in_callback.set(true);
+        let result = {
+            let mut callback = self.callback.borrow_mut();
+            callback(text, &self.input.css_font)
+        };
+        self.in_callback.set(false);
+
+        let validated = match result {
+            Ok(width) => self.validate_width(text, width),
+            Err(error) => Err(self.contextualize_callback_error(text, error)),
+        };
+
+        match validated {
+            Ok(width) => {
+                self.cache.borrow_mut().insert(text.to_string(), width);
+                width
+            }
+            Err(error) => {
+                self.record_error(error);
+                0.0
+            }
+        }
+    }
+
+    fn contextualize_callback_error(
+        &self,
+        text: &str,
+        error: DynamicTextMetricsError,
+    ) -> DynamicTextMetricsError {
+        DynamicTextMetricsError::new(format!(
+            "dynamic text measurement callback failed for {text:?} with font {:?}: {error}",
+            self.input.css_font
+        ))
+    }
+
+    fn validate_width(&self, text: &str, width: f64) -> Result<f64, DynamicTextMetricsError> {
+        if !width.is_finite() || width < 0.0 {
+            return Err(DynamicTextMetricsError::new(format!(
+                "dynamic text measurement for {text:?} with font {:?} must return a finite non-negative width",
+                self.input.css_font
+            )));
+        }
+        Ok(width)
+    }
+
+    fn record_error(&self, error: DynamicTextMetricsError) {
+        let mut first_error = self.first_error.borrow_mut();
+        if first_error.is_none() {
+            *first_error = Some(error);
+        }
+    }
+}
+
+impl<F> TextMetricsProvider for CallbackTextMetricsProvider<F>
+where
+    F: FnMut(&str, &str) -> Result<f64, DynamicTextMetricsError>,
+{
+    fn measure_line_width(&self, text: &str) -> f64 {
+        self.measure_text(text)
+    }
+
+    fn measure_scalar_width(&self, ch: char) -> f64 {
+        let mut text = [0_u8; 4];
+        self.measure_text(ch.encode_utf8(&mut text))
+    }
+
+    fn font_size(&self) -> f64 {
+        self.input.font_size_px
+    }
+
+    fn line_height(&self) -> f64 {
+        self.input.line_height_px
+    }
+
+    fn node_padding_x(&self) -> f64 {
+        self.node_padding_x
+    }
+
+    fn node_padding_y(&self) -> f64 {
+        self.node_padding_y
+    }
+
+    fn label_padding_x(&self) -> f64 {
+        DEFAULT_LABEL_PADDING_X
+    }
+
+    fn label_padding_y(&self) -> f64 {
+        DEFAULT_LABEL_PADDING_Y
+    }
+}
+
+fn validate_non_empty(field: &str, value: &str) -> Result<(), RenderError> {
+    if value.trim().is_empty() {
+        return Err(RenderError {
+            message: format!("dynamic text metrics field `{field}` must not be empty"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_positive_finite(field: &str, value: f64) -> Result<(), RenderError> {
+    if !value.is_finite() || value <= 0.0 {
+        return Err(RenderError {
+            message: format!(
+                "dynamic text metrics field `{field}` must be a finite positive number"
+            ),
+        });
+    }
+    Ok(())
+}
+
+pub fn render_graph_family_svg_with_dynamic_text_metrics<F>(
+    input: &str,
+    config: &RenderConfig,
+    dynamic_input: DynamicMetricsInput,
+    callback: F,
+) -> Result<String, RenderError>
+where
+    F: FnMut(&str, &str) -> Result<f64, DynamicTextMetricsError>,
+{
+    render_graph_family_with_dynamic_text_metrics(
+        input,
+        OutputFormat::Svg,
+        config,
+        dynamic_input,
+        callback,
+    )
+}
+
+pub fn render_graph_family_with_dynamic_text_metrics<F>(
+    input: &str,
+    format: OutputFormat,
+    config: &RenderConfig,
+    dynamic_input: DynamicMetricsInput,
+    callback: F,
+) -> Result<String, RenderError>
+where
+    F: FnMut(&str, &str) -> Result<f64, DynamicTextMetricsError>,
+{
+    if !matches!(format, OutputFormat::Svg) {
+        return Err(RenderError {
+            message: format!(
+                "browser dynamic text metrics only supports SVG output (requested {format})"
+            ),
+        });
+    }
+    if config.layout_engine.is_some() {
+        return Err(RenderError {
+            message: "browser dynamic text metrics does not accept layoutEngine; it always uses flux-layered SVG"
+                .to_string(),
+        });
+    }
+    if config.font_metrics_profile.is_some() {
+        return Err(RenderError {
+            message: "browser dynamic text metrics does not accept fontMetricsProfile; dynamic provider measurement is selected by this API"
+                .to_string(),
+        });
+    }
+
+    dynamic_input.validate()?;
+    super::validate_render_config(config)?;
+
+    match detect_input_frontend(input) {
+        Some(InputFrontend::Mmds) => {
+            return Err(RenderError {
+                message: "browser dynamic text metrics does not support MMDS input".to_string(),
+            });
+        }
+        Some(InputFrontend::Mermaid) => {}
+        None => {
+            return Err(RenderError {
+                message: "unknown diagram type".to_string(),
+            });
+        }
+    }
+
+    let registry = default_registry();
+    let resolved = registry.resolve(input).ok_or_else(|| RenderError {
+        message: "unknown diagram type".to_string(),
+    })?;
+    if !matches!(resolved.family(), DiagramFamily::Graph) {
+        return Err(RenderError {
+            message: format!(
+                "browser dynamic text metrics only supports graph-family Mermaid diagrams (detected {})",
+                resolved.diagram_id()
+            ),
+        });
+    }
+    if !resolved.supported_formats().contains(&OutputFormat::Svg) {
+        return Err(RenderError {
+            message: format!(
+                "{} diagrams do not support SVG output",
+                resolved.diagram_id()
+            ),
+        });
+    }
+
+    let instance = registry
+        .create(resolved.diagram_id())
+        .ok_or_else(|| RenderError {
+            message: format!(
+                "no implementation for diagram type: {}",
+                resolved.diagram_id()
+            ),
+        })?;
+    let parsed = instance.parse(input).map_err(|error| RenderError {
+        message: format!("parse error: {error}"),
+    })?;
+
+    let mut effective_config = super::effective_render_config(input, OutputFormat::Svg, config);
+    // Match the existing WASM SVG surface while keeping browser-measured layout
+    // on this separate export instead of accepting a caller layoutEngine knob.
+    apply_svg_surface_defaults(OutputFormat::Svg, &mut effective_config, true);
+    let mut options = effective_config.svg_render_options();
+    options.font_family = dynamic_input.font_family.clone();
+    options.font_size = dynamic_input.font_size_px;
+
+    let node_padding_x = effective_config
+        .svg_node_padding_x
+        .unwrap_or(DEFAULT_PROPORTIONAL_NODE_PADDING_X);
+    let node_padding_y = effective_config
+        .svg_node_padding_y
+        .unwrap_or(DEFAULT_PROPORTIONAL_NODE_PADDING_Y);
+    let provider = CallbackTextMetricsProvider::with_node_padding(
+        dynamic_input,
+        node_padding_x,
+        node_padding_y,
+        callback,
+    );
+
+    let payload =
+        super::payload::prepare_payload_for_render(parsed.into_payload()?, &effective_config);
+    let rendered = match payload {
+        Diagram::Flowchart(mut graph) => {
+            crate::runtime::graph_family::render_graph_family_svg_with_provider(
+                "flowchart",
+                &mut graph,
+                &effective_config,
+                &options,
+                &provider,
+            )
+        }
+        Diagram::Class(mut graph) => {
+            crate::runtime::graph_family::render_graph_family_svg_with_provider(
+                "class",
+                &mut graph,
+                &effective_config,
+                &options,
+                &provider,
+            )
+        }
+        Diagram::State(mut graph) => {
+            crate::runtime::graph_family::render_graph_family_svg_with_provider(
+                "state",
+                &mut graph,
+                &effective_config,
+                &options,
+                &provider,
+            )
+        }
+        Diagram::Sequence(_) => Err(RenderError {
+            message: "browser dynamic text metrics only supports graph-family Mermaid diagrams"
+                .to_string(),
+        }),
+    }?;
+
+    provider.finish()?;
+    Ok(rendered)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+
+    use super::*;
+    use crate::engines::graph::EngineAlgorithmId;
+    use crate::format::OutputFormat;
+    use crate::graph::measure::{
+        DEFAULT_GRAPH_FONT_FAMILY, TextMetricsProfileConfig, TextMetricsProvider,
+        resolve_text_metrics_profile,
+    };
+    use crate::runtime::config::RenderConfig;
+    use crate::runtime::render_diagram;
+
+    fn valid_input() -> DynamicMetricsInput {
+        serde_json::from_str(
+            r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24}"#,
+        )
+        .unwrap()
+    }
+
+    fn static_equivalent_input() -> DynamicMetricsInput {
+        let metrics = resolve_text_metrics_profile(TextMetricsProfileConfig::default())
+            .expect("default recorded text metrics should resolve")
+            .metrics;
+        DynamicMetricsInput {
+            css_font: format!("{}px {}", metrics.font_size(), DEFAULT_GRAPH_FONT_FAMILY),
+            font_family: DEFAULT_GRAPH_FONT_FAMILY.to_string(),
+            font_size_px: metrics.font_size(),
+            line_height_px: metrics.line_height(),
+        }
+    }
+
+    #[test]
+    fn dynamic_metrics_input_rejects_unknown_fields() {
+        let err = serde_json::from_str::<DynamicMetricsInput>(
+            r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"extra":true}"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("unknown field"), "{err}");
+        assert!(err.contains("extra"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_metrics_input_validates_required_style_fields() {
+        valid_input().validate().expect("valid input should pass");
+
+        for (field, input) in [
+            (
+                "cssFont",
+                DynamicMetricsInput {
+                    css_font: " ".to_string(),
+                    ..valid_input()
+                },
+            ),
+            (
+                "fontFamily",
+                DynamicMetricsInput {
+                    font_family: " ".to_string(),
+                    ..valid_input()
+                },
+            ),
+            (
+                "fontSizePx",
+                DynamicMetricsInput {
+                    font_size_px: 0.0,
+                    ..valid_input()
+                },
+            ),
+            (
+                "lineHeightPx",
+                DynamicMetricsInput {
+                    line_height_px: f64::INFINITY,
+                    ..valid_input()
+                },
+            ),
+        ] {
+            let err = input.validate().expect_err("invalid field should fail");
+            assert!(err.message.contains(field), "{err}");
+        }
+    }
+
+    #[test]
+    fn callback_provider_caches_repeated_measurements() {
+        let calls = Rc::new(Cell::new(0));
+        let observed_calls = Rc::clone(&calls);
+        let provider = CallbackTextMetricsProvider::new(valid_input(), move |text, _css_font| {
+            calls.set(calls.get() + 1);
+            Ok(text.len() as f64)
+        });
+
+        assert_eq!(provider.measure_line_width("Alpha"), 5.0);
+        assert_eq!(provider.measure_line_width("Alpha"), 5.0);
+        provider.finish().expect("cached measurements should pass");
+        assert_eq!(observed_calls.get(), 1);
+    }
+
+    #[test]
+    fn callback_provider_records_invalid_width_errors_with_text_and_font() {
+        for width in [f64::NAN, f64::INFINITY, -1.0] {
+            let provider =
+                CallbackTextMetricsProvider::new(valid_input(), move |_text, _font| Ok(width));
+
+            assert_eq!(provider.measure_line_width("Alpha"), 0.0);
+            let err = provider
+                .finish()
+                .expect_err("invalid width should be recorded");
+            assert!(err.message.contains("Alpha"), "{err}");
+            assert!(err.message.contains("16px Inter"), "{err}");
+            assert!(err.message.contains("finite non-negative width"), "{err}");
+        }
+    }
+
+    #[test]
+    fn callback_provider_records_callback_errors_with_text_and_font() {
+        let provider = CallbackTextMetricsProvider::new(valid_input(), |_text, _font| {
+            Err(DynamicTextMetricsError::new("canvas failed"))
+        });
+
+        assert_eq!(provider.measure_line_width("Beta"), 0.0);
+        let err = provider
+            .finish()
+            .expect_err("callback error should be recorded");
+        assert!(err.message.contains("Beta"), "{err}");
+        assert!(err.message.contains("16px Inter"), "{err}");
+        assert!(err.message.contains("canvas failed"), "{err}");
+    }
+
+    #[test]
+    fn callback_provider_reentry_errors_cleanly() {
+        let provider =
+            CallbackTextMetricsProvider::new(valid_input(), |text, _font| Ok(text.len() as f64));
+
+        provider.in_callback.set(true);
+        assert_eq!(provider.measure_line_width("Gamma"), 0.0);
+        provider.in_callback.set(false);
+
+        let err = provider.finish().expect_err("re-entry should be recorded");
+        assert!(err.message.contains("re-entered"), "{err}");
+        assert!(err.message.contains("Gamma"), "{err}");
+        assert!(err.message.contains("16px Inter"), "{err}");
+    }
+
+    #[test]
+    fn callback_provider_caches_line_and_scalar_measurements() {
+        let calls = Rc::new(Cell::new(0));
+        let observed_calls = Rc::clone(&calls);
+        let provider = CallbackTextMetricsProvider::new(valid_input(), move |text, _font| {
+            calls.set(calls.get() + 1);
+            Ok(text.len() as f64)
+        });
+
+        for line in ["Alpha", "Beta", "Alpha", "Beta"] {
+            provider.measure_line_width(line);
+        }
+        for ch in "Alpha Beta".chars().chain("Alpha Beta".chars()) {
+            provider.measure_scalar_width(ch);
+        }
+
+        provider.finish().expect("cached measurements should pass");
+        let unique_lines = 2;
+        let unique_scalars = "Alpha Beta"
+            .chars()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len();
+        assert_eq!(observed_calls.get(), unique_lines + unique_scalars);
+    }
+
+    #[test]
+    fn dynamic_svg_bridge_changes_label_background_width() {
+        let input = "graph TD\nA -->|mmmm| B";
+        let static_svg =
+            render_diagram(input, OutputFormat::Svg, &RenderConfig::default()).unwrap();
+        let dynamic_svg = render_graph_family_svg_with_dynamic_text_metrics(
+            input,
+            &RenderConfig::default(),
+            valid_input(),
+            |text, _css_font| Ok(if text.contains('m') { 100.0 } else { 8.0 }),
+        )
+        .unwrap();
+
+        assert_ne!(dynamic_svg, static_svg);
+        assert!(dynamic_svg.contains("<svg"), "{dynamic_svg}");
+        assert!(dynamic_svg.contains("width=\"108.00\""), "{dynamic_svg}");
+        assert!(!dynamic_svg.contains("metricsProfile"), "{dynamic_svg}");
+    }
+
+    #[test]
+    fn dynamic_svg_bridge_rejects_unsupported_output_formats() {
+        for format in [
+            OutputFormat::Text,
+            OutputFormat::Ascii,
+            OutputFormat::Mmds,
+            OutputFormat::Mermaid,
+        ] {
+            let err = render_graph_family_with_dynamic_text_metrics(
+                "graph TD\nA-->B",
+                format,
+                &RenderConfig::default(),
+                valid_input(),
+                |_text, _css_font| Ok(8.0),
+            )
+            .expect_err("unsupported output format should fail");
+            assert!(err.message.contains("only supports SVG output"), "{err}");
+        }
+    }
+
+    #[test]
+    fn dynamic_svg_bridge_rejects_mmds_input() {
+        let mmds = render_diagram(
+            "graph TD\nA-->B",
+            OutputFormat::Mmds,
+            &RenderConfig::default(),
+        )
+        .unwrap();
+
+        let err = render_graph_family_svg_with_dynamic_text_metrics(
+            &mmds,
+            &RenderConfig::default(),
+            valid_input(),
+            |_text, _css_font| Ok(8.0),
+        )
+        .expect_err("MMDS input should fail");
+
+        assert!(err.message.contains("does not support MMDS input"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_svg_bridge_rejects_sequence_input() {
+        let err = render_graph_family_svg_with_dynamic_text_metrics(
+            "sequenceDiagram\nAlice->>Bob: Hi",
+            &RenderConfig::default(),
+            valid_input(),
+            |_text, _css_font| Ok(8.0),
+        )
+        .expect_err("sequence input should fail");
+
+        assert!(
+            err.message
+                .contains("only supports graph-family Mermaid diagrams"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn dynamic_svg_bridge_rejects_layout_engine_override() {
+        let err = render_graph_family_svg_with_dynamic_text_metrics(
+            "graph TD\nA-->B",
+            &RenderConfig {
+                layout_engine: Some(EngineAlgorithmId::MERMAID_LAYERED),
+                ..RenderConfig::default()
+            },
+            valid_input(),
+            |_text, _css_font| Ok(8.0),
+        )
+        .expect_err("layout engine override should fail");
+
+        assert!(
+            err.message.contains("does not accept layoutEngine"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn dynamic_svg_bridge_rejects_static_font_metrics_profile() {
+        let err = render_graph_family_svg_with_dynamic_text_metrics(
+            "graph TD\nA-->B",
+            &RenderConfig {
+                font_metrics_profile: Some("mmdflux-sans-v1".to_string()),
+                ..RenderConfig::default()
+            },
+            valid_input(),
+            |_text, _css_font| Ok(8.0),
+        )
+        .expect_err("static font metrics profile should fail");
+
+        assert!(
+            err.message.contains("does not accept fontMetricsProfile"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn dynamic_svg_bridge_matches_static_svg_with_recorded_callback() {
+        let input = "graph TD\nA[mmmm]\nB[iiii]";
+        let static_svg =
+            render_diagram(input, OutputFormat::Svg, &RenderConfig::default()).unwrap();
+        let recorded = resolve_text_metrics_profile(TextMetricsProfileConfig::default())
+            .expect("default recorded text metrics should resolve")
+            .metrics;
+        let dynamic_svg = render_graph_family_svg_with_dynamic_text_metrics(
+            input,
+            &RenderConfig::default(),
+            static_equivalent_input(),
+            move |text, _css_font| Ok(recorded.measure_line_width(text)),
+        )
+        .unwrap();
+
+        assert_eq!(dynamic_svg, static_svg);
+    }
+}

--- a/src/runtime/graph_family.rs
+++ b/src/runtime/graph_family.rs
@@ -10,9 +10,8 @@ use crate::format::OutputFormat;
 use crate::graph::label_wrap::prepare_wrapped_labels_with_provider;
 use crate::graph::measure::{
     COMPATIBILITY_TEXT_METRICS_PROFILE_ID, DEFAULT_PROPORTIONAL_NODE_PADDING_X,
-    DEFAULT_PROPORTIONAL_NODE_PADDING_Y, ProportionalTextMetrics, ResolvedTextMetrics,
-    TextMetricsProfileConfig, TextMetricsProfileDescriptor, TextMetricsProvider,
-    resolve_text_metrics_profile,
+    DEFAULT_PROPORTIONAL_NODE_PADDING_Y, ResolvedTextMetrics, TextMetricsProfileConfig,
+    TextMetricsProfileDescriptor, TextMetricsProvider, resolve_text_metrics_profile,
 };
 use crate::graph::{GeometryLevel, Graph};
 use crate::mmds::Document;
@@ -85,6 +84,24 @@ pub(crate) fn materialize_graph_family(
     )
 }
 
+#[cfg(feature = "unstable-text-metrics-provider")]
+pub(in crate::runtime) fn render_graph_family_svg_with_provider(
+    diagram_id: &str,
+    diagram: &mut Graph,
+    config: &RenderConfig,
+    options: &SvgRenderOptions,
+    text_metrics: &dyn TextMetricsProvider,
+) -> Result<String, RenderError> {
+    let solve = solve_graph_family_with_provider(
+        diagram_id,
+        diagram,
+        OutputFormat::Svg,
+        config,
+        text_metrics,
+    )?;
+    render_svg_from_solve_result(diagram, &solve, options, config, text_metrics)
+}
+
 struct GraphFamilyRenderResult {
     solve: GraphSolveResult,
     text_metrics: ResolvedTextMetrics,
@@ -96,6 +113,28 @@ fn solve_graph_family_for_render(
     format: OutputFormat,
     config: &RenderConfig,
 ) -> Result<GraphFamilyRenderResult, RenderError> {
+    let text_metrics = resolve_text_metrics_for_config(format, config)?;
+    let solve = solve_graph_family_with_provider(
+        diagram_id,
+        diagram,
+        format,
+        config,
+        &text_metrics.metrics,
+    )?;
+
+    Ok(GraphFamilyRenderResult {
+        solve,
+        text_metrics,
+    })
+}
+
+fn solve_graph_family_with_provider(
+    diagram_id: &str,
+    diagram: &mut Graph,
+    format: OutputFormat,
+    config: &RenderConfig,
+    text_metrics: &dyn TextMetricsProvider,
+) -> Result<GraphSolveResult, RenderError> {
     let engine_id = config
         .layout_engine
         .unwrap_or(EngineAlgorithmId::FLUX_LAYERED);
@@ -114,22 +153,16 @@ fn solve_graph_family_for_render(
     // Threshold comes from `RenderConfig.layout.edge_label_max_width`; the
     // user-facing LayoutConfig default is `Some(200.0)` so wrap is on by
     // default. Explicit `None` disables wrap (dagre-parity fallback).
-    let text_metrics = resolve_text_metrics_for_config(format, config)?;
     prepare_wrapped_labels_with_provider(
         &mut diagram.edges,
-        &text_metrics.metrics,
+        text_metrics,
         config.layout.edge_label_max_width,
     );
 
-    let request = graph_solve_request_for(format, config, diagram_id, &text_metrics.metrics);
+    let request = graph_solve_request_for(format, config, diagram_id, text_metrics);
     let engine_config = EngineConfig::Layered(config.layout.clone().into());
     let engine_id = resolve_graph_engine_for_request(engine_id, &request);
-    let solve = solve_graph_family(diagram, engine_id, &engine_config, &request)?;
-
-    Ok(GraphFamilyRenderResult {
-        solve,
-        text_metrics,
-    })
+    solve_graph_family(diagram, engine_id, &engine_config, &request)
 }
 
 fn subgraph_direction_policy_for(diagram_id: &str) -> SubgraphDirectionPolicy {
@@ -143,7 +176,7 @@ fn graph_solve_request_for<'a>(
     format: OutputFormat,
     config: &RenderConfig,
     diagram_id: &str,
-    text_metrics: &'a ProportionalTextMetrics,
+    text_metrics: &'a dyn TextMetricsProvider,
 ) -> GraphSolveRequest<'a> {
     let routing_style = config
         .routing_style
@@ -159,7 +192,7 @@ fn graph_solve_request_for<'a>(
 
 fn measurement_mode_for_format(
     format: OutputFormat,
-    text_metrics: &ProportionalTextMetrics,
+    text_metrics: &dyn TextMetricsProvider,
 ) -> MeasurementMode<'_> {
     match format {
         OutputFormat::Svg | OutputFormat::Mmds => MeasurementMode::Proportional(text_metrics),
@@ -222,7 +255,7 @@ fn render_svg_from_solve_result(
     result: &GraphSolveResult,
     options: &SvgRenderOptions,
     config: &RenderConfig,
-    text_metrics: &ProportionalTextMetrics,
+    text_metrics: &dyn TextMetricsProvider,
 ) -> Result<String, RenderError> {
     let theme = resolve_configured_svg_theme(config)?;
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -5,6 +5,11 @@
 
 pub mod config;
 pub mod config_input;
+// Keep this gate in lockstep with the crate-root re-export so the experimental
+// dynamic metrics bridge stays opt-in and doc-hidden as a single surface.
+#[cfg(feature = "unstable-text-metrics-provider")]
+#[doc(hidden)]
+pub mod dynamic_text_metrics;
 
 pub(crate) mod graph_family;
 pub(crate) mod mmds;

--- a/src/runtime/payload.rs
+++ b/src/runtime/payload.rs
@@ -81,7 +81,10 @@ pub(in crate::runtime) fn materialize_payload(
     }
 }
 
-fn prepare_payload_for_render(payload: Diagram, config: &RenderConfig) -> Diagram {
+pub(in crate::runtime) fn prepare_payload_for_render(
+    payload: Diagram,
+    config: &RenderConfig,
+) -> Diagram {
     if config.show_ids {
         annotate_graph_payload_ids(payload)
     } else {

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -1566,7 +1566,9 @@ fn docs_and_schema_reference_text_metrics_extension_contract() {
     assert!(docs.contains("Liberation Sans Regular advances"));
     assert!(docs.contains("emitted SVG continues to use the existing Mermaid-style font stack"));
     assert!(docs.contains("Exposing SVG `fontFamily` remains future work"));
-    assert!(docs.contains("Dynamic/browser font measurement remains out of scope"));
+    assert!(docs.contains("experimental browser dynamic metrics export is SVG-only"));
+    assert!(docs.contains("does not emit"));
+    assert!(docs.contains("replay MMDS"));
     assert!(docs.contains("Sequence-family full text-metrics parity remains deferred"));
     assert!(docs.contains("line-height"));
 
@@ -1617,7 +1619,14 @@ fn docs_cover_live_style_scope_and_wasm_color_config() {
     assert!(wasm_docs.contains("The compatibility profile `mmdflux-heuristic-proportional-v1`"));
     assert!(wasm_docs.contains("Text and ASCII output ignore this setting"));
     assert!(wasm_docs.contains("SVG font-family and metrics profile are intentionally decoupled"));
-    assert!(wasm_docs.contains("Dynamic/browser font measurement remains out of scope"));
+    assert!(wasm_docs.contains("renderWithBrowserTextMetrics"));
+    assert!(wasm_docs.contains("existing `render` export remains static and deterministic"));
+    assert!(wasm_docs.contains("OffscreenCanvas"));
+    assert!(wasm_docs.contains("FontFaceSet"));
+    assert!(wasm_docs.contains("does not fall back"));
+    assert!(wasm_docs.contains("supports SVG graph-family Mermaid input"));
+    assert!(wasm_docs.contains("not emit"));
+    assert!(wasm_docs.contains("replay MMDS"));
     assert!(!wasm_docs.contains("currently accepts only"));
 
     let readme = std::fs::read_to_string("README.md").unwrap();

--- a/tests/wasm_cli_contract.rs
+++ b/tests/wasm_cli_contract.rs
@@ -96,6 +96,30 @@ fn cli_feature_enables_clap_dependency() {
 }
 
 #[test]
+fn unstable_text_metrics_provider_feature_is_non_default() {
+    let package = mmdflux_metadata();
+    let feature = package
+        .features
+        .get("unstable-text-metrics-provider")
+        .expect("unstable text metrics provider feature must be declared");
+    let default_features = package
+        .features
+        .get("default")
+        .expect("`default` feature set must be declared");
+
+    assert!(
+        feature.is_empty(),
+        "unstable text metrics provider feature should not enable dependencies yet"
+    );
+    assert!(
+        !default_features
+            .iter()
+            .any(|feature| feature == "unstable-text-metrics-provider"),
+        "`default` must not enable the unstable text metrics provider bridge"
+    );
+}
+
+#[test]
 fn mmdflux_binary_requires_cli_feature() {
     let package = mmdflux_metadata();
     let mmdflux_bin = package
@@ -242,6 +266,7 @@ fn runtime_config_input_rejects_dynamic_font_config_fields() {
             r#"{"fontFamily":"Inter","fontMetricsProfile":"browser-dynamic-v1"}"#,
             "fontFamily",
         ),
+        (r#"{"fontSize":16}"#, "fontSize"),
         (
             r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"18px"}}"#,
             "themeVariables",
@@ -254,6 +279,54 @@ fn runtime_config_input_rejects_dynamic_font_config_fields() {
             "{err}"
         );
     }
+}
+
+#[cfg(feature = "unstable-text-metrics-provider")]
+#[test]
+fn dynamic_metrics_input_rejects_unknown_fields() {
+    use mmdflux::dynamic_text_metrics::DynamicMetricsInput;
+
+    let err = serde_json::from_str::<DynamicMetricsInput>(
+        r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"extra":true}"#,
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(err.contains("unknown field"), "{err}");
+    assert!(err.contains("extra"), "{err}");
+}
+
+#[test]
+fn dynamic_text_metrics_bridge_is_feature_gated_and_doc_hidden() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let cargo_toml = std::fs::read_to_string(format!("{manifest_dir}/Cargo.toml")).unwrap();
+    let lib_source = std::fs::read_to_string(format!("{manifest_dir}/src/lib.rs")).unwrap();
+    let runtime_source =
+        std::fs::read_to_string(format!("{manifest_dir}/src/runtime/mod.rs")).unwrap_or_default();
+    let measure_source =
+        std::fs::read_to_string(format!("{manifest_dir}/src/graph/measure.rs")).unwrap();
+
+    assert!(
+        cargo_toml.contains("unstable-text-metrics-provider"),
+        "root Cargo.toml should declare the non-default unstable bridge feature"
+    );
+    assert!(
+        lib_source.contains("unstable-text-metrics-provider")
+            || runtime_source.contains("unstable-text-metrics-provider"),
+        "dynamic text metrics bridge should be gated by the unstable feature"
+    );
+    assert!(
+        lib_source.contains("#[doc(hidden)]") || runtime_source.contains("#[doc(hidden)]"),
+        "dynamic text metrics bridge should stay doc-hidden"
+    );
+    assert!(
+        measure_source.contains("pub(crate) trait TextMetricsProvider"),
+        "TextMetricsProvider must stay crate-private"
+    );
+    assert!(
+        !measure_source.contains("pub trait TextMetricsProvider"),
+        "TextMetricsProvider must not become normal public API"
+    );
 }
 
 #[test]

--- a/web/src/browser-text-metrics.test.ts
+++ b/web/src/browser-text-metrics.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type BrowserTextMetricsEnvironment,
+  buildCssFont,
+  prepareBrowserTextMetrics,
+} from "./browser-text-metrics";
+
+interface FakeTextMetrics {
+  width: number;
+}
+
+interface FakeCanvasContext {
+  font: string;
+  measureText: (text: string) => FakeTextMetrics;
+}
+
+interface FakeFontFaceSet {
+  load: (cssFont: string) => Promise<unknown[]>;
+  ready: Promise<unknown>;
+  check: (cssFont: string) => boolean;
+}
+
+function environmentFixture(
+  fonts: FakeFontFaceSet | undefined = fontSetFixture(),
+) {
+  const context: FakeCanvasContext = {
+    font: "",
+    measureText: vi.fn((text: string) => ({ width: text.length * 3 })),
+  };
+  class FakeOffscreenCanvas {
+    getContext(type: string): FakeCanvasContext | null {
+      return type === "2d" ? context : null;
+    }
+  }
+
+  const environment: BrowserTextMetricsEnvironment = {
+    OffscreenCanvas: FakeOffscreenCanvas,
+    fonts,
+  };
+
+  return {
+    context,
+    environment,
+  };
+}
+
+function fontSetFixture(
+  overrides: Partial<FakeFontFaceSet> = {},
+): FakeFontFaceSet {
+  return {
+    load: vi.fn(async () => [{}]),
+    ready: Promise.resolve(),
+    check: vi.fn(() => true),
+    ...overrides,
+  };
+}
+
+describe("prepareBrowserTextMetrics", () => {
+  it("fails honestly without OffscreenCanvas", async () => {
+    await expect(
+      prepareBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        { fonts: fontSetFixture() },
+      ),
+    ).rejects.toThrow("OffscreenCanvas");
+  });
+
+  it("fails honestly without worker FontFaceSet support", async () => {
+    const { environment } = environmentFixture();
+    environment.fonts = undefined;
+
+    await expect(
+      prepareBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        environment,
+      ),
+    ).rejects.toThrow("FontFaceSet");
+  });
+
+  it("uses load for readiness and post-load check for validity", async () => {
+    const calls: string[] = [];
+    const fonts = fontSetFixture({
+      load: vi.fn(async () => {
+        calls.push("load");
+        return [{}];
+      }),
+      ready: Promise.resolve().then(() => {
+        calls.push("ready");
+      }),
+      check: vi.fn(() => {
+        calls.push("check");
+        return true;
+      }),
+    });
+    const { environment } = environmentFixture(fonts);
+
+    const prepared = await prepareBrowserTextMetrics(
+      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      environment,
+    );
+
+    expect(fonts.load).toHaveBeenCalledWith('normal 400 16px "Inter"');
+    expect(fonts.check).toHaveBeenCalledWith('normal 400 16px "Inter"');
+    expect(calls).toEqual(["load", "ready", "check"]);
+    expect(JSON.parse(prepared.metricsJson)).toEqual({
+      cssFont: 'normal 400 16px "Inter"',
+      fontFamily: "Inter",
+      fontSizePx: 16,
+      lineHeightPx: 24,
+    });
+  });
+
+  it("rejects zero loaded faces as unavailable font", async () => {
+    const { environment } = environmentFixture(
+      fontSetFixture({
+        load: vi.fn(async () => []),
+      }),
+    );
+
+    await expect(
+      prepareBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        environment,
+      ),
+    ).rejects.toThrow("unavailable");
+  });
+
+  it("returns a synchronous finite width from canvas measureText", async () => {
+    const { context, environment } = environmentFixture();
+    const prepared = await prepareBrowserTextMetrics(
+      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      environment,
+    );
+
+    expect(prepared.measureText("Alpha", 'normal 400 16px "Inter"')).toBe(15);
+    expect(context.font).toBe('normal 400 16px "Inter"');
+  });
+
+  it("caches repeated exact text and font measurements", async () => {
+    const { context, environment } = environmentFixture();
+    const prepared = await prepareBrowserTextMetrics(
+      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      environment,
+    );
+
+    prepared.measureText("Alpha", 'normal 400 16px "Inter"');
+    prepared.measureText("Alpha", 'normal 400 16px "Inter"');
+    prepared.measureText("Alpha", 'normal 400 18px "Inter"');
+
+    expect(context.measureText).toHaveBeenCalledTimes(2);
+  });
+
+  it("quotes CSS font families and rejects invalid numeric style fields", async () => {
+    expect(
+      buildCssFont({
+        fontFamily: "Open Sans",
+        fontSizePx: 16,
+        lineHeightPx: 24,
+      }),
+    ).toBe('normal 400 16px "Open Sans"');
+
+    await expect(
+      prepareBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 0, lineHeightPx: 24 },
+        environmentFixture().environment,
+      ),
+    ).rejects.toThrow("fontSizePx");
+
+    await expect(
+      prepareBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: Number.NaN },
+        environmentFixture().environment,
+      ),
+    ).rejects.toThrow("lineHeightPx");
+  });
+});

--- a/web/src/browser-text-metrics.ts
+++ b/web/src/browser-text-metrics.ts
@@ -1,0 +1,132 @@
+export interface BrowserTextMetricsRequest {
+  fontFamily: string;
+  fontSizePx: number;
+  lineHeightPx: number;
+  fontStyle?: string;
+  fontWeight?: string;
+}
+
+export interface PreparedBrowserTextMetrics {
+  metricsJson: string;
+  measureText: (text: string, cssFont: string) => number;
+}
+
+export interface BrowserTextMetricsEnvironment {
+  OffscreenCanvas?: OffscreenCanvasFactory;
+  fonts?: WorkerFontFaceSet;
+}
+
+interface OffscreenCanvasFactory {
+  new (
+    width: number,
+    height: number,
+  ): {
+    getContext(type: "2d"): CanvasTextMeasureContext | null;
+  };
+}
+
+interface CanvasTextMeasureContext {
+  font: string;
+  measureText(text: string): { width: number };
+}
+
+interface WorkerFontFaceSet {
+  load(cssFont: string): Promise<unknown[]>;
+  ready?: Promise<unknown>;
+  check(cssFont: string): boolean;
+}
+
+export function browserTextMetricsEnvironment(
+  scope: unknown = globalThis,
+): BrowserTextMetricsEnvironment {
+  const candidate = scope as Partial<BrowserTextMetricsEnvironment>;
+  return {
+    OffscreenCanvas: candidate.OffscreenCanvas,
+    fonts: candidate.fonts,
+  };
+}
+
+export async function prepareBrowserTextMetrics(
+  input: BrowserTextMetricsRequest,
+  environment = browserTextMetricsEnvironment(),
+): Promise<PreparedBrowserTextMetrics> {
+  const cssFont = buildCssFont(input);
+  const fontSet = environment.fonts;
+  if (!fontSet) {
+    throw new Error("Dynamic text metrics require worker FontFaceSet support.");
+  }
+
+  const Canvas = environment.OffscreenCanvas;
+  if (!Canvas) {
+    throw new Error(
+      "Dynamic text metrics require OffscreenCanvas in the worker.",
+    );
+  }
+
+  const canvas = new Canvas(1, 1);
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Dynamic text metrics require a 2D canvas context.");
+  }
+
+  const loadedFaces = await fontSet.load(cssFont);
+  if (fontSet.ready) {
+    await fontSet.ready;
+  }
+
+  if (loadedFaces.length === 0 || !fontSet.check(cssFont)) {
+    throw new Error(
+      `Dynamic text metrics unavailable for font ${input.fontFamily}.`,
+    );
+  }
+
+  const cache = new Map<string, number>();
+  return {
+    metricsJson: JSON.stringify({
+      cssFont,
+      fontFamily: normalizeFontFamily(input.fontFamily),
+      fontSizePx: input.fontSizePx,
+      lineHeightPx: input.lineHeightPx,
+    }),
+    measureText: (text: string, measuredCssFont: string): number => {
+      const key = `${measuredCssFont}\0${text}`;
+      const cached = cache.get(key);
+      if (cached !== undefined) {
+        return cached;
+      }
+
+      context.font = measuredCssFont;
+      const width = context.measureText(text).width;
+      if (!Number.isFinite(width) || width < 0) {
+        throw new Error("Canvas measureText returned an invalid width.");
+      }
+      cache.set(key, width);
+      return width;
+    },
+  };
+}
+
+export function buildCssFont(input: BrowserTextMetricsRequest): string {
+  const fontFamily = normalizeFontFamily(input.fontFamily);
+  validatePositiveFinite("fontSizePx", input.fontSizePx);
+  validatePositiveFinite("lineHeightPx", input.lineHeightPx);
+
+  const fontStyle = input.fontStyle?.trim() || "normal";
+  const fontWeight = input.fontWeight?.trim() || "400";
+  const quotedFamily = fontFamily.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `${fontStyle} ${fontWeight} ${input.fontSizePx}px "${quotedFamily}"`;
+}
+
+function normalizeFontFamily(fontFamily: string): string {
+  const normalized = fontFamily.trim();
+  if (!normalized) {
+    throw new Error("fontFamily must not be empty.");
+  }
+  return normalized;
+}
+
+function validatePositiveFinite(field: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${field} must be a finite positive number.`);
+  }
+}

--- a/web/src/main.test.ts
+++ b/web/src/main.test.ts
@@ -27,6 +27,11 @@ describe("renderApp", () => {
             format: request.format,
             output: `${request.format}:${request.input}`,
           }),
+          renderWithBrowserTextMetrics: async (request) => ({
+            seq: request.seq,
+            format: "svg",
+            output: `svg:${request.input}`,
+          }),
           validate: async () => '{"valid":true}',
           terminate: () => {},
         }),

--- a/web/src/render-client.test.ts
+++ b/web/src/render-client.test.ts
@@ -6,9 +6,12 @@ import type {
 } from "./worker-protocol";
 
 class MockWorker {
-  onmessage: ((event: MessageEvent<WorkerResponseMessage>) => void) | null = null;
+  onmessage: ((event: MessageEvent<WorkerResponseMessage>) => void) | null =
+    null;
+  messages: WorkerRequestMessage[] = [];
 
   postMessage(message: WorkerRequestMessage): void {
+    this.messages.push(message);
     if (!this.onmessage) {
       throw new Error("worker message handler was not installed");
     }
@@ -21,6 +24,18 @@ class MockWorker {
             seq: message.seq,
             format: message.format,
             output: `${message.format}:${message.input}:${message.configJson}`,
+          },
+        } as MessageEvent<WorkerResponseMessage>);
+        return;
+      }
+
+      if (message.type === "renderWithBrowserTextMetrics") {
+        this.onmessage?.({
+          data: {
+            type: "result",
+            seq: message.seq,
+            format: message.format,
+            output: `${message.format}:${message.input}:${message.configJson}:${message.browserTextMetrics.fontFamily}`,
           },
         } as MessageEvent<WorkerResponseMessage>);
         return;
@@ -58,5 +73,39 @@ describe("createRenderWorkerClient", () => {
       output: 'svg:graph TD\nA-->B:{"padding":2}',
     });
     await expect(validatePromise).resolves.toBe('{"valid":true}');
+  });
+
+  it("posts dynamic browser text metrics render requests separately", async () => {
+    const worker = new MockWorker();
+    const client = createRenderWorkerClient(worker as unknown as Worker);
+
+    const response = await client.renderWithBrowserTextMetrics({
+      seq: 11,
+      input: "graph TD\nA-->B",
+      configJson: "{}",
+      browserTextMetrics: {
+        fontFamily: "Inter",
+        fontSizePx: 16,
+        lineHeightPx: 24,
+      },
+    });
+
+    expect(response).toEqual({
+      seq: 11,
+      format: "svg",
+      output: "svg:graph TD\nA-->B:{}:Inter",
+    });
+    expect(worker.messages.at(-1)).toEqual({
+      type: "renderWithBrowserTextMetrics",
+      seq: 11,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: "{}",
+      browserTextMetrics: {
+        fontFamily: "Inter",
+        fontSizePx: 16,
+        lineHeightPx: 24,
+      },
+    });
   });
 });

--- a/web/src/services/render-client.ts
+++ b/web/src/services/render-client.ts
@@ -1,3 +1,4 @@
+import type { BrowserTextMetricsRequest } from "../browser-text-metrics";
 import type {
   WorkerOutputFormat,
   WorkerRequestMessage,
@@ -17,6 +18,13 @@ export interface RenderResponse {
   output: string;
 }
 
+export interface BrowserTextMetricsRenderRequest {
+  seq: number;
+  input: string;
+  configJson?: string;
+  browserTextMetrics: BrowserTextMetricsRequest;
+}
+
 interface PendingRenderRequest {
   kind: "render";
   resolve: (response: RenderResponse) => void;
@@ -33,6 +41,9 @@ type PendingRequest = PendingRenderRequest | PendingValidateRequest;
 
 export interface RenderWorkerClient {
   render: (request: RenderRequest) => Promise<RenderResponse>;
+  renderWithBrowserTextMetrics: (
+    request: BrowserTextMetricsRenderRequest,
+  ) => Promise<RenderResponse>;
   validate: (input: string) => Promise<string>;
   terminate: () => void;
 }
@@ -114,6 +125,33 @@ export function createRenderWorkerClient(
           pending.delete(currentSeq);
           reject(
             new Error(`failed to post render request: ${toMessage(error)}`),
+          );
+        }
+      });
+    },
+    renderWithBrowserTextMetrics: (request) => {
+      const currentSeq = request.seq;
+
+      return new Promise<RenderResponse>((resolve, reject) => {
+        const message: WorkerRequestMessage = {
+          type: "renderWithBrowserTextMetrics",
+          seq: currentSeq,
+          input: request.input,
+          format: "svg",
+          configJson: request.configJson ?? "{}",
+          browserTextMetrics: request.browserTextMetrics,
+        };
+
+        pending.set(currentSeq, { kind: "render", resolve, reject });
+
+        try {
+          worker.postMessage(message);
+        } catch (error) {
+          pending.delete(currentSeq);
+          reject(
+            new Error(
+              `failed to post dynamic render request: ${toMessage(error)}`,
+            ),
           );
         }
       });

--- a/web/src/worker-protocol.ts
+++ b/web/src/worker-protocol.ts
@@ -1,3 +1,5 @@
+import type { BrowserTextMetricsRequest } from "./browser-text-metrics";
+
 export type WorkerOutputFormat = "text" | "ascii" | "svg" | "mmds" | "mermaid";
 
 export interface WorkerRenderRequestMessage {
@@ -14,8 +16,18 @@ export interface WorkerValidateRequestMessage {
   input: string;
 }
 
+export interface WorkerDynamicTextMetricsRenderRequestMessage {
+  type: "renderWithBrowserTextMetrics";
+  seq: number;
+  input: string;
+  format: "svg";
+  configJson: string;
+  browserTextMetrics: BrowserTextMetricsRequest;
+}
+
 export type WorkerRequestMessage =
   | WorkerRenderRequestMessage
+  | WorkerDynamicTextMetricsRenderRequestMessage
   | WorkerValidateRequestMessage;
 
 export interface WorkerResultMessage {

--- a/web/src/worker.test.ts
+++ b/web/src/worker.test.ts
@@ -8,6 +8,13 @@ import type {
 interface MockWasmModule {
   default: () => Promise<void>;
   render: (input: string, format: string, configJson: string) => string;
+  renderWithBrowserTextMetrics: (
+    input: string,
+    format: string,
+    configJson: string,
+    metricsJson: string,
+    measureText: (text: string, cssFont: string) => number,
+  ) => string;
   validate: (input: string) => string;
 }
 
@@ -19,11 +26,14 @@ describe("createWorkerRequestHandler", () => {
         return `${format}:${input}:${configJson}`;
       },
     );
-    const validate = vi.fn((input: string) => `{"valid":true,"input":"${input}"}`);
+    const validate = vi.fn(
+      (input: string) => `{"valid":true,"input":"${input}"}`,
+    );
     const loadWasmModule = vi.fn(
       async (): Promise<MockWasmModule> => ({
         default: initialize,
         render,
+        renderWithBrowserTextMetrics: () => "unused",
         validate,
       }),
     );
@@ -79,6 +89,7 @@ describe("createWorkerRequestHandler", () => {
         render: () => {
           throw new Error("unknown output format: bad");
         },
+        renderWithBrowserTextMetrics: () => "unused",
         validate: () => '{"valid":true}',
       }),
     );
@@ -113,6 +124,7 @@ describe("createWorkerRequestHandler", () => {
       async (): Promise<MockWasmModule> => ({
         default: initialize,
         render: () => "unused",
+        renderWithBrowserTextMetrics: () => "unused",
         validate: (input) =>
           JSON.stringify({
             valid: input.includes("A-->B"),
@@ -144,6 +156,113 @@ describe("createWorkerRequestHandler", () => {
         type: "validation",
         seq: -1,
         resultJson: '{"valid":true,"diagnostics":[]}',
+      },
+    ]);
+  });
+
+  it("prepares browser metrics and invokes the dynamic wasm export", async () => {
+    const measureText = vi.fn(() => 42);
+    const prepareBrowserTextMetrics = vi.fn(async () => ({
+      metricsJson: '{"cssFont":"16px Inter"}',
+      measureText,
+    }));
+    const renderWithBrowserTextMetrics = vi.fn(
+      (
+        input: string,
+        format: string,
+        configJson: string,
+        metricsJson: string,
+        callback: (text: string, cssFont: string) => number,
+      ) =>
+        `${format}:${input}:${configJson}:${metricsJson}:${callback("A", "font")}`,
+    );
+    const loadWasmModule = vi.fn(
+      async (): Promise<MockWasmModule> => ({
+        default: async () => {},
+        render: () => "static unused",
+        renderWithBrowserTextMetrics,
+        validate: () => '{"valid":true}',
+      }),
+    );
+
+    const responses: WorkerResponseMessage[] = [];
+    const handler = createWorkerRequestHandler({
+      loadWasmModule,
+      prepareBrowserTextMetrics,
+      postMessage: (message) => responses.push(message),
+    });
+
+    await handler({
+      type: "renderWithBrowserTextMetrics",
+      seq: 9,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: "{}",
+      browserTextMetrics: {
+        fontFamily: "Inter",
+        fontSizePx: 16,
+        lineHeightPx: 24,
+      },
+    });
+
+    expect(prepareBrowserTextMetrics).toHaveBeenCalledWith({
+      fontFamily: "Inter",
+      fontSizePx: 16,
+      lineHeightPx: 24,
+    });
+    expect(renderWithBrowserTextMetrics).toHaveBeenCalledWith(
+      "graph TD\nA-->B",
+      "svg",
+      "{}",
+      '{"cssFont":"16px Inter"}',
+      measureText,
+    );
+    expect(responses).toEqual([
+      {
+        type: "result",
+        seq: 9,
+        format: "svg",
+        output: 'svg:graph TD\nA-->B:{}:{"cssFont":"16px Inter"}:42',
+      },
+    ]);
+  });
+
+  it("returns structured errors for dynamic metric preparation failures", async () => {
+    const loadWasmModule = vi.fn(
+      async (): Promise<MockWasmModule> => ({
+        default: async () => {},
+        render: () => "static unused",
+        renderWithBrowserTextMetrics: () => "dynamic unused",
+        validate: () => '{"valid":true}',
+      }),
+    );
+    const responses: WorkerResponseMessage[] = [];
+    const handler = createWorkerRequestHandler({
+      loadWasmModule,
+      prepareBrowserTextMetrics: vi.fn(async () => {
+        throw new Error("Dynamic text metrics require OffscreenCanvas");
+      }),
+      postMessage: (message) => responses.push(message),
+    });
+
+    await handler({
+      type: "renderWithBrowserTextMetrics",
+      seq: 10,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: "{}",
+      browserTextMetrics: {
+        fontFamily: "Inter",
+        fontSizePx: 16,
+        lineHeightPx: 24,
+      },
+    });
+
+    expect(responses).toEqual([
+      {
+        type: "error",
+        seq: 10,
+        error: "Dynamic text metrics require OffscreenCanvas",
       },
     ]);
   });

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -1,3 +1,4 @@
+import { prepareBrowserTextMetrics } from "./browser-text-metrics";
 import type {
   WorkerRequestMessage,
   WorkerResponseMessage,
@@ -11,11 +12,19 @@ export type {
 interface WasmModule {
   default: () => Promise<void>;
   render: (input: string, format: string, configJson: string) => string;
+  renderWithBrowserTextMetrics: (
+    input: string,
+    format: string,
+    configJson: string,
+    metricsJson: string,
+    measureText: (text: string, cssFont: string) => number,
+  ) => string;
   validate: (input: string) => string;
 }
 
 interface RenderRequestHandlerOptions {
   loadWasmModule?: () => Promise<WasmModule>;
+  prepareBrowserTextMetrics?: typeof prepareBrowserTextMetrics;
   postMessage: (message: WorkerResponseMessage) => void;
 }
 
@@ -27,6 +36,8 @@ export function createWorkerRequestHandler(
   options: RenderRequestHandlerOptions,
 ): (message: WorkerRequestMessage) => Promise<void> {
   const loadModule = options.loadWasmModule ?? loadWasmModule;
+  const prepareMetrics =
+    options.prepareBrowserTextMetrics ?? prepareBrowserTextMetrics;
   const postMessage = options.postMessage;
   let modulePromise: Promise<WasmModule> | null = null;
 
@@ -49,6 +60,25 @@ export function createWorkerRequestHandler(
           message.input,
           message.format,
           message.configJson,
+        );
+
+        postMessage({
+          type: "result",
+          seq: message.seq,
+          format: message.format,
+          output,
+        });
+        return;
+      }
+
+      if (message.type === "renderWithBrowserTextMetrics") {
+        const prepared = await prepareMetrics(message.browserTextMetrics);
+        const output = wasmModule.renderWithBrowserTextMetrics(
+          message.input,
+          message.format,
+          message.configJson,
+          prepared.metricsJson,
+          prepared.measureText,
         );
 
         postMessage({

--- a/web/tests/examples.test.ts
+++ b/web/tests/examples.test.ts
@@ -10,6 +10,11 @@ function createFakeRenderClient() {
   }));
   return {
     render,
+    renderWithBrowserTextMetrics: vi.fn(async (request) => ({
+      seq: request.seq,
+      format: "svg",
+      output: `svg:${request.input}`,
+    })),
     validate: vi.fn(async () => '{"valid":true}'),
     terminate: vi.fn(),
   } satisfies RenderWorkerClient;

--- a/web/tests/state-persistence.test.ts
+++ b/web/tests/state-persistence.test.ts
@@ -27,6 +27,11 @@ function createFakeRenderClient() {
       format: request.format,
       output: `${request.format}:${request.input}`,
     })),
+    renderWithBrowserTextMetrics: vi.fn(async (request) => ({
+      seq: request.seq,
+      format: "svg",
+      output: `svg:${request.input}`,
+    })),
     validate: vi.fn(async () => '{"valid":true}'),
     terminate: vi.fn(),
   } satisfies RenderWorkerClient;
@@ -245,6 +250,11 @@ describe("playground state persistence", () => {
           request.format === "text"
             ? "\u001b[38;2;255;0;0mAlpha\u001b[0m"
             : `${request.format}:${request.input}`,
+      })),
+      renderWithBrowserTextMetrics: vi.fn(async (request) => ({
+        seq: request.seq,
+        format: "svg",
+        output: `svg:${request.input}`,
       })),
       validate: vi.fn(async () => '{"valid":true}'),
       terminate: vi.fn(),

--- a/web/tests/ui-controls.test.ts
+++ b/web/tests/ui-controls.test.ts
@@ -16,6 +16,11 @@ function createFakeRenderClient() {
 
   return {
     render,
+    renderWithBrowserTextMetrics: vi.fn(async (request) => ({
+      seq: request.seq,
+      format: "svg",
+      output: `svg:${request.input}`,
+    })),
     validate: vi.fn(async () => '{"valid":true}'),
     terminate: vi.fn(),
   } satisfies RenderWorkerClient;
@@ -135,6 +140,11 @@ describe("format-aware controls", () => {
           request.format === "text"
             ? "\u001b[38;2;255;0;0mAlpha\u001b[0m"
             : `${request.format}:${request.input}`,
+      })),
+      renderWithBrowserTextMetrics: vi.fn(async (request) => ({
+        seq: request.seq,
+        format: "svg",
+        output: `svg:${request.input}`,
       })),
       validate: vi.fn(async () => '{"valid":true}'),
       terminate: vi.fn(),


### PR DESCRIPTION
## Summary

- add a feature-gated dynamic text metrics bridge for browser-provided synchronous width measurement
- expose a separate WASM `renderWithBrowserTextMetrics` path while keeping existing `render` static and deterministic
- wire the web worker/client through an explicit browser metrics request path with font preflight and no fallback on measurement failure
- document the experimental SVG-only contract and preserve the MMDS/static profile boundaries

## Validation

- `cog check origin/main..HEAD`
- `cargo nextest run` — 2996 passed
- `cargo nextest run --features unstable-text-metrics-provider` — 3014 passed
- `just lint`
- `just architecture-check`
- `just check`
- `just wasm-test` — 23 browser tests passed
- `just wasm-size` — 1,736,351 raw / 600,884 gzip for web and bundler
- `cd web && npm run test` — 87 passed
- `cd web && npm run build`

## Manual deployment verification

Checked the Cloudflare Pages preview deployment in Chrome:

- Preview URL: https://e99aede6.mmdflux-play.pages.dev
- Production baseline: https://play.mmdflux.com
- Preview page loads and renders the playground normally with no console errors or warnings.
- Preview bundles contain the new dynamic path: `renderWithBrowserTextMetrics` is present in the entry bundle, worker bundle, and WASM JS wrapper; the worker bundle also contains `prepareBrowserTextMetrics`, `OffscreenCanvas`, and `FontFaceSet`.
- Production baseline does not contain `renderWithBrowserTextMetrics`, `prepareBrowserTextMetrics`, `OffscreenCanvas`, or `FontFaceSet`, confirming it is still the old static-only build.
- Directly invoked the deployed preview WASM export. `renderWithBrowserTextMetrics(..., "mmds", ...)` rejects with `browser dynamic text metrics only supports SVG output (requested mmds)`.
- Compared static `mmdflux-sans-v1` SVG output with dynamic browser measurement using `normal 400 16px "trebuchet ms", verdana, arial, sans-serif`. Outputs are not byte-identical and show small expected metric differences. Example for `graph TD\nA -->|mmmm| B`: static viewBox `0 0 86.67 230.00`, dynamic viewBox `0 0 85.44 230.00`; static label background width `61.31`, dynamic `61.12`.

## Notes

WASM size delta versus `origin/main` is +18,875 raw bytes and +9,347 gzip bytes for both web and bundler targets, still under the existing budgets.

Closes #305
