### PR TITLE
feat: add provider-bound dynamic MMDS replay

### DIFF
--- a/crates/mmdflux-wasm/tests/web.rs
+++ b/crates/mmdflux-wasm/tests/web.rs
@@ -33,6 +33,24 @@ fn dynamic_metrics_json_fixture() -> &'static str {
     r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24}"#
 }
 
+fn dynamic_metrics_json_with_profile_fixture() -> &'static str {
+    r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"profileId":"mmdflux-browser-canvas-v1"}"#
+}
+
+fn dynamic_metrics_json_with_profile_fields(
+    profile_id: &str,
+    profile_version: u32,
+    font_family: &str,
+    font_size_px: f64,
+    line_height_px: f64,
+    font_style: &str,
+    font_weight: &str,
+) -> String {
+    format!(
+        r#"{{"cssFont":"{font_size_px}px {font_family}","fontFamily":"{font_family}","fontSizePx":{font_size_px},"lineHeightPx":{line_height_px},"profileId":"{profile_id}","profileVersion":{profile_version},"fontStyle":"{font_style}","fontWeight":"{font_weight}"}}"#
+    )
+}
+
 fn callback(body: &str) -> js_sys::Function {
     js_sys::Function::new_with_args("text, cssFont", body)
 }
@@ -280,19 +298,206 @@ fn dynamic_text_metrics_callback_can_call_validate_without_corruption() {
 }
 
 #[wasm_bindgen_test]
-fn dynamic_text_metrics_rejects_mmds_output() {
+fn dynamic_text_metrics_renders_provider_bound_mmds_output() {
     let measure = callback("return text.length * 8;");
-    let err = render_with_browser_text_metrics(
+    let output = render_with_browser_text_metrics(
         "graph TD\nA-->B",
         "mmds",
         "{}",
-        dynamic_metrics_json_fixture(),
+        dynamic_metrics_json_with_profile_fixture(),
         &measure,
     )
-    .expect_err("dynamic browser metrics should remain SVG-only");
+    .expect("dynamic browser metrics should render provider-bound MMDS");
 
-    let message = error_debug(err);
-    assert!(message.contains("only supports SVG output"), "{message}");
+    assert!(output.contains("\"org.mmdflux.text-metrics.v1\""));
+    assert!(output.contains("\"source\": \"dynamic\""));
+    assert!(output.contains("\"id\": \"mmdflux-browser-canvas-v1\""));
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_replays_provider_bound_mmds_output() {
+    let measure = callback("return text.length * 8;");
+    let input = "graph TD\nA[Alpha] -->|a labeled edge| B[Beta]";
+    let config = r#"{"geometryLevel":"routed"}"#;
+    let direct_svg = render_with_browser_text_metrics(
+        input,
+        "svg",
+        config,
+        dynamic_metrics_json_with_profile_fixture(),
+        &measure,
+    )
+    .expect("direct dynamic svg should render");
+    let mmds = render_with_browser_text_metrics(
+        input,
+        "mmds",
+        config,
+        dynamic_metrics_json_with_profile_fixture(),
+        &measure,
+    )
+    .expect("dynamic mmds should render");
+    let replay_svg = render_with_browser_text_metrics(
+        &mmds,
+        "svg",
+        config,
+        dynamic_metrics_json_with_profile_fixture(),
+        &measure,
+    )
+    .expect("dynamic mmds replay should render");
+
+    assert_eq!(replay_svg, direct_svg);
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_rejects_mismatched_mmds_provider_identity() {
+    let measure = callback("return text.length * 8;");
+    let config = r#"{"geometryLevel":"routed"}"#;
+    let mmds = render_with_browser_text_metrics(
+        "graph TD\nA-->B",
+        "mmds",
+        config,
+        dynamic_metrics_json_with_profile_fixture(),
+        &measure,
+    )
+    .expect("dynamic mmds should render");
+
+    let mismatched_metrics = [
+        (
+            "profile id",
+            dynamic_metrics_json_with_profile_fields(
+                "other-provider-v1",
+                1,
+                "Inter",
+                16.0,
+                24.0,
+                "normal",
+                "400",
+            ),
+            "metricsProfile.id",
+        ),
+        (
+            "profile version",
+            dynamic_metrics_json_with_profile_fields(
+                "mmdflux-browser-canvas-v1",
+                2,
+                "Inter",
+                16.0,
+                24.0,
+                "normal",
+                "400",
+            ),
+            "metricsProfile.version",
+        ),
+        (
+            "font family",
+            dynamic_metrics_json_with_profile_fields(
+                "mmdflux-browser-canvas-v1",
+                1,
+                "Arial",
+                16.0,
+                24.0,
+                "normal",
+                "400",
+            ),
+            "defaultTextStyle.font-family",
+        ),
+        (
+            "font size",
+            dynamic_metrics_json_with_profile_fields(
+                "mmdflux-browser-canvas-v1",
+                1,
+                "Inter",
+                18.0,
+                24.0,
+                "normal",
+                "400",
+            ),
+            "defaultTextStyle.font-size",
+        ),
+        (
+            "font style",
+            dynamic_metrics_json_with_profile_fields(
+                "mmdflux-browser-canvas-v1",
+                1,
+                "Inter",
+                16.0,
+                24.0,
+                "italic",
+                "400",
+            ),
+            "defaultTextStyle.font-style",
+        ),
+        (
+            "font weight",
+            dynamic_metrics_json_with_profile_fields(
+                "mmdflux-browser-canvas-v1",
+                1,
+                "Inter",
+                16.0,
+                24.0,
+                "normal",
+                "700",
+            ),
+            "defaultTextStyle.font-weight",
+        ),
+        (
+            "line height",
+            dynamic_metrics_json_with_profile_fields(
+                "mmdflux-browser-canvas-v1",
+                1,
+                "Inter",
+                16.0,
+                30.0,
+                "normal",
+                "400",
+            ),
+            "defaultTextStyle.line-height",
+        ),
+    ];
+
+    for (name, metrics_json, expected_field) in mismatched_metrics {
+        let err = render_with_browser_text_metrics(&mmds, "svg", config, &metrics_json, &measure)
+            .expect_err("mismatched provider identity should fail");
+        let message = error_debug(err);
+        assert!(message.contains(expected_field), "{name}: {message}");
+    }
+
+    for (name, replay_config, expected_field) in [
+        (
+            "node padding x",
+            r#"{"geometryLevel":"routed","svgNodePaddingX":20}"#,
+            "layoutText.node-padding-x",
+        ),
+        (
+            "node padding y",
+            r#"{"geometryLevel":"routed","svgNodePaddingY":20}"#,
+            "layoutText.node-padding-y",
+        ),
+    ] {
+        let err = render_with_browser_text_metrics(
+            &mmds,
+            "svg",
+            replay_config,
+            dynamic_metrics_json_with_profile_fixture(),
+            &measure,
+        )
+        .expect_err("mismatched provider layout should fail");
+        let message = error_debug(err);
+        assert!(message.contains(expected_field), "{name}: {message}");
+    }
+
+    let mut value: serde_json::Value = serde_json::from_str(&mmds).unwrap();
+    value["extensions"]["org.mmdflux.text-metrics.v1"]["layoutText"]["label-padding-x"] =
+        serde_json::json!(8.0);
+    let mismatched_label_padding = serde_json::to_string(&value).unwrap();
+    let err = render_with_browser_text_metrics(
+        &mismatched_label_padding,
+        "svg",
+        config,
+        dynamic_metrics_json_with_profile_fixture(),
+        &measure,
+    )
+    .expect_err("persisted label padding mismatch should fail");
+    assert!(error_debug(err).contains("layoutText.label-padding-x"));
 }
 
 #[wasm_bindgen_test]

--- a/docs/development/wasm.md
+++ b/docs/development/wasm.md
@@ -154,9 +154,13 @@ request. Promises, objects, `NaN`, `Infinity`, negative values, and thrown error
 fail the render.
 
 The dynamic path does not fall back to `mmdflux-sans-v1` or
-`mmdflux-heuristic-proportional-v1` after a measurement failure. It also does
-not emit or replay MMDS and does not use `metricsProfile.source = "dynamic"` in
-this slice; provider-bound dynamic MMDS replay remains future work.
+`mmdflux-heuristic-proportional-v1` after a measurement failure. For dynamic
+MMDS output and replay, `metricsJson` carries provider identity
+(`profileId = "mmdflux-browser-canvas-v1"`, `profileVersion = 1`, font style,
+font weight, and line height). MMDS with `metricsProfile.source = "dynamic"` is
+provider-bound: replay succeeds only when the supplied dynamic descriptor
+matches the persisted extension. Provider-free measured dimensions remain
+deferred to [#308](https://github.com/kevinswiber/mmdflux/issues/308).
 
 ## Tracing and Diagnostics
 

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -416,7 +416,7 @@ Rules:
   compatibility metrics for wrap preparation.
 - `metricsProfile.source` is a provenance category: `heuristic` for the
   compatibility estimates, `recorded` for generated static tables, and
-  reserved `dynamic` for future live measurement backends.
+  `dynamic` for live provider-bound measurement.
 - The recorded profile source font is provenance, not an exact Mermaid or
   browser font claim.
 - SVG font-family and metrics profile are intentionally decoupled for static
@@ -426,8 +426,14 @@ Rules:
   `fontFamily` and `fontSize` are accepted only when they normalize to the
   selected static profile descriptor. A different custom style requires the
   browser dynamic metrics export.
-- The experimental browser dynamic metrics export is SVG-only and does not emit
-  or replay MMDS; provider-bound dynamic MMDS replay remains future work.
+- Dynamic MMDS (`source = "dynamic"`) is provider-bound. Measurement-dependent
+  replay to SVG requires a matching dynamic provider descriptor; provider-free
+  SVG/Text/ASCII replay rejects it instead of falling back to static metrics.
+- Provider-free MMDS-to-MMDS pass-through may preserve a dynamic text-metrics
+  extension when no text measurement is performed, but still validates the
+  extension shape.
+- Provider-free measured dimensions are deferred to
+  [#308](https://github.com/kevinswiber/mmdflux/issues/308).
 - Replay uses `metricsProfile.id` plus `layoutText` node padding and edge-label wrap width when the extension is present.
 - Replay is document-owned: a caller-supplied `fontMetricsProfile` must match the replay profile, and the replay profile plus persisted `layoutText` values override SVG font and node-padding config.
 - Older MMDS documents without the extension replay with the `mmdflux-heuristic-proportional-v1` compatibility defaults.
@@ -463,8 +469,9 @@ parity.
 
 Browser dynamic metrics keep font identity in `metricsJson`, not `configJson`.
 `renderWithBrowserTextMetrics` rejects `configJson.fontFamily`,
-`configJson.fontSize`, and `configJson.themeVariables`; provider-bound dynamic
-MMDS replay remains future work.
+`configJson.fontSize`, and `configJson.themeVariables`. Dynamic MMDS output and
+replay use the provider identity in `metricsJson`; the browser adapter emits
+`profileId = "mmdflux-browser-canvas-v1"`.
 
 ### Node
 

--- a/docs/mmds.schema.json
+++ b/docs/mmds.schema.json
@@ -439,7 +439,7 @@
         "source": {
           "type": "string",
           "enum": ["heuristic", "recorded", "dynamic"],
-          "description": "Profile provenance category: 'heuristic' for compatibility estimates, 'recorded' for generated static metrics, or reserved 'dynamic' for future live measurement backends."
+          "description": "Profile provenance category: 'heuristic' for compatibility estimates, 'recorded' for generated static metrics, or 'dynamic' for provider-bound live measurement."
         },
         "version": {
           "type": "integer",

--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -6604,6 +6604,10 @@ mod dynamic_text_metrics_topology_smoke_tests {
             font_family: DEFAULT_GRAPH_FONT_FAMILY.to_string(),
             font_size_px: metrics.font_size(),
             line_height_px: metrics.line_height(),
+            profile_id: None,
+            profile_version: None,
+            font_style: None,
+            font_weight: None,
         };
         let text_scales = text_scales
             .iter()

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -15,10 +15,12 @@ use crate::format::OutputFormat;
 use crate::frontends::{InputFrontend, detect_input_frontend};
 use crate::graph::measure::{
     DEFAULT_LABEL_PADDING_X, DEFAULT_LABEL_PADDING_Y, DEFAULT_PROPORTIONAL_NODE_PADDING_X,
-    DEFAULT_PROPORTIONAL_NODE_PADDING_Y, TextMetricsProvider,
+    DEFAULT_PROPORTIONAL_NODE_PADDING_Y, TextMetricsLayoutDescriptor, TextMetricsProfileDescriptor,
+    TextMetricsProvider, TextMetricsStyleDescriptor,
 };
 use crate::payload::Diagram;
 use crate::registry::DiagramFamily;
+use crate::render::graph::SvgRenderOptions;
 use crate::runtime::config::RenderConfig;
 use crate::runtime::config_input::apply_svg_surface_defaults;
 
@@ -29,6 +31,10 @@ pub struct DynamicMetricsInput {
     pub font_family: String,
     pub font_size_px: f64,
     pub line_height_px: f64,
+    pub profile_id: Option<String>,
+    pub profile_version: Option<u32>,
+    pub font_style: Option<String>,
+    pub font_weight: Option<String>,
 }
 
 impl DynamicMetricsInput {
@@ -37,7 +43,74 @@ impl DynamicMetricsInput {
         validate_non_empty("fontFamily", &self.font_family)?;
         validate_positive_finite("fontSizePx", self.font_size_px)?;
         validate_positive_finite("lineHeightPx", self.line_height_px)?;
+        if let Some(profile_id) = &self.profile_id {
+            validate_non_empty("profileId", profile_id)?;
+        }
+        if matches!(self.profile_version, Some(0)) {
+            return Err(RenderError {
+                message: "dynamic text metrics field `profileVersion` must be a positive integer"
+                    .to_string(),
+            });
+        }
+        if let Some(font_style) = &self.font_style {
+            validate_non_empty("fontStyle", font_style)?;
+        }
+        if let Some(font_weight) = &self.font_weight {
+            validate_non_empty("fontWeight", font_weight)?;
+        }
         Ok(())
+    }
+
+    pub(crate) fn profile_version_or_default(&self) -> u32 {
+        self.profile_version.unwrap_or(1)
+    }
+
+    pub(crate) fn font_style_or_default(&self) -> &str {
+        self.font_style.as_deref().unwrap_or("normal")
+    }
+
+    pub(crate) fn font_weight_or_default(&self) -> &str {
+        self.font_weight.as_deref().unwrap_or("400")
+    }
+
+    pub(crate) fn require_profile_id(&self, operation: &str) -> Result<&str, RenderError> {
+        match self.profile_id.as_deref() {
+            Some(profile_id) if !profile_id.trim().is_empty() => Ok(profile_id),
+            _ => Err(RenderError {
+                message: format!(
+                    "dynamic text metrics field `profileId` is required for {operation}"
+                ),
+            }),
+        }
+    }
+
+    pub(crate) fn text_metrics_descriptor_for_layout(
+        &self,
+        node_padding_x: f64,
+        node_padding_y: f64,
+        edge_label_max_width: Option<f64>,
+    ) -> Result<TextMetricsProfileDescriptor, RenderError> {
+        self.validate()?;
+        let profile_id = self.require_profile_id("dynamic MMDS descriptor")?;
+        Ok(TextMetricsProfileDescriptor {
+            profile_id: profile_id.to_string(),
+            source: "dynamic".to_string(),
+            version: self.profile_version_or_default(),
+            default_text_style: TextMetricsStyleDescriptor {
+                font_family: self.font_family.clone(),
+                font_size: self.font_size_px,
+                font_style: self.font_style_or_default().to_string(),
+                font_weight: self.font_weight_or_default().to_string(),
+                line_height: self.line_height_px,
+            },
+            layout_text: TextMetricsLayoutDescriptor {
+                node_padding_x,
+                node_padding_y,
+                label_padding_x: DEFAULT_LABEL_PADDING_X,
+                label_padding_y: DEFAULT_LABEL_PADDING_Y,
+                edge_label_max_width,
+            },
+        })
     }
 }
 
@@ -266,9 +339,11 @@ pub fn render_graph_family_with_dynamic_text_metrics<F>(
 where
     F: FnMut(&str, &str) -> Result<f64, DynamicTextMetricsError>,
 {
-    if !matches!(format, OutputFormat::Svg) {
+    if !matches!(format, OutputFormat::Svg | OutputFormat::Mmds) {
         return Err(RenderError {
-            message: format!("dynamic text metrics only supports SVG output (requested {format})"),
+            message: format!(
+                "dynamic text metrics supports SVG and provider-bound MMDS output (requested {format})"
+            ),
         });
     }
     if config.layout_engine.is_some() {
@@ -296,9 +371,43 @@ where
 
     match detect_input_frontend(input) {
         Some(InputFrontend::Mmds) => {
-            return Err(RenderError {
-                message: "dynamic text metrics does not support MMDS input".to_string(),
-            });
+            let mut effective_config = super::effective_render_config(input, format, config);
+            if matches!(format, OutputFormat::Svg) {
+                apply_svg_surface_defaults(OutputFormat::Svg, &mut effective_config, true);
+            }
+            let font_family = dynamic_input.font_family.clone();
+            let font_size = dynamic_input.font_size_px;
+            let node_padding_x = effective_config
+                .svg_node_padding_x
+                .unwrap_or(DEFAULT_PROPORTIONAL_NODE_PADDING_X);
+            let node_padding_y = effective_config
+                .svg_node_padding_y
+                .unwrap_or(DEFAULT_PROPORTIONAL_NODE_PADDING_Y);
+            let text_metrics_descriptor = dynamic_input.text_metrics_descriptor_for_layout(
+                node_padding_x,
+                node_padding_y,
+                effective_config.layout.edge_label_max_width,
+            )?;
+            let provider = CallbackTextMetricsProvider::with_node_padding(
+                dynamic_input,
+                node_padding_x,
+                node_padding_y,
+                callback,
+            );
+            let mut options = effective_config.svg_render_options();
+            options.font_family = font_family;
+            options.font_size = font_size;
+            let svg_theme = super::resolve_configured_svg_theme(&effective_config)?;
+            let rendered = crate::runtime::mmds::render_input_with_dynamic_text_metrics(
+                input,
+                format,
+                &options,
+                svg_theme.as_ref(),
+                &text_metrics_descriptor,
+                &provider,
+            )?;
+            provider.finish()?;
+            return Ok(rendered);
         }
         Some(InputFrontend::Mermaid) => {}
         None => {
@@ -320,10 +429,10 @@ where
             ),
         });
     }
-    if !resolved.supported_formats().contains(&OutputFormat::Svg) {
+    if !resolved.supported_formats().contains(&format) {
         return Err(RenderError {
             message: format!(
-                "{} diagrams do not support SVG output",
+                "{} diagrams do not support {format} output",
                 resolved.diagram_id()
             ),
         });
@@ -341,13 +450,15 @@ where
         message: format!("parse error: {error}"),
     })?;
 
-    let mut effective_config = super::effective_render_config(input, OutputFormat::Svg, config);
-    // Match the existing Wasm SVG surface while keeping dynamic-measured layout
-    // on this separate export instead of accepting a caller layoutEngine knob.
-    apply_svg_surface_defaults(OutputFormat::Svg, &mut effective_config, true);
-    let mut options = effective_config.svg_render_options();
-    options.font_family = dynamic_input.font_family.clone();
-    options.font_size = dynamic_input.font_size_px;
+    let mut effective_config = super::effective_render_config(input, format, config);
+    if matches!(format, OutputFormat::Svg) {
+        // Match the existing Wasm SVG surface while keeping dynamic-measured
+        // layout on this separate export instead of accepting a caller
+        // layoutEngine knob.
+        apply_svg_surface_defaults(OutputFormat::Svg, &mut effective_config, true);
+    }
+    let font_family = dynamic_input.font_family.clone();
+    let font_size = dynamic_input.font_size_px;
 
     let node_padding_x = effective_config
         .svg_node_padding_x
@@ -355,42 +466,45 @@ where
     let node_padding_y = effective_config
         .svg_node_padding_y
         .unwrap_or(DEFAULT_PROPORTIONAL_NODE_PADDING_Y);
+    let text_metrics_descriptor = if matches!(format, OutputFormat::Mmds) {
+        Some(dynamic_input.text_metrics_descriptor_for_layout(
+            node_padding_x,
+            node_padding_y,
+            effective_config.layout.edge_label_max_width,
+        )?)
+    } else {
+        None
+    };
     let provider = CallbackTextMetricsProvider::with_node_padding(
         dynamic_input,
         node_padding_x,
         node_padding_y,
         callback,
     );
+    let mut options = effective_config.svg_render_options();
+    options.font_family = font_family;
+    options.font_size = font_size;
+    let render_context = DynamicGraphFamilyRenderContext {
+        format,
+        config: &effective_config,
+        svg_options: &options,
+        text_metrics_descriptor: text_metrics_descriptor.as_ref(),
+        provider: &provider,
+    };
 
     let payload =
         super::payload::prepare_payload_for_render(parsed.into_payload()?, &effective_config);
     let rendered = match payload {
-        Diagram::Flowchart(mut graph) => {
-            crate::runtime::graph_family::render_graph_family_svg_with_provider(
-                "flowchart",
-                &mut graph,
-                &effective_config,
-                &options,
-                &provider,
-            )
-        }
+        Diagram::Flowchart(mut graph) => render_graph_family_payload_with_dynamic_metrics(
+            "flowchart",
+            &mut graph,
+            &render_context,
+        ),
         Diagram::Class(mut graph) => {
-            crate::runtime::graph_family::render_graph_family_svg_with_provider(
-                "class",
-                &mut graph,
-                &effective_config,
-                &options,
-                &provider,
-            )
+            render_graph_family_payload_with_dynamic_metrics("class", &mut graph, &render_context)
         }
         Diagram::State(mut graph) => {
-            crate::runtime::graph_family::render_graph_family_svg_with_provider(
-                "state",
-                &mut graph,
-                &effective_config,
-                &options,
-                &provider,
-            )
+            render_graph_family_payload_with_dynamic_metrics("state", &mut graph, &render_context)
         }
         Diagram::Sequence(_) => Err(RenderError {
             message: "dynamic text metrics only supports graph-family Mermaid diagrams".to_string(),
@@ -401,6 +515,45 @@ where
     Ok(rendered)
 }
 
+struct DynamicGraphFamilyRenderContext<'a> {
+    format: OutputFormat,
+    config: &'a RenderConfig,
+    svg_options: &'a SvgRenderOptions,
+    text_metrics_descriptor: Option<&'a TextMetricsProfileDescriptor>,
+    provider: &'a dyn TextMetricsProvider,
+}
+
+fn render_graph_family_payload_with_dynamic_metrics(
+    diagram_id: &str,
+    graph: &mut crate::graph::Graph,
+    context: &DynamicGraphFamilyRenderContext<'_>,
+) -> Result<String, RenderError> {
+    match context.format {
+        OutputFormat::Svg => crate::runtime::graph_family::render_graph_family_svg_with_provider(
+            diagram_id,
+            graph,
+            context.config,
+            context.svg_options,
+            context.provider,
+        ),
+        OutputFormat::Mmds => {
+            let descriptor = context.text_metrics_descriptor.ok_or_else(|| RenderError {
+                message:
+                    "dynamic text metrics field `profileId` is required for dynamic MMDS descriptor"
+                        .to_string(),
+            })?;
+            crate::runtime::graph_family::render_graph_family_mmds_with_provider(
+                diagram_id,
+                graph,
+                context.config,
+                descriptor,
+                context.provider,
+            )
+        }
+        _ => unreachable!("format validation restricts dynamic text metrics output"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::rc::Rc;
@@ -408,6 +561,7 @@ mod tests {
     use super::*;
     use crate::engines::graph::EngineAlgorithmId;
     use crate::format::OutputFormat;
+    use crate::graph::GeometryLevel;
     use crate::graph::measure::{
         DEFAULT_GRAPH_FONT_FAMILY, TextMetricsProfileConfig, TextMetricsProvider,
         resolve_text_metrics_profile,
@@ -422,6 +576,41 @@ mod tests {
         .unwrap()
     }
 
+    fn profiled_input(profile_id: &str) -> DynamicMetricsInput {
+        serde_json::from_str(&format!(
+            r#"{{
+              "cssFont":"16px Inter",
+              "fontFamily":"Inter",
+              "fontSizePx":16,
+              "lineHeightPx":24,
+              "profileId":"{profile_id}"
+            }}"#
+        ))
+        .unwrap()
+    }
+
+    fn deterministic_width(text: &str, _css_font: &str) -> Result<f64, DynamicTextMetricsError> {
+        Ok(text.len() as f64 * 8.0)
+    }
+
+    fn routed_config() -> RenderConfig {
+        RenderConfig {
+            geometry_level: GeometryLevel::Routed,
+            ..RenderConfig::default()
+        }
+    }
+
+    fn dynamic_mmds_fixture() -> String {
+        render_graph_family_with_dynamic_text_metrics(
+            "graph TD\nA[Alpha] -->|a labeled edge| B[Beta]",
+            OutputFormat::Mmds,
+            &routed_config(),
+            profiled_input("browser-test-v1"),
+            deterministic_width,
+        )
+        .expect("dynamic MMDS fixture should render")
+    }
+
     fn static_equivalent_input() -> DynamicMetricsInput {
         let metrics = resolve_text_metrics_profile(TextMetricsProfileConfig::default())
             .expect("default recorded text metrics should resolve")
@@ -431,7 +620,173 @@ mod tests {
             font_family: DEFAULT_GRAPH_FONT_FAMILY.to_string(),
             font_size_px: metrics.font_size(),
             line_height_px: metrics.line_height(),
+            profile_id: None,
+            profile_version: None,
+            font_style: None,
+            font_weight: None,
         }
+    }
+
+    #[test]
+    fn dynamic_metrics_input_accepts_optional_provider_identity_for_svg() {
+        let input: DynamicMetricsInput = serde_json::from_str(
+            r#"{
+              "cssFont":"16px Inter",
+              "fontFamily":"Inter",
+              "fontSizePx":16,
+              "lineHeightPx":24,
+              "profileId":"browser-inter-v1",
+              "profileVersion":2,
+              "fontStyle":"italic",
+              "fontWeight":"700"
+            }"#,
+        )
+        .unwrap();
+
+        input.validate().unwrap();
+        assert_eq!(
+            input.require_profile_id("dynamic MMDS").unwrap(),
+            "browser-inter-v1"
+        );
+        assert_eq!(input.profile_version_or_default(), 2);
+        assert_eq!(input.font_style_or_default(), "italic");
+        assert_eq!(input.font_weight_or_default(), "700");
+    }
+
+    #[test]
+    fn dynamic_metrics_input_keeps_existing_svg_metrics_json_valid() {
+        let input = valid_input();
+
+        input.validate().unwrap();
+        assert_eq!(input.profile_version_or_default(), 1);
+        assert_eq!(input.font_style_or_default(), "normal");
+        assert_eq!(input.font_weight_or_default(), "400");
+        let err = input
+            .require_profile_id("dynamic MMDS")
+            .expect_err("profile id should only be required for descriptor operations");
+        assert!(err.message.contains("profileId"), "{err}");
+        assert!(err.message.contains("dynamic MMDS"), "{err}");
+        assert!(!err.message.contains("browser"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_metrics_input_rejects_zero_profile_version() {
+        let input: DynamicMetricsInput = serde_json::from_str(
+            r#"{
+              "cssFont":"16px Inter",
+              "fontFamily":"Inter",
+              "fontSizePx":16,
+              "lineHeightPx":24,
+              "profileVersion":0
+            }"#,
+        )
+        .unwrap();
+
+        let err = input
+            .validate()
+            .expect_err("zero profileVersion should fail");
+        assert!(err.message.contains("profileVersion"), "{err}");
+        assert!(err.message.contains("positive"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_metrics_input_rejects_empty_optional_identity_fields() {
+        for (field, json) in [
+            (
+                "profileId",
+                r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"profileId":" "}"#,
+            ),
+            (
+                "fontStyle",
+                r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"fontStyle":" "}"#,
+            ),
+            (
+                "fontWeight",
+                r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"fontWeight":" "}"#,
+            ),
+        ] {
+            let input: DynamicMetricsInput = serde_json::from_str(json).unwrap();
+            let err = input
+                .validate()
+                .expect_err("empty optional field should fail");
+            assert!(err.message.contains(field), "{err}");
+        }
+    }
+
+    #[test]
+    fn dynamic_metrics_input_builds_provider_bound_descriptor() {
+        let input: DynamicMetricsInput = serde_json::from_str(
+            r#"{
+              "cssFont":"16px Inter",
+              "fontFamily":"Inter",
+              "fontSizePx":16,
+              "lineHeightPx":24,
+              "profileId":"browser-inter-v1"
+            }"#,
+        )
+        .unwrap();
+
+        let descriptor = input
+            .text_metrics_descriptor_for_layout(15.0, 16.0, Some(200.0))
+            .unwrap();
+
+        assert_eq!(descriptor.profile_id, "browser-inter-v1");
+        assert_eq!(descriptor.source, "dynamic");
+        assert_eq!(descriptor.version, 1);
+        assert_eq!(descriptor.default_text_style.font_family, "Inter");
+        assert_eq!(descriptor.default_text_style.font_size, 16.0);
+        assert_eq!(descriptor.default_text_style.font_style, "normal");
+        assert_eq!(descriptor.default_text_style.font_weight, "400");
+        assert_eq!(descriptor.default_text_style.line_height, 24.0);
+        assert_eq!(descriptor.layout_text.node_padding_x, 15.0);
+        assert_eq!(descriptor.layout_text.node_padding_y, 16.0);
+        assert_eq!(
+            descriptor.layout_text.label_padding_x,
+            DEFAULT_LABEL_PADDING_X
+        );
+        assert_eq!(
+            descriptor.layout_text.label_padding_y,
+            DEFAULT_LABEL_PADDING_Y
+        );
+        assert_eq!(descriptor.layout_text.edge_label_max_width, Some(200.0));
+    }
+
+    #[test]
+    fn dynamic_metrics_descriptor_mirrors_adapter_owned_style_and_version() {
+        let input: DynamicMetricsInput = serde_json::from_str(
+            r#"{
+              "cssFont":"italic 700 16px Inter",
+              "fontFamily":"Inter",
+              "fontSizePx":16,
+              "lineHeightPx":24,
+              "profileId":"browser-inter-v2",
+              "profileVersion":2,
+              "fontStyle":"italic",
+              "fontWeight":"700"
+            }"#,
+        )
+        .unwrap();
+
+        let descriptor = input
+            .text_metrics_descriptor_for_layout(12.0, 13.0, None)
+            .unwrap();
+
+        assert_eq!(descriptor.profile_id, "browser-inter-v2");
+        assert_eq!(descriptor.version, 2);
+        assert_eq!(descriptor.default_text_style.font_style, "italic");
+        assert_eq!(descriptor.default_text_style.font_weight, "700");
+        assert_eq!(descriptor.layout_text.edge_label_max_width, None);
+    }
+
+    #[test]
+    fn dynamic_metrics_descriptor_requires_profile_id() {
+        let err = valid_input()
+            .text_metrics_descriptor_for_layout(15.0, 15.0, Some(200.0))
+            .expect_err("descriptor construction should require profileId");
+
+        assert!(err.message.contains("profileId"), "{err}");
+        assert!(err.message.contains("dynamic MMDS descriptor"), "{err}");
+        assert!(!err.message.contains("browser"), "{err}");
     }
 
     #[test]
@@ -595,23 +950,227 @@ mod tests {
         for format in [
             OutputFormat::Text,
             OutputFormat::Ascii,
-            OutputFormat::Mmds,
             OutputFormat::Mermaid,
         ] {
             let err = render_graph_family_with_dynamic_text_metrics(
                 "graph TD\nA-->B",
                 format,
                 &RenderConfig::default(),
-                valid_input(),
+                profiled_input("browser-test-v1"),
                 |_text, _css_font| Ok(8.0),
             )
             .expect_err("unsupported output format should fail");
-            assert!(err.message.contains("only supports SVG output"), "{err}");
+            assert!(
+                err.message
+                    .contains("supports SVG and provider-bound MMDS output"),
+                "{err}"
+            );
         }
     }
 
     #[test]
-    fn dynamic_svg_bridge_rejects_mmds_input() {
+    fn dynamic_mmds_output_emits_provider_bound_text_metrics_extension() {
+        let output = render_graph_family_with_dynamic_text_metrics(
+            "graph TD\nA[Alpha] --> B[Beta]",
+            OutputFormat::Mmds,
+            &RenderConfig::default(),
+            profiled_input("browser-test-v1"),
+            |text, _css_font| Ok(text.len() as f64 * 8.0),
+        )
+        .expect("dynamic MMDS output should render");
+
+        let value: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let extension = &value["extensions"]["org.mmdflux.text-metrics.v1"];
+        assert_eq!(extension["metricsProfile"]["source"], "dynamic");
+        assert_eq!(extension["metricsProfile"]["id"], "browser-test-v1");
+        assert_eq!(extension["metricsProfile"]["version"], 1);
+        assert_eq!(extension["defaultTextStyle"]["font-family"], "Inter");
+        assert_eq!(extension["defaultTextStyle"]["font-size"], 16.0);
+        assert_eq!(extension["defaultTextStyle"]["line-height"], 24.0);
+        assert!(
+            value["extensions"]
+                .get("org.mmdflux.text-measurements.v1")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn dynamic_mmds_output_requires_profile_id() {
+        let err = render_graph_family_with_dynamic_text_metrics(
+            "graph TD\nA-->B",
+            OutputFormat::Mmds,
+            &RenderConfig::default(),
+            valid_input(),
+            |_text, _css_font| Ok(8.0),
+        )
+        .expect_err("dynamic MMDS output should require provider identity");
+
+        assert!(err.message.contains("profileId"), "{err}");
+        assert!(err.message.contains("dynamic MMDS descriptor"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_mmds_output_rejects_sequence_input() {
+        let err = render_graph_family_with_dynamic_text_metrics(
+            "sequenceDiagram\nAlice->>Bob: Hi",
+            OutputFormat::Mmds,
+            &RenderConfig::default(),
+            profiled_input("browser-test-v1"),
+            |_text, _css_font| Ok(8.0),
+        )
+        .expect_err("sequence input should fail");
+
+        assert!(
+            err.message
+                .contains("only supports graph-family Mermaid diagrams"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn dynamic_mmds_output_rejects_layout_engine_override() {
+        let err = render_graph_family_with_dynamic_text_metrics(
+            "graph TD\nA-->B",
+            OutputFormat::Mmds,
+            &RenderConfig {
+                layout_engine: Some(EngineAlgorithmId::MERMAID_LAYERED),
+                ..RenderConfig::default()
+            },
+            profiled_input("browser-test-v1"),
+            |_text, _css_font| Ok(8.0),
+        )
+        .expect_err("layout engine override should fail");
+
+        assert!(
+            err.message.contains("does not accept layoutEngine"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn dynamic_mmds_replay_with_matching_provider_matches_direct_dynamic_svg() {
+        let input = "graph TD\nA[Alpha] -->|a labeled edge| B[Beta]";
+        let config = routed_config();
+        let metrics = profiled_input("browser-test-v1");
+        let direct_svg = render_graph_family_with_dynamic_text_metrics(
+            input,
+            OutputFormat::Svg,
+            &config,
+            metrics.clone(),
+            deterministic_width,
+        )
+        .expect("direct dynamic SVG should render");
+        let mmds = render_graph_family_with_dynamic_text_metrics(
+            input,
+            OutputFormat::Mmds,
+            &config,
+            metrics.clone(),
+            deterministic_width,
+        )
+        .expect("dynamic MMDS should render");
+
+        let replay_svg = render_graph_family_with_dynamic_text_metrics(
+            &mmds,
+            OutputFormat::Svg,
+            &config,
+            metrics,
+            deterministic_width,
+        )
+        .expect("dynamic MMDS replay should render with matching provider");
+
+        assert_eq!(replay_svg, direct_svg);
+    }
+
+    #[test]
+    fn dynamic_mmds_replay_rejects_provider_descriptor_mismatches() {
+        let mmds = dynamic_mmds_fixture();
+
+        let mut version = profiled_input("browser-test-v1");
+        version.profile_version = Some(2);
+        let mut font_family = profiled_input("browser-test-v1");
+        font_family.font_family = "Arial".to_string();
+        let mut font_size = profiled_input("browser-test-v1");
+        font_size.font_size_px = 18.0;
+        let mut font_style = profiled_input("browser-test-v1");
+        font_style.font_style = Some("italic".to_string());
+        let mut font_weight = profiled_input("browser-test-v1");
+        font_weight.font_weight = Some("700".to_string());
+        let mut line_height = profiled_input("browser-test-v1");
+        line_height.line_height_px = 30.0;
+
+        for (name, metrics, expected_field) in [
+            (
+                "profile id",
+                profiled_input("browser-other-v1"),
+                "metricsProfile.id",
+            ),
+            ("version", version, "metricsProfile.version"),
+            ("font family", font_family, "defaultTextStyle.font-family"),
+            ("font size", font_size, "defaultTextStyle.font-size"),
+            ("font style", font_style, "defaultTextStyle.font-style"),
+            ("font weight", font_weight, "defaultTextStyle.font-weight"),
+            ("line height", line_height, "defaultTextStyle.line-height"),
+        ] {
+            let err = render_graph_family_with_dynamic_text_metrics(
+                &mmds,
+                OutputFormat::Svg,
+                &routed_config(),
+                metrics,
+                deterministic_width,
+            )
+            .unwrap_err();
+            assert!(err.message.contains(expected_field), "{name}: {err}");
+        }
+
+        let mut node_padding_config = routed_config();
+        node_padding_config.svg_node_padding_x = Some(20.0);
+        let err = render_graph_family_with_dynamic_text_metrics(
+            &mmds,
+            OutputFormat::Svg,
+            &node_padding_config,
+            profiled_input("browser-test-v1"),
+            deterministic_width,
+        )
+        .expect_err("node padding mismatch should fail");
+        assert!(err.message.contains("layoutText.node-padding-x"), "{err}");
+
+        let mut edge_width_config = routed_config();
+        edge_width_config.layout.edge_label_max_width = Some(120.0);
+        let err = render_graph_family_with_dynamic_text_metrics(
+            &mmds,
+            OutputFormat::Svg,
+            &edge_width_config,
+            profiled_input("browser-test-v1"),
+            deterministic_width,
+        )
+        .expect_err("edge label max width mismatch should fail");
+        assert!(
+            err.message.contains("layoutText.edge-label-max-width"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn dynamic_mmds_replay_rejects_persisted_label_padding_mismatch() {
+        let mut value: serde_json::Value = serde_json::from_str(&dynamic_mmds_fixture()).unwrap();
+        value["extensions"]["org.mmdflux.text-metrics.v1"]["layoutText"]["label-padding-x"] =
+            serde_json::json!(8.0);
+        let mmds = serde_json::to_string(&value).unwrap();
+
+        let err = render_graph_family_with_dynamic_text_metrics(
+            &mmds,
+            OutputFormat::Svg,
+            &routed_config(),
+            profiled_input("browser-test-v1"),
+            deterministic_width,
+        )
+        .expect_err("label padding mismatch should fail");
+
+        assert!(err.message.contains("layoutText.label-padding-x"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_mmds_replay_rejects_static_mmds_input() {
         let mmds = render_diagram(
             "graph TD\nA-->B",
             OutputFormat::Mmds,
@@ -622,12 +1181,13 @@ mod tests {
         let err = render_graph_family_svg_with_dynamic_text_metrics(
             &mmds,
             &RenderConfig::default(),
-            valid_input(),
+            profiled_input("browser-test-v1"),
             |_text, _css_font| Ok(8.0),
         )
-        .expect_err("MMDS input should fail");
+        .expect_err("static MMDS input should fail on the dynamic replay path");
 
-        assert!(err.message.contains("does not support MMDS input"), "{err}");
+        assert!(err.message.contains("metricsProfile.source"), "{err}");
+        assert!(err.message.contains("not dynamic"), "{err}");
     }
 
     #[test]

--- a/src/runtime/graph_family.rs
+++ b/src/runtime/graph_family.rs
@@ -103,6 +103,32 @@ pub(in crate::runtime) fn render_graph_family_svg_with_provider(
     render_svg_from_solve_result(diagram, &solve, options, config, text_metrics)
 }
 
+#[cfg(feature = "unstable-text-metrics-provider")]
+pub(in crate::runtime) fn render_graph_family_mmds_with_provider(
+    diagram_id: &str,
+    diagram: &mut Graph,
+    config: &RenderConfig,
+    text_metrics_descriptor: &TextMetricsProfileDescriptor,
+    text_metrics: &dyn TextMetricsProvider,
+) -> Result<String, RenderError> {
+    let solve = solve_graph_family_with_provider(
+        diagram_id,
+        diagram,
+        OutputFormat::Mmds,
+        config,
+        text_metrics,
+    )?;
+    render_mmds_from_solve_result(
+        diagram_id,
+        diagram,
+        &solve,
+        text_metrics_descriptor,
+        text_metrics,
+        config.geometry_level,
+        config.path_simplification,
+    )
+}
+
 struct GraphFamilyRenderResult {
     solve: GraphSolveResult,
     text_metrics: ResolvedTextMetrics,

--- a/src/runtime/mmds.rs
+++ b/src/runtime/mmds.rs
@@ -10,10 +10,12 @@ use serde_json::{Map, Value};
 use crate::errors::RenderError;
 use crate::format::OutputFormat;
 use crate::graph::GeometryLevel;
+#[cfg(feature = "unstable-text-metrics-provider")]
+use crate::graph::measure::TextMetricsProvider;
 use crate::graph::measure::{
-    DEFAULT_EDGE_LABEL_MAX_WIDTH, DEFAULT_PROPORTIONAL_NODE_PADDING_X,
-    DEFAULT_PROPORTIONAL_NODE_PADDING_Y, LEGACY_MMDS_TEXT_METRICS_PROFILE_ID, ResolvedTextMetrics,
-    TextMetricsProfileConfig, TextMetricsProfileDescriptor, resolve_text_metrics_profile,
+    LEGACY_MMDS_TEXT_METRICS_PROFILE_ID, ResolvedTextMetrics, TextMetricsLayoutDescriptor,
+    TextMetricsProfileConfig, TextMetricsProfileDescriptor, TextMetricsStyleDescriptor,
+    resolve_text_metrics_profile,
 };
 use crate::mmds::{
     Document, TEXT_METRICS_EXTENSION_NAMESPACE, from_document, generate_mermaid,
@@ -51,6 +53,27 @@ pub(crate) fn render_input(
     )
 }
 
+#[cfg(feature = "unstable-text-metrics-provider")]
+pub(in crate::runtime) fn render_input_with_dynamic_text_metrics(
+    input: &str,
+    format: OutputFormat,
+    svg_options: &SvgRenderOptions,
+    svg_theme: Option<&ResolvedSvgTheme>,
+    provider_descriptor: &TextMetricsProfileDescriptor,
+    provider: &dyn TextMetricsProvider,
+) -> Result<String, RenderError> {
+    let payload =
+        parse_input(input).map_err(|error| prefixed_display_error("parse error", error))?;
+    render_document_with_dynamic_text_metrics(
+        &payload,
+        format,
+        svg_options,
+        svg_theme,
+        provider_descriptor,
+        provider,
+    )
+}
+
 /// Render a parsed MMDS document through the MMDS replay path.
 pub(crate) fn render_document(
     payload: &Document,
@@ -65,6 +88,7 @@ pub(crate) fn render_document(
     let has_routed_geometry = payload.geometry_level == GeometryLevel::Routed;
 
     if matches!(format, OutputFormat::Mmds) {
+        validate_text_metrics_extension_shape(payload)?;
         let output = if has_routed_geometry && geometry_level == GeometryLevel::Layout {
             strip_routed_fields(payload)
         } else {
@@ -149,6 +173,61 @@ pub(crate) fn render_document(
     }
 }
 
+#[cfg(feature = "unstable-text-metrics-provider")]
+fn render_document_with_dynamic_text_metrics(
+    payload: &Document,
+    format: OutputFormat,
+    svg_options: &SvgRenderOptions,
+    svg_theme: Option<&ResolvedSvgTheme>,
+    provider_descriptor: &TextMetricsProfileDescriptor,
+    provider: &dyn TextMetricsProvider,
+) -> Result<String, RenderError> {
+    if !matches!(format, OutputFormat::Svg) {
+        return Err(RenderError {
+            message: format!(
+                "dynamic text metrics MMDS replay only supports SVG output (requested {format})"
+            ),
+        });
+    }
+
+    let _diagram_id = resolve_logical_diagram_id(payload)?;
+    let persisted_descriptor = dynamic_text_metrics_descriptor_for_replay(payload)?;
+    ensure_persisted_descriptor_matches_dynamic_provider(
+        &persisted_descriptor,
+        provider_descriptor,
+    )?;
+
+    let has_routed_geometry = payload.geometry_level == GeometryLevel::Routed;
+    let mut diagram = from_document(payload).map_err(display_error)?;
+    crate::graph::label_wrap::prepare_wrapped_labels_with_provider(
+        &mut diagram.edges,
+        provider,
+        provider_descriptor.layout_text.edge_label_max_width,
+    );
+
+    let geometry = hydrate_graph_geometry_from_document_with_diagram(payload, &diagram)
+        .map_err(display_error)?;
+    let routed = has_routed_geometry
+        .then(|| hydrate_routed_geometry_from_document_with_provider(payload, provider))
+        .transpose()
+        .map_err(display_error)?;
+    let options = svg_options_with_text_metrics(svg_options, provider_descriptor);
+
+    Ok(match routed.as_ref() {
+        Some(routed) => render_svg_from_routed_geometry_with_theme_and_metrics(
+            &diagram, routed, &options, svg_theme, provider,
+        ),
+        None => render_svg_from_geometry_with_theme_routing_and_metrics(
+            &diagram,
+            &geometry,
+            &options,
+            edge_routing_from_style(options.routing_style),
+            svg_theme,
+            provider,
+        ),
+    })
+}
+
 fn is_shared_coordinates_view(payload: &Document) -> bool {
     payload
         .extensions
@@ -183,37 +262,122 @@ fn resolve_text_metrics_for_replay(
         .map_err(display_error);
     };
 
+    let persisted_descriptor = parse_text_metrics_descriptor(extension)?;
+    let profile_id = persisted_descriptor.profile_id.as_str();
+    if persisted_descriptor.source == "dynamic" {
+        return Err(dynamic_text_metrics_provider_required(profile_id));
+    }
+    ensure_requested_profile_matches_replay(requested_text_metrics_profile, profile_id)?;
+
+    let layout_text = &persisted_descriptor.layout_text;
+    let resolved = resolve_text_metrics_profile(TextMetricsProfileConfig {
+        profile_id: Some(profile_id),
+        node_padding_x: layout_text.node_padding_x,
+        node_padding_y: layout_text.node_padding_y,
+        edge_label_max_width: layout_text.edge_label_max_width,
+    })
+    .map_err(display_error)?;
+    ensure_persisted_descriptor_matches_static_profile(
+        &persisted_descriptor,
+        &resolved.descriptor,
+    )?;
+
+    Ok(ReplayTextMetrics {
+        resolved,
+        from_extension: true,
+    })
+}
+
+fn validate_text_metrics_extension_shape(payload: &Document) -> Result<(), RenderError> {
+    if let Some(extension) = payload.extensions.get(TEXT_METRICS_EXTENSION_NAMESPACE) {
+        parse_text_metrics_descriptor(extension)?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "unstable-text-metrics-provider")]
+fn dynamic_text_metrics_descriptor_for_replay(
+    payload: &Document,
+) -> Result<TextMetricsProfileDescriptor, RenderError> {
+    let extension = payload
+        .extensions
+        .get(TEXT_METRICS_EXTENSION_NAMESPACE)
+        .ok_or_else(|| invalid_text_metrics_extension("missing dynamic text metrics extension"))?;
+    let descriptor = parse_text_metrics_descriptor(extension)?;
+    if descriptor.source != "dynamic" {
+        return Err(invalid_text_metrics_extension(format!(
+            "metricsProfile.source {:?} is not dynamic",
+            descriptor.source
+        )));
+    }
+    Ok(descriptor)
+}
+
+fn dynamic_text_metrics_provider_required(profile_id: &str) -> RenderError {
+    RenderError {
+        message: format!(
+            "dynamic text metrics profile '{profile_id}' requires a matching provider for MMDS replay"
+        ),
+    }
+}
+
+fn parse_text_metrics_descriptor(
+    extension: &Map<String, Value>,
+) -> Result<TextMetricsProfileDescriptor, RenderError> {
     let metrics_profile = required_object(extension, "metricsProfile")?;
     let profile_id = metrics_profile
         .get("id")
         .and_then(Value::as_str)
         .ok_or_else(|| invalid_text_metrics_extension("missing metricsProfile.id"))?;
-    required_string_field(metrics_profile, "metricsProfile", "source")?;
-    required_integer_field(metrics_profile, "metricsProfile", "version")?;
-    validate_default_text_style(required_object(extension, "defaultTextStyle")?)?;
+    let source = required_string_field(metrics_profile, "metricsProfile", "source")?;
+    let version = required_integer_field(metrics_profile, "metricsProfile", "version")?;
+
+    let default_text_style = required_object(extension, "defaultTextStyle")?;
+    validate_default_text_style(default_text_style)?;
     let layout_text = required_object(extension, "layoutText")?;
     validate_layout_text(layout_text)?;
-    ensure_requested_profile_matches_replay(requested_text_metrics_profile, profile_id)?;
 
-    let resolved = resolve_text_metrics_profile(TextMetricsProfileConfig {
-        profile_id: Some(profile_id),
-        node_padding_x: optional_number_field(
-            Some(layout_text),
-            "node-padding-x",
-            DEFAULT_PROPORTIONAL_NODE_PADDING_X,
-        )?,
-        node_padding_y: optional_number_field(
-            Some(layout_text),
-            "node-padding-y",
-            DEFAULT_PROPORTIONAL_NODE_PADDING_Y,
-        )?,
-        edge_label_max_width: optional_edge_label_max_width(Some(layout_text))?,
-    })
-    .map_err(display_error)?;
-
-    Ok(ReplayTextMetrics {
-        resolved,
-        from_extension: true,
+    Ok(TextMetricsProfileDescriptor {
+        profile_id: profile_id.to_string(),
+        source: source.to_string(),
+        version,
+        default_text_style: TextMetricsStyleDescriptor {
+            font_family: required_string_field(
+                default_text_style,
+                "defaultTextStyle",
+                "font-family",
+            )?
+            .to_string(),
+            font_size: required_number_field(default_text_style, "defaultTextStyle", "font-size")?,
+            font_style: required_string_field(
+                default_text_style,
+                "defaultTextStyle",
+                "font-style",
+            )?
+            .to_string(),
+            font_weight: required_string_field(
+                default_text_style,
+                "defaultTextStyle",
+                "font-weight",
+            )?
+            .to_string(),
+            line_height: required_number_field(
+                default_text_style,
+                "defaultTextStyle",
+                "line-height",
+            )?,
+        },
+        layout_text: TextMetricsLayoutDescriptor {
+            node_padding_x: required_number_field(layout_text, "layoutText", "node-padding-x")?,
+            node_padding_y: required_number_field(layout_text, "layoutText", "node-padding-y")?,
+            label_padding_x: required_number_field(layout_text, "layoutText", "label-padding-x")?,
+            label_padding_y: required_number_field(layout_text, "layoutText", "label-padding-y")?,
+            edge_label_max_width: required_number_or_null_field(
+                layout_text,
+                "layoutText",
+                "edge-label-max-width",
+            )?,
+        },
     })
 }
 
@@ -241,20 +405,19 @@ fn required_integer_field(
     object: &Map<String, Value>,
     object_name: &str,
     field: &str,
-) -> Result<(), RenderError> {
+) -> Result<u32, RenderError> {
     let Some(number) = object.get(field).and_then(Value::as_number) else {
         return Err(invalid_text_metrics_extension(format!(
             "{object_name}.{field} must be an integer"
         )));
     };
 
-    if number.as_i64().is_some() || number.as_u64().is_some() {
-        Ok(())
-    } else {
-        Err(invalid_text_metrics_extension(format!(
-            "{object_name}.{field} must be an integer"
-        )))
-    }
+    number
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| {
+            invalid_text_metrics_extension(format!("{object_name}.{field} must be an integer"))
+        })
 }
 
 fn required_number_field(
@@ -320,36 +483,188 @@ fn ensure_requested_profile_matches_replay(
     Ok(())
 }
 
-fn optional_number_field(
-    layout_text: Option<&Map<String, Value>>,
-    field: &str,
-    default: f64,
-) -> Result<f64, RenderError> {
-    let Some(value) = layout_text.and_then(|layout_text| layout_text.get(field)) else {
-        return Ok(default);
-    };
-
-    value.as_f64().ok_or_else(|| {
-        invalid_text_metrics_extension(format!("layoutText.{field} must be a number"))
-    })
+fn ensure_persisted_descriptor_matches_static_profile(
+    persisted: &TextMetricsProfileDescriptor,
+    expected: &TextMetricsProfileDescriptor,
+) -> Result<(), RenderError> {
+    ensure_persisted_descriptor_matches_profile(persisted, expected, false)
 }
 
-fn optional_edge_label_max_width(
-    layout_text: Option<&Map<String, Value>>,
-) -> Result<Option<f64>, RenderError> {
-    let Some(value) = layout_text.and_then(|layout_text| layout_text.get("edge-label-max-width"))
-    else {
-        return Ok(Some(DEFAULT_EDGE_LABEL_MAX_WIDTH));
-    };
+#[cfg(feature = "unstable-text-metrics-provider")]
+fn ensure_persisted_descriptor_matches_dynamic_provider(
+    persisted: &TextMetricsProfileDescriptor,
+    expected: &TextMetricsProfileDescriptor,
+) -> Result<(), RenderError> {
+    ensure_persisted_descriptor_matches_profile(persisted, expected, true)
+}
 
-    match value {
-        Value::Null => Ok(None),
-        value => value.as_f64().map(Some).ok_or_else(|| {
-            invalid_text_metrics_extension(
-                "layoutText.edge-label-max-width must be a number or null",
-            )
-        }),
+fn ensure_persisted_descriptor_matches_profile(
+    persisted: &TextMetricsProfileDescriptor,
+    expected: &TextMetricsProfileDescriptor,
+    include_document_owned_layout: bool,
+) -> Result<(), RenderError> {
+    ensure_string_descriptor_field(
+        "metricsProfile.id",
+        &persisted.profile_id,
+        &expected.profile_id,
+        expected,
+    )?;
+    ensure_string_descriptor_field(
+        "metricsProfile.source",
+        &persisted.source,
+        &expected.source,
+        expected,
+    )?;
+    ensure_u32_descriptor_field(
+        "metricsProfile.version",
+        persisted.version,
+        expected.version,
+        expected,
+    )?;
+    ensure_string_descriptor_field(
+        "defaultTextStyle.font-family",
+        &persisted.default_text_style.font_family,
+        &expected.default_text_style.font_family,
+        expected,
+    )?;
+    ensure_f64_descriptor_field(
+        "defaultTextStyle.font-size",
+        persisted.default_text_style.font_size,
+        expected.default_text_style.font_size,
+        expected,
+    )?;
+    ensure_string_descriptor_field(
+        "defaultTextStyle.font-style",
+        &persisted.default_text_style.font_style,
+        &expected.default_text_style.font_style,
+        expected,
+    )?;
+    ensure_string_descriptor_field(
+        "defaultTextStyle.font-weight",
+        &persisted.default_text_style.font_weight,
+        &expected.default_text_style.font_weight,
+        expected,
+    )?;
+    ensure_f64_descriptor_field(
+        "defaultTextStyle.line-height",
+        persisted.default_text_style.line_height,
+        expected.default_text_style.line_height,
+        expected,
+    )?;
+    ensure_f64_descriptor_field(
+        "layoutText.label-padding-x",
+        persisted.layout_text.label_padding_x,
+        expected.layout_text.label_padding_x,
+        expected,
+    )?;
+    ensure_f64_descriptor_field(
+        "layoutText.label-padding-y",
+        persisted.layout_text.label_padding_y,
+        expected.layout_text.label_padding_y,
+        expected,
+    )?;
+    if include_document_owned_layout {
+        ensure_f64_descriptor_field(
+            "layoutText.node-padding-x",
+            persisted.layout_text.node_padding_x,
+            expected.layout_text.node_padding_x,
+            expected,
+        )?;
+        ensure_f64_descriptor_field(
+            "layoutText.node-padding-y",
+            persisted.layout_text.node_padding_y,
+            expected.layout_text.node_padding_y,
+            expected,
+        )?;
+        ensure_optional_f64_descriptor_field(
+            "layoutText.edge-label-max-width",
+            persisted.layout_text.edge_label_max_width,
+            expected.layout_text.edge_label_max_width,
+            expected,
+        )?;
     }
+    Ok(())
+}
+
+fn ensure_string_descriptor_field(
+    field: &str,
+    actual: &str,
+    expected_value: &str,
+    expected: &TextMetricsProfileDescriptor,
+) -> Result<(), RenderError> {
+    if actual == expected_value {
+        return Ok(());
+    }
+    Err(descriptor_mismatch_error(
+        field,
+        format!("{actual:?}"),
+        format!("{expected_value:?}"),
+        expected,
+    ))
+}
+
+fn ensure_u32_descriptor_field(
+    field: &str,
+    actual: u32,
+    expected_value: u32,
+    expected: &TextMetricsProfileDescriptor,
+) -> Result<(), RenderError> {
+    if actual == expected_value {
+        return Ok(());
+    }
+    Err(descriptor_mismatch_error(
+        field,
+        actual.to_string(),
+        expected_value.to_string(),
+        expected,
+    ))
+}
+
+fn ensure_f64_descriptor_field(
+    field: &str,
+    actual: f64,
+    expected_value: f64,
+    expected: &TextMetricsProfileDescriptor,
+) -> Result<(), RenderError> {
+    if (actual - expected_value).abs() <= 1e-9 {
+        return Ok(());
+    }
+    Err(descriptor_mismatch_error(
+        field,
+        actual.to_string(),
+        expected_value.to_string(),
+        expected,
+    ))
+}
+
+fn ensure_optional_f64_descriptor_field(
+    field: &str,
+    actual: Option<f64>,
+    expected_value: Option<f64>,
+    expected: &TextMetricsProfileDescriptor,
+) -> Result<(), RenderError> {
+    match (actual, expected_value) {
+        (Some(actual), Some(expected_value)) if (actual - expected_value).abs() <= 1e-9 => Ok(()),
+        (None, None) => Ok(()),
+        _ => Err(descriptor_mismatch_error(
+            field,
+            format!("{actual:?}"),
+            format!("{expected_value:?}"),
+            expected,
+        )),
+    }
+}
+
+fn descriptor_mismatch_error(
+    field: &str,
+    actual: String,
+    expected_value: String,
+    expected: &TextMetricsProfileDescriptor,
+) -> RenderError {
+    invalid_text_metrics_extension(format!(
+        "{field} {actual} does not match text metrics profile '{}' expected {expected_value}",
+        expected.profile_id
+    ))
 }
 
 fn invalid_text_metrics_extension(message: impl Into<String>) -> RenderError {

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -182,6 +182,55 @@ fn compatibility_text_metrics_extension() -> Value {
     })
 }
 
+fn recorded_routed_mmds_value() -> Value {
+    serde_json::from_str(&render_json_with_level(
+        "graph TD\nA[Alpha] -->|a labeled edge| B[Beta]",
+        GeometryLevel::Routed,
+    ))
+    .unwrap()
+}
+
+fn compat_mmds_value_with_text_metrics_extension() -> Value {
+    let mut value: Value = serde_json::from_str(&styled_mmds_layout_with_label("mmmm")).unwrap();
+    value["profiles"]
+        .as_array_mut()
+        .unwrap()
+        .push(Value::String("mmdflux-text-metrics-v1".to_string()));
+    value["extensions"]["org.mmdflux.text-metrics.v1"] = compatibility_text_metrics_extension();
+    value
+}
+
+fn dynamic_mmds_value_with_text_metrics_extension() -> Value {
+    let mut value = recorded_routed_mmds_value();
+    set_text_metrics_extension_field(
+        &mut value,
+        &["metricsProfile", "id"],
+        json!("browser-test-v1"),
+    );
+    set_text_metrics_extension_field(&mut value, &["metricsProfile", "source"], json!("dynamic"));
+    set_text_metrics_extension_field(
+        &mut value,
+        &["defaultTextStyle", "font-family"],
+        json!("Inter"),
+    );
+    set_text_metrics_extension_field(
+        &mut value,
+        &["defaultTextStyle", "line-height"],
+        json!(24.0),
+    );
+    value
+}
+
+fn set_text_metrics_extension_field(value: &mut Value, path: &[&str], replacement: Value) {
+    let mut cursor = &mut value["extensions"]["org.mmdflux.text-metrics.v1"];
+    for segment in &path[..path.len() - 1] {
+        cursor = cursor
+            .get_mut(*segment)
+            .unwrap_or_else(|| panic!("missing text metrics extension path segment {segment}"));
+    }
+    cursor[path[path.len() - 1]] = replacement;
+}
+
 fn styled_mmds_layout_with_label(label: &str) -> String {
     let mut value: Value = serde_json::from_str(STYLED_MMDS_LAYOUT).unwrap();
     value["edges"][0]["label"] = Value::String(label.to_string());
@@ -603,6 +652,168 @@ fn mmdflux_sans_replay_rejects_mismatched_caller_profile() {
         )),
         "{err}"
     );
+}
+
+#[test]
+fn text_metrics_static_replay_rejects_recorded_source_profile_mismatch() {
+    let mut value = recorded_routed_mmds_value();
+    set_text_metrics_extension_field(
+        &mut value,
+        &["metricsProfile", "source"],
+        json!("heuristic"),
+    );
+    let input = serde_json::to_string(&value).unwrap();
+
+    let err = render_mmds_input_result(&input, OutputFormat::Svg, RenderConfig::default())
+        .expect_err("recorded source/profile mismatch should fail");
+
+    assert!(err.message.contains("metricsProfile.source"), "{err}");
+    assert!(
+        err.message.contains(RECORDED_SANS_TEXT_METRICS_PROFILE_ID),
+        "{err}"
+    );
+    assert!(err.message.contains("recorded"), "{err}");
+}
+
+#[test]
+fn text_metrics_static_replay_rejects_heuristic_source_profile_mismatch() {
+    let mut value = compat_mmds_value_with_text_metrics_extension();
+    set_text_metrics_extension_field(&mut value, &["metricsProfile", "source"], json!("recorded"));
+    let input = serde_json::to_string(&value).unwrap();
+
+    let err = render_mmds_input_result(&input, OutputFormat::Svg, RenderConfig::default())
+        .expect_err("heuristic source/profile mismatch should fail");
+
+    assert!(err.message.contains("metricsProfile.source"), "{err}");
+    assert!(
+        err.message.contains(COMPATIBILITY_TEXT_METRICS_PROFILE_ID),
+        "{err}"
+    );
+    assert!(err.message.contains("heuristic"), "{err}");
+}
+
+#[test]
+fn text_metrics_static_replay_rejects_profile_id_swap_via_source_mismatch() {
+    let mut value = recorded_routed_mmds_value();
+    set_text_metrics_extension_field(
+        &mut value,
+        &["metricsProfile", "id"],
+        json!(COMPATIBILITY_TEXT_METRICS_PROFILE_ID),
+    );
+    let input = serde_json::to_string(&value).unwrap();
+
+    let err = render_mmds_input_result(&input, OutputFormat::Svg, RenderConfig::default())
+        .expect_err("known-but-wrong profile id should fail descriptor validation");
+
+    // The swapped id resolves the compatibility profile, then the persisted
+    // recorded source proves the descriptor is not internally consistent.
+    assert!(err.message.contains("metricsProfile.source"), "{err}");
+    assert!(
+        err.message.contains(COMPATIBILITY_TEXT_METRICS_PROFILE_ID),
+        "{err}"
+    );
+    assert!(err.message.contains("heuristic"), "{err}");
+}
+
+#[test]
+fn text_metrics_static_replay_rejects_profile_version_mismatch() {
+    let mut value = recorded_routed_mmds_value();
+    set_text_metrics_extension_field(&mut value, &["metricsProfile", "version"], json!(2));
+    let input = serde_json::to_string(&value).unwrap();
+
+    let err = render_mmds_input_result(&input, OutputFormat::Svg, RenderConfig::default())
+        .expect_err("profile version mismatch should fail");
+
+    assert!(err.message.contains("metricsProfile.version"), "{err}");
+    assert!(err.message.contains("1"), "{err}");
+}
+
+#[test]
+fn text_metrics_static_replay_rejects_default_text_style_mismatch() {
+    for (field, replacement) in [
+        ("font-family", json!("Inter, sans-serif")),
+        ("font-size", json!(18.0)),
+        ("font-style", json!("italic")),
+        ("font-weight", json!("700")),
+        ("line-height", json!(30.0)),
+    ] {
+        let mut value = recorded_routed_mmds_value();
+        set_text_metrics_extension_field(&mut value, &["defaultTextStyle", field], replacement);
+        let input = serde_json::to_string(&value).unwrap();
+
+        let err = render_mmds_input_result(&input, OutputFormat::Svg, RenderConfig::default())
+            .expect_err("default text style mismatch should fail");
+
+        assert!(
+            err.message.contains(&format!("defaultTextStyle.{field}")),
+            "{err}"
+        );
+    }
+}
+
+#[test]
+fn text_metrics_static_replay_rejects_layout_text_mismatch() {
+    for (field, replacement) in [
+        ("label-padding-x", json!(8.0)),
+        ("label-padding-y", json!(4.0)),
+    ] {
+        let mut value = recorded_routed_mmds_value();
+        set_text_metrics_extension_field(&mut value, &["layoutText", field], replacement);
+        let input = serde_json::to_string(&value).unwrap();
+
+        let err = render_mmds_input_result(&input, OutputFormat::Svg, RenderConfig::default())
+            .expect_err("layout text mismatch should fail");
+
+        assert!(
+            err.message.contains(&format!("layoutText.{field}")),
+            "{err}"
+        );
+    }
+}
+
+#[test]
+fn dynamic_mmds_replay_without_provider_fails_before_remeasurement() {
+    let input = serde_json::to_string(&dynamic_mmds_value_with_text_metrics_extension()).unwrap();
+
+    for format in [OutputFormat::Svg, OutputFormat::Text, OutputFormat::Ascii] {
+        let err = render_mmds_input_result(&input, format, RenderConfig::default())
+            .expect_err("dynamic MMDS replay should require a provider");
+
+        assert!(err.message.contains("dynamic text metrics"), "{err}");
+        assert!(err.message.contains("provider"), "{err}");
+        assert!(err.message.contains("browser-test-v1"), "{err}");
+        assert!(
+            !err.message.contains("unsupported text metrics profile"),
+            "{err}"
+        );
+    }
+}
+
+#[test]
+fn provider_free_mmds_pass_through_preserves_dynamic_text_metrics_extension() {
+    let input = serde_json::to_string(&dynamic_mmds_value_with_text_metrics_extension()).unwrap();
+
+    let output = render_mmds_input(&input, OutputFormat::Mmds, RenderConfig::default());
+    let value: Value = serde_json::from_str(&output).unwrap();
+    let extension = &value["extensions"]["org.mmdflux.text-metrics.v1"];
+
+    assert_eq!(extension["metricsProfile"]["id"], "browser-test-v1");
+    assert_eq!(extension["metricsProfile"]["source"], "dynamic");
+}
+
+#[test]
+fn provider_free_mmds_pass_through_validates_dynamic_text_metrics_shape() {
+    let mut value = dynamic_mmds_value_with_text_metrics_extension();
+    value["extensions"]["org.mmdflux.text-metrics.v1"]
+        .as_object_mut()
+        .unwrap()
+        .remove("layoutText");
+    let input = serde_json::to_string(&value).unwrap();
+
+    let err = render_mmds_input_result(&input, OutputFormat::Mmds, RenderConfig::default())
+        .expect_err("MMDS pass-through should validate text metrics extension shape");
+
+    assert!(err.message.contains("layoutText"), "{err}");
 }
 
 #[test]
@@ -1586,9 +1797,9 @@ fn docs_and_schema_reference_text_metrics_extension_contract() {
     assert!(
         docs.contains("provider-free static profiles do not accept arbitrary custom font style")
     );
-    assert!(docs.contains("experimental browser dynamic metrics export is SVG-only"));
-    assert!(docs.contains("does not emit"));
-    assert!(docs.contains("replay MMDS"));
+    assert!(docs.contains("source = \"dynamic\""));
+    assert!(docs.contains("provider-bound"));
+    assert!(docs.contains("#308"));
     assert!(docs.contains("Sequence-family full text-metrics parity remains deferred"));
     assert!(docs.contains("line-height"));
 
@@ -1618,7 +1829,8 @@ fn docs_describe_graph_font_config_contract() {
         mmds_docs
             .contains("provider-free static profiles do not accept arbitrary custom font style")
     );
-    assert!(mmds_docs.contains("dynamic MMDS replay remains future work"));
+    assert!(mmds_docs.contains("Dynamic MMDS output and"));
+    assert!(mmds_docs.contains("mmdflux-browser-canvas-v1"));
     assert!(mmds_docs.contains("Migrating from Mermaid init"));
 }
 
@@ -1668,8 +1880,10 @@ fn docs_cover_live_style_scope_and_wasm_color_config() {
     assert!(wasm_docs.contains("FontFaceSet"));
     assert!(wasm_docs.contains("does not fall back"));
     assert!(wasm_docs.contains("supports SVG graph-family Mermaid input"));
-    assert!(wasm_docs.contains("not emit"));
-    assert!(wasm_docs.contains("replay MMDS"));
+    assert!(wasm_docs.contains("MMDS output and replay"));
+    assert!(wasm_docs.contains("mmdflux-browser-canvas-v1"));
+    assert!(wasm_docs.contains("provider-bound"));
+    assert!(wasm_docs.contains("#308"));
     assert!(!wasm_docs.contains("currently accepts only"));
 
     let readme = std::fs::read_to_string("README.md").unwrap();

--- a/web/src/browser-text-metrics.test.ts
+++ b/web/src/browser-text-metrics.test.ts
@@ -177,6 +177,10 @@ describe("prepareBrowserTextMetrics", () => {
       fontFamily: "Inter",
       fontSizePx: 16,
       lineHeightPx: 24,
+      profileId: "mmdflux-browser-canvas-v1",
+      profileVersion: 1,
+      fontStyle: "normal",
+      fontWeight: "400",
     });
   });
 
@@ -301,6 +305,12 @@ describe("prepareMainThreadBrowserTextMetrics", () => {
     expect(calls).toEqual(["load", "check"]);
     expect(fonts.load).toHaveBeenCalledWith('normal 400 16px "Inter"');
     expect(fonts.check).toHaveBeenCalledWith('normal 400 16px "Inter"');
+    expect(JSON.parse(prepared.metricsJson)).toMatchObject({
+      profileId: "mmdflux-browser-canvas-v1",
+      profileVersion: 1,
+      fontStyle: "normal",
+      fontWeight: "400",
+    });
     expect(prepared.measureText("Alpha", 'normal 400 16px "Inter"')).toBe(15);
     expect(context.font).toBe('normal 400 16px "Inter"');
   });

--- a/web/src/browser-text-metrics.ts
+++ b/web/src/browser-text-metrics.ts
@@ -6,6 +6,8 @@ export interface BrowserTextMetricsRequest {
   fontWeight?: string;
 }
 
+export const BROWSER_TEXT_METRICS_PROFILE_ID = "mmdflux-browser-canvas-v1";
+
 export interface PreparedBrowserTextMetrics {
   metricsJson: string;
   measureText: (text: string, cssFont: string) => number;
@@ -188,6 +190,10 @@ function preparedMetrics(
       fontFamily: normalizeFontFamily(input.fontFamily),
       fontSizePx: input.fontSizePx,
       lineHeightPx: input.lineHeightPx,
+      profileId: BROWSER_TEXT_METRICS_PROFILE_ID,
+      profileVersion: 1,
+      fontStyle: fontStyleFor(input),
+      fontWeight: fontWeightFor(input),
     }),
     measureText: (text: string, measuredCssFont: string): number => {
       const key = `${measuredCssFont}\0${text}`;
@@ -226,9 +232,15 @@ export function buildCssFont(input: BrowserTextMetricsRequest): string {
   validatePositiveFinite("fontSizePx", input.fontSizePx);
   validatePositiveFinite("lineHeightPx", input.lineHeightPx);
 
-  const fontStyle = input.fontStyle?.trim() || "normal";
-  const fontWeight = input.fontWeight?.trim() || "400";
-  return `${fontStyle} ${fontWeight} ${input.fontSizePx}px ${fontFamily}`;
+  return `${fontStyleFor(input)} ${fontWeightFor(input)} ${input.fontSizePx}px ${fontFamily}`;
+}
+
+function fontStyleFor(input: BrowserTextMetricsRequest): string {
+  return input.fontStyle?.trim() || "normal";
+}
+
+function fontWeightFor(input: BrowserTextMetricsRequest): string {
+  return input.fontWeight?.trim() || "400";
 }
 
 function normalizeFontFamily(fontFamily: string): string {


### PR DESCRIPTION
## Summary

- add provider-bound dynamic MMDS output and replay for the experimental dynamic text metrics path
- extend dynamic metrics input with adapter-owned profile identity (`profileId`, `profileVersion`, style, weight) and persist `metricsProfile.source = "dynamic"` descriptors in MMDS output
- reject provider-free dynamic MMDS replay before measurement, while preserving provider-free MMDS-to-MMDS pass-through when no measurement is needed
- replay provider-bound dynamic MMDS with a matching provider and reject descriptor mismatches across identity, text style, and layout text fields
- update the browser metrics adapter to emit `mmdflux-browser-canvas-v1` and refresh MMDS/Wasm docs and schema wording

Closes #307

## Non-goals

- provider-free measured text dimensions remain deferred to #308
- web render-client dynamic MMDS fallback is not exposed because browser dynamic metrics currently drives SVG rendering only
- sequence/Text/ASCII dynamic metrics remain out of scope
- the Rust-side dynamic bridge remains behind the `unstable-text-metrics-provider` feature and `#[doc(hidden)]`; the stable public Rust API surface is unchanged

## Validation

- `just check` — 3023/3023 default tests passing
- `cargo nextest run --features unstable-text-metrics-provider` — 3056/3056 passing
- `cargo test -p mmdflux-wasm` — 35/35 native tests passing
- `./scripts/run-wasm-browser-tests.sh` — 29/29 browser tests passing
- `cd web && npm run test` — 107/107 passing
- `cd web && npm run build`
- `just wasm-size` — web/bundler both 1,780,261 raw / 615,790 gzip, within budget
  - main baseline: 1,769,544 raw / 611,822 gzip
  - PR delta: +10,717 raw / +3,968 gzip per target
- `cog check origin/main..HEAD`
