### PR TITLE
feat: add public graph font config contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ engine handles flowchart/class/state text, SVG, and MMDS output. Switch to
 | [`@mmds/core`](https://www.npmjs.com/package/@mmds/core)             | MMDS normalization, traversal, and validation utilities (npm) |
 | [`@mmds/excalidraw`](https://www.npmjs.com/package/@mmds/excalidraw) | MMDS to Excalidraw `.excalidraw` JSON (npm)                   |
 | [`@mmds/tldraw`](https://www.npmjs.com/package/@mmds/tldraw)         | MMDS to tldraw `.tldr` JSON (npm)                             |
-| [Playground](https://play.mmdflux.com)                               | Interactive browser editor (WASM-powered)                     |
+| [Playground](https://play.mmdflux.com)                               | Interactive browser editor (Wasm-powered)                     |
 
 ## Install
 
@@ -277,6 +277,15 @@ let svg = render_diagram(
 ```
 
 SVG `<defs>` blocks are also pruned to the markers each diagram actually uses, so simple flowcharts and sequence diagrams no longer carry unused arrowhead definitions.
+
+### Graph font config
+
+Rust and JSON/Wasm config can carry graph-family `fontFamily` and `fontSize`
+values, including the narrow Mermaid aliases `themeVariables.fontFamily` and
+`themeVariables.fontSize`. These fields describe text measurement identity, not
+SVG-only styling. Provider-free static rendering accepts only values that match
+the selected static profile descriptor; arbitrary browser fonts require the
+separate browser dynamic metrics export.
 
 ## Adapter workflows
 

--- a/crates/mmdflux-wasm/src/lib.rs
+++ b/crates/mmdflux-wasm/src/lib.rs
@@ -77,7 +77,7 @@ pub fn validate(input: &str) -> String {
 fn parse_render_config(format: OutputFormat, config_json: &str) -> Result<RenderConfig, JsError> {
     if config_json.trim().is_empty() {
         let mut config = RenderConfig::default();
-        // WASM forces flux-layered for SVG.
+        // Wasm forces flux-layered for SVG.
         apply_svg_surface_defaults(format, &mut config, true);
         return Ok(config);
     }
@@ -87,7 +87,7 @@ fn parse_render_config(format: OutputFormat, config_json: &str) -> Result<Render
     let mut config = input
         .into_render_config()
         .map_err(|err| js_error(err.message))?;
-    // WASM forces flux-layered for SVG.
+    // Wasm forces flux-layered for SVG.
     apply_svg_surface_defaults(format, &mut config, true);
     Ok(config)
 }
@@ -99,9 +99,15 @@ fn parse_dynamic_render_config(config_json: &str) -> Result<RenderConfig, JsErro
 
     let input: RuntimeConfigInput = serde_json::from_str(config_json)
         .map_err(|error| js_error(format!("invalid config_json: {error}")))?;
-    input
+    let config = input
         .into_render_config()
-        .map_err(|err| js_error(err.message))
+        .map_err(|err| js_error(err.message))?;
+    if config.graph_text_style.is_some() {
+        return Err(js_error(
+            "renderWithBrowserTextMetrics uses metricsJson for font identity; do not pass fontFamily, fontSize, or themeVariables in configJson",
+        ));
+    }
+    Ok(config)
 }
 
 fn parse_dynamic_metrics_input(metrics_json: &str) -> Result<DynamicMetricsInput, RenderError> {

--- a/crates/mmdflux-wasm/tests/web.rs
+++ b/crates/mmdflux-wasm/tests/web.rs
@@ -107,6 +107,52 @@ fn static_render_export_stays_byte_stable_after_dynamic_render() {
 }
 
 #[wasm_bindgen_test]
+fn static_wasm_render_rejects_custom_provider_free_font_style() {
+    for (format, expected) in [
+        ("svg", "dynamic text metrics"),
+        ("mmds", "dynamic text metrics"),
+        ("text", "not supported"),
+        ("ascii", "not supported"),
+    ] {
+        let error = render(
+            "graph TD\nA-->B",
+            format,
+            r#"{"fontFamily":"Inter","fontSize":16}"#,
+        )
+        .expect_err("custom provider-free font style should fail");
+
+        let message = error_debug(error);
+        assert!(message.contains(expected), "{message}");
+    }
+}
+
+#[wasm_bindgen_test]
+fn static_wasm_render_accepts_static_descriptor_matching_font_style() {
+    let output = render(
+        "graph TD\nA-->B",
+        "svg",
+        r#"{"fontFamily":"\"trebuchet ms\", verdana, arial, sans-serif","fontSize":16}"#,
+    )
+    .expect("static descriptor matching style should render");
+
+    assert!(output.contains("<svg"));
+}
+
+#[wasm_bindgen_test]
+fn static_wasm_render_accepts_equivalent_static_descriptor_spelling_byte_stable() {
+    let input = "graph TD\nA[mmmm]-->B[iiii]";
+    let default_output = render(input, "svg", "{}").expect("default render");
+    let styled_output = render(
+        input,
+        "svg",
+        r#"{"fontFamily":"Trebuchet MS, Verdana, Arial, sans-serif","fontSize":16}"#,
+    )
+    .expect("equivalent descriptor spelling should render");
+
+    assert_eq!(styled_output, default_output);
+}
+
+#[wasm_bindgen_test]
 fn dynamic_text_metrics_callback_throw_errors() {
     let measure = callback("throw new Error('canvas failed');");
     let err = render_with_browser_text_metrics(
@@ -247,6 +293,29 @@ fn dynamic_text_metrics_rejects_mmds_output() {
 
     let message = error_debug(err);
     assert!(message.contains("only supports SVG output"), "{message}");
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_rejects_config_json_font_style() {
+    let measure = callback("return text.length * 8;");
+
+    for config_json in [
+        r#"{"fontFamily":"Inter","fontSize":16}"#,
+        r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"16px"}}"#,
+    ] {
+        let err = render_with_browser_text_metrics(
+            "graph TD\nA-->B",
+            "svg",
+            config_json,
+            dynamic_metrics_json_fixture(),
+            &measure,
+        )
+        .expect_err("dynamic export should reject configJson font style");
+
+        let message = error_debug(err);
+        assert!(message.contains("configJson"), "{message}");
+        assert!(message.contains("metricsJson"), "{message}");
+    }
 }
 
 #[wasm_bindgen_test]

--- a/docs/development/wasm.md
+++ b/docs/development/wasm.md
@@ -1,10 +1,10 @@
-# WASM Build and Test Commands
+# Wasm Build and Test Commands
 
-Use these reproducible local entrypoints when validating WASM readiness.
+Use these reproducible local entrypoints when validating Wasm readiness.
 
 ## Prerequisite
 
-Install the WASM target and wasm-pack once per environment:
+Install the Wasm target and wasm-pack once per environment:
 
 ```bash
 rustup target add wasm32-unknown-unknown
@@ -62,6 +62,11 @@ Supported top-level keys:
 - `svgNodePaddingY`
 - `fontMetricsProfile` (default: `mmdflux-sans-v1`; compatibility:
   `mmdflux-heuristic-proportional-v1`)
+- `fontFamily`
+- `fontSize`
+- `themeVariables` object:
+  - `fontFamily`
+  - `fontSize`
 - `showIds`
 - `color` (`off`, `auto`, `always`)
 - `geometryLevel` (`layout`, `routed`)
@@ -71,23 +76,30 @@ Supported top-level keys:
 
 Notes:
 
-- For SVG output, if `layoutEngine` is omitted, WASM defaults to `flux-layered`.
+- For SVG output, if `layoutEngine` is omitted, Wasm defaults to `flux-layered`.
 - When SVG rendering uses `flux-layered` and no explicit edge style is provided,
-  WASM defaults to the `smooth-step` preset.
+  Wasm defaults to the `smooth-step` preset.
 - `color` only affects text/ascii output. `always` forces ANSI escapes, while `auto`
-  resolves to plain text in WASM because there is no terminal-capability probe.
+  resolves to plain text in Wasm because there is no terminal-capability probe.
 - `fontMetricsProfile` defaults to `mmdflux-sans-v1` for direct graph-family
   rendering. The compatibility profile `mmdflux-heuristic-proportional-v1`
   remains available for callers that need the previous heuristic geometry.
   Text and ASCII output ignore this setting and remain pinned to
   compatibility metrics for wrap preparation. Unsupported profile IDs are
   rejected.
-- WASM uses the same static profile tables as native rendering; browser
+- Wasm uses the same static profile tables as native rendering; browser
   `measureText` is not used by these profiles.
-- SVG font-family and metrics profile are intentionally decoupled for now: the
-  default recorded profile uses Liberation Sans Regular advances, while emitted
-  SVG continues to use the existing Mermaid-style font stack. Exposing SVG
-  `fontFamily` remains future work.
+- `fontFamily` and `fontSize` are graph text-style inputs, not styling-only SVG
+  overrides. Provider-free static rendering accepts them only when they
+  normalize to the selected static profile descriptor. A different
+  custom graph font style requires dynamic text metrics through the separate dynamic
+  export.
+- `themeVariables` is intentionally narrow. Only `themeVariables.fontFamily`
+  and `themeVariables.fontSize` are accepted; other Mermaid theme variables are
+  rejected.
+- SVG font-family and metrics profile are intentionally decoupled for static
+  profiles: the default recorded profile uses Liberation Sans Regular advances,
+  while emitted SVG continues to use the existing Mermaid-style font stack.
 - Release wasm artifacts use a size-optimized Cargo profile:
   `opt-level=z`, `codegen-units=1`, `lto=fat`, `panic=abort`.
 - Legacy keys such as `edgeRouting`, `edgeStyle`, `svgEdgeCurve`, and
@@ -115,6 +127,10 @@ static profile.
   "lineHeightPx": 24
 }
 ```
+
+`renderWithBrowserTextMetrics uses metricsJson for font identity`.
+`configJson.fontFamily`, `configJson.fontSize`, and `configJson.themeVariables`
+are rejected on this export even when they match `metricsJson`.
 
 The JavaScript adapter must complete async font preflight before Rust layout
 starts. The v1 worker path requires `OffscreenCanvas` and a worker
@@ -162,7 +178,7 @@ Example:
 
 ## npm Release Contract
 
-WASM publishing is tag-driven via:
+Wasm publishing is tag-driven via:
 
 - `.github/workflows/wasm-release.yml`
 

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -419,8 +419,13 @@ Rules:
   reserved `dynamic` for future live measurement backends.
 - The recorded profile source font is provenance, not an exact Mermaid or
   browser font claim.
-- SVG font-family and metrics profile are intentionally decoupled for now: the default recorded profile uses Liberation Sans Regular advances, while emitted SVG continues to use the existing Mermaid-style font stack.
-- Exposing SVG `fontFamily` remains future work.
+- SVG font-family and metrics profile are intentionally decoupled for static
+  profiles: the default recorded profile uses Liberation Sans Regular advances,
+  while emitted SVG continues to use the existing Mermaid-style font stack.
+- provider-free static profiles do not accept arbitrary custom font style:
+  `fontFamily` and `fontSize` are accepted only when they normalize to the
+  selected static profile descriptor. A different custom style requires the
+  browser dynamic metrics export.
 - The experimental browser dynamic metrics export is SVG-only and does not emit
   or replay MMDS; provider-bound dynamic MMDS replay remains future work.
 - Replay uses `metricsProfile.id` plus `layoutText` node padding and edge-label wrap width when the extension is present.
@@ -428,6 +433,38 @@ Rules:
 - Older MMDS documents without the extension replay with the `mmdflux-heuristic-proportional-v1` compatibility defaults.
 - A recognized text metrics extension with an unsupported `metricsProfile.id` is a replay error.
 - Sequence-family full text-metrics parity remains deferred.
+
+### Graph Font Config And Mermaid Init
+
+Runtime JSON config accepts canonical top-level `fontFamily` and `fontSize`
+for graph-family text style. It also accepts the narrow Mermaid-compatible
+aliases `themeVariables.fontFamily` and `themeVariables.fontSize`.
+
+These fields are layout-affecting text-style identity, not SVG-only cosmetics.
+provider-free static profiles do not accept arbitrary custom font style. If the
+requested style matches the selected static profile descriptor after
+normalizing quote, case, comma spacing, and ASCII whitespace, rendering proceeds
+with descriptor-owned SVG spelling and byte-stable static geometry. If it does
+not match, SVG/MMDS rendering fails and tells callers to use dynamic text
+metrics.
+
+`themeVariables.fontSize` accepts positive numbers, bare numeric strings, and
+`px` strings such as `"14px"` or `"14.5 px"`. Other units are rejected.
+Matching top-level and `themeVariables` values are accepted; conflicting values
+are rejected.
+
+#### Migrating from Mermaid init
+
+mmdflux does not import Mermaid's full `themeVariables` object. Only
+`themeVariables.fontFamily` and `themeVariables.fontSize` are supported here.
+Other Mermaid theme variables such as `primaryColor`, `lineColor`, `textColor`,
+and `darkMode` are rejected so callers do not accidentally assume broader theme
+parity.
+
+Browser dynamic metrics keep font identity in `metricsJson`, not `configJson`.
+`renderWithBrowserTextMetrics` rejects `configJson.fontFamily`,
+`configJson.fontSize`, and `configJson.themeVariables`; provider-bound dynamic
+MMDS replay remains future work.
 
 ### Node
 

--- a/src/graph/measure.rs
+++ b/src/graph/measure.rs
@@ -394,6 +394,71 @@ fn text_metrics_descriptor(
     }
 }
 
+pub(crate) fn text_style_matches_descriptor(
+    font_family: &str,
+    font_size_px: f64,
+    descriptor: &TextMetricsStyleDescriptor,
+) -> Result<bool, String> {
+    let requested_family = font_family_compare_key(font_family)?;
+    let descriptor_family = font_family_compare_key(&descriptor.font_family)?;
+    Ok(requested_family == descriptor_family
+        && (font_size_px - descriptor.font_size).abs() <= f64::EPSILON)
+}
+
+pub(crate) fn font_family_compare_key(value: &str) -> Result<Vec<String>, String> {
+    let tokens: Vec<String> = value
+        .split(',')
+        .map(normalize_font_family_token)
+        .collect::<Result<_, _>>()?;
+
+    if tokens.is_empty() {
+        return Err("must contain at least one font family".to_string());
+    }
+
+    Ok(tokens)
+}
+
+fn normalize_font_family_token(token: &str) -> Result<String, String> {
+    let token = token.trim();
+    let token = strip_one_quote_layer(token).trim();
+    let token = collapse_ascii_whitespace(token);
+    if token.is_empty() {
+        return Err("must not contain empty font family tokens".to_string());
+    }
+    Ok(token.to_ascii_lowercase())
+}
+
+fn strip_one_quote_layer(token: &str) -> &str {
+    if token.len() >= 2 {
+        let bytes = token.as_bytes();
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &token[1..token.len() - 1];
+        }
+    }
+    token
+}
+
+fn collapse_ascii_whitespace(value: &str) -> String {
+    let mut normalized = String::new();
+    let mut previous_was_space = false;
+
+    for ch in value.chars() {
+        if ch.is_ascii_whitespace() {
+            if !normalized.is_empty() && !previous_was_space {
+                normalized.push(' ');
+            }
+            previous_was_space = true;
+        } else {
+            normalized.push(ch);
+            previous_was_space = false;
+        }
+    }
+
+    normalized.trim().to_string()
+}
+
 /// Greedy word-wrap that honors `max_width` in pixels using `metrics` for
 /// per-character width estimates. `'\n'` in `text` is treated as a hard
 /// break; each segment is wrapped independently. Falls back to per-character

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,17 +342,17 @@ pub use engines::graph::EngineAlgorithmId;
 /// Engine identifier (e.g., `Flux`, `Mermaid`, `Elk`).
 pub use engines::graph::EngineId;
 pub use errors::RenderError;
-/// Policy for resolving `--color auto` in CLI/WASM adapters.
+/// Policy for resolving `--color auto` in CLI/Wasm adapters.
 pub use format::ColorWhen;
 pub use format::OutputFormat;
 /// Text output color mode (plain, styled, or ANSI).
 pub use format::TextColorMode;
+pub use runtime::config::{GraphTextStyleConfig, RenderConfig, SvgThemeConfig, SvgThemeMode};
 /// Layout configuration for the Sugiyama hierarchical engine.
 pub use runtime::config::{
     LabelDummyPlacement, LabelDummyRouting, LayoutConfig, LayoutDirection, Ranker,
 };
-pub use runtime::config::{RenderConfig, SvgThemeConfig, SvgThemeMode};
-/// Serde-friendly config input for JSON consumers (WASM, API).
+/// Serde-friendly config input for JSON consumers (Wasm, API).
 pub use runtime::config_input::RuntimeConfigInput;
 /// Apply default SVG surface settings (curve, engine) when format is SVG.
 pub use runtime::config_input::apply_svg_surface_defaults;

--- a/src/main.rs
+++ b/src/main.rs
@@ -711,6 +711,7 @@ fn main() -> io::Result<()> {
         svg_diagram_padding: cli.svg_diagram_padding,
         svg_theme: svg_theme_from_cli(&cli),
         font_metrics_profile,
+        graph_text_style: None,
         show_ids: cli.show_ids,
         geometry_level: cli.geometry_level.map(Into::into).unwrap_or_default(),
         path_simplification: cli.path_simplification.map(Into::into).unwrap_or_default(),

--- a/src/runtime/config.rs
+++ b/src/runtime/config.rs
@@ -42,6 +42,28 @@ pub struct SvgThemeConfig {
     pub border: Option<String>,
 }
 
+/// Graph-family text style requested through public render config.
+///
+/// This is a layout-affecting style identity, not a generic SVG font override.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct GraphTextStyleConfig {
+    /// CSS font-family list used for graph-family text measurement identity.
+    pub font_family: String,
+    /// Font size in CSS pixels.
+    pub font_size_px: f64,
+}
+
+impl GraphTextStyleConfig {
+    /// Build graph-family text style config.
+    pub fn new(font_family: impl Into<String>, font_size_px: f64) -> Self {
+        Self {
+            font_family: font_family.into(),
+            font_size_px,
+        }
+    }
+}
+
 /// Configuration for rendering.
 #[derive(Debug, Clone, Default)]
 pub struct RenderConfig {
@@ -75,6 +97,8 @@ pub struct RenderConfig {
     pub svg_theme: Option<SvgThemeConfig>,
     /// Graph-family text metrics profile selector.
     pub font_metrics_profile: Option<String>,
+    /// Graph-family text style config.
+    pub graph_text_style: Option<GraphTextStyleConfig>,
     /// Show node IDs alongside labels.
     pub show_ids: bool,
     /// MMDS geometry level for JSON output.
@@ -156,6 +180,24 @@ mod tests {
         assert_eq!(options.output_format, OutputFormat::Text);
         assert_eq!(options.routing_style, RoutingStyle::Orthogonal);
         assert!(!options.use_pinned_ranks);
+    }
+
+    #[test]
+    fn render_config_default_has_no_graph_text_style() {
+        let config = RenderConfig::default();
+
+        assert!(config.graph_text_style.is_none());
+    }
+
+    #[test]
+    fn graph_text_style_config_carries_family_and_size() {
+        let style = GraphTextStyleConfig {
+            font_family: "Inter, system-ui, sans-serif".to_string(),
+            font_size_px: 14.0,
+        };
+
+        assert_eq!(style.font_family, "Inter, system-ui, sans-serif");
+        assert_eq!(style.font_size_px, 14.0);
     }
 
     #[test]

--- a/src/runtime/config_input.rs
+++ b/src/runtime/config_input.rs
@@ -1,4 +1,4 @@
-//! Serde-friendly config input for JSON-based consumers (WASM, API, etc.).
+//! Serde-friendly config input for JSON-based consumers (Wasm, API, etc.).
 //!
 //! [`RuntimeConfigInput`] mirrors [`RenderConfig`] but uses `Option<String>`
 //! for enum fields so that it can be deserialized from camelCase JSON.
@@ -12,8 +12,11 @@ use crate::format::{
     ColorWhen, Curve, EdgePreset, OutputFormat, RoutingStyle, normalize_enum_token,
 };
 use crate::graph::GeometryLevel;
-use crate::graph::measure::validate_text_metrics_profile_id;
-use crate::runtime::config::{RenderConfig, SvgThemeConfig, SvgThemeMode};
+use crate::graph::measure::{
+    DEFAULT_GRAPH_FONT_FAMILY, DEFAULT_PROPORTIONAL_FONT_SIZE, font_family_compare_key,
+    validate_text_metrics_profile_id,
+};
+use crate::runtime::config::{GraphTextStyleConfig, RenderConfig, SvgThemeConfig, SvgThemeMode};
 use crate::simplification::PathSimplification;
 
 /// Serde-friendly render config accepted from JSON callers.
@@ -37,6 +40,9 @@ pub struct RuntimeConfigInput {
     pub svg_node_padding_x: Option<f64>,
     pub svg_node_padding_y: Option<f64>,
     pub font_metrics_profile: Option<String>,
+    pub font_family: Option<String>,
+    pub font_size: Option<f64>,
+    pub theme_variables: Option<ThemeVariablesInput>,
     pub show_ids: Option<bool>,
     pub color: Option<String>,
     pub geometry_level: Option<String>,
@@ -70,6 +76,22 @@ pub struct SvgThemeConfigInput {
     pub border: Option<String>,
 }
 
+/// Narrow Mermaid-compatible themeVariables subset for graph font style.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+pub struct ThemeVariablesInput {
+    pub font_family: Option<String>,
+    pub font_size: Option<ThemeFontSizeInput>,
+}
+
+/// Mermaid-compatible font-size alias accepted under themeVariables.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum ThemeFontSizeInput {
+    Number(f64),
+    String(String),
+}
+
 impl RuntimeConfigInput {
     /// Validate and convert into a typed [`RenderConfig`].
     pub fn into_render_config(self) -> Result<RenderConfig, RenderError> {
@@ -95,6 +117,8 @@ impl RuntimeConfigInput {
             })?;
             config.font_metrics_profile = Some(font_metrics_profile);
         }
+        config.graph_text_style =
+            graph_text_style_from_input(self.font_family, self.font_size, self.theme_variables)?;
         if let Some(layout_engine) = self.layout_engine {
             config.layout_engine = Some(EngineAlgorithmId::parse(&layout_engine)?);
         }
@@ -139,6 +163,147 @@ impl RuntimeConfigInput {
 
         Ok(config)
     }
+}
+
+fn graph_text_style_from_input(
+    font_family: Option<String>,
+    font_size: Option<f64>,
+    theme_variables: Option<ThemeVariablesInput>,
+) -> Result<Option<GraphTextStyleConfig>, RenderError> {
+    let theme_family = theme_variables
+        .as_ref()
+        .and_then(|theme| theme.font_family.as_ref());
+    let theme_size = theme_variables
+        .as_ref()
+        .and_then(|theme| theme.font_size.as_ref());
+
+    if font_family.is_none()
+        && font_size.is_none()
+        && theme_family.is_none()
+        && theme_size.is_none()
+    {
+        return Ok(None);
+    }
+
+    let canonical_family = font_family
+        .as_ref()
+        .map(|value| normalize_font_family("fontFamily", value))
+        .transpose()?;
+    let theme_family = theme_family
+        .map(|value| normalize_font_family("themeVariables.fontFamily", value))
+        .transpose()?;
+    if let (Some(canonical), Some(theme)) = (&canonical_family, &theme_family)
+        && canonical.compare_key != theme.compare_key
+    {
+        return Err(RenderError {
+            message: "conflicting fontFamily and themeVariables.fontFamily".to_string(),
+        });
+    }
+
+    let canonical_size = font_size
+        .map(|value| validate_font_size_px("fontSize", value))
+        .transpose()?;
+    let theme_size = theme_variables
+        .and_then(|theme| theme.font_size)
+        .map(theme_font_size_to_px)
+        .transpose()?;
+    if let (Some(canonical), Some(theme)) = (canonical_size, theme_size)
+        && (canonical - theme).abs() > f64::EPSILON
+    {
+        return Err(RenderError {
+            message: "conflicting fontSize and themeVariables.fontSize".to_string(),
+        });
+    }
+
+    let font_family = match canonical_family.or(theme_family) {
+        Some(value) => value.display,
+        None => DEFAULT_GRAPH_FONT_FAMILY.to_string(),
+    };
+    let font_size_px = match canonical_size.or(theme_size) {
+        Some(value) => value,
+        None => DEFAULT_PROPORTIONAL_FONT_SIZE,
+    };
+
+    Ok(Some(GraphTextStyleConfig {
+        font_family,
+        font_size_px,
+    }))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedFontFamily {
+    display: String,
+    compare_key: Vec<String>,
+}
+
+fn normalize_font_family(field: &str, value: &str) -> Result<NormalizedFontFamily, RenderError> {
+    let trimmed = value.trim();
+    let compare_key = font_family_compare_key_for_field(field, trimmed)?;
+    Ok(NormalizedFontFamily {
+        display: trimmed.to_string(),
+        compare_key,
+    })
+}
+
+fn validate_font_size_px(field: &str, value: f64) -> Result<f64, RenderError> {
+    if value.is_finite() && value > 0.0 {
+        Ok(value)
+    } else {
+        Err(RenderError {
+            message: format!("{field} must be a finite positive number"),
+        })
+    }
+}
+
+fn theme_font_size_to_px(input: ThemeFontSizeInput) -> Result<f64, RenderError> {
+    match input {
+        ThemeFontSizeInput::Number(value) => {
+            validate_font_size_px("themeVariables.fontSize", value)
+        }
+        ThemeFontSizeInput::String(value) => parse_theme_font_size_string(&value),
+    }
+}
+
+fn parse_theme_font_size_string(value: &str) -> Result<f64, RenderError> {
+    let field = "themeVariables.fontSize";
+    let trimmed = value.trim();
+    let numeric = if trimmed
+        .get(trimmed.len().saturating_sub(2)..)
+        .is_some_and(|suffix| suffix.eq_ignore_ascii_case("px"))
+    {
+        trimmed[..trimmed.len() - 2].trim_end()
+    } else {
+        trimmed
+    };
+
+    if !is_plain_decimal_number(numeric) {
+        return Err(RenderError {
+            message: format!("{field} must be a positive number or px value"),
+        });
+    }
+
+    let value = numeric.parse::<f64>().map_err(|_| RenderError {
+        message: format!("{field} must be a positive number or px value"),
+    })?;
+    validate_font_size_px(field, value)
+}
+
+fn is_plain_decimal_number(value: &str) -> bool {
+    let Some((head, tail)) = value.split_once('.') else {
+        return !value.is_empty() && value.chars().all(|ch| ch.is_ascii_digit());
+    };
+
+    !head.is_empty()
+        && !tail.is_empty()
+        && head.chars().all(|ch| ch.is_ascii_digit())
+        && tail.chars().all(|ch| ch.is_ascii_digit())
+        && !tail.contains('.')
+}
+
+fn font_family_compare_key_for_field(field: &str, value: &str) -> Result<Vec<String>, RenderError> {
+    font_family_compare_key(value).map_err(|message| RenderError {
+        message: format!("{field} {message}"),
+    })
 }
 
 impl SvgThemeConfigInput {
@@ -194,7 +359,7 @@ pub fn default_svg_engine() -> EngineAlgorithmId {
 ///
 /// The `force_engine` parameter controls whether to force the default SVG
 /// engine when none is set:
-/// - `true`: WASM behavior — always set flux-layered for SVG.
+/// - `true`: Wasm behavior — always set flux-layered for SVG.
 /// - `false`: CLI behavior — leave engine unset (auto-detect later).
 pub fn apply_svg_surface_defaults(
     format: OutputFormat,
@@ -215,5 +380,45 @@ pub fn apply_svg_surface_defaults(
 
     if config.layout_engine.unwrap_or(default_svg_engine()) == default_svg_engine() {
         config.edge_preset = Some(EdgePreset::SmoothStep);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn font_family_compare_key_normalizes_quotes_case_and_spacing() {
+        let first = font_family_compare_key_for_field(
+            "fontFamily",
+            r#" "Trebuchet   MS" , Verdana, ARIAL , sans-serif "#,
+        )
+        .unwrap();
+        let second = font_family_compare_key_for_field(
+            "fontFamily",
+            r#"trebuchet ms,verdana,arial,sans-serif"#,
+        )
+        .unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first,
+            vec!["trebuchet ms", "verdana", "arial", "sans-serif"]
+        );
+    }
+
+    #[test]
+    fn font_family_compare_key_rejects_empty_tokens() {
+        let err = font_family_compare_key_for_field("fontFamily", "Inter, , Arial").unwrap_err();
+
+        assert!(err.message.contains("fontFamily"), "{err}");
+    }
+
+    #[test]
+    fn validate_font_size_rejects_non_finite_values() {
+        for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let err = validate_font_size_px("fontSize", value).unwrap_err();
+            assert!(err.message.contains("fontSize"), "{err}");
+        }
     }
 }

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -1,4 +1,4 @@
-//! Experimental dynamic text metrics contract for browser/WASM adapters.
+//! Experimental dynamic text metrics contract for callback-backed adapters.
 //!
 //! This module is feature-gated and doc-hidden because its callback-backed
 //! provider API is not part of the stable Rust facade.
@@ -268,20 +268,25 @@ where
 {
     if !matches!(format, OutputFormat::Svg) {
         return Err(RenderError {
-            message: format!(
-                "browser dynamic text metrics only supports SVG output (requested {format})"
-            ),
+            message: format!("dynamic text metrics only supports SVG output (requested {format})"),
         });
     }
     if config.layout_engine.is_some() {
         return Err(RenderError {
-            message: "browser dynamic text metrics does not accept layoutEngine; it always uses flux-layered SVG"
-                .to_string(),
+            message:
+                "dynamic text metrics does not accept layoutEngine; it always uses flux-layered SVG"
+                    .to_string(),
         });
     }
     if config.font_metrics_profile.is_some() {
         return Err(RenderError {
-            message: "browser dynamic text metrics does not accept fontMetricsProfile; dynamic provider measurement is selected by this API"
+            message: "dynamic text metrics does not accept fontMetricsProfile; provider measurement is selected by this API"
+                .to_string(),
+        });
+    }
+    if config.graph_text_style.is_some() {
+        return Err(RenderError {
+            message: "dynamic text metrics uses DynamicMetricsInput for font identity; do not pass RenderConfig.graph_text_style"
                 .to_string(),
         });
     }
@@ -292,7 +297,7 @@ where
     match detect_input_frontend(input) {
         Some(InputFrontend::Mmds) => {
             return Err(RenderError {
-                message: "browser dynamic text metrics does not support MMDS input".to_string(),
+                message: "dynamic text metrics does not support MMDS input".to_string(),
             });
         }
         Some(InputFrontend::Mermaid) => {}
@@ -310,7 +315,7 @@ where
     if !matches!(resolved.family(), DiagramFamily::Graph) {
         return Err(RenderError {
             message: format!(
-                "browser dynamic text metrics only supports graph-family Mermaid diagrams (detected {})",
+                "dynamic text metrics only supports graph-family Mermaid diagrams (detected {})",
                 resolved.diagram_id()
             ),
         });
@@ -337,7 +342,7 @@ where
     })?;
 
     let mut effective_config = super::effective_render_config(input, OutputFormat::Svg, config);
-    // Match the existing WASM SVG surface while keeping browser-measured layout
+    // Match the existing Wasm SVG surface while keeping dynamic-measured layout
     // on this separate export instead of accepting a caller layoutEngine knob.
     apply_svg_surface_defaults(OutputFormat::Svg, &mut effective_config, true);
     let mut options = effective_config.svg_render_options();
@@ -388,8 +393,7 @@ where
             )
         }
         Diagram::Sequence(_) => Err(RenderError {
-            message: "browser dynamic text metrics only supports graph-family Mermaid diagrams"
-                .to_string(),
+            message: "dynamic text metrics only supports graph-family Mermaid diagrams".to_string(),
         }),
     }?;
 
@@ -408,7 +412,7 @@ mod tests {
         DEFAULT_GRAPH_FONT_FAMILY, TextMetricsProfileConfig, TextMetricsProvider,
         resolve_text_metrics_profile,
     };
-    use crate::runtime::config::RenderConfig;
+    use crate::runtime::config::{GraphTextStyleConfig, RenderConfig};
     use crate::runtime::render_diagram;
 
     fn valid_input() -> DynamicMetricsInput {
@@ -677,6 +681,28 @@ mod tests {
 
         assert!(
             err.message.contains("does not accept fontMetricsProfile"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn dynamic_svg_rejects_config_graph_text_style() {
+        let config = RenderConfig {
+            graph_text_style: Some(GraphTextStyleConfig::new("Inter", 16.0)),
+            ..RenderConfig::default()
+        };
+
+        let err = render_graph_family_svg_with_dynamic_text_metrics(
+            "graph TD\nA-->B",
+            &config,
+            valid_input(),
+            |_text, _css_font| Ok(8.0),
+        )
+        .expect_err("config graph text style should fail");
+
+        assert!(err.message.contains("DynamicMetricsInput"), "{err}");
+        assert!(
+            err.message.contains("RenderConfig.graph_text_style"),
             "{err}"
         );
     }

--- a/src/runtime/graph_family.rs
+++ b/src/runtime/graph_family.rs
@@ -12,6 +12,7 @@ use crate::graph::measure::{
     COMPATIBILITY_TEXT_METRICS_PROFILE_ID, DEFAULT_PROPORTIONAL_NODE_PADDING_X,
     DEFAULT_PROPORTIONAL_NODE_PADDING_Y, ResolvedTextMetrics, TextMetricsProfileConfig,
     TextMetricsProfileDescriptor, TextMetricsProvider, resolve_text_metrics_profile,
+    text_style_matches_descriptor,
 };
 use crate::graph::{GeometryLevel, Graph};
 use crate::mmds::Document;
@@ -114,6 +115,7 @@ fn solve_graph_family_for_render(
     config: &RenderConfig,
 ) -> Result<GraphFamilyRenderResult, RenderError> {
     let text_metrics = resolve_text_metrics_for_config(format, config)?;
+    validate_provider_free_graph_text_style(format, config, &text_metrics.descriptor)?;
     let solve = solve_graph_family_with_provider(
         diagram_id,
         diagram,
@@ -126,6 +128,51 @@ fn solve_graph_family_for_render(
         solve,
         text_metrics,
     })
+}
+
+fn validate_provider_free_graph_text_style(
+    format: OutputFormat,
+    config: &RenderConfig,
+    descriptor: &TextMetricsProfileDescriptor,
+) -> Result<(), RenderError> {
+    let Some(style) = &config.graph_text_style else {
+        return Ok(());
+    };
+
+    if matches!(format, OutputFormat::Text | OutputFormat::Ascii) {
+        return Err(RenderError {
+            message: format!(
+                "graph font style is not supported for {format} output; remove fontFamily/fontSize"
+            ),
+        });
+    }
+
+    if !matches!(format, OutputFormat::Svg | OutputFormat::Mmds) {
+        return Ok(());
+    }
+
+    match text_style_matches_descriptor(
+        &style.font_family,
+        style.font_size_px,
+        &descriptor.default_text_style,
+    ) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(provider_free_graph_text_style_error(descriptor)),
+        Err(message) => Err(RenderError {
+            message: format!("fontFamily {message}"),
+        }),
+    }
+}
+
+fn provider_free_graph_text_style_error(descriptor: &TextMetricsProfileDescriptor) -> RenderError {
+    RenderError {
+        message: format!(
+            "custom graph font style requires dynamic text metrics; provider-free static rendering only accepts fontFamily '{}' and fontSize {} for text metrics profile '{}'",
+            descriptor.default_text_style.font_family,
+            descriptor.default_text_style.font_size,
+            descriptor.profile_id
+        ),
+    }
 }
 
 fn solve_graph_family_with_provider(

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -11,7 +11,8 @@ use std::path::Path;
 use mmdflux::graph::attachment::PortFace;
 use mmdflux::graph::geometry::EdgeLabelSide;
 use mmdflux::graph::measure::{
-    COMPATIBILITY_TEXT_METRICS_PROFILE_ID, RECORDED_SANS_TEXT_METRICS_PROFILE_ID,
+    COMPATIBILITY_TEXT_METRICS_PROFILE_ID, DEFAULT_PROPORTIONAL_FONT_SIZE,
+    RECORDED_SANS_TEXT_METRICS_PROFILE_ID,
 };
 use mmdflux::graph::{Arrow, Direction, GeometryLevel, Shape, Stroke};
 use mmdflux::mmds::{
@@ -21,8 +22,8 @@ use mmdflux::mmds::{
 };
 use mmdflux::simplification::PathSimplification;
 use mmdflux::{
-    EngineAlgorithmId, OutputFormat, RenderConfig, TextColorMode, materialize_diagram,
-    render_diagram,
+    EngineAlgorithmId, GraphTextStyleConfig, OutputFormat, RenderConfig, TextColorMode,
+    materialize_diagram, render_diagram,
 };
 use serde_json::{Value, json};
 
@@ -428,6 +429,23 @@ fn font_metrics_explicit_recorded_profile_matches_default_mmds_geometry() {
     assert_eq!(explicit_mmds["nodes"], default_mmds["nodes"]);
     assert_eq!(explicit_mmds["edges"], default_mmds["edges"]);
     assert_eq!(explicit_mmds["subgraphs"], default_mmds["subgraphs"]);
+}
+
+#[test]
+fn provider_free_mmds_rejects_custom_graph_font_style() {
+    let config = RenderConfig {
+        graph_text_style: Some(GraphTextStyleConfig::new(
+            "Inter",
+            DEFAULT_PROPORTIONAL_FONT_SIZE,
+        )),
+        ..RenderConfig::default()
+    };
+
+    let err = render_diagram("graph TD\nA-->B", OutputFormat::Mmds, &config)
+        .expect_err("custom provider-free graph font style should fail");
+
+    assert!(err.message.contains("fontFamily"), "{err}");
+    assert!(err.message.contains("dynamic text metrics"), "{err}");
 }
 
 #[test]
@@ -1565,7 +1583,9 @@ fn docs_and_schema_reference_text_metrics_extension_contract() {
     assert!(docs.contains("SVG font-family and metrics profile are intentionally decoupled"));
     assert!(docs.contains("Liberation Sans Regular advances"));
     assert!(docs.contains("emitted SVG continues to use the existing Mermaid-style font stack"));
-    assert!(docs.contains("Exposing SVG `fontFamily` remains future work"));
+    assert!(
+        docs.contains("provider-free static profiles do not accept arbitrary custom font style")
+    );
     assert!(docs.contains("experimental browser dynamic metrics export is SVG-only"));
     assert!(docs.contains("does not emit"));
     assert!(docs.contains("replay MMDS"));
@@ -1582,6 +1602,24 @@ fn docs_and_schema_reference_text_metrics_extension_contract() {
     assert!(schema.contains("recorded"));
     assert!(schema.contains("dynamic"));
     assert!(schema.contains("edge-label-max-width"));
+}
+
+#[test]
+fn docs_describe_graph_font_config_contract() {
+    let wasm_docs = std::fs::read_to_string("docs/development/wasm.md").unwrap();
+    let mmds_docs = std::fs::read_to_string("docs/mmds.md").unwrap();
+
+    assert!(wasm_docs.contains("fontFamily"));
+    assert!(wasm_docs.contains("fontSize"));
+    assert!(wasm_docs.contains("themeVariables"));
+    assert!(wasm_docs.contains("renderWithBrowserTextMetrics uses metricsJson for font identity"));
+    assert!(wasm_docs.contains("custom graph font style requires dynamic text metrics"));
+    assert!(
+        mmds_docs
+            .contains("provider-free static profiles do not accept arbitrary custom font style")
+    );
+    assert!(mmds_docs.contains("dynamic MMDS replay remains future work"));
+    assert!(mmds_docs.contains("Migrating from Mermaid init"));
 }
 
 #[test]

--- a/tests/svg_render.rs
+++ b/tests/svg_render.rs
@@ -5,11 +5,13 @@ use std::path::Path;
 
 use mmdflux::format::{CornerStyle, Curve, RoutingStyle};
 use mmdflux::graph::measure::{
-    COMPATIBILITY_TEXT_METRICS_PROFILE_ID, RECORDED_SANS_TEXT_METRICS_PROFILE_ID,
+    COMPATIBILITY_TEXT_METRICS_PROFILE_ID, DEFAULT_GRAPH_FONT_FAMILY,
+    DEFAULT_PROPORTIONAL_FONT_SIZE, RECORDED_SANS_TEXT_METRICS_PROFILE_ID,
 };
 use mmdflux::simplification::PathSimplification;
 use mmdflux::{
-    EngineAlgorithmId, OutputFormat, RenderConfig, SvgThemeConfig, SvgThemeMode, render_diagram,
+    EngineAlgorithmId, GraphTextStyleConfig, OutputFormat, RenderConfig, SvgThemeConfig,
+    SvgThemeMode, render_diagram,
 };
 
 fn load_flowchart_fixture(name: &str) -> String {
@@ -112,6 +114,87 @@ fn font_metrics_unsupported_profile_fails_svg_before_output() {
         err.message
             .contains("unsupported text metrics profile 'mermaid-sans-v1'"),
         "{err}"
+    );
+}
+
+#[test]
+fn provider_free_svg_rejects_custom_graph_font_style() {
+    let config = RenderConfig {
+        graph_text_style: Some(GraphTextStyleConfig::new(
+            "Inter",
+            DEFAULT_PROPORTIONAL_FONT_SIZE,
+        )),
+        ..RenderConfig::default()
+    };
+
+    let err = render_diagram("graph TD\nA-->B", OutputFormat::Svg, &config)
+        .expect_err("custom provider-free graph font style should fail");
+
+    assert!(err.message.contains("fontFamily"), "{err}");
+    assert!(err.message.contains("dynamic text metrics"), "{err}");
+    assert!(err.message.contains(DEFAULT_GRAPH_FONT_FAMILY), "{err}");
+}
+
+#[test]
+fn provider_free_svg_accepts_style_matching_static_profile_descriptor() {
+    let config = RenderConfig {
+        graph_text_style: Some(GraphTextStyleConfig::new(
+            DEFAULT_GRAPH_FONT_FAMILY,
+            DEFAULT_PROPORTIONAL_FONT_SIZE,
+        )),
+        ..RenderConfig::default()
+    };
+
+    let output = render_diagram("graph TD\nA-->B", OutputFormat::Svg, &config).unwrap();
+
+    assert!(output.contains("<svg"));
+}
+
+#[test]
+fn provider_free_svg_accepts_equivalent_static_profile_font_stack_spelling_byte_stable() {
+    let input = "graph TD\nA[mmmm]-->B[iiii]";
+    let default_output = render_diagram(input, OutputFormat::Svg, &RenderConfig::default())
+        .expect("default SVG render");
+    let config = RenderConfig {
+        graph_text_style: Some(GraphTextStyleConfig::new(
+            "Trebuchet MS, Verdana, Arial, sans-serif",
+            DEFAULT_PROPORTIONAL_FONT_SIZE,
+        )),
+        ..RenderConfig::default()
+    };
+
+    let styled_output =
+        render_diagram(input, OutputFormat::Svg, &config).expect("descriptor-matching style");
+
+    assert_eq!(styled_output, default_output);
+}
+
+#[test]
+fn provider_free_text_and_ascii_reject_custom_graph_font_style() {
+    let config = RenderConfig {
+        graph_text_style: Some(GraphTextStyleConfig::new(
+            "Inter",
+            DEFAULT_PROPORTIONAL_FONT_SIZE,
+        )),
+        ..RenderConfig::default()
+    };
+
+    for format in [OutputFormat::Text, OutputFormat::Ascii] {
+        let err = render_diagram("graph TD\nA-->B", format, &config)
+            .expect_err("terminal output should reject graph font style");
+        assert!(err.message.contains("font style"), "{err}");
+        assert!(err.message.contains("not supported"), "{err}");
+    }
+}
+
+#[test]
+fn default_svg_rendering_remains_byte_stable_after_graph_font_config_contract() {
+    let input = include_str!("fixtures/flowchart/labeled_edges.mmd");
+    let output = render_diagram(input, OutputFormat::Svg, &RenderConfig::default()).unwrap();
+
+    assert_eq!(
+        output,
+        include_str!("svg-snapshots/flowchart/labeled_edges.svg")
     );
 }
 

--- a/tests/wasm_cli_contract.rs
+++ b/tests/wasm_cli_contract.rs
@@ -164,7 +164,7 @@ fn cli_and_wasm_use_the_same_render_config_contract() {
     use mmdflux::format::EdgePreset;
     use mmdflux::{RenderConfig, RuntimeConfigInput, SvgThemeConfig, SvgThemeMode};
 
-    // JSON config as WASM receives it.
+    // JSON config as Wasm receives it.
     let json = r##"{
         "edgePreset":"smooth-step",
         "svgTheme": {
@@ -258,27 +258,140 @@ fn runtime_config_input_rejects_unsupported_font_metrics_profile() {
 }
 
 #[test]
-fn runtime_config_input_rejects_dynamic_font_config_fields() {
+fn runtime_config_input_accepts_canonical_graph_font_style() {
     use mmdflux::RuntimeConfigInput;
 
-    for (json, field) in [
+    let input: RuntimeConfigInput =
+        serde_json::from_str(r#"{"fontFamily":"Inter, system-ui","fontSize":14}"#).unwrap();
+    let config = input.into_render_config().unwrap();
+    let style = config.graph_text_style.expect("graph text style");
+
+    assert_eq!(style.font_family, "Inter, system-ui");
+    assert_eq!(style.font_size_px, 14.0);
+}
+
+#[test]
+fn runtime_config_input_fills_missing_canonical_graph_font_style_defaults() {
+    use mmdflux::RuntimeConfigInput;
+    use mmdflux::graph::measure::{DEFAULT_GRAPH_FONT_FAMILY, DEFAULT_PROPORTIONAL_FONT_SIZE};
+
+    let input: RuntimeConfigInput = serde_json::from_str(r#"{"fontFamily":"Inter"}"#).unwrap();
+    let config = input.into_render_config().unwrap();
+    let style = config.graph_text_style.expect("graph text style");
+    assert_eq!(style.font_family, "Inter");
+    assert_eq!(style.font_size_px, DEFAULT_PROPORTIONAL_FONT_SIZE);
+
+    let input: RuntimeConfigInput = serde_json::from_str(r#"{"fontSize":14}"#).unwrap();
+    let config = input.into_render_config().unwrap();
+    let style = config.graph_text_style.expect("graph text style");
+    assert_eq!(style.font_family, DEFAULT_GRAPH_FONT_FAMILY);
+    assert_eq!(style.font_size_px, 14.0);
+}
+
+#[test]
+fn runtime_config_input_rejects_invalid_canonical_graph_font_style() {
+    use mmdflux::RuntimeConfigInput;
+
+    for (json, expected) in [
+        (r#"{"fontFamily":"","fontSize":14}"#, "fontFamily"),
         (
-            r#"{"fontFamily":"Inter","fontMetricsProfile":"browser-dynamic-v1"}"#,
+            r#"{"fontFamily":"Inter, , Arial","fontSize":14}"#,
             "fontFamily",
         ),
-        (r#"{"fontSize":16}"#, "fontSize"),
+        (r#"{"fontFamily":"Inter","fontSize":0}"#, "fontSize"),
+        (r#"{"fontFamily":"Inter","fontSize":-1}"#, "fontSize"),
+    ] {
+        let input: RuntimeConfigInput = serde_json::from_str(json).unwrap();
+        let err = input.into_render_config().unwrap_err();
+        assert!(err.message.contains(expected), "{err}");
+    }
+}
+
+#[test]
+fn runtime_config_input_accepts_theme_variables_font_aliases() {
+    use mmdflux::RuntimeConfigInput;
+
+    for (json, expected_size) in [
         (
-            r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"18px"}}"#,
-            "themeVariables",
+            r#"{"themeVariables":{"fontFamily":"Inter","fontSize":14}}"#,
+            14.0,
+        ),
+        (
+            r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"14"}}"#,
+            14.0,
+        ),
+        (
+            r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"14px"}}"#,
+            14.0,
+        ),
+        (
+            r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"14PX"}}"#,
+            14.0,
+        ),
+        (
+            r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"14.5 px"}}"#,
+            14.5,
         ),
     ] {
-        let err = serde_json::from_str::<RuntimeConfigInput>(json).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains(&format!("unknown field `{field}`")),
-            "{err}"
-        );
+        let input: RuntimeConfigInput = serde_json::from_str(json).unwrap();
+        let config = input.into_render_config().unwrap();
+        let style = config.graph_text_style.expect("graph text style");
+        assert_eq!(style.font_family, "Inter");
+        assert_eq!(style.font_size_px, expected_size);
     }
+}
+
+#[test]
+fn runtime_config_input_rejects_unknown_theme_variables_and_units() {
+    use mmdflux::RuntimeConfigInput;
+
+    let unknown = serde_json::from_str::<RuntimeConfigInput>(
+        r##"{"themeVariables":{"primaryColor":"#fff"}}"##,
+    )
+    .unwrap_err();
+    assert!(unknown.to_string().contains("unknown field `primaryColor`"));
+
+    let input: RuntimeConfigInput =
+        serde_json::from_str(r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"1rem"}}"#)
+            .unwrap();
+    let err = input.into_render_config().unwrap_err();
+    assert!(err.message.contains("themeVariables.fontSize"), "{err}");
+
+    for json in [
+        r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"+14px"}}"#,
+        r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"1.4e1"}}"#,
+        r#"{"themeVariables":{"fontFamily":"Inter","fontSize":"px"}}"#,
+    ] {
+        let input: RuntimeConfigInput = serde_json::from_str(json).unwrap();
+        let err = input.into_render_config().unwrap_err();
+        assert!(err.message.contains("themeVariables.fontSize"), "{err}");
+    }
+}
+
+#[test]
+fn runtime_config_input_rejects_conflicting_font_aliases() {
+    use mmdflux::RuntimeConfigInput;
+
+    for json in [
+        r#"{"fontFamily":"Inter","fontSize":14,"themeVariables":{"fontFamily":"Arial","fontSize":"14px"}}"#,
+        r#"{"fontFamily":"Inter","fontSize":14,"themeVariables":{"fontFamily":"Inter","fontSize":"16px"}}"#,
+    ] {
+        let input: RuntimeConfigInput = serde_json::from_str(json).unwrap();
+        let err = input.into_render_config().unwrap_err();
+        assert!(err.message.contains("conflicting"), "{err}");
+    }
+}
+
+#[test]
+fn runtime_config_input_accepts_equivalent_font_family_alias_spelling() {
+    use mmdflux::RuntimeConfigInput;
+
+    let input: RuntimeConfigInput = serde_json::from_str(
+        r#"{"fontFamily":"\"Trebuchet MS\", Verdana, Arial, sans-serif","fontSize":16,"themeVariables":{"fontFamily":"trebuchet ms,verdana,arial,sans-serif","fontSize":"16px"}}"#,
+    )
+    .unwrap();
+
+    input.into_render_config().unwrap();
 }
 
 #[cfg(feature = "unstable-text-metrics-provider")]
@@ -392,7 +505,7 @@ fn facade_render_unknown_diagram_uses_lowercase_error() {
     .unwrap_err();
 
     // The facade must use lowercase "unknown diagram type" to match the
-    // published WASM contract (web.rs line 92).
+    // published Wasm contract (web.rs line 92).
     assert!(
         err.message.contains("unknown diagram type"),
         "facade error must use lowercase: got {:?}",


### PR DESCRIPTION
## Summary

- add public `GraphTextStyleConfig` plus strict JSON parsing for `fontFamily`, `fontSize`, and the narrow `themeVariables.fontFamily/fontSize` aliases (typed sub-object, `deny_unknown_fields`)
- enforce the provider-free static rendering contract: arbitrary graph font identities are rejected unless they normalize to the selected static profile descriptor
- the dynamic export (Rust + Wasm) rejects config font style fields entirely; `metricsJson` remains the single source of font identity
- pin the contract: byte-stable SVG output for default `RenderConfig`, equivalent-spelling acceptance, and Text/ASCII rejection
- update docs and contract tests for the static/dynamic font config boundary, including a Mermaid `init` migration section

Closes #306

## Non-goals (deferred)

- public CLI font flags (no CLI-reachable dynamic provider yet)
- dynamic MMDS replay / `metricsProfile.source = "dynamic"` (tracked in #307, #308)
- main-thread browser fallback (#313)
- sequence/Text/ASCII dynamic metrics (#314)
- broad Mermaid `themeVariables` import (only `fontFamily` + `fontSize`)

## Validation

- `just check` — 3014/3014 default-features tests passing
- `cargo nextest run --features unstable-text-metrics-provider` — 3033/3033 passing
- `cog check origin/main..HEAD`
