### PR TITLE
fix: harden dynamic metrics unsupported surfaces

### DIFF
--- a/crates/mmdflux-wasm/tests/web.rs
+++ b/crates/mmdflux-wasm/tests/web.rs
@@ -186,6 +186,46 @@ fn dynamic_text_metrics_callback_throw_errors() {
 }
 
 #[wasm_bindgen_test]
+fn dynamic_text_metrics_rejects_terminal_formats_before_measurement() {
+    for format in ["text", "ascii"] {
+        let measure = callback("throw new Error('callback should not run');");
+        let err = render_with_browser_text_metrics(
+            "graph TD\nA[Alpha] --> B[Beta]",
+            format,
+            "{}",
+            dynamic_metrics_json_with_profile_fixture(),
+            &measure,
+        )
+        .expect_err("terminal dynamic output should reject");
+
+        let message = error_debug(err);
+        assert!(message.contains(format), "{message}");
+        assert!(message.contains("terminal"), "{message}");
+        assert!(message.contains("unsupported"), "{message}");
+        assert!(!message.contains("callback should not run"), "{message}");
+    }
+}
+
+#[wasm_bindgen_test]
+fn dynamic_text_metrics_rejects_sequence_before_measurement() {
+    let measure = callback("throw new Error('callback should not run');");
+    let err = render_with_browser_text_metrics(
+        "sequenceDiagram\nAlice->>Bob: Hi",
+        "svg",
+        "{}",
+        dynamic_metrics_json_with_profile_fixture(),
+        &measure,
+    )
+    .expect_err("sequence dynamic output should reject");
+
+    let message = error_debug(err);
+    assert!(message.contains("sequence"), "{message}");
+    assert!(message.contains("timeline"), "{message}");
+    assert!(message.contains("unsupported"), "{message}");
+    assert!(!message.contains("callback should not run"), "{message}");
+}
+
+#[wasm_bindgen_test]
 fn dynamic_text_metrics_callback_rejects_non_number_returns() {
     for (body, expected) in [
         ("return Promise.resolve(12);", "synchronous"),

--- a/docs/development/wasm.md
+++ b/docs/development/wasm.md
@@ -164,6 +164,12 @@ when the sidecar is complete. Missing measured queries remain explicit replay
 errors; Text/ASCII, sequence, and relayout after changing constraints are still
 unsupported.
 
+Text and ASCII reject dynamic metrics because browser pixel widths do not map to
+the monospaced terminal grid used by those outputs. Sequence diagrams also
+reject dynamic metrics: they use a separate timeline-family layout path and
+would need a dedicated timeline metrics plan before browser measurement could be
+honestly applied.
+
 ## Tracing and Diagnostics
 
 The wasm adapter depends on the root `mmdflux` crate with

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -431,6 +431,11 @@ Rules:
   a complete `org.mmdflux.text-measurements.v1` sidecar. With that sidecar,
   public `mmdflux::render_diagram` accepts graph-family dynamic MMDS for
   provider-free SVG replay. Text/ASCII replay remains unsupported.
+- provider-free dynamic MMDS replay remains graph-family SVG only. It rejects
+  Text/ASCII output because terminal renderers use a monospaced grid, and it
+  rejects sequence because sequence diagrams use the timeline-family path.
+- provider-bound dynamic MMDS replay rejects Text/ASCII output for the same
+  terminal-grid reason.
 - `org.mmdflux.text-measurements.v1` stores the exact line and scalar width
   queries observed during dynamic rendering. Missing measured queries fail
   replay instead of falling back to `mmdflux-sans-v1`, the compatibility

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -353,6 +353,36 @@ fn validate_positive_finite(field: &str, value: f64) -> Result<(), RenderError> 
     Ok(())
 }
 
+fn unsupported_dynamic_output_format(format: OutputFormat) -> RenderError {
+    let message = match format {
+        OutputFormat::Text | OutputFormat::Ascii => format!(
+            "dynamic text metrics unsupported for {format} output; Text and ASCII are terminal grid outputs and remain static-profile based"
+        ),
+        _ => format!(
+            "dynamic text metrics supports SVG and provider-bound MMDS output (requested {format})"
+        ),
+    };
+
+    RenderError { message }
+}
+
+fn unsupported_dynamic_diagram_family(diagram_id: &str) -> RenderError {
+    RenderError {
+        message: format!(
+            "dynamic text metrics unsupported for {diagram_id}/timeline-family diagrams; sequence requires a separate timeline metrics plan"
+        ),
+    }
+}
+
+fn mmds_input_diagram_type(input: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(input).ok()?;
+    value
+        .get("metadata")
+        .and_then(|metadata| metadata.get("diagram_type"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+}
+
 pub fn render_graph_family_svg_with_dynamic_text_metrics<F>(
     input: &str,
     config: &RenderConfig,
@@ -382,11 +412,7 @@ where
     F: FnMut(&str, &str) -> Result<f64, DynamicTextMetricsError>,
 {
     if !matches!(format, OutputFormat::Svg | OutputFormat::Mmds) {
-        return Err(RenderError {
-            message: format!(
-                "dynamic text metrics supports SVG and provider-bound MMDS output (requested {format})"
-            ),
-        });
+        return Err(unsupported_dynamic_output_format(format));
     }
     if config.layout_engine.is_some() {
         return Err(RenderError {
@@ -430,6 +456,9 @@ where
                 node_padding_y,
                 effective_config.layout.edge_label_max_width,
             )?;
+            if mmds_input_diagram_type(input).as_deref() == Some("sequence") {
+                return Err(unsupported_dynamic_diagram_family("sequence"));
+            }
             let provider = CallbackTextMetricsProvider::with_node_padding(
                 dynamic_input,
                 node_padding_x,
@@ -464,12 +493,7 @@ where
         message: "unknown diagram type".to_string(),
     })?;
     if !matches!(resolved.family(), DiagramFamily::Graph) {
-        return Err(RenderError {
-            message: format!(
-                "dynamic text metrics only supports graph-family Mermaid diagrams (detected {})",
-                resolved.diagram_id()
-            ),
-        });
+        return Err(unsupported_dynamic_diagram_family(resolved.diagram_id()));
     }
     if !resolved.supported_formats().contains(&format) {
         return Err(RenderError {
@@ -548,9 +572,7 @@ where
         Diagram::State(mut graph) => {
             render_graph_family_payload_with_dynamic_metrics("state", &mut graph, &render_context)
         }
-        Diagram::Sequence(_) => Err(RenderError {
-            message: "dynamic text metrics only supports graph-family Mermaid diagrams".to_string(),
-        }),
+        Diagram::Sequence(_) => Err(unsupported_dynamic_diagram_family("sequence")),
     }?;
 
     provider.finish()?;
@@ -612,7 +634,8 @@ mod tests {
     use crate::format::OutputFormat;
     use crate::graph::GeometryLevel;
     use crate::graph::measure::{
-        DEFAULT_GRAPH_FONT_FAMILY, TextMetricsProfileConfig, TextMetricsProvider,
+        COMPATIBILITY_TEXT_METRICS_PROFILE_ID, DEFAULT_GRAPH_FONT_FAMILY,
+        RECORDED_SANS_TEXT_METRICS_PROFILE_ID, TextMetricsProfileConfig, TextMetricsProvider,
         resolve_text_metrics_profile,
     };
     use crate::runtime::config::{GraphTextStyleConfig, RenderConfig};
@@ -1055,23 +1078,79 @@ mod tests {
 
     #[test]
     fn dynamic_svg_bridge_rejects_unsupported_output_formats() {
-        for format in [
-            OutputFormat::Text,
-            OutputFormat::Ascii,
+        let err = render_graph_family_with_dynamic_text_metrics(
+            "graph TD\nA-->B",
             OutputFormat::Mermaid,
-        ] {
+            &RenderConfig::default(),
+            profiled_input("browser-test-v1"),
+            |_text, _css_font| Ok(8.0),
+        )
+        .expect_err("unsupported output format should fail");
+        assert!(
+            err.message
+                .contains("supports SVG and provider-bound MMDS output"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn dynamic_text_metrics_rejects_terminal_formats_before_measurement() {
+        for format in [OutputFormat::Text, OutputFormat::Ascii] {
+            let mut calls = 0;
             let err = render_graph_family_with_dynamic_text_metrics(
-                "graph TD\nA-->B",
+                "graph TD\nA[Alpha] --> B[Beta]",
                 format,
                 &RenderConfig::default(),
                 profiled_input("browser-test-v1"),
-                |_text, _css_font| Ok(8.0),
+                |_text, _css_font| {
+                    calls += 1;
+                    Ok(8.0)
+                },
             )
-            .expect_err("unsupported output format should fail");
-            assert!(
-                err.message
-                    .contains("supports SVG and provider-bound MMDS output"),
-                "{err}"
+            .expect_err("terminal dynamic output should reject");
+
+            assert_eq!(calls, 0, "dynamic callback must not run for {format}");
+            assert!(err.message.contains(&format.to_string()), "{err}");
+            assert!(err.message.contains("terminal"), "{err}");
+            assert!(err.message.contains("unsupported"), "{err}");
+        }
+    }
+
+    #[test]
+    fn static_terminal_output_stays_byte_stable_after_dynamic_render() {
+        let input = "graph TD\nA[Alpha] -->|edge label| B[Beta]";
+
+        for profile in [
+            None,
+            Some(RECORDED_SANS_TEXT_METRICS_PROFILE_ID),
+            Some(COMPATIBILITY_TEXT_METRICS_PROFILE_ID),
+        ] {
+            let config = RenderConfig {
+                font_metrics_profile: profile.map(str::to_string),
+                ..RenderConfig::default()
+            };
+            let text_before =
+                render_diagram(input, OutputFormat::Text, &config).expect("text render before");
+            let ascii_before =
+                render_diagram(input, OutputFormat::Ascii, &config).expect("ascii render before");
+
+            let dynamic_svg = render_graph_family_with_dynamic_text_metrics(
+                input,
+                OutputFormat::Svg,
+                &RenderConfig::default(),
+                profiled_input("browser-test-v1"),
+                |text, _css_font| Ok(text.len() as f64 * 11.0),
+            )
+            .expect("dynamic SVG render should succeed");
+            assert!(dynamic_svg.contains("<svg"), "{dynamic_svg}");
+
+            assert_eq!(
+                render_diagram(input, OutputFormat::Text, &config).expect("text render after"),
+                text_before
+            );
+            assert_eq!(
+                render_diagram(input, OutputFormat::Ascii, &config).expect("ascii render after"),
+                ascii_before
             );
         }
     }
@@ -1372,18 +1451,24 @@ mod tests {
 
     #[test]
     fn dynamic_mmds_output_rejects_sequence_input() {
+        let mut calls = 0;
         let err = render_graph_family_with_dynamic_text_metrics(
             "sequenceDiagram\nAlice->>Bob: Hi",
             OutputFormat::Mmds,
             &RenderConfig::default(),
             profiled_input("browser-test-v1"),
-            |_text, _css_font| Ok(8.0),
+            |_text, _css_font| {
+                calls += 1;
+                Ok(8.0)
+            },
         )
         .expect_err("sequence input should fail");
 
+        assert_eq!(calls, 0, "dynamic callback must not run for sequence");
         assert!(
-            err.message
-                .contains("only supports graph-family Mermaid diagrams"),
+            err.message.contains("sequence")
+                && err.message.contains("timeline")
+                && err.message.contains("unsupported"),
             "{err}"
         );
     }
@@ -1553,17 +1638,54 @@ mod tests {
 
     #[test]
     fn dynamic_svg_bridge_rejects_sequence_input() {
+        let mut calls = 0;
         let err = render_graph_family_svg_with_dynamic_text_metrics(
             "sequenceDiagram\nAlice->>Bob: Hi",
             &RenderConfig::default(),
             valid_input(),
-            |_text, _css_font| Ok(8.0),
+            |_text, _css_font| {
+                calls += 1;
+                Ok(8.0)
+            },
         )
         .expect_err("sequence input should fail");
 
+        assert_eq!(calls, 0, "dynamic callback must not run for sequence");
         assert!(
-            err.message
-                .contains("only supports graph-family Mermaid diagrams"),
+            err.message.contains("sequence")
+                && err.message.contains("timeline")
+                && err.message.contains("unsupported"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn dynamic_mmds_replay_rejects_sequence_input_before_measurement() {
+        let sequence_mmds = render_diagram(
+            "sequenceDiagram\nAlice->>Bob: Hi",
+            OutputFormat::Mmds,
+            &RenderConfig::default(),
+        )
+        .expect("sequence MMDS should render");
+
+        let mut calls = 0;
+        let err = render_graph_family_with_dynamic_text_metrics(
+            &sequence_mmds,
+            OutputFormat::Svg,
+            &RenderConfig::default(),
+            profiled_input("browser-test-v1"),
+            |_text, _css_font| {
+                calls += 1;
+                Ok(8.0)
+            },
+        )
+        .expect_err("sequence MMDS should fail on dynamic replay path");
+
+        assert_eq!(calls, 0, "dynamic callback must not run for sequence MMDS");
+        assert!(
+            err.message.contains("sequence")
+                && err.message.contains("timeline")
+                && err.message.contains("unsupported"),
             "{err}"
         );
     }
@@ -1592,7 +1714,7 @@ mod tests {
         let err = render_graph_family_svg_with_dynamic_text_metrics(
             "graph TD\nA-->B",
             &RenderConfig {
-                font_metrics_profile: Some("mmdflux-sans-v1".to_string()),
+                font_metrics_profile: Some(RECORDED_SANS_TEXT_METRICS_PROFILE_ID.to_string()),
                 ..RenderConfig::default()
             },
             valid_input(),

--- a/src/runtime/payload.rs
+++ b/src/runtime/payload.rs
@@ -32,6 +32,9 @@ pub(in crate::runtime) fn render_payload(
         }
         Diagram::Sequence(model) => match format {
             OutputFormat::Svg => {
+                // Sequence uses the timeline-family compatibility metrics path.
+                // Browser dynamic metrics remain graph-family-only until a
+                // dedicated timeline provider seam exists.
                 let metrics = measure::default_proportional_text_metrics();
                 let font_family = "\"trebuchet ms\", verdana, arial, sans-serif";
                 let theme = super::resolve_configured_svg_theme(config)?;
@@ -43,6 +46,8 @@ pub(in crate::runtime) fn render_payload(
                 ))
             }
             OutputFormat::Mmds => {
+                // Keep sequence MMDS on the same timeline-family compatibility
+                // metrics path as sequence SVG.
                 let metrics = measure::default_proportional_text_metrics();
                 Ok(super::timeline_family::to_json(&model, &metrics))
             }

--- a/tests/compliance_sequence.rs
+++ b/tests/compliance_sequence.rs
@@ -9,6 +9,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use mmdflux::builtins::default_registry;
+use mmdflux::graph::measure::{
+    COMPATIBILITY_TEXT_METRICS_PROFILE_ID, RECORDED_SANS_TEXT_METRICS_PROFILE_ID,
+};
 use mmdflux::{OutputFormat, RenderConfig};
 
 fn sequence_fixture_dir() -> PathBuf {
@@ -42,12 +45,19 @@ fn list_sequence_fixtures() -> Vec<String> {
     fixtures
 }
 
-fn render_sequence_text(fixture: &str) -> String {
+fn read_sequence_fixture(fixture: &str) -> String {
     let path = sequence_fixture_dir().join(fixture);
-    let input = fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Failed to read fixture {fixture}: {e}"));
-    mmdflux::render_diagram(&input, OutputFormat::Text, &RenderConfig::default())
-        .expect("Failed to render sequence fixture")
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read fixture {fixture}: {e}"))
+}
+
+fn render_sequence_text(fixture: &str) -> String {
+    render_sequence_text_with_config(fixture, &RenderConfig::default())
+}
+
+fn render_sequence_text_with_config(fixture: &str, config: &RenderConfig) -> String {
+    let input = read_sequence_fixture(fixture);
+    mmdflux::render_diagram(&input, OutputFormat::Text, config)
+        .expect("Failed to render sequence text fixture")
 }
 
 // --- Text snapshots ---
@@ -114,8 +124,7 @@ fn sequence_all_fixtures_render_text() {
 #[test]
 fn sequence_all_fixtures_render_ascii() {
     for fixture in list_sequence_fixtures() {
-        let path = sequence_fixture_dir().join(&fixture);
-        let input = fs::read_to_string(&path).unwrap();
+        let input = read_sequence_fixture(&fixture);
         let output = mmdflux::render_diagram(&input, OutputFormat::Ascii, &RenderConfig::default())
             .expect("render failed");
         assert!(
@@ -126,11 +135,19 @@ fn sequence_all_fixtures_render_ascii() {
 }
 
 fn render_sequence_svg(fixture: &str) -> String {
-    let path = sequence_fixture_dir().join(fixture);
-    let input = fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("Failed to read fixture {fixture}: {e}"));
-    mmdflux::render_diagram(&input, OutputFormat::Svg, &RenderConfig::default())
+    render_sequence_svg_with_config(fixture, &RenderConfig::default())
+}
+
+fn render_sequence_svg_with_config(fixture: &str, config: &RenderConfig) -> String {
+    let input = read_sequence_fixture(fixture);
+    mmdflux::render_diagram(&input, OutputFormat::Svg, config)
         .expect("Failed to render sequence SVG")
+}
+
+fn render_sequence_mmds_with_config(fixture: &str, config: &RenderConfig) -> String {
+    let input = read_sequence_fixture(fixture);
+    mmdflux::render_diagram(&input, OutputFormat::Mmds, config)
+        .expect("Failed to render sequence MMDS")
 }
 
 fn sequence_svg_snapshot_dir() -> PathBuf {
@@ -182,6 +199,40 @@ fn sequence_all_fixtures_render_svg() {
         assert!(
             output.contains("</svg>"),
             "SVG output should contain closing tag for {fixture}"
+        );
+    }
+}
+
+#[test]
+fn sequence_rendering_ignores_graph_family_font_metrics_profile_contract() {
+    let fixture = "simple.mmd";
+    let default_text = render_sequence_text(fixture);
+    let default_svg = render_sequence_svg(fixture);
+    let default_mmds = render_sequence_mmds_with_config(fixture, &RenderConfig::default());
+
+    for profile in [
+        RECORDED_SANS_TEXT_METRICS_PROFILE_ID,
+        COMPATIBILITY_TEXT_METRICS_PROFILE_ID,
+    ] {
+        let config = RenderConfig {
+            font_metrics_profile: Some(profile.to_string()),
+            ..RenderConfig::default()
+        };
+
+        assert_eq!(
+            render_sequence_text_with_config(fixture, &config),
+            default_text,
+            "sequence Text changed for graph-family profile {profile}"
+        );
+        assert_eq!(
+            render_sequence_svg_with_config(fixture, &config),
+            default_svg,
+            "sequence SVG changed for graph-family profile {profile}"
+        );
+        assert_eq!(
+            render_sequence_mmds_with_config(fixture, &config),
+            default_mmds,
+            "sequence MMDS changed for graph-family profile {profile}"
         );
     }
 }

--- a/tests/integration_full.rs
+++ b/tests/integration_full.rs
@@ -9,7 +9,9 @@ use std::fs;
 use std::path::Path;
 
 use mmdflux::builtins::default_registry;
-use mmdflux::graph::measure::COMPATIBILITY_TEXT_METRICS_PROFILE_ID;
+use mmdflux::graph::measure::{
+    COMPATIBILITY_TEXT_METRICS_PROFILE_ID, RECORDED_SANS_TEXT_METRICS_PROFILE_ID,
+};
 use mmdflux::mmds::generate_mermaid_from_str;
 use mmdflux::{OutputFormat, RenderConfig, render_diagram};
 
@@ -53,6 +55,32 @@ fn font_metrics_explicit_compatibility_profile_matches_default_text_output() {
     .expect("explicit compatibility profile text render should succeed");
 
     assert_eq!(explicit, default);
+}
+
+#[test]
+fn font_metrics_profiles_do_not_change_terminal_output() {
+    let input = "graph TD\nA[Collect metrics] -->|edge label| B[Render output]";
+    let default_text = render_diagram(input, OutputFormat::Text, &RenderConfig::default())
+        .expect("default text render should succeed");
+    let default_ascii = render_diagram(input, OutputFormat::Ascii, &RenderConfig::default())
+        .expect("default ascii render should succeed");
+
+    for profile in [
+        COMPATIBILITY_TEXT_METRICS_PROFILE_ID,
+        RECORDED_SANS_TEXT_METRICS_PROFILE_ID,
+    ] {
+        let config = RenderConfig {
+            font_metrics_profile: Some(profile.to_string()),
+            ..RenderConfig::default()
+        };
+        let text = render_diagram(input, OutputFormat::Text, &config)
+            .expect("profile-selected text render should succeed");
+        let ascii = render_diagram(input, OutputFormat::Ascii, &config)
+            .expect("profile-selected ascii render should succeed");
+
+        assert_eq!(text, default_text, "Text output changed for {profile}");
+        assert_eq!(ascii, default_ascii, "ASCII output changed for {profile}");
+    }
 }
 
 fn render_flowchart_svg(input: &str) -> String {

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -2042,6 +2042,19 @@ fn docs_cover_live_style_scope_and_wasm_color_config() {
 }
 
 #[test]
+fn docs_describe_dynamic_metrics_unsupported_surfaces() {
+    let wasm_docs = std::fs::read_to_string("docs/development/wasm.md").unwrap();
+    assert!(wasm_docs.contains("Text and ASCII reject dynamic metrics"));
+    assert!(wasm_docs.contains("terminal grid"));
+    assert!(wasm_docs.contains("sequence"));
+    assert!(wasm_docs.contains("timeline-family"));
+
+    let mmds_docs = std::fs::read_to_string("docs/mmds.md").unwrap();
+    assert!(mmds_docs.contains("provider-free dynamic MMDS replay remains graph-family SVG only"));
+    assert!(mmds_docs.contains("provider-bound dynamic MMDS replay rejects Text/ASCII output"));
+}
+
+#[test]
 fn mmds_docs_point_to_fixture_backed_examples_and_rust_replay_example() {
     let docs = std::fs::read_to_string("docs/mmds.md").unwrap();
 


### PR DESCRIPTION
## Summary

- reject dynamic text metrics for Text and ASCII before invoking measurement callbacks, with terminal-grid-specific errors
- reject sequence and sequence MMDS dynamic metrics before provider construction, keeping sequence on the timeline-family compatibility path
- pin terminal output and sequence Text/SVG/MMDS byte stability across explicit graph-family profile selection
- document the unsupported dynamic metrics support matrix in Wasm and MMDS docs

Closes #314

## Contract changes

- `renderWithBrowserTextMetrics` now guarantees the measurement callback is not invoked when the output format or diagram family is unsupported. Unsupported surfaces fail before provider construction instead of partially setting up dynamic measurement and returning a generic graph-family error.

## Non-goals

- no dynamic browser metrics for Text, ASCII, or sequence; these remain unsupported by design
- no terminal-grid projection for proportional browser widths
- no sequence provider seam in `src/render/timeline/svg_layout.rs`
- no public exposure of `TextMetricsProvider`
- no fallback from requested dynamic metrics to recorded/static profiles

## Validation

- `cargo nextest run --features unstable-text-metrics-provider -E 'test(dynamic_text_metrics)'` — 51/51 passing
- `cargo nextest run --features unstable-text-metrics-provider --no-fail-fast` — 3093/3093 passing
- `cargo test -p mmdflux-wasm` — 35/35 passing
- `just wasm-test` — 32/32 browser tests passing
- `cargo nextest run --test compliance_sequence -E 'test(sequence_text_snapshots) or test(sequence_svg_snapshots) or test(sequence_all_fixtures_render_ascii) or test(sequence_rendering_deterministic) or test(sequence_rendering_ignores_graph_family_font_metrics_profile_contract)'` — 5/5 passing
- `cargo nextest run --test mmds_json -E 'test(dynamic_mmds) or test(text_measurements) or test(sequence_mmds) or test(font_config) or test(browser_text_metrics) or test(docs_describe_dynamic_metrics_unsupported_surfaces)'` — 20/20 passing
- `just check` — 3044/3044 default tests passing
- `just architecture-check`
