### PR TITLE
feat(web): add main-thread browser text metrics fallback

### DIFF
--- a/docs/development/wasm.md
+++ b/docs/development/wasm.md
@@ -133,13 +133,25 @@ static profile.
 are rejected on this export even when they match `metricsJson`.
 
 The JavaScript adapter must complete async font preflight before Rust layout
-starts. The v1 worker path requires `OffscreenCanvas` and a worker
-`FontFaceSet`: call `fonts.load(cssFont)`, await `fonts.ready`, and then use a
-post-load `fonts.check(cssFont)` validity gate before invoking Rust. The
-`measureText` callback itself is synchronous from Rust's perspective and must
-return a finite non-negative width number for each `(text, cssFont)` request.
-Promises, objects, `NaN`, `Infinity`, negative values, and thrown errors fail
-the render.
+starts. Both browser modes call `load(cssFont)`, await `ready`, and then use a
+post-load `check(cssFont)` validity gate before invoking Rust. `check()` alone
+is not proof that a requested font loaded.
+
+| Mode | Required browser capabilities | Notes |
+| ---- | ----------------------------- | ----- |
+| Worker dynamic metrics | worker `FontFaceSet` (`self.fonts`) and `OffscreenCanvas` | Preferred path. Layout and `measureText` stay inside the worker. |
+| Main-thread dynamic metrics | `document.fonts` and a normal canvas | Fallback for worker font/canvas capability gaps. This can block the UI during render. |
+
+Main-thread fallback is used only when worker dynamic metrics fail because the
+worker lacks font or canvas capabilities. Missing fonts, failed post-load
+`check()`, invalid `measureText` output, and Rust render errors remain explicit
+failures; they do not retry through another mode or fall back to static
+profiles.
+
+The `measureText` callback itself is synchronous from Rust's perspective and
+must return a finite non-negative width number for each `(text, cssFont)`
+request. Promises, objects, `NaN`, `Infinity`, negative values, and thrown errors
+fail the render.
 
 The dynamic path does not fall back to `mmdflux-sans-v1` or
 `mmdflux-heuristic-proportional-v1` after a measurement failure. It also does

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -1659,6 +1659,11 @@ fn docs_cover_live_style_scope_and_wasm_color_config() {
     assert!(wasm_docs.contains("SVG font-family and metrics profile are intentionally decoupled"));
     assert!(wasm_docs.contains("renderWithBrowserTextMetrics"));
     assert!(wasm_docs.contains("existing `render` export remains static and deterministic"));
+    assert!(wasm_docs.contains("Worker dynamic metrics"));
+    assert!(wasm_docs.contains("Main-thread dynamic metrics"));
+    assert!(wasm_docs.contains("document.fonts"));
+    assert!(wasm_docs.contains("normal canvas"));
+    assert!(wasm_docs.contains("can block the UI"));
     assert!(wasm_docs.contains("OffscreenCanvas"));
     assert!(wasm_docs.contains("FontFaceSet"));
     assert!(wasm_docs.contains("does not fall back"));

--- a/web/src/app/bootstrap.ts
+++ b/web/src/app/bootstrap.ts
@@ -23,6 +23,10 @@ import {
 } from "../preview";
 import { createPreviewControls } from "../preview-controls";
 import {
+  createMainThreadBrowserTextMetricsRenderer,
+  type MainThreadBrowserTextMetricsRenderer,
+} from "../services/main-thread-browser-text-metrics";
+import {
   persistPlaygroundState,
   readPersistedPlaygroundState,
   resolveStateStorage,
@@ -31,6 +35,7 @@ import {
 import {
   createRenderWorkerClient,
   type RenderWorkerClient,
+  type RenderWorkerClientOptions,
 } from "../services/render-client";
 import {
   copyTextToClipboard,
@@ -60,11 +65,44 @@ interface RenderControlBinding {
 
 export interface RenderAppOptions {
   renderClientFactory?: () => RenderWorkerClient | null;
+  mainThreadBrowserTextMetricsRendererFactory?: () => MainThreadBrowserTextMetricsRenderer;
   debounceMs?: LiveUpdateDebounceSetting;
   stateStorage?: StateStorage;
 }
 
 type SearchLocation = URL | Pick<Location, "search">;
+
+interface BrowserMetricsDebugOptions {
+  input?: string;
+  fontFamily?: string;
+  fontSizePx?: number;
+  lineHeightPx?: number;
+  configJson?: string;
+  show?: boolean;
+  forceMainThread?: boolean;
+}
+
+interface BrowserMetricsDebugResult {
+  seq: number;
+  format: "svg";
+  output: string;
+  source: "worker-client" | "main-thread";
+}
+
+interface BrowserMetricsDebugApi {
+  renderBrowserMetrics: (
+    options?: BrowserMetricsDebugOptions,
+  ) => Promise<BrowserMetricsDebugResult>;
+  renderBrowserMetricsMainThread: (
+    options?: Omit<BrowserMetricsDebugOptions, "forceMainThread">,
+  ) => Promise<BrowserMetricsDebugResult>;
+}
+
+declare global {
+  interface Window {
+    __mmdfluxDebug?: BrowserMetricsDebugApi;
+  }
+}
 
 function defaultAdaptiveDebounce(requestInput: string): number {
   const length = requestInput.length;
@@ -78,6 +116,31 @@ function defaultAdaptiveDebounce(requestInput: string): number {
     return 80;
   }
   return 120;
+}
+
+function isBrowserMetricsDebugEnabled(
+  locationValue: SearchLocation = window.location,
+): boolean {
+  const params = new URLSearchParams(locationValue.search);
+  const rawValue = params.get("debugBrowserMetrics");
+  if (rawValue === null) {
+    return false;
+  }
+
+  const normalized = rawValue.trim().toLowerCase();
+  return normalized === "" || normalized === "1" || normalized === "true";
+}
+
+function positiveFiniteNumber(value: number, label: string): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be a positive finite number`);
+  }
+
+  return value;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isLayoutEngine(value: string): value is ShareLayoutEngine {
@@ -133,6 +196,24 @@ const THEME_ICONS: Record<ThemePreference, string> = {
   system:
     '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="12" rx="2"></rect><path d="M9 20h6"></path><path d="M12 16v4"></path></svg>',
 };
+
+type RenderWorkerClientFactory = (
+  worker?: Worker,
+  options?: RenderWorkerClientOptions,
+) => RenderWorkerClient;
+
+export function createDefaultRenderWorkerClient(
+  createClient: RenderWorkerClientFactory = createRenderWorkerClient,
+  createMainThreadRenderer: () => MainThreadBrowserTextMetricsRenderer = createMainThreadBrowserTextMetricsRenderer,
+): RenderWorkerClient | null {
+  if (typeof Worker === "undefined") {
+    return null;
+  }
+
+  return createClient(undefined, {
+    mainThreadBrowserTextMetricsRenderer: createMainThreadRenderer(),
+  });
+}
 
 function viewportHeight(): number {
   return window.innerHeight || document.documentElement.clientHeight || 0;
@@ -553,11 +634,12 @@ export function renderApp(
     output: previewOutput,
     error: previewError,
   });
+  const createMainThreadRenderer =
+    options.mainThreadBrowserTextMetricsRendererFactory ??
+    createMainThreadBrowserTextMetricsRenderer;
   const workerClient = options.renderClientFactory
     ? options.renderClientFactory()
-    : typeof Worker === "undefined"
-      ? null
-      : createRenderWorkerClient();
+    : createDefaultRenderWorkerClient(undefined, createMainThreadRenderer);
   const editor = createEditorController({
     root: editorRoot,
     initialValue: stateStore.getState().input,
@@ -722,6 +804,20 @@ export function renderApp(
     return JSON.stringify(config);
   };
 
+  const currentSvgConfigJson = (): string => {
+    const { renderSettings } = stateStore.getState();
+    const config: Record<string, string> = {};
+    if (renderSettings.layoutEngine !== "auto") {
+      config.layoutEngine = renderSettings.layoutEngine;
+    }
+    if (renderSettings.edgePreset !== "auto") {
+      config.edgePreset = renderSettings.edgePreset;
+    }
+    config.pathSimplification = renderSettings.pathSimplification;
+
+    return JSON.stringify(config);
+  };
+
   const setAdvancedPanelOpen = (open: boolean): void => {
     stateStore.setAdvancedOpen(open);
     advancedPanel.hidden = !open;
@@ -839,6 +935,91 @@ export function renderApp(
       previewControls.onResult("text");
     },
   });
+
+  let nextBrowserMetricsDebugSeq = -1_000_000;
+  let browserMetricsDebugMainThreadRenderer: MainThreadBrowserTextMetricsRenderer | null =
+    null;
+
+  const getBrowserMetricsDebugMainThreadRenderer =
+    (): MainThreadBrowserTextMetricsRenderer => {
+      browserMetricsDebugMainThreadRenderer ??= createMainThreadRenderer();
+      return browserMetricsDebugMainThreadRenderer;
+    };
+
+  const renderBrowserMetricsDebug = async (
+    options: BrowserMetricsDebugOptions = {},
+  ): Promise<BrowserMetricsDebugResult> => {
+    const fontFamily = (options.fontFamily ?? "Arial, sans-serif").trim();
+    if (fontFamily.length === 0) {
+      throw new Error("fontFamily must not be empty");
+    }
+
+    const fontSizePx = positiveFiniteNumber(
+      options.fontSizePx ?? 16,
+      "fontSizePx",
+    );
+    const lineHeightPx = positiveFiniteNumber(
+      options.lineHeightPx ?? fontSizePx * 1.5,
+      "lineHeightPx",
+    );
+    const request = {
+      seq: nextBrowserMetricsDebugSeq,
+      input: options.input ?? editor.getValue(),
+      configJson: options.configJson ?? currentSvgConfigJson(),
+      browserTextMetrics: {
+        fontFamily,
+        fontSizePx,
+        lineHeightPx,
+      },
+    };
+    nextBrowserMetricsDebugSeq -= 1;
+
+    const source = options.forceMainThread ? "main-thread" : "worker-client";
+
+    try {
+      const response = options.forceMainThread
+        ? await getBrowserMetricsDebugMainThreadRenderer().renderWithBrowserTextMetrics(
+            request,
+          )
+        : await workerClient.renderWithBrowserTextMetrics(request);
+      const result: BrowserMetricsDebugResult = {
+        seq: response.seq,
+        format: "svg",
+        output: response.output,
+        source,
+      };
+
+      if (options.show !== false) {
+        setFormat("svg");
+        preview.showResult({
+          format: "svg",
+          output: result.output,
+        });
+        previewControls.onResult("svg");
+        updateShareStatus(`Rendered browser metrics via ${source}.`);
+      }
+
+      return result;
+    } catch (error) {
+      if (options.show !== false) {
+        preview.showError(toErrorMessage(error));
+        previewControls.onResult("text");
+      }
+      throw error;
+    }
+  };
+
+  // Hidden manual-QA hook for preview deployments. This is not product UI or a
+  // public playground API.
+  if (isBrowserMetricsDebugEnabled()) {
+    window.__mmdfluxDebug = {
+      renderBrowserMetrics: renderBrowserMetricsDebug,
+      renderBrowserMetricsMainThread: (options = {}) =>
+        renderBrowserMetricsDebug({ ...options, forceMainThread: true }),
+    };
+  } else {
+    delete window.__mmdfluxDebug;
+  }
 
   scheduleRender = (inputOverride?: string): void => {
     const currentState = stateStore.getState();

--- a/web/src/browser-text-metrics.test.ts
+++ b/web/src/browser-text-metrics.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  BrowserTextMetricsCapabilityError,
   type BrowserTextMetricsEnvironment,
   buildCssFont,
+  type MainThreadBrowserTextMetricsEnvironment,
   prepareBrowserTextMetrics,
+  prepareMainThreadBrowserTextMetrics,
 } from "./browser-text-metrics";
 
 interface FakeTextMetrics {
@@ -44,6 +47,42 @@ function environmentFixture(
   };
 }
 
+function mainThreadEnvironmentFixture(
+  fonts: FakeFontFaceSet | undefined = fontSetFixture(),
+) {
+  const context: FakeCanvasContext = {
+    font: "",
+    measureText: vi.fn((text: string) => ({ width: text.length * 3 })),
+  };
+  const canvas = {
+    getContext: (type: "2d"): FakeCanvasContext | null =>
+      type === "2d" ? context : null,
+  };
+  const document = {
+    fonts,
+    createElement: vi.fn(function (
+      this: unknown,
+      tagName: "canvas",
+    ): typeof canvas {
+      if (this !== document) {
+        throw new Error("createElement lost document receiver");
+      }
+      if (tagName !== "canvas") {
+        throw new Error(`unexpected element: ${tagName}`);
+      }
+      return canvas;
+    }),
+  };
+  const environment: MainThreadBrowserTextMetricsEnvironment = {
+    document,
+  };
+
+  return {
+    context,
+    environment,
+  };
+}
+
 function fontSetFixture(
   overrides: Partial<FakeFontFaceSet> = {},
 ): FakeFontFaceSet {
@@ -62,7 +101,16 @@ describe("prepareBrowserTextMetrics", () => {
         { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
         { fonts: fontSetFixture() },
       ),
-    ).rejects.toThrow("OffscreenCanvas");
+    ).rejects.toMatchObject({
+      code: "worker-offscreen-canvas-unavailable",
+      fallbackEligible: true,
+    });
+    await expect(
+      prepareBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        { fonts: fontSetFixture() },
+      ),
+    ).rejects.toBeInstanceOf(BrowserTextMetricsCapabilityError);
   });
 
   it("fails honestly without worker FontFaceSet support", async () => {
@@ -74,7 +122,31 @@ describe("prepareBrowserTextMetrics", () => {
         { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
         environment,
       ),
-    ).rejects.toThrow("FontFaceSet");
+    ).rejects.toMatchObject({
+      code: "worker-font-face-set-unavailable",
+      fallbackEligible: true,
+    });
+  });
+
+  it("classifies missing 2D canvas context as fallback-eligible", async () => {
+    class FakeOffscreenCanvasWithout2dContext {
+      getContext(): null {
+        return null;
+      }
+    }
+
+    await expect(
+      prepareBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        {
+          OffscreenCanvas: FakeOffscreenCanvasWithout2dContext,
+          fonts: fontSetFixture(),
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "canvas-2d-context-unavailable",
+      fallbackEligible: true,
+    });
   });
 
   it("uses load for readiness and post-load check for validity", async () => {
@@ -84,9 +156,7 @@ describe("prepareBrowserTextMetrics", () => {
         calls.push("load");
         return [{}];
       }),
-      ready: Promise.resolve().then(() => {
-        calls.push("ready");
-      }),
+      ready: new Promise(() => {}),
       check: vi.fn(() => {
         calls.push("check");
         return true;
@@ -101,7 +171,7 @@ describe("prepareBrowserTextMetrics", () => {
 
     expect(fonts.load).toHaveBeenCalledWith('normal 400 16px "Inter"');
     expect(fonts.check).toHaveBeenCalledWith('normal 400 16px "Inter"');
-    expect(calls).toEqual(["load", "ready", "check"]);
+    expect(calls).toEqual(["load", "check"]);
     expect(JSON.parse(prepared.metricsJson)).toEqual({
       cssFont: 'normal 400 16px "Inter"',
       fontFamily: "Inter",
@@ -110,10 +180,28 @@ describe("prepareBrowserTextMetrics", () => {
     });
   });
 
-  it("rejects zero loaded faces as unavailable font", async () => {
+  it("accepts system fonts that pass post-load validation without loaded font faces", async () => {
     const { environment } = environmentFixture(
       fontSetFixture({
         load: vi.fn(async () => []),
+        check: vi.fn(() => true),
+      }),
+    );
+
+    await expect(
+      prepareBrowserTextMetrics(
+        { fontFamily: "Arial", fontSizePx: 16, lineHeightPx: 24 },
+        environment,
+      ),
+    ).resolves.toMatchObject({
+      metricsJson: expect.stringContaining('"fontFamily":"Arial"'),
+    });
+  });
+
+  it("does not classify failed post-load checks as fallback-eligible", async () => {
+    const { environment } = environmentFixture(
+      fontSetFixture({
+        check: vi.fn(() => false),
       }),
     );
 
@@ -123,6 +211,12 @@ describe("prepareBrowserTextMetrics", () => {
         environment,
       ),
     ).rejects.toThrow("unavailable");
+    await expect(
+      prepareBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        environment,
+      ),
+    ).rejects.not.toMatchObject({ fallbackEligible: true });
   });
 
   it("returns a synchronous finite width from canvas measureText", async () => {
@@ -159,6 +253,14 @@ describe("prepareBrowserTextMetrics", () => {
       }),
     ).toBe('normal 400 16px "Open Sans"');
 
+    expect(
+      buildCssFont({
+        fontFamily: 'Arial, "Trebuchet MS", sans-serif',
+        fontSizePx: 16,
+        lineHeightPx: 24,
+      }),
+    ).toBe('normal 400 16px "Arial", "Trebuchet MS", sans-serif');
+
     await expect(
       prepareBrowserTextMetrics(
         { fontFamily: "Inter", fontSizePx: 0, lineHeightPx: 24 },
@@ -172,5 +274,112 @@ describe("prepareBrowserTextMetrics", () => {
         environmentFixture().environment,
       ),
     ).rejects.toThrow("lineHeightPx");
+  });
+});
+
+describe("prepareMainThreadBrowserTextMetrics", () => {
+  it("prepares main-thread metrics with document fonts and a canvas", async () => {
+    const calls: string[] = [];
+    const fonts = fontSetFixture({
+      load: vi.fn(async () => {
+        calls.push("load");
+        return [{}];
+      }),
+      ready: Promise.resolve(),
+      check: vi.fn(() => {
+        calls.push("check");
+        return true;
+      }),
+    });
+    const { context, environment } = mainThreadEnvironmentFixture(fonts);
+
+    const prepared = await prepareMainThreadBrowserTextMetrics(
+      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      environment,
+    );
+
+    expect(calls).toEqual(["load", "check"]);
+    expect(fonts.load).toHaveBeenCalledWith('normal 400 16px "Inter"');
+    expect(fonts.check).toHaveBeenCalledWith('normal 400 16px "Inter"');
+    expect(prepared.measureText("Alpha", 'normal 400 16px "Inter"')).toBe(15);
+    expect(context.font).toBe('normal 400 16px "Inter"');
+  });
+
+  it("fails clearly without main-thread FontFaceSet support", async () => {
+    const { environment } = mainThreadEnvironmentFixture();
+    if (!environment.document) {
+      throw new Error("fixture did not create a document");
+    }
+    environment.document.fonts = undefined;
+
+    await expect(
+      prepareMainThreadBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        environment,
+      ),
+    ).rejects.toMatchObject({
+      code: "main-thread-font-face-set-unavailable",
+      fallbackEligible: false,
+    });
+  });
+
+  it("fails clearly without a main-thread canvas context", async () => {
+    const environment: MainThreadBrowserTextMetricsEnvironment = {
+      document: {
+        fonts: fontSetFixture(),
+        createElement: vi.fn(() => ({
+          getContext: () => null,
+        })),
+      },
+    };
+
+    await expect(
+      prepareMainThreadBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        environment,
+      ),
+    ).rejects.toMatchObject({
+      code: "main-thread-canvas-2d-context-unavailable",
+      fallbackEligible: false,
+    });
+  });
+
+  it("does not classify main-thread unavailable fonts as fallback-eligible", async () => {
+    const { environment } = mainThreadEnvironmentFixture(
+      fontSetFixture({
+        check: vi.fn(() => false),
+      }),
+    );
+
+    await expect(
+      prepareMainThreadBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        environment,
+      ),
+    ).rejects.toThrow("unavailable");
+    await expect(
+      prepareMainThreadBrowserTextMetrics(
+        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        environment,
+      ),
+    ).rejects.not.toMatchObject({ fallbackEligible: true });
+  });
+
+  it("caches repeated main-thread measurements per prepared provider", async () => {
+    const { context, environment } = mainThreadEnvironmentFixture();
+    const first = await prepareMainThreadBrowserTextMetrics(
+      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      environment,
+    );
+    const second = await prepareMainThreadBrowserTextMetrics(
+      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      environment,
+    );
+
+    first.measureText("Alpha", 'normal 400 16px "Inter"');
+    first.measureText("Alpha", 'normal 400 16px "Inter"');
+    second.measureText("Alpha", 'normal 400 16px "Inter"');
+
+    expect(context.measureText).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/browser-text-metrics.ts
+++ b/web/src/browser-text-metrics.ts
@@ -11,9 +11,42 @@ export interface PreparedBrowserTextMetrics {
   measureText: (text: string, cssFont: string) => number;
 }
 
+export type BrowserTextMetricsCapabilityCode =
+  | "worker-font-face-set-unavailable"
+  | "worker-offscreen-canvas-unavailable"
+  | "canvas-2d-context-unavailable"
+  | "main-thread-font-face-set-unavailable"
+  | "main-thread-canvas-unavailable"
+  | "main-thread-canvas-2d-context-unavailable";
+
+export class BrowserTextMetricsCapabilityError extends Error {
+  readonly fallbackEligible: boolean;
+
+  constructor(
+    readonly code: BrowserTextMetricsCapabilityCode,
+    message: string,
+    fallbackEligible = true,
+  ) {
+    super(message);
+    this.name = "BrowserTextMetricsCapabilityError";
+    this.fallbackEligible = fallbackEligible;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export function isBrowserTextMetricsCapabilityError(
+  error: unknown,
+): error is BrowserTextMetricsCapabilityError {
+  return error instanceof BrowserTextMetricsCapabilityError;
+}
+
 export interface BrowserTextMetricsEnvironment {
   OffscreenCanvas?: OffscreenCanvasFactory;
-  fonts?: WorkerFontFaceSet;
+  fonts?: BrowserFontFaceSet;
+}
+
+export interface MainThreadBrowserTextMetricsEnvironment {
+  document?: MainThreadTextMetricsDocument;
 }
 
 interface OffscreenCanvasFactory {
@@ -30,10 +63,17 @@ interface CanvasTextMeasureContext {
   measureText(text: string): { width: number };
 }
 
-interface WorkerFontFaceSet {
+interface BrowserFontFaceSet {
   load(cssFont: string): Promise<unknown[]>;
   ready?: Promise<unknown>;
   check(cssFont: string): boolean;
+}
+
+interface MainThreadTextMetricsDocument {
+  fonts?: BrowserFontFaceSet;
+  createElement?(tagName: "canvas"): {
+    getContext(type: "2d"): CanvasTextMeasureContext | null;
+  } | null;
 }
 
 export function browserTextMetricsEnvironment(
@@ -46,6 +86,15 @@ export function browserTextMetricsEnvironment(
   };
 }
 
+export function mainThreadBrowserTextMetricsEnvironment(
+  scope: unknown = globalThis,
+): MainThreadBrowserTextMetricsEnvironment {
+  const candidate = scope as Partial<MainThreadBrowserTextMetricsEnvironment>;
+  return {
+    document: candidate.document,
+  };
+}
+
 export async function prepareBrowserTextMetrics(
   input: BrowserTextMetricsRequest,
   environment = browserTextMetricsEnvironment(),
@@ -53,12 +102,16 @@ export async function prepareBrowserTextMetrics(
   const cssFont = buildCssFont(input);
   const fontSet = environment.fonts;
   if (!fontSet) {
-    throw new Error("Dynamic text metrics require worker FontFaceSet support.");
+    throw new BrowserTextMetricsCapabilityError(
+      "worker-font-face-set-unavailable",
+      "Dynamic text metrics require worker FontFaceSet support.",
+    );
   }
 
   const Canvas = environment.OffscreenCanvas;
   if (!Canvas) {
-    throw new Error(
+    throw new BrowserTextMetricsCapabilityError(
+      "worker-offscreen-canvas-unavailable",
       "Dynamic text metrics require OffscreenCanvas in the worker.",
     );
   }
@@ -66,20 +119,68 @@ export async function prepareBrowserTextMetrics(
   const canvas = new Canvas(1, 1);
   const context = canvas.getContext("2d");
   if (!context) {
-    throw new Error("Dynamic text metrics require a 2D canvas context.");
-  }
-
-  const loadedFaces = await fontSet.load(cssFont);
-  if (fontSet.ready) {
-    await fontSet.ready;
-  }
-
-  if (loadedFaces.length === 0 || !fontSet.check(cssFont)) {
-    throw new Error(
-      `Dynamic text metrics unavailable for font ${input.fontFamily}.`,
+    throw new BrowserTextMetricsCapabilityError(
+      "canvas-2d-context-unavailable",
+      "Dynamic text metrics require a 2D canvas context.",
     );
   }
 
+  await loadAndValidateFontSet(fontSet, cssFont, input.fontFamily);
+
+  return preparedMetrics(input, cssFont, context);
+}
+
+export async function prepareMainThreadBrowserTextMetrics(
+  input: BrowserTextMetricsRequest,
+  environment = mainThreadBrowserTextMetricsEnvironment(),
+): Promise<PreparedBrowserTextMetrics> {
+  const cssFont = buildCssFont(input);
+  const document = environment.document;
+  if (!document?.fonts) {
+    throw new BrowserTextMetricsCapabilityError(
+      "main-thread-font-face-set-unavailable",
+      "Dynamic text metrics require document.fonts on the main thread.",
+      false,
+    );
+  }
+
+  const fontSet = document.fonts;
+  if (!document.createElement) {
+    throw new BrowserTextMetricsCapabilityError(
+      "main-thread-canvas-unavailable",
+      "Dynamic text metrics require a main-thread canvas.",
+      false,
+    );
+  }
+
+  const canvas = document.createElement("canvas");
+  if (!canvas) {
+    throw new BrowserTextMetricsCapabilityError(
+      "main-thread-canvas-unavailable",
+      "Dynamic text metrics require a main-thread canvas.",
+      false,
+    );
+  }
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new BrowserTextMetricsCapabilityError(
+      "main-thread-canvas-2d-context-unavailable",
+      "Dynamic text metrics require a main-thread 2D canvas context.",
+      false,
+    );
+  }
+
+  await loadAndValidateFontSet(fontSet, cssFont, input.fontFamily);
+
+  return preparedMetrics(input, cssFont, context);
+}
+
+function preparedMetrics(
+  input: BrowserTextMetricsRequest,
+  cssFont: string,
+  context: CanvasTextMeasureContext,
+): PreparedBrowserTextMetrics {
   const cache = new Map<string, number>();
   return {
     metricsJson: JSON.stringify({
@@ -106,15 +207,28 @@ export async function prepareBrowserTextMetrics(
   };
 }
 
+async function loadAndValidateFontSet(
+  fontSet: BrowserFontFaceSet,
+  cssFont: string,
+  fontFamily: string,
+): Promise<void> {
+  // Do not await FontFaceSet.ready here. Chrome worker FontFaceSet.ready can
+  // stay pending for system-font stacks even after load resolves and check
+  // passes; load plus post-load check is the requested-font contract.
+  await fontSet.load(cssFont);
+  if (!fontSet.check(cssFont)) {
+    throw new Error(`Dynamic text metrics unavailable for font ${fontFamily}.`);
+  }
+}
+
 export function buildCssFont(input: BrowserTextMetricsRequest): string {
-  const fontFamily = normalizeFontFamily(input.fontFamily);
+  const fontFamily = fontFamilyStackToCss(input.fontFamily);
   validatePositiveFinite("fontSizePx", input.fontSizePx);
   validatePositiveFinite("lineHeightPx", input.lineHeightPx);
 
   const fontStyle = input.fontStyle?.trim() || "normal";
   const fontWeight = input.fontWeight?.trim() || "400";
-  const quotedFamily = fontFamily.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-  return `${fontStyle} ${fontWeight} ${input.fontSizePx}px "${quotedFamily}"`;
+  return `${fontStyle} ${fontWeight} ${input.fontSizePx}px ${fontFamily}`;
 }
 
 function normalizeFontFamily(fontFamily: string): string {
@@ -123,6 +237,60 @@ function normalizeFontFamily(fontFamily: string): string {
     throw new Error("fontFamily must not be empty.");
   }
   return normalized;
+}
+
+function fontFamilyStackToCss(fontFamily: string): string {
+  return normalizeFontFamily(fontFamily)
+    .split(",")
+    .map((family) => familyTokenToCss(family))
+    .join(", ");
+}
+
+function familyTokenToCss(family: string): string {
+  const unquoted = stripOneQuoteLayer(family.trim());
+  if (!unquoted) {
+    throw new Error("fontFamily must not contain empty family names.");
+  }
+
+  if (isGenericFamily(unquoted)) {
+    return unquoted.toLowerCase();
+  }
+
+  const escaped = unquoted.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+function stripOneQuoteLayer(value: string): string {
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    return value.slice(1, -1).trim();
+  }
+
+  return value;
+}
+
+function isGenericFamily(family: string): boolean {
+  switch (family.toLowerCase()) {
+    case "serif":
+    case "sans-serif":
+    case "monospace":
+    case "cursive":
+    case "fantasy":
+    case "system-ui":
+    case "ui-serif":
+    case "ui-sans-serif":
+    case "ui-monospace":
+    case "ui-rounded":
+    case "emoji":
+    case "math":
+    case "fangsong":
+      return true;
+    default:
+      return false;
+  }
 }
 
 function validatePositiveFinite(field: string, value: number): void {

--- a/web/src/main-thread-browser-text-metrics.test.ts
+++ b/web/src/main-thread-browser-text-metrics.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMainThreadBrowserTextMetricsRenderer } from "./services/main-thread-browser-text-metrics";
+import type { BrowserTextMetricsRenderRequest } from "./services/render-client";
+
+interface MockWasmModule {
+  default: () => Promise<void>;
+  render: (input: string, format: string, configJson: string) => string;
+  renderWithBrowserTextMetrics: (
+    input: string,
+    format: string,
+    configJson: string,
+    metricsJson: string,
+    measureText: (text: string, cssFont: string) => number,
+  ) => string;
+  validate: (input: string) => string;
+}
+
+function renderRequest(
+  overrides: Partial<BrowserTextMetricsRenderRequest> = {},
+): BrowserTextMetricsRenderRequest {
+  return {
+    seq: 13,
+    input: "graph TD\nA-->B",
+    configJson: "{}",
+    browserTextMetrics: {
+      fontFamily: "Inter",
+      fontSizePx: 16,
+      lineHeightPx: 24,
+    },
+    ...overrides,
+  };
+}
+
+function wasmModuleFixture(
+  renderWithBrowserTextMetrics = vi.fn(
+    (
+      input: string,
+      format: string,
+      configJson: string,
+      metricsJson: string,
+      callback: (text: string, cssFont: string) => number,
+    ) =>
+      `${format}:${input}:${configJson}:${metricsJson}:${callback("A", "font")}`,
+  ),
+) {
+  const initialize = vi.fn(async () => {});
+  const render = vi.fn(() => "static unused");
+  const validate = vi.fn(() => '{"valid":true}');
+  const module: MockWasmModule = {
+    default: initialize,
+    render,
+    renderWithBrowserTextMetrics,
+    validate,
+  };
+
+  return {
+    initialize,
+    module,
+    render,
+    renderWithBrowserTextMetrics,
+    validate,
+  };
+}
+
+describe("createMainThreadBrowserTextMetricsRenderer", () => {
+  it("does not import or initialize wasm at service construction time", () => {
+    const loadWasmModule = vi.fn(async () => wasmModuleFixture().module);
+
+    createMainThreadBrowserTextMetricsRenderer({
+      loadWasmModule,
+      prepareMainThreadBrowserTextMetrics: vi.fn(),
+    });
+
+    expect(loadWasmModule).not.toHaveBeenCalled();
+  });
+
+  it("prepares main-thread metrics and calls the dynamic wasm export", async () => {
+    const measureText = vi.fn(() => 42);
+    const prepareMainThreadBrowserTextMetrics = vi.fn(async () => ({
+      metricsJson: '{"cssFont":"16px Inter"}',
+      measureText,
+    }));
+    const fixture = wasmModuleFixture();
+    const loadWasmModule = vi.fn(async () => fixture.module);
+    const renderer = createMainThreadBrowserTextMetricsRenderer({
+      loadWasmModule,
+      prepareMainThreadBrowserTextMetrics,
+    });
+    const request = renderRequest();
+
+    await expect(
+      renderer.renderWithBrowserTextMetrics(request),
+    ).resolves.toEqual({
+      seq: request.seq,
+      format: "svg",
+      output: 'svg:graph TD\nA-->B:{}:{"cssFont":"16px Inter"}:42',
+    });
+
+    expect(prepareMainThreadBrowserTextMetrics).toHaveBeenCalledWith(
+      request.browserTextMetrics,
+    );
+    expect(fixture.renderWithBrowserTextMetrics).toHaveBeenCalledWith(
+      request.input,
+      "svg",
+      request.configJson,
+      '{"cssFont":"16px Inter"}',
+      measureText,
+    );
+    expect(fixture.render).not.toHaveBeenCalled();
+  });
+
+  it("initializes wasm once and prepares fresh metrics for each render", async () => {
+    const firstMeasure = vi.fn(() => 1);
+    const secondMeasure = vi.fn(() => 2);
+    const prepareMainThreadBrowserTextMetrics = vi
+      .fn()
+      .mockResolvedValueOnce({
+        metricsJson: '{"cssFont":"first"}',
+        measureText: firstMeasure,
+      })
+      .mockResolvedValueOnce({
+        metricsJson: '{"cssFont":"second"}',
+        measureText: secondMeasure,
+      });
+    const fixture = wasmModuleFixture();
+    const loadWasmModule = vi.fn(async () => fixture.module);
+    const renderer = createMainThreadBrowserTextMetricsRenderer({
+      loadWasmModule,
+      prepareMainThreadBrowserTextMetrics,
+    });
+
+    await renderer.renderWithBrowserTextMetrics(renderRequest({ seq: 1 }));
+    await renderer.renderWithBrowserTextMetrics(renderRequest({ seq: 2 }));
+
+    expect(loadWasmModule).toHaveBeenCalledTimes(1);
+    expect(fixture.initialize).toHaveBeenCalledTimes(1);
+    expect(prepareMainThreadBrowserTextMetrics).toHaveBeenCalledTimes(2);
+    expect(firstMeasure).toHaveBeenCalledTimes(1);
+    expect(secondMeasure).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects preparation failures without loading wasm", async () => {
+    const loadWasmModule = vi.fn(async () => wasmModuleFixture().module);
+    const renderer = createMainThreadBrowserTextMetricsRenderer({
+      loadWasmModule,
+      prepareMainThreadBrowserTextMetrics: vi.fn(async () => {
+        throw new Error("Dynamic text metrics require document.fonts");
+      }),
+    });
+
+    await expect(
+      renderer.renderWithBrowserTextMetrics(renderRequest()),
+    ).rejects.toThrow("document.fonts");
+    expect(loadWasmModule).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/main.test.ts
+++ b/web/src/main.test.ts
@@ -1,7 +1,8 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
-import { renderApp } from "./main";
+import { describe, expect, it, vi } from "vitest";
+import { createDefaultRenderWorkerClient, renderApp } from "./main";
+import type { BrowserTextMetricsRenderRequest } from "./services/render-client";
 
 describe("renderApp", () => {
   it("main bootstraps the app without owning render or persistence logic", async () => {
@@ -13,6 +14,34 @@ describe("renderApp", () => {
     expect(source).toMatch(/bootstrapPlaygroundApp/);
     expect(source).not.toMatch(/localStorage\.setItem/);
     expect(source).not.toMatch(/new Worker/);
+  });
+
+  it("wires main-thread browser metrics fallback into the default worker client", () => {
+    const client = {
+      render: vi.fn(),
+      renderWithBrowserTextMetrics: vi.fn(),
+      validate: vi.fn(),
+      terminate: vi.fn(),
+    };
+    const fallbackRenderer = {
+      renderWithBrowserTextMetrics: vi.fn(),
+    };
+    const createClient = vi.fn(() => client);
+    const createFallbackRenderer = vi.fn(() => fallbackRenderer);
+
+    vi.stubGlobal("Worker", class FakeWorker {});
+    try {
+      expect(
+        createDefaultRenderWorkerClient(createClient, createFallbackRenderer),
+      ).toBe(client);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    expect(createFallbackRenderer).toHaveBeenCalledTimes(1);
+    expect(createClient).toHaveBeenCalledWith(undefined, {
+      mainThreadBrowserTextMetricsRenderer: fallbackRenderer,
+    });
   });
 
   it("renders redesigned playground shell", () => {
@@ -54,8 +83,102 @@ describe("renderApp", () => {
       expect(root.querySelector("[data-preview-controls]")).not.toBeNull();
       expect(root.querySelector("[data-theme-toggle]")).not.toBeNull();
       expect(exampleSelect?.value).toBe("__draft__");
+      expect(window.__mmdfluxDebug).toBeUndefined();
     } finally {
       history.replaceState(null, "", window.location.pathname);
+      delete window.__mmdfluxDebug;
+    }
+  });
+
+  it("installs a query-gated browser metrics debug console helper", async () => {
+    const renderWithBrowserTextMetrics = vi.fn(
+      async (request: BrowserTextMetricsRenderRequest) => ({
+        seq: request.seq,
+        format: "svg" as const,
+        output: `<span>${request.browserTextMetrics.fontFamily}:${request.input}</span>`,
+      }),
+    );
+    const mainThreadRenderWithBrowserTextMetrics = vi.fn(
+      async (request: BrowserTextMetricsRenderRequest) => ({
+        seq: request.seq,
+        format: "svg" as const,
+        output: `<span>main-thread:${request.input}</span>`,
+      }),
+    );
+
+    try {
+      history.replaceState(null, "", "?debugBrowserMetrics=1");
+
+      const root = document.createElement("div");
+      renderApp(root, {
+        renderClientFactory: () => ({
+          render: async (request) => ({
+            seq: request.seq,
+            format: request.format,
+            output: `${request.format}:${request.input}`,
+          }),
+          renderWithBrowserTextMetrics,
+          validate: async () => '{"valid":true}',
+          terminate: () => {},
+        }),
+        mainThreadBrowserTextMetricsRendererFactory: () => ({
+          renderWithBrowserTextMetrics: mainThreadRenderWithBrowserTextMetrics,
+        }),
+        debounceMs: 10_000,
+        stateStorage: {
+          getItem: () => null,
+          setItem: () => {},
+        },
+      });
+
+      const debug = window.__mmdfluxDebug;
+      expect(debug).toBeDefined();
+
+      const workerResult = await debug?.renderBrowserMetrics({
+        input: "graph TD\nA-->B",
+        fontFamily: "Arial",
+        fontSizePx: 18,
+        lineHeightPx: 27,
+      });
+
+      expect(workerResult).toMatchObject({
+        format: "svg",
+        output: "<span>Arial:graph TD\nA-->B</span>",
+        source: "worker-client",
+      });
+      expect(renderWithBrowserTextMetrics).toHaveBeenCalledWith({
+        seq: expect.any(Number),
+        input: "graph TD\nA-->B",
+        configJson: '{"pathSimplification":"lossless"}',
+        browserTextMetrics: {
+          fontFamily: "Arial",
+          fontSizePx: 18,
+          lineHeightPx: 27,
+        },
+      });
+      expect(root.querySelector("[data-preview-output]")?.textContent).toBe(
+        "Arial:graph TD\nA-->B",
+      );
+
+      await debug?.renderBrowserMetricsMainThread({
+        input: "graph TD\nM-->N",
+        show: false,
+      });
+
+      expect(mainThreadRenderWithBrowserTextMetrics).toHaveBeenCalledWith({
+        seq: expect.any(Number),
+        input: "graph TD\nM-->N",
+        configJson: '{"pathSimplification":"lossless"}',
+        browserTextMetrics: {
+          fontFamily: "Arial, sans-serif",
+          fontSizePx: 16,
+          lineHeightPx: 24,
+        },
+      });
+      expect(renderWithBrowserTextMetrics).toHaveBeenCalledTimes(1);
+    } finally {
+      history.replaceState(null, "", window.location.pathname);
+      delete window.__mmdfluxDebug;
     }
   });
 });

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -2,6 +2,7 @@ import "../styles/main.css";
 
 export {
   bootstrapPlaygroundApp,
+  createDefaultRenderWorkerClient,
   isBenchmarkModeEnabled,
   type RenderAppOptions,
   renderApp,

--- a/web/src/render-client.test.ts
+++ b/web/src/render-client.test.ts
@@ -1,17 +1,33 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { MainThreadBrowserTextMetricsRenderer } from "./services/main-thread-browser-text-metrics";
 import { createRenderWorkerClient } from "./services/render-client";
 import type {
   WorkerRequestMessage,
   WorkerResponseMessage,
 } from "./worker-protocol";
 
+interface MockWorkerOptions {
+  dynamicResponse?: WorkerResponseMessage;
+  suppressDynamicResponse?: boolean;
+  throwOnDynamicPost?: boolean;
+}
+
 class MockWorker {
   onmessage: ((event: MessageEvent<WorkerResponseMessage>) => void) | null =
     null;
   messages: WorkerRequestMessage[] = [];
 
+  constructor(private readonly options: MockWorkerOptions = {}) {}
+
   postMessage(message: WorkerRequestMessage): void {
     this.messages.push(message);
+    if (
+      message.type === "renderWithBrowserTextMetrics" &&
+      this.options.throwOnDynamicPost
+    ) {
+      throw new Error("worker post failed");
+    }
+
     if (!this.onmessage) {
       throw new Error("worker message handler was not installed");
     }
@@ -30,6 +46,17 @@ class MockWorker {
       }
 
       if (message.type === "renderWithBrowserTextMetrics") {
+        if (this.options.suppressDynamicResponse) {
+          return;
+        }
+
+        if (this.options.dynamicResponse) {
+          this.onmessage?.({
+            data: this.options.dynamicResponse,
+          } as MessageEvent<WorkerResponseMessage>);
+          return;
+        }
+
         this.onmessage?.({
           data: {
             type: "result",
@@ -52,6 +79,18 @@ class MockWorker {
   }
 
   terminate(): void {}
+}
+
+function mainThreadRendererFixture(
+  output = "main-thread-svg",
+): MainThreadBrowserTextMetricsRenderer {
+  return {
+    renderWithBrowserTextMetrics: vi.fn(async (request) => ({
+      seq: request.seq,
+      format: "svg" as const,
+      output,
+    })),
+  };
 }
 
 describe("createRenderWorkerClient", () => {
@@ -77,7 +116,10 @@ describe("createRenderWorkerClient", () => {
 
   it("posts dynamic browser text metrics render requests separately", async () => {
     const worker = new MockWorker();
-    const client = createRenderWorkerClient(worker as unknown as Worker);
+    const mainThreadRenderer = mainThreadRendererFixture();
+    const client = createRenderWorkerClient(worker as unknown as Worker, {
+      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
+    });
 
     const response = await client.renderWithBrowserTextMetrics({
       seq: 11,
@@ -90,6 +132,9 @@ describe("createRenderWorkerClient", () => {
       },
     });
 
+    expect(
+      mainThreadRenderer.renderWithBrowserTextMetrics,
+    ).not.toHaveBeenCalled();
     expect(response).toEqual({
       seq: 11,
       format: "svg",
@@ -107,5 +152,138 @@ describe("createRenderWorkerClient", () => {
         lineHeightPx: 24,
       },
     });
+  });
+
+  it("falls back to main-thread dynamic rendering on worker capability errors", async () => {
+    const worker = new MockWorker({
+      dynamicResponse: {
+        type: "error",
+        seq: 11,
+        error: "Dynamic text metrics require OffscreenCanvas in the worker.",
+        code: "dynamic-metrics-capability",
+      },
+    });
+    const mainThreadRenderer = mainThreadRendererFixture();
+    const client = createRenderWorkerClient(worker as unknown as Worker, {
+      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
+    });
+
+    await expect(
+      client.renderWithBrowserTextMetrics({
+        seq: 11,
+        input: "graph TD\nA-->B",
+        configJson: "{}",
+        browserTextMetrics: {
+          fontFamily: "Inter",
+          fontSizePx: 16,
+          lineHeightPx: 24,
+        },
+      }),
+    ).resolves.toEqual({
+      seq: 11,
+      format: "svg",
+      output: "main-thread-svg",
+    });
+    expect(
+      mainThreadRenderer.renderWithBrowserTextMetrics,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to main-thread dynamic rendering when the worker does not respond", async () => {
+    const worker = new MockWorker({ suppressDynamicResponse: true });
+    const mainThreadRenderer = mainThreadRendererFixture();
+    const client = createRenderWorkerClient(worker as unknown as Worker, {
+      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
+      dynamicMetricsWorkerTimeoutMs: 1,
+    });
+
+    await expect(
+      client.renderWithBrowserTextMetrics({
+        seq: 14,
+        input: "graph TD\nA-->B",
+        configJson: "{}",
+        browserTextMetrics: {
+          fontFamily: "Arial",
+          fontSizePx: 16,
+          lineHeightPx: 24,
+        },
+      }),
+    ).resolves.toEqual({
+      seq: 14,
+      format: "svg",
+      output: "main-thread-svg",
+    });
+    expect(
+      mainThreadRenderer.renderWithBrowserTextMetrics,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fallback on ordinary dynamic worker errors", async () => {
+    const worker = new MockWorker({
+      dynamicResponse: {
+        type: "error",
+        seq: 12,
+        error: "Dynamic text metrics unavailable for font Inter.",
+      },
+    });
+    const mainThreadRenderer = mainThreadRendererFixture();
+    const client = createRenderWorkerClient(worker as unknown as Worker, {
+      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
+    });
+
+    await expect(
+      client.renderWithBrowserTextMetrics({
+        seq: 12,
+        input: "graph TD\nA-->B",
+        configJson: "{}",
+        browserTextMetrics: {
+          fontFamily: "Inter",
+          fontSizePx: 16,
+          lineHeightPx: 24,
+        },
+      }),
+    ).rejects.toThrow("unavailable");
+    expect(
+      mainThreadRenderer.renderWithBrowserTextMetrics,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("does not fallback when posting dynamic requests fails", async () => {
+    const worker = new MockWorker({ throwOnDynamicPost: true });
+    const mainThreadRenderer = mainThreadRendererFixture();
+    const client = createRenderWorkerClient(worker as unknown as Worker, {
+      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
+    });
+
+    await expect(
+      client.renderWithBrowserTextMetrics({
+        seq: 13,
+        input: "graph TD\nA-->B",
+        configJson: "{}",
+        browserTextMetrics: {
+          fontFamily: "Inter",
+          fontSizePx: 16,
+          lineHeightPx: 24,
+        },
+      }),
+    ).rejects.toThrow("failed to post dynamic render request");
+    expect(
+      mainThreadRenderer.renderWithBrowserTextMetrics,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("does not use main-thread dynamic rendering for validation", async () => {
+    const worker = new MockWorker();
+    const mainThreadRenderer = mainThreadRendererFixture();
+    const client = createRenderWorkerClient(worker as unknown as Worker, {
+      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
+    });
+
+    await expect(client.validate("graph TD\nA-->B")).resolves.toBe(
+      '{"valid":true}',
+    );
+    expect(
+      mainThreadRenderer.renderWithBrowserTextMetrics,
+    ).not.toHaveBeenCalled();
   });
 });

--- a/web/src/services/main-thread-browser-text-metrics.ts
+++ b/web/src/services/main-thread-browser-text-metrics.ts
@@ -1,0 +1,58 @@
+import { prepareMainThreadBrowserTextMetrics } from "../browser-text-metrics";
+import { loadWasmModule, type WasmModule } from "../wasm-module";
+import type {
+  BrowserTextMetricsRenderRequest,
+  RenderResponse,
+} from "./render-client";
+
+export interface MainThreadBrowserTextMetricsRenderer {
+  renderWithBrowserTextMetrics: (
+    request: BrowserTextMetricsRenderRequest,
+  ) => Promise<RenderResponse>;
+}
+
+export interface MainThreadBrowserTextMetricsRendererOptions {
+  loadWasmModule?: () => Promise<WasmModule>;
+  prepareMainThreadBrowserTextMetrics?: typeof prepareMainThreadBrowserTextMetrics;
+}
+
+export function createMainThreadBrowserTextMetricsRenderer(
+  options: MainThreadBrowserTextMetricsRendererOptions = {},
+): MainThreadBrowserTextMetricsRenderer {
+  const loadModule = options.loadWasmModule ?? loadWasmModule;
+  const prepareMetrics =
+    options.prepareMainThreadBrowserTextMetrics ??
+    prepareMainThreadBrowserTextMetrics;
+  let modulePromise: Promise<WasmModule> | null = null;
+
+  const getWasmModule = async (): Promise<WasmModule> => {
+    if (!modulePromise) {
+      modulePromise = loadModule().then(async (module) => {
+        await module.default();
+        return module;
+      });
+    }
+
+    return modulePromise;
+  };
+
+  return {
+    renderWithBrowserTextMetrics: async (request) => {
+      const prepared = await prepareMetrics(request.browserTextMetrics);
+      const wasmModule = await getWasmModule();
+      const output = wasmModule.renderWithBrowserTextMetrics(
+        request.input,
+        "svg",
+        request.configJson ?? "{}",
+        prepared.metricsJson,
+        prepared.measureText,
+      );
+
+      return {
+        seq: request.seq,
+        format: "svg",
+        output,
+      };
+    },
+  };
+}

--- a/web/src/services/render-client.ts
+++ b/web/src/services/render-client.ts
@@ -4,6 +4,7 @@ import type {
   WorkerRequestMessage,
   WorkerResponseMessage,
 } from "../worker-protocol";
+import type { MainThreadBrowserTextMetricsRenderer } from "./main-thread-browser-text-metrics";
 
 export interface RenderRequest {
   seq: number;
@@ -29,6 +30,8 @@ interface PendingRenderRequest {
   kind: "render";
   resolve: (response: RenderResponse) => void;
   reject: (error: Error) => void;
+  mainThreadFallback?: () => Promise<RenderResponse>;
+  timeoutHandle?: ReturnType<typeof setTimeout>;
 }
 
 interface PendingValidateRequest {
@@ -48,6 +51,11 @@ export interface RenderWorkerClient {
   terminate: () => void;
 }
 
+export interface RenderWorkerClientOptions {
+  mainThreadBrowserTextMetricsRenderer?: MainThreadBrowserTextMetricsRenderer;
+  dynamicMetricsWorkerTimeoutMs?: number;
+}
+
 function createDefaultWorker(): Worker {
   return new Worker(new URL("../worker.ts", import.meta.url), {
     type: "module",
@@ -60,8 +68,12 @@ function toMessage(error: unknown): string {
 
 export function createRenderWorkerClient(
   worker: Worker = createDefaultWorker(),
+  options: RenderWorkerClientOptions = {},
 ): RenderWorkerClient {
   const pending = new Map<number, PendingRequest>();
+  const mainThreadRenderer = options.mainThreadBrowserTextMetricsRenderer;
+  const dynamicMetricsWorkerTimeoutMs =
+    options.dynamicMetricsWorkerTimeoutMs ?? 5_000;
   let nextValidationSeq = -1;
 
   worker.onmessage = (event: MessageEvent<WorkerResponseMessage>) => {
@@ -72,6 +84,9 @@ export function createRenderWorkerClient(
     }
 
     pending.delete(response.seq);
+    if (pendingRequest.kind === "render" && pendingRequest.timeoutHandle) {
+      clearTimeout(pendingRequest.timeoutHandle);
+    }
 
     if (response.type === "result") {
       if (pendingRequest.kind !== "render") {
@@ -98,6 +113,17 @@ export function createRenderWorkerClient(
       }
 
       pendingRequest.resolve(response.resultJson);
+      return;
+    }
+
+    if (
+      pendingRequest.kind === "render" &&
+      response.code === "dynamic-metrics-capability" &&
+      pendingRequest.mainThreadFallback
+    ) {
+      pendingRequest
+        .mainThreadFallback()
+        .then(pendingRequest.resolve, pendingRequest.reject);
       return;
     }
 
@@ -133,6 +159,15 @@ export function createRenderWorkerClient(
       const currentSeq = request.seq;
 
       return new Promise<RenderResponse>((resolve, reject) => {
+        const mainThreadFallback = mainThreadRenderer
+          ? () => mainThreadRenderer.renderWithBrowserTextMetrics(request)
+          : undefined;
+        const pendingRequest: PendingRenderRequest = {
+          kind: "render",
+          resolve,
+          reject,
+          mainThreadFallback,
+        };
         const message: WorkerRequestMessage = {
           type: "renderWithBrowserTextMetrics",
           seq: currentSeq,
@@ -142,11 +177,29 @@ export function createRenderWorkerClient(
           browserTextMetrics: request.browserTextMetrics,
         };
 
-        pending.set(currentSeq, { kind: "render", resolve, reject });
+        if (
+          mainThreadFallback &&
+          Number.isFinite(dynamicMetricsWorkerTimeoutMs) &&
+          dynamicMetricsWorkerTimeoutMs > 0
+        ) {
+          pendingRequest.timeoutHandle = setTimeout(() => {
+            if (pending.get(currentSeq) !== pendingRequest) {
+              return;
+            }
+
+            pending.delete(currentSeq);
+            mainThreadFallback().then(resolve, reject);
+          }, dynamicMetricsWorkerTimeoutMs);
+        }
+
+        pending.set(currentSeq, pendingRequest);
 
         try {
           worker.postMessage(message);
         } catch (error) {
+          if (pendingRequest.timeoutHandle) {
+            clearTimeout(pendingRequest.timeoutHandle);
+          }
           pending.delete(currentSeq);
           reject(
             new Error(

--- a/web/src/wasm-module.ts
+++ b/web/src/wasm-module.ts
@@ -1,0 +1,16 @@
+export interface WasmModule {
+  default: () => Promise<void>;
+  render: (input: string, format: string, configJson: string) => string;
+  renderWithBrowserTextMetrics: (
+    input: string,
+    format: string,
+    configJson: string,
+    metricsJson: string,
+    measureText: (text: string, cssFont: string) => number,
+  ) => string;
+  validate: (input: string) => string;
+}
+
+export async function loadWasmModule(): Promise<WasmModule> {
+  return (await import("./wasm-pkg/mmdflux_wasm.js")) as unknown as WasmModule;
+}

--- a/web/src/worker-protocol.ts
+++ b/web/src/worker-protocol.ts
@@ -47,6 +47,7 @@ export interface WorkerErrorMessage {
   type: "error";
   seq: number;
   error: string;
+  code?: "dynamic-metrics-capability";
 }
 
 export type WorkerResponseMessage =

--- a/web/src/worker.test.ts
+++ b/web/src/worker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { BrowserTextMetricsCapabilityError } from "./browser-text-metrics";
 import { createWorkerRequestHandler } from "./worker";
 import type {
   WorkerRequestMessage,
@@ -263,6 +264,102 @@ describe("createWorkerRequestHandler", () => {
         type: "error",
         seq: 10,
         error: "Dynamic text metrics require OffscreenCanvas",
+      },
+    ]);
+  });
+
+  it("codes dynamic metric capability errors without leaking adapter subcodes", async () => {
+    const loadWasmModule = vi.fn(
+      async (): Promise<MockWasmModule> => ({
+        default: async () => {},
+        render: () => "static unused",
+        renderWithBrowserTextMetrics: () => "dynamic unused",
+        validate: () => '{"valid":true}',
+      }),
+    );
+    const responses: WorkerResponseMessage[] = [];
+    const handler = createWorkerRequestHandler({
+      loadWasmModule,
+      prepareBrowserTextMetrics: vi.fn(async () => {
+        throw new BrowserTextMetricsCapabilityError(
+          "worker-offscreen-canvas-unavailable",
+          "Dynamic text metrics require OffscreenCanvas in the worker.",
+        );
+      }),
+      postMessage: (message) => responses.push(message),
+    });
+
+    await handler({
+      type: "renderWithBrowserTextMetrics",
+      seq: 11,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: "{}",
+      browserTextMetrics: {
+        fontFamily: "Inter",
+        fontSizePx: 16,
+        lineHeightPx: 24,
+      },
+    });
+
+    expect(responses).toEqual([
+      {
+        type: "error",
+        seq: 11,
+        error: "Dynamic text metrics require OffscreenCanvas in the worker.",
+        code: "dynamic-metrics-capability",
+      },
+    ]);
+    expect(responses[0]).not.toHaveProperty(
+      "code",
+      "worker-offscreen-canvas-unavailable",
+    );
+    expect(JSON.stringify(responses[0])).not.toContain(
+      "worker-offscreen-canvas-unavailable",
+    );
+  });
+
+  it("does not code fallback-ineligible dynamic metric capability errors", async () => {
+    const loadWasmModule = vi.fn(
+      async (): Promise<MockWasmModule> => ({
+        default: async () => {},
+        render: () => "static unused",
+        renderWithBrowserTextMetrics: () => "dynamic unused",
+        validate: () => '{"valid":true}',
+      }),
+    );
+    const responses: WorkerResponseMessage[] = [];
+    const handler = createWorkerRequestHandler({
+      loadWasmModule,
+      prepareBrowserTextMetrics: vi.fn(async () => {
+        throw new BrowserTextMetricsCapabilityError(
+          "main-thread-font-face-set-unavailable",
+          "Dynamic text metrics require document.fonts on the main thread.",
+          false,
+        );
+      }),
+      postMessage: (message) => responses.push(message),
+    });
+
+    await handler({
+      type: "renderWithBrowserTextMetrics",
+      seq: 12,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: "{}",
+      browserTextMetrics: {
+        fontFamily: "Inter",
+        fontSizePx: 16,
+        lineHeightPx: 24,
+      },
+    });
+
+    expect(responses).toEqual([
+      {
+        type: "error",
+        seq: 12,
+        error:
+          "Dynamic text metrics require document.fonts on the main thread.",
       },
     ]);
   });

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -1,4 +1,8 @@
-import { prepareBrowserTextMetrics } from "./browser-text-metrics";
+import {
+  isBrowserTextMetricsCapabilityError,
+  prepareBrowserTextMetrics,
+} from "./browser-text-metrics";
+import { loadWasmModule, type WasmModule } from "./wasm-module";
 import type {
   WorkerRequestMessage,
   WorkerResponseMessage,
@@ -9,27 +13,10 @@ export type {
   WorkerResponseMessage,
 } from "./worker-protocol";
 
-interface WasmModule {
-  default: () => Promise<void>;
-  render: (input: string, format: string, configJson: string) => string;
-  renderWithBrowserTextMetrics: (
-    input: string,
-    format: string,
-    configJson: string,
-    metricsJson: string,
-    measureText: (text: string, cssFont: string) => number,
-  ) => string;
-  validate: (input: string) => string;
-}
-
 interface RenderRequestHandlerOptions {
   loadWasmModule?: () => Promise<WasmModule>;
   prepareBrowserTextMetrics?: typeof prepareBrowserTextMetrics;
   postMessage: (message: WorkerResponseMessage) => void;
-}
-
-export async function loadWasmModule(): Promise<WasmModule> {
-  return (await import("./wasm-pkg/mmdflux_wasm.js")) as unknown as WasmModule;
 }
 
 export function createWorkerRequestHandler(
@@ -101,6 +88,9 @@ export function createWorkerRequestHandler(
         type: "error",
         seq: message.seq,
         error: formatError(error),
+        ...(isBrowserTextMetricsCapabilityError(error) && error.fallbackEligible
+          ? { code: "dynamic-metrics-capability" as const }
+          : {}),
       });
     }
   };


### PR DESCRIPTION
## Summary

- classify worker browser-text-metrics capability failures and only emit the dynamic retry wire code for fallback-eligible capability errors
- add a main-thread browser text metrics preparer and lazy main-thread dynamic render service that reuses the existing Wasm dynamic export
- wire the web render client to prefer the worker path, then retry on the main thread only for `dynamic-metrics-capability` worker failures
- install the fallback in the default playground render client while keeping static `render(...)` and validation paths unchanged
- document the worker/main-thread capability matrix and pin the docs with contract tests

Closes #313

## Boundaries

- No static-profile fallback when dynamic browser metrics are requested
- No dynamic MMDS replay changes; #307 and #308 remain separate
- No sequence/Text/ASCII dynamic metrics changes; #314 remains separate
- No second `.wasm` artifact in the web build

## Validation

- `cd web && npm run test` — 104/104 passing
- `cd web && npm run build`
- `cargo nextest run --features unstable-text-metrics-provider -E 'test(dynamic_text_metrics)'` — 19/19 passing
- `cargo test -p mmdflux-wasm`
- `just wasm-test` — 27/27 browser Wasm tests passing
- `just wasm-size` — 1,769,544 raw / 611,822 gzip for both targets
- `just check` — 3014/3014 passing, 8 skipped
- `cog check origin/main..HEAD`

## Bundle Evidence

Compared with a fresh `origin/main` web build, generated JS gzip changed from 949,613 bytes to 950,767 bytes (`+1,154` bytes). The build emits one `.wasm` artifact.