### PR TITLE
feat: add style-aware dynamic graph fonts

### DIFF
--- a/crates/mmdflux-wasm/src/lib.rs
+++ b/crates/mmdflux-wasm/src/lib.rs
@@ -235,17 +235,23 @@ mod tests {
         let _version: fn() -> String = version;
     }
 
+    const STRICT_DYNAMIC_METRICS_JSON: &str = r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}]}"#;
+
     #[test]
     fn parse_dynamic_metrics_input_accepts_strict_contract() {
-        let input = parse_dynamic_metrics_input(
-            r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24}"#,
-        )
-        .expect("dynamic metrics input should parse");
+        let input = parse_dynamic_metrics_input(STRICT_DYNAMIC_METRICS_JSON)
+            .expect("dynamic metrics input should parse");
 
-        assert_eq!(input.css_font, "16px Inter");
-        assert_eq!(input.font_family, "Inter");
-        assert_eq!(input.font_size_px, 16.0);
-        assert_eq!(input.line_height_px, 24.0);
+        assert_eq!(input.default_style, "s0");
+        assert_eq!(input.text_styles.len(), 1);
+        let style = &input.text_styles[0];
+        assert_eq!(style.id, "s0");
+        assert_eq!(style.css_font, "16px Inter");
+        assert_eq!(style.font_family, "Inter");
+        assert_eq!(style.font_size, 16.0);
+        assert_eq!(style.font_style, "normal");
+        assert_eq!(style.font_weight, "400");
+        assert_eq!(style.line_height, 24.0);
     }
 
     #[test]
@@ -257,7 +263,7 @@ mod tests {
     #[test]
     fn parse_dynamic_metrics_input_rejects_unknown_fields() {
         let err = parse_dynamic_metrics_input(
-            r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"extra":true}"#,
+            r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}],"extra":true}"#,
         )
         .expect_err("unknown field should fail");
         assert!(err.message.contains("unknown field"), "{err}");
@@ -268,20 +274,20 @@ mod tests {
     fn parse_dynamic_metrics_input_validates_required_fields() {
         for (field, json) in [
             (
-                "cssFont",
-                r#"{"cssFont":"","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24}"#,
+                "textStyles.cssFont",
+                r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":""}]}"#,
             ),
             (
-                "fontFamily",
-                r#"{"cssFont":"16px Inter","fontFamily":"","fontSizePx":16,"lineHeightPx":24}"#,
+                "textStyles.fontFamily",
+                r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}]}"#,
             ),
             (
-                "fontSizePx",
-                r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":0,"lineHeightPx":24}"#,
+                "textStyles.fontSize",
+                r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":0,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}]}"#,
             ),
             (
-                "lineHeightPx",
-                r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":-1}"#,
+                "textStyles.lineHeight",
+                r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":-1,"cssFont":"16px Inter"}]}"#,
             ),
         ] {
             let err = parse_dynamic_metrics_input(json).expect_err("invalid field should fail");

--- a/crates/mmdflux-wasm/tests/web.rs
+++ b/crates/mmdflux-wasm/tests/web.rs
@@ -30,11 +30,11 @@ fn strip_ansi(input: &str) -> String {
 }
 
 fn dynamic_metrics_json_fixture() -> &'static str {
-    r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24}"#
+    r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}]}"#
 }
 
 fn dynamic_metrics_json_with_profile_fixture() -> &'static str {
-    r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"profileId":"mmdflux-browser-canvas-v1"}"#
+    r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}],"profileId":"mmdflux-browser-canvas-v1"}"#
 }
 
 fn dynamic_metrics_json_with_profile_fields(
@@ -47,7 +47,7 @@ fn dynamic_metrics_json_with_profile_fields(
     font_weight: &str,
 ) -> String {
     format!(
-        r#"{{"cssFont":"{font_size_px}px {font_family}","fontFamily":"{font_family}","fontSizePx":{font_size_px},"lineHeightPx":{line_height_px},"profileId":"{profile_id}","profileVersion":{profile_version},"fontStyle":"{font_style}","fontWeight":"{font_weight}"}}"#
+        r#"{{"defaultStyle":"s0","textStyles":[{{"id":"s0","fontFamily":"{font_family}","fontSize":{font_size_px},"fontStyle":"{font_style}","fontWeight":"{font_weight}","lineHeight":{line_height_px},"cssFont":"{font_style} {font_weight} {font_size_px}px {font_family}"}}],"profileId":"{profile_id}","profileVersion":{profile_version}}}"#
     )
 }
 

--- a/crates/mmdflux-wasm/tests/web.rs
+++ b/crates/mmdflux-wasm/tests/web.rs
@@ -37,6 +37,10 @@ fn dynamic_metrics_json_with_profile_fixture() -> &'static str {
     r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}],"profileId":"mmdflux-browser-canvas-v1"}"#
 }
 
+fn dynamic_multi_style_metrics_json_fixture() -> &'static str {
+    r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"},{"id":"s1","fontFamily":"Verdana","fontSize":8,"fontStyle":"normal","fontWeight":"400","lineHeight":12,"cssFont":"8px Verdana"}],"profileId":"mmdflux-browser-canvas-v1"}"#
+}
+
 fn dynamic_metrics_json_with_profile_fields(
     profile_id: &str,
     profile_version: u32,
@@ -103,6 +107,38 @@ fn dynamic_text_metrics_callback_changes_svg_geometry() {
     assert_ne!(dynamic_output, static_output);
     assert!(dynamic_output.contains("<svg"));
     assert!(dynamic_output.contains("width=\"108.00\""));
+}
+
+#[wasm_bindgen_test]
+fn render_with_browser_text_metrics_passes_per_style_css_font() {
+    let calls = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+    let calls_for_callback = calls.clone();
+    let closure = wasm_bindgen::closure::Closure::<dyn FnMut(String, String) -> f64>::new(
+        move |text: String, css_font: String| {
+            if text == "Same" {
+                calls_for_callback.borrow_mut().push(css_font.clone());
+            }
+            if css_font.contains("Verdana") {
+                text.len() as f64 * 6.0
+            } else {
+                text.len() as f64 * 10.0
+            }
+        },
+    );
+    let measure = closure.as_ref().unchecked_ref::<js_sys::Function>();
+    let output = render_with_browser_text_metrics(
+        "graph TD\nA[Same] --> B[Same]\nstyle B font-family:Verdana,font-size:8px",
+        "svg",
+        "{}",
+        dynamic_multi_style_metrics_json_fixture(),
+        measure,
+    )
+    .expect("dynamic multi-style svg should render");
+
+    assert!(output.contains("<svg"));
+    let calls = calls.borrow();
+    assert!(calls.iter().any(|font| font == "16px Inter"), "{calls:?}");
+    assert!(calls.iter().any(|font| font == "8px Verdana"), "{calls:?}");
 }
 
 #[wasm_bindgen_test]

--- a/crates/mmdflux-wasm/tests/web.rs
+++ b/crates/mmdflux-wasm/tests/web.rs
@@ -41,6 +41,10 @@ fn dynamic_multi_style_metrics_json_fixture() -> &'static str {
     r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"},{"id":"s1","fontFamily":"Verdana","fontSize":8,"fontStyle":"normal","fontWeight":"400","lineHeight":12,"cssFont":"8px Verdana"}],"profileId":"mmdflux-browser-canvas-v1"}"#
 }
 
+fn dynamic_mermaid_multi_font_metrics_json_fixture() -> &'static str {
+    r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"},{"id":"s1","fontFamily":"Verdana","fontSize":8,"fontStyle":"normal","fontWeight":"400","lineHeight":12,"cssFont":"8px Verdana"},{"id":"s2","fontFamily":"Courier New","fontSize":20,"fontStyle":"normal","fontWeight":"400","lineHeight":30,"cssFont":"20px Courier New"},{"id":"s3","fontFamily":"Times New Roman","fontSize":32,"fontStyle":"normal","fontWeight":"400","lineHeight":48,"cssFont":"32px Times New Roman"}],"profileId":"mmdflux-browser-canvas-v1"}"#
+}
+
 fn dynamic_metrics_json_with_profile_fields(
     profile_id: &str,
     profile_version: u32,
@@ -445,6 +449,47 @@ fn browser_dynamic_mmds_replays_provider_free_through_static_render() {
         &measure,
     )
     .expect("dynamic mmds should render");
+
+    let replay_svg =
+        render(&mmds, "svg", config).expect("static render should replay measured dynamic MMDS");
+
+    assert_eq!(replay_svg, direct_svg);
+}
+
+#[wasm_bindgen_test]
+fn browser_dynamic_multifont_mmds_replays_provider_free_through_static_render() {
+    let measure = callback(
+        r#"
+        if (cssFont.includes("Times New Roman")) return text.length * 30;
+        if (cssFont.includes("Courier New")) return text.length * 15;
+        if (cssFont.includes("Verdana")) return text.length * 4;
+        return text.length * 8;
+        "#,
+    );
+    let input = include_str!("../../../tests/fixtures/flowchart/dynamic/multi_font_styles.mmd");
+    let config = r#"{"geometryLevel":"routed"}"#;
+    let direct_svg = render_with_browser_text_metrics(
+        input,
+        "svg",
+        config,
+        dynamic_mermaid_multi_font_metrics_json_fixture(),
+        &measure,
+    )
+    .expect("direct dynamic multi-font svg should render");
+    let mmds = render_with_browser_text_metrics(
+        input,
+        "mmds",
+        config,
+        dynamic_mermaid_multi_font_metrics_json_fixture(),
+        &measure,
+    )
+    .expect("dynamic multi-font mmds should render");
+
+    assert!(direct_svg.contains("font-family=\"Verdana\""));
+    assert!(direct_svg.contains("font-family=\"Courier New\""));
+    assert!(direct_svg.contains("font-family=\"Times New Roman\""));
+    assert!(mmds.contains("\"textStyles\""));
+    assert!(mmds.contains("\"Times New Roman\""));
 
     let replay_svg =
         render(&mmds, "svg", config).expect("static render should replay measured dynamic MMDS");

--- a/docs/development/wasm.md
+++ b/docs/development/wasm.md
@@ -121,10 +121,29 @@ diagrams are rejected instead of silently falling back to a static profile.
 
 ```json
 {
-  "cssFont": "normal 400 16px \"Inter\"",
-  "fontFamily": "Inter",
-  "fontSizePx": 16,
-  "lineHeightPx": 24
+  "profileId": "mmdflux-browser-canvas-v1",
+  "profileVersion": 1,
+  "defaultStyle": "s0",
+  "textStyles": [
+    {
+      "id": "s0",
+      "fontFamily": "Verdana",
+      "fontSize": 8,
+      "fontStyle": "normal",
+      "fontWeight": "400",
+      "lineHeight": 12,
+      "cssFont": "normal 400 8px Verdana"
+    },
+    {
+      "id": "s1",
+      "fontFamily": "Times New Roman",
+      "fontSize": 32,
+      "fontStyle": "normal",
+      "fontWeight": "400",
+      "lineHeight": 48,
+      "cssFont": "normal 400 32px Times New Roman"
+    }
+  ]
 }
 ```
 
@@ -134,8 +153,8 @@ are rejected on this export even when they match `metricsJson`.
 
 The JavaScript adapter must complete async font preflight before Rust layout
 starts. Both browser modes call `load(cssFont)`, await `ready`, and then use a
-post-load `check(cssFont)` validity gate before invoking Rust. `check()` alone
-is not proof that a requested font loaded.
+post-load `check(cssFont)` validity gate for every entry in `textStyles` before
+invoking Rust. `check()` alone is not proof that a requested font loaded.
 
 | Mode | Required browser capabilities | Notes |
 | ---- | ----------------------------- | ----- |
@@ -156,12 +175,16 @@ fail the render.
 The dynamic path does not fall back to `mmdflux-sans-v1` or
 `mmdflux-heuristic-proportional-v1` after a measurement failure. For dynamic
 MMDS output and provider-bound replay, `metricsJson` carries provider identity
-(`profileId = "mmdflux-browser-canvas-v1"`, `profileVersion = 1`, font style,
-font weight, and line height). Dynamic MMDS output includes
-`org.mmdflux.text-measurements.v1`, a measured-query sidecar that lets the
-static `render` export replay graph-family dynamic MMDS to SVG provider-free
-when the sidecar is complete. Missing measured queries remain explicit replay
-errors; Text/ASCII, sequence, and relayout after changing constraints are still
+(`profileId = "mmdflux-browser-canvas-v1"`, `profileVersion = 1`) plus a
+style set. Each style supplies `fontFamily`, `fontSize`, `fontStyle`,
+`fontWeight`, `lineHeight`, and `cssFont`; the browser callback receives the
+CSS font for each measured text query. Dynamic MMDS output includes
+`org.mmdflux.text-measurements.v1`, a measured-query sidecar keyed by
+`textStyles`, `lineWidths`, and `scalarWidths`. That sidecar lets the static
+`render` export replay graph-family dynamic MMDS to SVG provider-free when it
+is complete; this is the static `render` export replay path for dynamic MMDS.
+Missing measured queries remain explicit replay errors;
+Text/ASCII, sequence, and relayout after changing constraints are still
 unsupported.
 
 Text and ASCII reject dynamic metrics because browser pixel widths do not map to

--- a/docs/development/wasm.md
+++ b/docs/development/wasm.md
@@ -151,6 +151,14 @@ diagrams are rejected instead of silently falling back to a static profile.
 `configJson.fontFamily`, `configJson.fontSize`, and `configJson.themeVariables`
 are rejected on this export even when they match `metricsJson`.
 
+Mermaid graph styles can override `font-family`, `font-size`, `font-style`, and
+`font-weight`, but they do not carry a per-element line-height. mmdflux derives a
+styled element's line-height from the default style's line-height ratio. For
+example, a default style of `fontSize = 16` and `lineHeight = 24` gives an 8-px
+Mermaid-styled label a required `lineHeight = 12` entry in `metricsJson`.
+Supplying the same font identity with a different `lineHeight` is rejected so
+layout and replay stay keyed to the same measured style.
+
 The JavaScript adapter must complete async font preflight before Rust layout
 starts. Both browser modes call `load(cssFont)`, await `ready`, and then use a
 post-load `check(cssFont)` validity gate for every entry in `textStyles` before

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -333,7 +333,8 @@ MMDS keeps core graph semantics compact while allowing renderer- or adapter-spec
 
 ### Node Style Extension
 
-When at least one node carries a non-empty internal `NodeStyle`, mmdflux emits:
+When at least one node or edge label carries a non-empty internal style,
+mmdflux emits:
 
 - profile: `mmdflux-node-style-v1`
 - extension namespace: `org.mmdflux.node-style.v1`
@@ -351,6 +352,14 @@ Payload shape:
           "stroke": "#333",
           "color": "#111"
         }
+      },
+      "edges": {
+        "e0": {
+          "font-family": "Times New Roman",
+          "font-size": "32px",
+          "font-style": "normal",
+          "font-weight": "400"
+        }
       }
     }
   }
@@ -359,9 +368,13 @@ Payload shape:
 
 Rules:
 
-- Omit the profile and extension entirely when no node styles are present.
+- Omit the profile and extension entirely when no node or edge-label styles are
+  present.
 - `fill`, `stroke`, and `color` preserve the raw Mermaid/MMDS color token.
-- MMDS input hydration replays this extension back into internal node styles for text and SVG rendering.
+- Edge-label entries are keyed by MMDS edge id and preserve Mermaid `linkStyle`
+  font tokens for SVG rendering and dynamic text measurement replay.
+- MMDS input hydration replays this extension back into internal node and edge
+  label styles for text and SVG rendering.
 - Mermaid generation from MMDS style extensions is still deferred.
 
 ### Text Metrics Extension
@@ -451,6 +464,82 @@ Rules:
 - Older MMDS documents without the extension replay with the `mmdflux-heuristic-proportional-v1` compatibility defaults.
 - A recognized text metrics extension with an unsupported `metricsProfile.id` is a replay error.
 - Sequence-family full text-metrics parity remains deferred.
+
+## Style-keyed dynamic text measurements
+
+Dynamic graph-family rendering can persist provider-free replay data in
+`org.mmdflux.text-measurements.v1`. The sidecar is a query cache, not a font
+registry: it records the exact measured widths the dynamic provider observed
+for each `(style, text)` line query and each `(style, scalar)` character query.
+
+Payload shape:
+
+```json
+{
+  "extensions": {
+    "org.mmdflux.text-measurements.v1": {
+      "profileRef": {
+        "id": "mmdflux-browser-canvas-v1",
+        "source": "dynamic",
+        "version": 1
+      },
+      "textStyles": [
+        {
+          "id": "s0",
+          "fontFamily": "Verdana",
+          "fontSize": 8,
+          "fontStyle": "normal",
+          "fontWeight": "400",
+          "lineHeight": 12,
+          "cssFont": "normal 400 8px Verdana"
+        },
+        {
+          "id": "s1",
+          "fontFamily": "Times New Roman",
+          "fontSize": 32,
+          "fontStyle": "normal",
+          "fontWeight": "400",
+          "lineHeight": 48,
+          "cssFont": "normal 400 32px Times New Roman"
+        }
+      ],
+      "lineWidths": [
+        { "style": "s0", "text": "Regular", "width": 31.5 },
+        { "style": "s1", "text": "link", "width": 52.25 }
+      ],
+      "scalarWidths": [
+        { "style": "s0", "text": "R", "width": 5.75 },
+        { "style": "s1", "text": "k", "width": 15.5 }
+      ]
+    }
+  }
+}
+```
+
+Rules:
+
+- `profileRef` must match the sibling `org.mmdflux.text-metrics.v1`
+  `metricsProfile`; dynamic measurement sidecars are valid only for
+  `source = "dynamic"`.
+- `textStyles` defines the style ids referenced by `lineWidths` and
+  `scalarWidths`. Descriptor keys are camelCase: `fontFamily`, `fontSize`,
+  `fontStyle`, `fontWeight`, `lineHeight`, and `cssFont`.
+- `lineWidths` entries require a style id, exact line text, and a finite
+  non-negative width.
+- `scalarWidths` entries require a style id, exact text containing one Unicode
+  scalar value, and a finite non-negative width. No Unicode normalization is
+  performed; cache keys are exact strings as observed by the renderer.
+- Missing measured queries fail replay instead of falling back to static
+  profiles or browser remeasurement.
+- Text/ASCII and sequence remain unsupported for dynamic metrics. Text and
+  ASCII use terminal-grid projection; sequence uses the timeline-family layout
+  path.
+- Playground controls for editing these Mermaid-compatible font styles are
+  deferred to #323. The current contract is core plumbing and replay data, not
+  UI exposure.
+- MMDS document size grows with the number of unique `(style, text)` and
+  `(style, scalar)` queries. Typical diagrams add a small sidecar; diagrams
+  with many unique labels and many distinct font styles can add more.
 
 ### Graph Font Config And Mermaid Init
 

--- a/docs/mmds.schema.json
+++ b/docs/mmds.schema.json
@@ -403,7 +403,6 @@
     },
     "NodeStyleExtension": {
       "type": "object",
-      "required": ["nodes"],
       "properties": {
         "nodes": {
           "type": "object",
@@ -411,8 +410,17 @@
           "additionalProperties": {
             "$ref": "#/$defs/NodeStyle"
           }
+        },
+        "edges": {
+          "type": "object",
+          "description": "Edge-ID keyed style overrides replayed into renderer-visible edge label font properties.",
+          "additionalProperties": {
+            "$ref": "#/$defs/EdgeLabelStyle"
+          }
         }
-      }
+      },
+      "anyOf": [{ "required": ["nodes"] }, { "required": ["edges"] }],
+      "additionalProperties": false
     },
     "TextMetricsExtension": {
       "type": "object",
@@ -441,6 +449,7 @@
         "textStyles": {
           "type": "array",
           "minItems": 1,
+          "uniqueItems": true,
           "items": {
             "$ref": "#/$defs/TextMeasurementTextStyle"
           },
@@ -522,6 +531,37 @@
           "type": "string",
           "minLength": 1,
           "description": "Canonical CSS font shorthand measured by the dynamic provider."
+        }
+      },
+      "additionalProperties": false
+    },
+    "EdgeLabelStyle": {
+      "type": "object",
+      "properties": {
+        "stroke-width": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Raw Mermaid linkStyle stroke-width token."
+        },
+        "font-family": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Raw Mermaid linkStyle font-family token for the edge label."
+        },
+        "font-size": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Raw Mermaid linkStyle font-size token for the edge label."
+        },
+        "font-style": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Raw Mermaid linkStyle font-style token for the edge label."
+        },
+        "font-weight": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Raw Mermaid linkStyle font-weight token for the edge label."
         }
       },
       "additionalProperties": false

--- a/docs/mmds.schema.json
+++ b/docs/mmds.schema.json
@@ -433,10 +433,18 @@
     },
     "TextMeasurementsExtension": {
       "type": "object",
-      "required": ["profileRef", "lineWidths", "scalarWidths"],
+      "required": ["profileRef", "textStyles", "lineWidths", "scalarWidths"],
       "properties": {
         "profileRef": {
           "$ref": "#/$defs/TextMeasurementsProfileRef"
+        },
+        "textStyles": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/TextMeasurementTextStyle"
+          },
+          "description": "Dynamic text style identities used by measurement cache entries."
         },
         "lineWidths": {
           "type": "array",
@@ -476,10 +484,57 @@
       },
       "additionalProperties": false
     },
+    "TextMeasurementTextStyle": {
+      "type": "object",
+      "required": ["id", "fontFamily", "fontSize", "fontStyle", "fontWeight", "lineHeight", "cssFont"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Style id referenced by lineWidths and scalarWidths entries."
+        },
+        "fontFamily": {
+          "type": "string",
+          "minLength": 1,
+          "description": "CSS font-family identity for this text style."
+        },
+        "fontSize": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Font size in pixels for this text style."
+        },
+        "fontStyle": {
+          "type": "string",
+          "minLength": 1,
+          "description": "CSS font-style identity for this text style."
+        },
+        "fontWeight": {
+          "type": "string",
+          "minLength": 1,
+          "description": "CSS font-weight identity for this text style."
+        },
+        "lineHeight": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Line height in pixels for this text style."
+        },
+        "cssFont": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Canonical CSS font shorthand measured by the dynamic provider."
+        }
+      },
+      "additionalProperties": false
+    },
     "TextMeasurementLineWidth": {
       "type": "object",
-      "required": ["text", "width"],
+      "required": ["style", "text", "width"],
       "properties": {
+        "style": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Style id from textStyles for this measured line query."
+        },
         "text": {
           "type": "string",
           "description": "Exact text passed to measure_line_width."
@@ -494,8 +549,13 @@
     },
     "TextMeasurementScalarWidth": {
       "type": "object",
-      "required": ["text", "width"],
+      "required": ["style", "text", "width"],
       "properties": {
+        "style": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Style id from textStyles for this measured scalar query."
+        },
         "text": {
           "type": "string",
           "minLength": 1,
@@ -621,6 +681,14 @@
         "color": {
           "type": "string",
           "description": "Raw color token for node label text."
+        },
+        "font-family": {
+          "type": "string",
+          "description": "CSS font-family value for node label text."
+        },
+        "font-size": {
+          "type": "string",
+          "description": "CSS font-size value for node label text."
         },
         "font-style": {
           "type": "string",

--- a/src/diagrams/flowchart/compiler.rs
+++ b/src/diagrams/flowchart/compiler.rs
@@ -1292,6 +1292,74 @@ mod tests {
     }
 
     #[test]
+    fn compiler_resolves_distinct_node_and_edge_label_font_styles() {
+        let input = r#"graph TD
+            A[Regular] -->|link| B(Styled Node)
+            style A font-family:Verdana,font-size:8px
+            style B font-family:Courier New,font-size:20px
+            linkStyle 0 font-family:Times New Roman,font-size:32px
+        "#;
+
+        let flowchart = parse_flowchart(input).unwrap();
+        let graph = compile_to_graph(&flowchart);
+        let a = graph.nodes.get("A").unwrap();
+        let b = graph.nodes.get("B").unwrap();
+        let edge = &graph.edges[0];
+
+        assert_eq!(a.style.font_family.as_deref(), Some("Verdana"));
+        assert_eq!(a.style.font_size.as_deref(), Some("8px"));
+        assert_eq!(b.style.font_family.as_deref(), Some("Courier New"));
+        assert_eq!(b.style.font_size.as_deref(), Some("20px"));
+        assert_eq!(edge.style.font_family.as_deref(), Some("Times New Roman"));
+        assert_eq!(edge.style.font_size.as_deref(), Some("32px"));
+    }
+
+    #[test]
+    fn classdef_font_properties_apply_and_direct_style_overrides_property_by_property() {
+        let input = r#"graph TD
+            classDef default font-family:Arial,font-size:16px,font-style:normal,font-weight:400
+            classDef compact font-family:Verdana,font-size:8px,font-style:italic,font-weight:700
+            A:::compact --> B
+            class B compact
+            style A font-size:12px,font-weight:500
+        "#;
+
+        let flowchart = parse_flowchart(input).unwrap();
+        let graph = compile_to_graph(&flowchart);
+        let a = graph.nodes.get("A").unwrap();
+        let b = graph.nodes.get("B").unwrap();
+
+        assert_eq!(a.style.font_family.as_deref(), Some("Verdana"));
+        assert_eq!(a.style.font_size.as_deref(), Some("12px"));
+        assert_eq!(a.style.font_style.as_deref(), Some("italic"));
+        assert_eq!(a.style.font_weight.as_deref(), Some("500"));
+        assert_eq!(b.style.font_family.as_deref(), Some("Verdana"));
+        assert_eq!(b.style.font_size.as_deref(), Some("8px"));
+        assert_eq!(b.style.font_style.as_deref(), Some("italic"));
+        assert_eq!(b.style.font_weight.as_deref(), Some("700"));
+    }
+
+    #[test]
+    fn classdef_default_font_properties_apply_to_unclassified_nodes() {
+        let flowchart = parse_flowchart(
+            "graph TD\nclassDef default font-family:Arial,font-size:16px\nA --> B:::custom\nclassDef custom font-family:Verdana\n",
+        )
+        .unwrap();
+        let diagram = compile_to_graph(&flowchart);
+
+        assert_eq!(
+            diagram.nodes["A"].style.font_family.as_deref(),
+            Some("Arial")
+        );
+        assert_eq!(diagram.nodes["A"].style.font_size.as_deref(), Some("16px"));
+        assert_eq!(
+            diagram.nodes["B"].style.font_family.as_deref(),
+            Some("Verdana")
+        );
+        assert_eq!(diagram.nodes["B"].style.font_size.as_deref(), None);
+    }
+
+    #[test]
     fn classdef_multi_class_names() {
         let flowchart =
             parse_flowchart("graph TD\nclassDef a,b fill:#f00\nA:::a --> B:::b --> C\n").unwrap();
@@ -1326,6 +1394,24 @@ mod tests {
             "#0f0"
         );
         assert_eq!(diagram.edges[1].style.stroke_width.as_deref(), Some("2px"));
+    }
+
+    #[test]
+    fn linkstyle_default_and_index_font_styles_merge_property_by_property() {
+        let flowchart = parse_flowchart(
+            "graph TD\nA -->|first| B\nB -->|second| C\nlinkStyle default font-family:Arial,font-size:16px,font-style:normal,font-weight:400\nlinkStyle 1 font-size:24px,font-weight:700\n",
+        )
+        .unwrap();
+        let diagram = compile_to_graph(&flowchart);
+
+        assert_eq!(diagram.edges[0].style.font_family.as_deref(), Some("Arial"));
+        assert_eq!(diagram.edges[0].style.font_size.as_deref(), Some("16px"));
+        assert_eq!(diagram.edges[0].style.font_style.as_deref(), Some("normal"));
+        assert_eq!(diagram.edges[0].style.font_weight.as_deref(), Some("400"));
+        assert_eq!(diagram.edges[1].style.font_family.as_deref(), Some("Arial"));
+        assert_eq!(diagram.edges[1].style.font_size.as_deref(), Some("24px"));
+        assert_eq!(diagram.edges[1].style.font_style.as_deref(), Some("normal"));
+        assert_eq!(diagram.edges[1].style.font_weight.as_deref(), Some("700"));
     }
 
     fn compile_fixture_diagram(name: &str) -> Graph {

--- a/src/diagrams/flowchart/validation.rs
+++ b/src/diagrams/flowchart/validation.rs
@@ -247,10 +247,10 @@ mod tests {
 
     #[test]
     fn classdef_unsupported_property_warned() {
-        let input = "graph TD\n  classDef foo fill:#f00,font-size:14px\n  A:::foo\n";
+        let input = "graph TD\n  classDef foo fill:#f00,shape-padding:14px\n  A:::foo\n";
         let warnings = collect_unsupported_warnings(input);
         assert!(
-            warnings.iter().any(|w| w.message.contains("font-size")),
+            warnings.iter().any(|w| w.message.contains("shape-padding")),
             "unsupported property in classDef should warn: {:?}",
             warnings
         );

--- a/src/engines/graph/algorithms/layered/float_layout.rs
+++ b/src/engines/graph/algorithms/layered/float_layout.rs
@@ -13,8 +13,9 @@ use crate::graph::direction_policy::build_node_directions;
 use crate::graph::geometry::{GraphGeometry, RoutedEdgeGeometry};
 use crate::graph::grid::GridLayoutConfig;
 use crate::graph::measure::{
-    TextMetricsProvider, edge_label_dimensions_for_provider,
-    edge_label_dimensions_wrapped_for_provider, proportional_node_dimensions_with_provider,
+    TextMetricsProvider, edge_label_dimensions_for_provider_and_style,
+    edge_label_dimensions_wrapped_for_provider_and_style, edge_text_style_key,
+    proportional_node_dimensions_with_provider,
 };
 use crate::graph::routing::{EdgeRouting, route_graph_geometry_with_provider};
 use crate::graph::{Direction, Edge, Graph, Stroke};
@@ -25,12 +26,15 @@ fn edge_label_dims_proportional(
     metrics: &dyn TextMetricsProvider,
     edge: &Edge,
 ) -> Option<(f64, f64)> {
+    let style = edge_text_style_key(metrics, edge);
     if let Some(lines) = edge.wrapped_label_lines.as_deref() {
-        return Some(edge_label_dimensions_wrapped_for_provider(metrics, lines));
+        return Some(edge_label_dimensions_wrapped_for_provider_and_style(
+            metrics, &style, lines,
+        ));
     }
     edge.label
         .as_deref()
-        .map(|label| edge_label_dimensions_for_provider(metrics, label))
+        .map(|label| edge_label_dimensions_for_provider_and_style(metrics, &style, label))
 }
 
 /// Stroke thickness in layout units used for ELK label-dummy padding.

--- a/src/engines/graph/algorithms/layered/measurement.rs
+++ b/src/engines/graph/algorithms/layered/measurement.rs
@@ -13,9 +13,9 @@ use crate::errors::RenderError;
 use crate::graph::geometry::GraphGeometry;
 use crate::graph::grid::{GridLayoutConfig, GridRanker};
 use crate::graph::measure::{
-    TextMetricsProvider, edge_label_dimensions_for_provider,
-    edge_label_dimensions_wrapped_for_provider, grid_edge_label_dimensions,
-    grid_edge_label_dimensions_wrapped, grid_node_dimensions,
+    TextMetricsProvider, edge_label_dimensions_for_provider_and_style,
+    edge_label_dimensions_wrapped_for_provider_and_style, edge_text_style_key,
+    grid_edge_label_dimensions, grid_edge_label_dimensions_wrapped, grid_node_dimensions,
     proportional_node_dimensions_with_provider,
 };
 use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
@@ -65,12 +65,15 @@ fn edge_label_dims_proportional_for_run(
     metrics: &dyn TextMetricsProvider,
     edge: &Edge,
 ) -> Option<(f64, f64)> {
+    let style = edge_text_style_key(metrics, edge);
     if let Some(lines) = edge.wrapped_label_lines.as_deref() {
-        return Some(edge_label_dimensions_wrapped_for_provider(metrics, lines));
+        return Some(edge_label_dimensions_wrapped_for_provider_and_style(
+            metrics, &style, lines,
+        ));
     }
     edge.label
         .as_deref()
-        .map(|label| edge_label_dimensions_for_provider(metrics, label))
+        .map(|label| edge_label_dimensions_for_provider_and_style(metrics, &style, label))
 }
 
 fn grid_edge_label_layout_dimensions(edge: &Edge) -> Option<(f64, f64)> {

--- a/src/engines/graph/tests.rs
+++ b/src/engines/graph/tests.rs
@@ -13,7 +13,10 @@ use super::{
 };
 use crate::engines::graph::algorithms::layered::kernel::types::AcyclicPolicy;
 use crate::format::RoutingStyle;
-use crate::graph::measure::{ProportionalTextMetrics, default_proportional_text_metrics};
+use crate::graph::measure::{
+    GraphTextStyleKey, ProportionalTextMetrics, TextMetricsProvider,
+    default_proportional_text_metrics,
+};
 use crate::graph::routing::EdgeRouting;
 use crate::graph::{GeometryLevel, Graph};
 use crate::internal_tests::stub_metrics::{NonCloneProvider, WideMProvider};
@@ -119,6 +122,37 @@ fn layered_measurement_uses_provider_for_node_widths() {
     );
 }
 
+#[test]
+fn styled_node_dimensions_use_each_node_effective_text_style() {
+    let provider = StyleStubProvider::new()
+        .with_line_width("small", "Same", 24.0)
+        .with_line_width("large", "Same", 96.0);
+    let flowchart = crate::mermaid::parse_flowchart(
+        "graph TD\nA[Same] --> C\nB[Same] --> C\nstyle A font-family:small\nstyle B font-family:large\n",
+    )
+    .expect("fixture parses");
+    let diagram = crate::diagrams::flowchart::compile_to_graph(&flowchart);
+    let request = GraphSolveRequest::new(
+        MeasurementMode::Proportional(&provider),
+        GraphGeometryContract::Visual,
+        GeometryLevel::Layout,
+        None,
+        Default::default(),
+    );
+    let config = EngineConfig::Layered(LayoutConfig::default());
+
+    let result = FluxLayeredEngine::text()
+        .solve(&diagram, &config, &request)
+        .expect("solve should succeed");
+
+    let small = result.geometry.nodes["A"].rect.width;
+    let large = result.geometry.nodes["B"].rect.width;
+    assert!(
+        large > small + 50.0,
+        "styled provider should make large-style node wider: small={small} large={large}"
+    );
+}
+
 fn grid_request(
     level: GeometryLevel,
     routing_style: Option<RoutingStyle>,
@@ -145,6 +179,64 @@ fn proportional_request(
         routing_style,
         Default::default(),
     )
+}
+
+#[derive(Default)]
+struct StyleStubProvider {
+    line_widths: std::collections::BTreeMap<(GraphTextStyleKey, String), f64>,
+}
+
+impl StyleStubProvider {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn with_line_width(mut self, style: &str, text: &str, width: f64) -> Self {
+        self.line_widths
+            .insert((GraphTextStyleKey::test(style), text.to_string()), width);
+        self
+    }
+}
+
+impl TextMetricsProvider for StyleStubProvider {
+    fn measure_line_width(&self, _text: &str) -> f64 {
+        0.0
+    }
+
+    fn measure_scalar_width(&self, _ch: char) -> f64 {
+        0.0
+    }
+
+    fn measure_line_width_for_style(&self, style: &GraphTextStyleKey, text: &str) -> f64 {
+        self.line_widths
+            .get(&(style.clone(), text.to_string()))
+            .copied()
+            .unwrap_or(0.0)
+    }
+
+    fn font_size(&self) -> f64 {
+        16.0
+    }
+
+    fn line_height(&self) -> f64 {
+        24.0
+    }
+
+    fn node_padding_x(&self) -> f64 {
+        15.0
+    }
+
+    fn node_padding_y(&self) -> f64 {
+        15.0
+    }
+
+    fn label_padding_x(&self) -> f64 {
+        4.0
+    }
+
+    fn label_padding_y(&self) -> f64 {
+        2.0
+    }
 }
 
 #[test]

--- a/src/graph/label_wrap.rs
+++ b/src/graph/label_wrap.rs
@@ -14,7 +14,8 @@
 
 use crate::graph::Edge;
 use crate::graph::measure::{
-    ProportionalTextMetrics, TextMetricsProvider, wrap_lines_with_provider,
+    ProportionalTextMetrics, TextMetricsProvider, edge_text_style_key,
+    wrap_lines_with_provider_for_style,
 };
 
 /// Greedy-wrap every labeled edge's `label` against `max_width` using
@@ -54,7 +55,10 @@ pub(crate) fn prepare_wrapped_labels_with_provider(
         if label.is_empty() {
             continue;
         }
-        edge.wrapped_label_lines = Some(wrap_lines_with_provider(provider, label, max_width));
+        let style = edge_text_style_key(provider, edge);
+        edge.wrapped_label_lines = Some(wrap_lines_with_provider_for_style(
+            provider, &style, label, max_width,
+        ));
     }
 }
 
@@ -62,7 +66,9 @@ pub(crate) fn prepare_wrapped_labels_with_provider(
 mod tests {
     use super::*;
     use crate::graph::Edge;
-    use crate::graph::measure::default_proportional_text_metrics;
+    use crate::graph::measure::{
+        GraphTextStyleKey, TextMetricsProvider, default_proportional_text_metrics,
+    };
 
     #[test]
     fn prepare_wrapped_labels_populates_wrapped_lines_for_labeled_edges() {
@@ -104,5 +110,92 @@ mod tests {
             Some(vec!["custom".to_string(), "override".to_string()].as_slice()),
             "idempotent: pre-populated wrap must not be overwritten"
         );
+    }
+
+    #[test]
+    fn styled_edge_label_wrapping_uses_edge_effective_text_style_before_solve() {
+        let provider = StyleWrapProvider::new()
+            .with_line_width("narrow", "alpha", 20.0)
+            .with_line_width("narrow", "beta", 20.0)
+            .with_line_width("wide", "alpha", 50.0)
+            .with_line_width("wide", "beta", 50.0);
+        let mut narrow = Edge::new("A", "B").with_label("alpha beta");
+        narrow.style.font_family = Some("narrow".to_string());
+        let mut wide = Edge::new("B", "C").with_label("alpha beta");
+        wide.style.font_family = Some("wide".to_string());
+        let mut edges = vec![narrow, wide];
+
+        prepare_wrapped_labels_with_provider(&mut edges, &provider, Some(60.0));
+
+        assert_eq!(
+            edges[0].wrapped_label_lines.as_deref(),
+            Some(vec!["alpha beta".to_string()].as_slice())
+        );
+        assert_eq!(
+            edges[1].wrapped_label_lines.as_deref(),
+            Some(vec!["alpha".to_string(), "beta".to_string()].as_slice())
+        );
+    }
+
+    #[derive(Default)]
+    struct StyleWrapProvider {
+        line_widths: std::collections::BTreeMap<(GraphTextStyleKey, String), f64>,
+    }
+
+    impl StyleWrapProvider {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn with_line_width(mut self, style: &str, text: &str, width: f64) -> Self {
+            self.line_widths
+                .insert((GraphTextStyleKey::test(style), text.to_string()), width);
+            self
+        }
+    }
+
+    impl TextMetricsProvider for StyleWrapProvider {
+        fn measure_line_width(&self, _text: &str) -> f64 {
+            0.0
+        }
+
+        fn measure_scalar_width(&self, _ch: char) -> f64 {
+            0.0
+        }
+
+        fn measure_line_width_for_style(&self, style: &GraphTextStyleKey, text: &str) -> f64 {
+            self.line_widths
+                .get(&(style.clone(), text.to_string()))
+                .copied()
+                .unwrap_or(0.0)
+        }
+
+        fn measure_scalar_width_for_style(&self, _style: &GraphTextStyleKey, ch: char) -> f64 {
+            if ch == ' ' { 5.0 } else { 0.0 }
+        }
+
+        fn font_size(&self) -> f64 {
+            16.0
+        }
+
+        fn line_height(&self) -> f64 {
+            24.0
+        }
+
+        fn node_padding_x(&self) -> f64 {
+            15.0
+        }
+
+        fn node_padding_y(&self) -> f64 {
+            15.0
+        }
+
+        fn label_padding_x(&self) -> f64 {
+            4.0
+        }
+
+        fn label_padding_y(&self) -> f64 {
+            2.0
+        }
     }
 }

--- a/src/graph/measure.rs
+++ b/src/graph/measure.rs
@@ -201,18 +201,23 @@ fn text_style_key_from_parts(
     font_weight: Option<&str>,
 ) -> GraphTextStyleKey {
     let default_style = provider.default_text_style_key();
+    let default_font_family = default_style.font_family.clone();
+    let default_font_style = default_style.font_style.clone();
+    let default_font_weight = default_style.font_weight.clone();
     let font_size_px = font_size
         .and_then(|value| parse_font_size_px(value).ok())
         .unwrap_or_else(|| default_style.font_size_px());
     let line_height_px = provider_line_height_for_font_size(provider, font_size_px);
-    GraphTextStyleKey::new(
-        font_family.unwrap_or(default_style.font_family.as_str()),
+    match GraphTextStyleKey::new(
+        font_family.unwrap_or(default_font_family.as_str()),
         font_size_px,
         line_height_px,
-        font_style.unwrap_or(default_style.font_style.as_str()),
-        font_weight.unwrap_or(default_style.font_weight.as_str()),
-    )
-    .expect("graph text style fields are valid after parser validation and defaults")
+        font_style.unwrap_or(default_font_style.as_str()),
+        font_weight.unwrap_or(default_font_weight.as_str()),
+    ) {
+        Ok(style) => style,
+        Err(_) => default_style,
+    }
 }
 
 fn provider_line_height_for_font_size(
@@ -1118,6 +1123,14 @@ mod tests {
         fn assert_key<T: Eq + Ord + std::hash::Hash>() {}
 
         assert_key::<GraphTextStyleKey>();
+    }
+
+    #[test]
+    fn style_key_resolution_falls_back_instead_of_panicking_on_invalid_internal_values() {
+        let provider = FixedWidthProvider;
+        let style = text_style_key_from_parts(&provider, Some(" "), None, None, None);
+
+        assert_eq!(style, GraphTextStyleKey::default_provider_style(&provider));
     }
 
     #[test]

--- a/src/graph/measure.rs
+++ b/src/graph/measure.rs
@@ -12,7 +12,8 @@ use crate::graph::font_metrics::{
     RECORDED_SANS_CSS_LINE_HEIGHT_RATIO, RECORDED_SANS_PROFILE_ID, RECORDED_SANS_PROFILE_SOURCE,
     RecordedMetricsProfile,
 };
-use crate::graph::{Direction, Node, Shape};
+use crate::graph::style::{EdgeStyle, NodeStyle, parse_font_size_px};
+use crate::graph::{Direction, Edge, Node, Shape};
 
 /// Compatibility profile for the existing function-backed proportional heuristic.
 pub const COMPATIBILITY_TEXT_METRICS_PROFILE_ID: &str = "mmdflux-heuristic-proportional-v1";
@@ -63,6 +64,180 @@ pub struct ProportionalTextMetrics {
     width_model: ProportionalWidthModel,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct GraphTextStyleKey {
+    pub(crate) font_family: String,
+    pub(crate) font_size_mpx: u32,
+    pub(crate) line_height_mpx: u32,
+    pub(crate) font_style: String,
+    pub(crate) font_weight: String,
+}
+
+impl GraphTextStyleKey {
+    pub(crate) fn new(
+        font_family: impl Into<String>,
+        font_size_px: f64,
+        line_height_px: f64,
+        font_style: impl Into<String>,
+        font_weight: impl Into<String>,
+    ) -> Result<Self, String> {
+        let font_family = non_empty_style_string("font-family", font_family.into())?;
+        let font_style = non_empty_style_string("font-style", font_style.into())?;
+        let font_weight = non_empty_style_string("font-weight", font_weight.into())?;
+        Ok(Self {
+            font_family,
+            font_size_mpx: px_to_millipixels("font-size", font_size_px)?,
+            line_height_mpx: px_to_millipixels("line-height", line_height_px)?,
+            font_style,
+            font_weight,
+        })
+    }
+
+    pub(crate) fn default_profile_style(metrics: &ProportionalTextMetrics) -> Self {
+        Self::new(
+            DEFAULT_GRAPH_FONT_FAMILY,
+            metrics.font_size,
+            metrics.line_height,
+            "normal",
+            "400",
+        )
+        .expect("default profile text style is valid")
+    }
+
+    pub(crate) fn default_provider_style(provider: &dyn TextMetricsProvider) -> Self {
+        Self::new(
+            DEFAULT_GRAPH_FONT_FAMILY,
+            provider.font_size(),
+            provider.line_height(),
+            "normal",
+            "400",
+        )
+        .expect("default provider text style is valid")
+    }
+
+    pub(crate) fn from_descriptor(descriptor: &TextMetricsStyleDescriptor) -> Result<Self, String> {
+        Self::new(
+            &descriptor.font_family,
+            descriptor.font_size,
+            descriptor.line_height,
+            &descriptor.font_style,
+            &descriptor.font_weight,
+        )
+    }
+
+    pub(crate) fn font_size_px(&self) -> f64 {
+        self.font_size_mpx as f64 / 1000.0
+    }
+
+    pub(crate) fn line_height_px(&self) -> f64 {
+        self.line_height_mpx as f64 / 1000.0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test(name: &str) -> Self {
+        Self::new(name, DEFAULT_PROPORTIONAL_FONT_SIZE, 24.0, "normal", "400")
+            .expect("test style is valid")
+    }
+}
+
+fn non_empty_style_string(field: &str, value: String) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        Err(format!("{field} cannot be empty"))
+    } else {
+        Ok(trimmed.to_string())
+    }
+}
+
+fn px_to_millipixels(field: &str, value: f64) -> Result<u32, String> {
+    if !value.is_finite() || value <= 0.0 {
+        return Err(format!("{field} must be a positive finite number"));
+    }
+    let rounded = (value * 1000.0).round();
+    if rounded > u32::MAX as f64 {
+        return Err(format!("{field} is too large"));
+    }
+    Ok(rounded as u32)
+}
+
+pub(crate) fn node_text_style_key(
+    provider: &dyn TextMetricsProvider,
+    node: &Node,
+) -> GraphTextStyleKey {
+    text_style_key_from_node_style(provider, &node.style)
+}
+
+pub(crate) fn edge_text_style_key(
+    provider: &dyn TextMetricsProvider,
+    edge: &Edge,
+) -> GraphTextStyleKey {
+    text_style_key_from_edge_style(provider, &edge.style)
+}
+
+fn text_style_key_from_node_style(
+    provider: &dyn TextMetricsProvider,
+    style: &NodeStyle,
+) -> GraphTextStyleKey {
+    text_style_key_from_parts(
+        provider,
+        style.font_family.as_deref(),
+        style.font_size.as_deref(),
+        style.font_style.as_deref(),
+        style.font_weight.as_deref(),
+    )
+}
+
+fn text_style_key_from_edge_style(
+    provider: &dyn TextMetricsProvider,
+    style: &EdgeStyle,
+) -> GraphTextStyleKey {
+    text_style_key_from_parts(
+        provider,
+        style.font_family.as_deref(),
+        style.font_size.as_deref(),
+        style.font_style.as_deref(),
+        style.font_weight.as_deref(),
+    )
+}
+
+fn text_style_key_from_parts(
+    provider: &dyn TextMetricsProvider,
+    font_family: Option<&str>,
+    font_size: Option<&str>,
+    font_style: Option<&str>,
+    font_weight: Option<&str>,
+) -> GraphTextStyleKey {
+    let font_size_px = font_size
+        .and_then(|value| parse_font_size_px(value).ok())
+        .unwrap_or_else(|| provider.font_size());
+    let line_height_px = provider_line_height_for_font_size(provider, font_size_px);
+    GraphTextStyleKey::new(
+        font_family.unwrap_or(DEFAULT_GRAPH_FONT_FAMILY),
+        font_size_px,
+        line_height_px,
+        font_style.unwrap_or("normal"),
+        font_weight.unwrap_or("400"),
+    )
+    .expect("graph text style fields are valid after parser validation and defaults")
+}
+
+fn provider_line_height_for_font_size(
+    provider: &dyn TextMetricsProvider,
+    font_size_px: f64,
+) -> f64 {
+    let base_font_size = provider.font_size();
+    let base_line_height = provider.line_height();
+    if base_font_size.is_finite()
+        && base_font_size > 0.0
+        && base_line_height.is_finite()
+        && base_line_height > 0.0
+    {
+        font_size_px * (base_line_height / base_font_size)
+    } else {
+        font_size_px * 1.5
+    }
+}
+
 /// Internal graph-family text measurement seam.
 ///
 /// This is intentionally crate-local until browser/provider-backed measurement
@@ -79,6 +254,22 @@ pub(crate) trait TextMetricsProvider {
 
     fn measure_space_width(&self) -> f64 {
         self.measure_scalar_width(' ')
+    }
+
+    fn measure_line_width_for_style(&self, _style: &GraphTextStyleKey, text: &str) -> f64 {
+        self.measure_line_width(text)
+    }
+
+    fn measure_scalar_width_for_style(&self, _style: &GraphTextStyleKey, ch: char) -> f64 {
+        self.measure_scalar_width(ch)
+    }
+
+    fn font_size_for_style(&self, _style: &GraphTextStyleKey) -> f64 {
+        self.font_size()
+    }
+
+    fn line_height_for_style(&self, _style: &GraphTextStyleKey) -> f64 {
+        self.line_height()
     }
 }
 
@@ -495,14 +686,25 @@ pub(crate) fn measure_text_with_padding_for_provider(
     padding_x: f64,
     padding_y: f64,
 ) -> (f64, f64) {
+    let style = GraphTextStyleKey::default_provider_style(provider);
+    measure_text_with_padding_for_provider_and_style(provider, &style, text, padding_x, padding_y)
+}
+
+pub(crate) fn measure_text_with_padding_for_provider_and_style(
+    provider: &dyn TextMetricsProvider,
+    style: &GraphTextStyleKey,
+    text: &str,
+    padding_x: f64,
+    padding_y: f64,
+) -> (f64, f64) {
     let lines: Vec<&str> = text.split('\n').collect();
     let line_count = lines.len().max(1) as f64;
     let max_width = lines
         .iter()
-        .map(|line| provider.measure_line_width(line))
+        .map(|line| provider.measure_line_width_for_style(style, line))
         .fold(0.0, f64::max);
     let width = max_width + padding_x * 2.0;
-    let height = provider.line_height() * line_count + padding_y * 2.0;
+    let height = provider.line_height_for_style(style) * line_count + padding_y * 2.0;
     (width, height)
 }
 
@@ -510,8 +712,18 @@ pub(crate) fn edge_label_dimensions_for_provider(
     provider: &dyn TextMetricsProvider,
     label: &str,
 ) -> (f64, f64) {
-    measure_text_with_padding_for_provider(
+    let style = GraphTextStyleKey::default_provider_style(provider);
+    edge_label_dimensions_for_provider_and_style(provider, &style, label)
+}
+
+pub(crate) fn edge_label_dimensions_for_provider_and_style(
+    provider: &dyn TextMetricsProvider,
+    style: &GraphTextStyleKey,
+    label: &str,
+) -> (f64, f64) {
+    measure_text_with_padding_for_provider_and_style(
         provider,
+        style,
         label,
         provider.label_padding_x(),
         provider.label_padding_y(),
@@ -522,13 +734,23 @@ pub(crate) fn edge_label_dimensions_wrapped_for_provider(
     provider: &dyn TextMetricsProvider,
     lines: &[String],
 ) -> (f64, f64) {
+    let style = GraphTextStyleKey::default_provider_style(provider);
+    edge_label_dimensions_wrapped_for_provider_and_style(provider, &style, lines)
+}
+
+pub(crate) fn edge_label_dimensions_wrapped_for_provider_and_style(
+    provider: &dyn TextMetricsProvider,
+    style: &GraphTextStyleKey,
+    lines: &[String],
+) -> (f64, f64) {
     let line_count = lines.len().max(1) as f64;
     let max_width = lines
         .iter()
-        .map(|line| provider.measure_line_width(line))
+        .map(|line| provider.measure_line_width_for_style(style, line))
         .fold(0.0, f64::max);
     let width = max_width + provider.label_padding_x() * 2.0;
-    let height = provider.line_height() * line_count + provider.label_padding_y() * 2.0;
+    let height =
+        provider.line_height_for_style(style) * line_count + provider.label_padding_y() * 2.0;
     (width, height)
 }
 
@@ -537,13 +759,23 @@ pub(crate) fn wrap_lines_with_provider(
     text: &str,
     max_width: f64,
 ) -> Vec<String> {
-    let space_w = provider.measure_space_width();
+    let style = GraphTextStyleKey::default_provider_style(provider);
+    wrap_lines_with_provider_for_style(provider, &style, text, max_width)
+}
+
+pub(crate) fn wrap_lines_with_provider_for_style(
+    provider: &dyn TextMetricsProvider,
+    style: &GraphTextStyleKey,
+    text: &str,
+    max_width: f64,
+) -> Vec<String> {
+    let space_w = provider.measure_scalar_width_for_style(style, ' ');
     let mut out = Vec::new();
     for segment in text.split('\n') {
         let mut current = String::new();
         let mut current_w = 0.0_f64;
         for word in segment.split_whitespace() {
-            let ww = provider.measure_line_width(word);
+            let ww = provider.measure_line_width_for_style(style, word);
             if ww > max_width {
                 // Oversized word: fall back to per-character splits regardless
                 // of whether the word is first on the line. GPT-5.4 review of
@@ -555,7 +787,7 @@ pub(crate) fn wrap_lines_with_provider(
                     current_w = 0.0;
                 }
                 for ch in word.chars() {
-                    let cw = provider.measure_scalar_width(ch);
+                    let cw = provider.measure_scalar_width_for_style(style, ch);
                     if current_w + cw > max_width && !current.is_empty() {
                         out.push(std::mem::take(&mut current));
                         current_w = 0.0;
@@ -675,8 +907,9 @@ pub(crate) fn proportional_node_dimensions_with_provider(
     node: &Node,
     direction: Direction,
 ) -> (f64, f64) {
+    let style = node_text_style_key(provider, node);
     let (label_w, label_h) =
-        measure_text_with_padding_for_provider(provider, &node.label, 0.0, 0.0);
+        measure_text_with_padding_for_provider_and_style(provider, &style, &node.label, 0.0, 0.0);
 
     let (mut width, mut height) = match node.shape {
         Shape::Rectangle => (
@@ -853,6 +1086,49 @@ mod tests {
         assert_eq!(
             provider.measure_space_width(),
             metrics.measure_space_width()
+        );
+    }
+
+    #[test]
+    fn graph_text_style_key_is_hashable_and_orderable_without_raw_f64_fields() {
+        fn assert_key<T: Eq + Ord + std::hash::Hash>() {}
+
+        assert_key::<GraphTextStyleKey>();
+    }
+
+    #[test]
+    fn style_aware_provider_distinguishes_same_text_under_different_styles() {
+        let provider = StyleStubProvider::new()
+            .with_line_width("small", "Same", 20.0)
+            .with_line_width("large", "Same", 80.0);
+
+        let small = GraphTextStyleKey::test("small");
+        let large = GraphTextStyleKey::test("large");
+
+        assert_eq!(provider.measure_line_width_for_style(&small, "Same"), 20.0);
+        assert_eq!(provider.measure_line_width_for_style(&large, "Same"), 80.0);
+    }
+
+    #[test]
+    fn static_profile_default_style_matches_existing_widths() {
+        let metrics = default_proportional_text_metrics();
+        let default_style = GraphTextStyleKey::default_profile_style(&metrics);
+
+        assert_eq!(
+            metrics.measure_line_width_for_style(&default_style, "Alpha"),
+            metrics.measure_line_width("Alpha")
+        );
+        assert_eq!(
+            metrics.measure_scalar_width_for_style(&default_style, 'A'),
+            metrics.measure_scalar_width('A')
+        );
+        assert_eq!(
+            metrics.font_size_for_style(&default_style),
+            metrics.font_size()
+        );
+        assert_eq!(
+            metrics.line_height_for_style(&default_style),
+            metrics.line_height()
         );
     }
 
@@ -1183,5 +1459,63 @@ mod tests {
             (actual - expected).abs() < 1e-9,
             "actual={actual} expected={expected}"
         );
+    }
+
+    #[derive(Default)]
+    struct StyleStubProvider {
+        line_widths: std::collections::BTreeMap<(GraphTextStyleKey, String), f64>,
+    }
+
+    impl StyleStubProvider {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn with_line_width(mut self, style: &str, text: &str, width: f64) -> Self {
+            self.line_widths
+                .insert((GraphTextStyleKey::test(style), text.to_string()), width);
+            self
+        }
+    }
+
+    impl TextMetricsProvider for StyleStubProvider {
+        fn measure_line_width(&self, text: &str) -> f64 {
+            self.measure_line_width_for_style(&GraphTextStyleKey::test("default"), text)
+        }
+
+        fn measure_scalar_width(&self, _ch: char) -> f64 {
+            8.0
+        }
+
+        fn measure_line_width_for_style(&self, style: &GraphTextStyleKey, text: &str) -> f64 {
+            self.line_widths
+                .get(&(style.clone(), text.to_string()))
+                .copied()
+                .unwrap_or(0.0)
+        }
+
+        fn font_size(&self) -> f64 {
+            16.0
+        }
+
+        fn line_height(&self) -> f64 {
+            24.0
+        }
+
+        fn node_padding_x(&self) -> f64 {
+            15.0
+        }
+
+        fn node_padding_y(&self) -> f64 {
+            15.0
+        }
+
+        fn label_padding_x(&self) -> f64 {
+            DEFAULT_LABEL_PADDING_X
+        }
+
+        fn label_padding_y(&self) -> f64 {
+            DEFAULT_LABEL_PADDING_Y
+        }
     }
 }

--- a/src/graph/measure.rs
+++ b/src/graph/measure.rs
@@ -105,14 +105,7 @@ impl GraphTextStyleKey {
     }
 
     pub(crate) fn default_provider_style(provider: &dyn TextMetricsProvider) -> Self {
-        Self::new(
-            DEFAULT_GRAPH_FONT_FAMILY,
-            provider.font_size(),
-            provider.line_height(),
-            "normal",
-            "400",
-        )
-        .expect("default provider text style is valid")
+        provider.default_text_style_key()
     }
 
     pub(crate) fn from_descriptor(descriptor: &TextMetricsStyleDescriptor) -> Result<Self, String> {
@@ -207,16 +200,17 @@ fn text_style_key_from_parts(
     font_style: Option<&str>,
     font_weight: Option<&str>,
 ) -> GraphTextStyleKey {
+    let default_style = provider.default_text_style_key();
     let font_size_px = font_size
         .and_then(|value| parse_font_size_px(value).ok())
-        .unwrap_or_else(|| provider.font_size());
+        .unwrap_or_else(|| default_style.font_size_px());
     let line_height_px = provider_line_height_for_font_size(provider, font_size_px);
     GraphTextStyleKey::new(
-        font_family.unwrap_or(DEFAULT_GRAPH_FONT_FAMILY),
+        font_family.unwrap_or(default_style.font_family.as_str()),
         font_size_px,
         line_height_px,
-        font_style.unwrap_or("normal"),
-        font_weight.unwrap_or("400"),
+        font_style.unwrap_or(default_style.font_style.as_str()),
+        font_weight.unwrap_or(default_style.font_weight.as_str()),
     )
     .expect("graph text style fields are valid after parser validation and defaults")
 }
@@ -256,6 +250,17 @@ pub(crate) trait TextMetricsProvider {
         self.measure_scalar_width(' ')
     }
 
+    fn default_text_style_key(&self) -> GraphTextStyleKey {
+        GraphTextStyleKey::new(
+            DEFAULT_GRAPH_FONT_FAMILY,
+            self.font_size(),
+            self.line_height(),
+            "normal",
+            "400",
+        )
+        .expect("default provider text style is valid")
+    }
+
     fn measure_line_width_for_style(&self, _style: &GraphTextStyleKey, text: &str) -> f64 {
         self.measure_line_width(text)
     }
@@ -275,17 +280,36 @@ pub(crate) trait TextMetricsProvider {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct TextMeasurementCache {
-    pub line_widths: BTreeMap<String, f64>,
-    pub scalar_widths: BTreeMap<char, f64>,
+    pub default_style: String,
+    pub text_styles: BTreeMap<String, TextMeasurementStyle>,
+    pub line_widths: BTreeMap<(String, String), f64>,
+    pub scalar_widths: BTreeMap<(String, char), f64>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TextMeasurementStyle {
+    pub(crate) id: String,
+    pub(crate) style: GraphTextStyleKey,
+    pub(crate) css_font: String,
 }
 
 impl TextMeasurementCache {
     pub(crate) fn line_width(&self, text: &str) -> Option<f64> {
-        self.line_widths.get(text).copied()
+        self.line_width_for_style(&self.default_style, text)
     }
 
     pub(crate) fn scalar_width(&self, ch: char) -> Option<f64> {
-        self.scalar_widths.get(&ch).copied()
+        self.scalar_width_for_style(&self.default_style, ch)
+    }
+
+    pub(crate) fn line_width_for_style(&self, style_id: &str, text: &str) -> Option<f64> {
+        self.line_widths
+            .get(&(style_id.to_string(), text.to_string()))
+            .copied()
+    }
+
+    pub(crate) fn scalar_width_for_style(&self, style_id: &str, ch: char) -> Option<f64> {
+        self.scalar_widths.get(&(style_id.to_string(), ch)).copied()
     }
 }
 

--- a/src/graph/routing/label_lanes.rs
+++ b/src/graph/routing/label_lanes.rs
@@ -11,8 +11,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::graph::geometry::GraphGeometry;
 use crate::graph::measure::{
-    TextMetricsProvider, edge_label_dimensions_for_provider,
-    edge_label_dimensions_wrapped_for_provider,
+    TextMetricsProvider, edge_label_dimensions_for_provider_and_style,
+    edge_label_dimensions_wrapped_for_provider_and_style, edge_text_style_key,
 };
 use crate::graph::routing::labels::arc_length_midpoint;
 use crate::graph::space::{FPoint, FRect};
@@ -544,9 +544,12 @@ pub(super) fn build_label_descriptors(
         // failure. Prefer `wrapped_label_lines` when present; fall back
         // to single-line measurement for edges that opted out of the
         // pre-engine wrap (dagre-parity mode).
+        let style = edge_text_style_key(metrics, edge);
         let (w, h) = match edge.wrapped_label_lines.as_deref() {
-            Some(lines) => edge_label_dimensions_wrapped_for_provider(metrics, lines),
-            None => edge_label_dimensions_for_provider(metrics, label_text),
+            Some(lines) => {
+                edge_label_dimensions_wrapped_for_provider_and_style(metrics, &style, lines)
+            }
+            None => edge_label_dimensions_for_provider_and_style(metrics, &style, label_text),
         };
 
         let direction_sign = if *backward_flags.get(&edge_index).unwrap_or(&false) {

--- a/src/graph/routing/label_rewrap.rs
+++ b/src/graph/routing/label_rewrap.rs
@@ -65,7 +65,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::graph::geometry::RoutedEdgeGeometry;
 use crate::graph::measure::{
-    TextMetricsProvider, edge_label_dimensions_wrapped_for_provider, wrap_lines_with_provider,
+    TextMetricsProvider, edge_label_dimensions_wrapped_for_provider_and_style, edge_text_style_key,
+    wrap_lines_with_provider_for_style,
 };
 use crate::graph::routing::label_lanes::{LANE_GAP, LabelTrackOutcome, MIN_LABEL_LANE_STEP};
 use crate::graph::space::FPoint;
@@ -182,9 +183,11 @@ pub(super) fn re_wrap_labels_for_lane_fit(
                 continue;
             }
 
+            let style = edge_text_style_key(metrics, source_edge);
             let target = (outcome.label_step * REWRAP_SAFETY).max(MIN_REWRAP_WIDTH);
-            let new_lines = wrap_lines_with_provider(metrics, label_text, target);
-            let (new_w, new_h) = edge_label_dimensions_wrapped_for_provider(metrics, &new_lines);
+            let new_lines = wrap_lines_with_provider_for_style(metrics, &style, label_text, target);
+            let (new_w, new_h) =
+                edge_label_dimensions_wrapped_for_provider_and_style(metrics, &style, &new_lines);
 
             // Skip edges where the re-wrap would not actually narrow the
             // rect. Can happen with single oversized words where the

--- a/src/graph/routing/mod.rs
+++ b/src/graph/routing/mod.rs
@@ -37,7 +37,9 @@ mod tests {
 
     use super::*;
     use crate::graph::attachment::PortFace;
-    use crate::graph::measure::default_proportional_text_metrics;
+    use crate::graph::measure::{
+        GraphTextStyleKey, TextMetricsProvider, default_proportional_text_metrics,
+    };
     use crate::graph::routing::EdgeRouting;
     use crate::internal_tests::stub_metrics::WideMProvider;
 
@@ -1689,6 +1691,116 @@ mod tests {
         );
     }
 
+    #[test]
+    fn routed_edge_label_dimensions_use_each_edge_effective_style() {
+        let provider = StyleRoutingProvider::new()
+            .with_line_width("small", "same", 24.0)
+            .with_line_width("large", "same", 96.0);
+
+        let mut diagram = Graph::new(crate::graph::Direction::TopDown);
+        diagram.add_node(crate::graph::Node::new("A"));
+        diagram.add_node(crate::graph::Node::new("B"));
+        diagram.add_node(crate::graph::Node::new("C"));
+        let mut small = crate::graph::Edge::new("A", "B").with_label("same");
+        small.style.font_family = Some("small".to_string());
+        diagram.add_edge(small);
+        let mut large = crate::graph::Edge::new("A", "C").with_label("same");
+        large.style.font_family = Some("large".to_string());
+        diagram.add_edge(large);
+
+        let mut nodes = HashMap::new();
+        nodes.insert(
+            "A".into(),
+            PositionedNode {
+                id: "A".into(),
+                rect: FRect::new(50.0, 25.0, 40.0, 20.0),
+                shape: crate::graph::Shape::Rectangle,
+                label: "A".into(),
+                parent: None,
+            },
+        );
+        nodes.insert(
+            "B".into(),
+            PositionedNode {
+                id: "B".into(),
+                rect: FRect::new(30.0, 105.0, 40.0, 20.0),
+                shape: crate::graph::Shape::Rectangle,
+                label: "B".into(),
+                parent: None,
+            },
+        );
+        nodes.insert(
+            "C".into(),
+            PositionedNode {
+                id: "C".into(),
+                rect: FRect::new(90.0, 105.0, 40.0, 20.0),
+                shape: crate::graph::Shape::Rectangle,
+                label: "C".into(),
+                parent: None,
+            },
+        );
+        let geom = GraphGeometry {
+            nodes,
+            edges: vec![
+                LayoutEdge {
+                    index: 0,
+                    from: "A".into(),
+                    to: "B".into(),
+                    waypoints: vec![],
+                    label_position: Some(FPoint::new(50.0, 70.0)),
+                    label_side: None,
+                    from_subgraph: None,
+                    to_subgraph: None,
+                    layout_path_hint: Some(vec![FPoint::new(70.0, 35.0), FPoint::new(50.0, 105.0)]),
+                    preserve_orthogonal_topology: false,
+                    label_geometry: None,
+                    effective_wrapped_lines: None,
+                },
+                LayoutEdge {
+                    index: 1,
+                    from: "A".into(),
+                    to: "C".into(),
+                    waypoints: vec![],
+                    label_position: Some(FPoint::new(90.0, 70.0)),
+                    label_side: None,
+                    from_subgraph: None,
+                    to_subgraph: None,
+                    layout_path_hint: Some(vec![
+                        FPoint::new(70.0, 35.0),
+                        FPoint::new(110.0, 105.0),
+                    ]),
+                    preserve_orthogonal_topology: false,
+                    label_geometry: None,
+                    effective_wrapped_lines: None,
+                },
+            ],
+            subgraphs: HashMap::new(),
+            self_edges: vec![],
+            direction: crate::graph::Direction::TopDown,
+            node_directions: HashMap::new(),
+            bounds: FRect::new(0.0, 0.0, 140.0, 140.0),
+            reversed_edges: vec![],
+            engine_hints: None,
+            grid_projection: None,
+            rerouted_edges: std::collections::HashSet::new(),
+            enhanced_backward_routing: false,
+        };
+
+        let routed = route_graph_geometry_with_provider(
+            &diagram,
+            &geom,
+            EdgeRouting::PolylineRoute,
+            &provider,
+        );
+
+        let small_rect = routed.edges[0].label_geometry.as_ref().unwrap().rect;
+        let large_rect = routed.edges[1].label_geometry.as_ref().unwrap().rect;
+        assert!(
+            large_rect.width > small_rect.width + 50.0,
+            "styled provider should drive routed label rect widths: small={small_rect:?} large={large_rect:?}"
+        );
+    }
+
     /// Routed bounds must cover all edge path points, even when routing
     /// pushes paths beyond the original layout bounds (e.g. backward channels).
     #[test]
@@ -1803,6 +1915,64 @@ mod tests {
                     edge.to
                 );
             }
+        }
+    }
+
+    #[derive(Default)]
+    struct StyleRoutingProvider {
+        line_widths: std::collections::BTreeMap<(GraphTextStyleKey, String), f64>,
+    }
+
+    impl StyleRoutingProvider {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn with_line_width(mut self, style: &str, text: &str, width: f64) -> Self {
+            self.line_widths
+                .insert((GraphTextStyleKey::test(style), text.to_string()), width);
+            self
+        }
+    }
+
+    impl TextMetricsProvider for StyleRoutingProvider {
+        fn measure_line_width(&self, _text: &str) -> f64 {
+            0.0
+        }
+
+        fn measure_scalar_width(&self, _ch: char) -> f64 {
+            0.0
+        }
+
+        fn measure_line_width_for_style(&self, style: &GraphTextStyleKey, text: &str) -> f64 {
+            self.line_widths
+                .get(&(style.clone(), text.to_string()))
+                .copied()
+                .unwrap_or(0.0)
+        }
+
+        fn font_size(&self) -> f64 {
+            16.0
+        }
+
+        fn line_height(&self) -> f64 {
+            24.0
+        }
+
+        fn node_padding_x(&self) -> f64 {
+            15.0
+        }
+
+        fn node_padding_y(&self) -> f64 {
+            15.0
+        }
+
+        fn label_padding_x(&self) -> f64 {
+            4.0
+        }
+
+        fn label_padding_y(&self) -> f64 {
+            2.0
         }
     }
 }

--- a/src/graph/routing/stage.rs
+++ b/src/graph/routing/stage.rs
@@ -14,8 +14,8 @@ use crate::graph::geometry::{
     RoutedGraphGeometry, RoutedSelfEdge,
 };
 use crate::graph::measure::{
-    ProportionalTextMetrics, TextMetricsProvider, edge_label_dimensions_for_provider,
-    edge_label_dimensions_wrapped_for_provider,
+    ProportionalTextMetrics, TextMetricsProvider, edge_label_dimensions_for_provider_and_style,
+    edge_label_dimensions_wrapped_for_provider_and_style, edge_text_style_key,
 };
 use crate::graph::space::{FPoint, FRect};
 use crate::graph::{Direction, Graph, Shape};
@@ -950,9 +950,16 @@ fn populate_label_geometry(
         }
         // Prefer the pre-engine wrap artifact when present so the reserved
         // rect matches what SVG text and the MMDS replay emit.
+        let style = diagram_edge
+            .map(|edge| edge_text_style_key(metrics, edge))
+            .unwrap_or_else(|| {
+                crate::graph::measure::GraphTextStyleKey::default_provider_style(metrics)
+            });
         let (w, h) = match diagram_edge.and_then(|e| e.wrapped_label_lines.as_deref()) {
-            Some(lines) => edge_label_dimensions_wrapped_for_provider(metrics, lines),
-            None => edge_label_dimensions_for_provider(metrics, label),
+            Some(lines) => {
+                edge_label_dimensions_wrapped_for_provider_and_style(metrics, &style, lines)
+            }
+            None => edge_label_dimensions_for_provider_and_style(metrics, &style, label),
         };
         let side = routed_edge.label_side.unwrap_or(EdgeLabelSide::Center);
         routed_edge.label_geometry = Some(EdgeLabelGeometry {
@@ -1012,9 +1019,12 @@ fn align_backward_side_offset_labels(
         if label.is_empty() {
             continue;
         }
+        let style = edge_text_style_key(metrics, diagram_edge);
         let (_, label_height) = match diagram_edge.wrapped_label_lines.as_deref() {
-            Some(lines) => edge_label_dimensions_wrapped_for_provider(metrics, lines),
-            None => edge_label_dimensions_for_provider(metrics, label),
+            Some(lines) => {
+                edge_label_dimensions_wrapped_for_provider_and_style(metrics, &style, lines)
+            }
+            None => edge_label_dimensions_for_provider_and_style(metrics, &style, label),
         };
         if let Some(aligned) = project_side_aware_anchor(&routed_edge.path, label_height, side) {
             routed_edge.label_position = Some(aligned);

--- a/src/graph/routing/trace.rs
+++ b/src/graph/routing/trace.rs
@@ -7,8 +7,8 @@ use crate::graph::geometry::{
     EdgeLabelSide, GraphGeometry, RoutedEdgeGeometry, RoutedGraphGeometry,
 };
 use crate::graph::measure::{
-    TextMetricsProvider, edge_label_dimensions_for_provider,
-    edge_label_dimensions_wrapped_for_provider,
+    TextMetricsProvider, edge_label_dimensions_for_provider_and_style,
+    edge_label_dimensions_wrapped_for_provider_and_style, edge_text_style_key,
 };
 use crate::graph::space::{FPoint, FRect};
 use crate::graph::{Direction, Graph, Shape};
@@ -340,9 +340,12 @@ impl RouteInputSnapshot {
                     return None;
                 }
                 let midpoint = edge.label_position?;
+                let style = edge_text_style_key(metrics, diagram_edge);
                 let (width, height) = match diagram_edge.wrapped_label_lines.as_deref() {
-                    Some(lines) => edge_label_dimensions_wrapped_for_provider(metrics, lines),
-                    None => edge_label_dimensions_for_provider(metrics, label),
+                    Some(lines) => {
+                        edge_label_dimensions_wrapped_for_provider_and_style(metrics, &style, lines)
+                    }
+                    None => edge_label_dimensions_for_provider_and_style(metrics, &style, label),
                 };
                 let (axis_dim, cross_dim, axis_center, cross_center) = match geometry.direction {
                     Direction::TopDown | Direction::BottomTop => {

--- a/src/graph/style.rs
+++ b/src/graph/style.rs
@@ -16,6 +16,10 @@ pub struct NodeStyle {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<ColorToken>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_family: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_style: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<String>,
@@ -32,6 +36,8 @@ impl NodeStyle {
         self.fill.is_none()
             && self.stroke.is_none()
             && self.color.is_none()
+            && self.font_family.is_none()
+            && self.font_size.is_none()
             && self.font_style.is_none()
             && self.font_weight.is_none()
             && self.stroke_width.is_none()
@@ -59,6 +65,11 @@ impl NodeStyle {
             fill: overlay.fill.clone().or_else(|| self.fill.clone()),
             stroke: overlay.stroke.clone().or_else(|| self.stroke.clone()),
             color: overlay.color.clone().or_else(|| self.color.clone()),
+            font_family: overlay
+                .font_family
+                .clone()
+                .or_else(|| self.font_family.clone()),
+            font_size: overlay.font_size.clone().or_else(|| self.font_size.clone()),
             font_style: overlay
                 .font_style
                 .clone()
@@ -87,11 +98,24 @@ pub struct EdgeStyle {
     pub stroke: Option<ColorToken>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_family: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_style: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub font_weight: Option<String>,
 }
 
 impl EdgeStyle {
     pub fn is_empty(&self) -> bool {
-        self.stroke.is_none() && self.stroke_width.is_none()
+        self.stroke.is_none()
+            && self.stroke_width.is_none()
+            && self.font_family.is_none()
+            && self.font_size.is_none()
+            && self.font_style.is_none()
+            && self.font_weight.is_none()
     }
 
     pub fn merge(&self, overlay: &Self) -> Self {
@@ -101,6 +125,19 @@ impl EdgeStyle {
                 .stroke_width
                 .clone()
                 .or_else(|| self.stroke_width.clone()),
+            font_family: overlay
+                .font_family
+                .clone()
+                .or_else(|| self.font_family.clone()),
+            font_size: overlay.font_size.clone().or_else(|| self.font_size.clone()),
+            font_style: overlay
+                .font_style
+                .clone()
+                .or_else(|| self.font_style.clone()),
+            font_weight: overlay
+                .font_weight
+                .clone()
+                .or_else(|| self.font_weight.clone()),
         }
     }
 }
@@ -181,6 +218,7 @@ pub struct ParsedNodeStyleDirective {
 pub enum NodeStyleIssue {
     UnsupportedProperty { property: String },
     UnsupportedColorSyntax { property: String, value: String },
+    InvalidFontSize { value: String },
     MalformedDeclaration { declaration: String },
 }
 
@@ -188,12 +226,16 @@ impl NodeStyleIssue {
     pub fn message(&self) -> String {
         match self {
             NodeStyleIssue::UnsupportedProperty { property } => format!(
-                "style property '{}' is not supported; supported properties are fill, stroke, and color",
+                "style property '{}' is not supported; supported properties are fill, stroke, color, font-family, font-size, font-style, font-weight, stroke-width, stroke-dasharray, and rx",
                 property
             ),
             NodeStyleIssue::UnsupportedColorSyntax { property, value } => format!(
                 "style property '{}' uses unsupported color syntax '{}'; supported color formats are #rgb, #rrggbb, and named colors",
                 property, value
+            ),
+            NodeStyleIssue::InvalidFontSize { value } => format!(
+                "style property 'font-size' has unsupported value '{}'; supported values are positive numbers with optional px units",
+                value
             ),
             NodeStyleIssue::MalformedDeclaration { declaration } => format!(
                 "style declaration '{}' must use key:value syntax",
@@ -207,6 +249,7 @@ impl NodeStyleIssue {
 pub enum EdgeStyleIssue {
     UnsupportedProperty { property: String },
     UnsupportedColorSyntax { property: String, value: String },
+    InvalidFontSize { value: String },
     MalformedDeclaration { declaration: String },
     InvalidLinkIndex { token: String },
 }
@@ -215,12 +258,16 @@ impl EdgeStyleIssue {
     pub fn message(&self) -> String {
         match self {
             EdgeStyleIssue::UnsupportedProperty { property } => format!(
-                "linkStyle property '{}' is not supported; supported properties are stroke and stroke-width",
+                "linkStyle property '{}' is not supported; supported properties are stroke, stroke-width, font-family, font-size, font-style, and font-weight",
                 property
             ),
             EdgeStyleIssue::UnsupportedColorSyntax { property, value } => format!(
                 "linkStyle property '{}' uses unsupported color syntax '{}'; supported color formats are #rgb, #rrggbb, and named colors",
                 property, value
+            ),
+            EdgeStyleIssue::InvalidFontSize { value } => format!(
+                "linkStyle property 'font-size' has unsupported value '{}'; supported values are positive numbers with optional px units",
+                value
             ),
             EdgeStyleIssue::MalformedDeclaration { declaration } => format!(
                 "linkStyle declaration '{}' must use key:value syntax",
@@ -267,6 +314,48 @@ pub fn parse_node_style_statement(raw: &str) -> Option<ParsedNodeStyleDirective>
         style: parsed.style,
         issues: parsed.issues,
     })
+}
+
+pub(crate) fn parse_font_size_px(value: &str) -> Result<f64, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("font-size cannot be empty".to_string());
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let numeric = match lower.strip_suffix("px") {
+        Some(_) => trimmed[..trimmed.len() - 2].trim_end(),
+        None => trimmed,
+    };
+
+    if !is_plain_decimal_number(numeric) {
+        return Err(format!("unsupported font-size value '{value}'"));
+    }
+
+    let parsed: f64 = numeric
+        .parse()
+        .map_err(|_| format!("unsupported font-size value '{value}'"))?;
+    if !parsed.is_finite() || parsed <= 0.0 {
+        return Err(format!("unsupported font-size value '{value}'"));
+    }
+    Ok(parsed)
+}
+
+fn is_plain_decimal_number(value: &str) -> bool {
+    let mut seen_dot = false;
+    let mut digits_before_dot = 0usize;
+    let mut digits_after_dot = 0usize;
+
+    for ch in value.chars() {
+        match ch {
+            '0'..='9' if seen_dot => digits_after_dot += 1,
+            '0'..='9' => digits_before_dot += 1,
+            '.' if !seen_dot => seen_dot = true,
+            _ => return false,
+        }
+    }
+
+    digits_before_dot > 0 && (!seen_dot || digits_after_dot > 0)
 }
 
 /// Reassemble comma-split fragments: if a fragment has no `:` it's part of the
@@ -319,6 +408,19 @@ pub(crate) fn parse_node_style_declarations(raw: &str) -> ParsedNodeStyleDeclara
 
         // String-valued properties (non-color).
         match property.as_str() {
+            "font-family" => {
+                style.font_family = Some(value.to_string());
+                continue;
+            }
+            "font-size" => {
+                match parse_font_size_px(value) {
+                    Ok(_) => style.font_size = Some(value.to_string()),
+                    Err(_) => issues.push(NodeStyleIssue::InvalidFontSize {
+                        value: value.to_string(),
+                    }),
+                }
+                continue;
+            }
             "font-style" => {
                 style.font_style = Some(value.to_string());
                 continue;
@@ -417,6 +519,21 @@ pub(crate) fn parse_edge_style_declarations(raw: &str) -> ParsedEdgeStyleDeclara
         }
 
         match property.as_str() {
+            "font-family" => {
+                style.font_family = Some(value.to_string());
+            }
+            "font-size" => match parse_font_size_px(value) {
+                Ok(_) => style.font_size = Some(value.to_string()),
+                Err(_) => issues.push(EdgeStyleIssue::InvalidFontSize {
+                    value: value.to_string(),
+                }),
+            },
+            "font-style" => {
+                style.font_style = Some(value.to_string());
+            }
+            "font-weight" => {
+                style.font_weight = Some(value.to_string());
+            }
             "stroke-width" => {
                 style.stroke_width = Some(value.to_string());
             }
@@ -720,6 +837,64 @@ mod tests {
         assert!(parsed.issues.is_empty());
     }
 
+    #[test]
+    fn parse_node_style_accepts_font_family_and_size() {
+        let parsed = parse_node_style_declarations(
+            "font-family:Verdana,font-size:8px,font-style:italic,font-weight:700",
+        );
+
+        assert_eq!(parsed.style.font_family.as_deref(), Some("Verdana"));
+        assert_eq!(parsed.style.font_size.as_deref(), Some("8px"));
+        assert_eq!(parsed.style.font_style.as_deref(), Some("italic"));
+        assert_eq!(parsed.style.font_weight.as_deref(), Some("700"));
+        assert!(parsed.issues.is_empty(), "{:?}", parsed.issues);
+    }
+
+    #[test]
+    fn parse_node_style_accepts_font_size_subset() {
+        for (input, expected) in [
+            ("font-size:14", "14"),
+            ("font-size:14px", "14px"),
+            ("font-size:14PX", "14PX"),
+            ("font-size:14.5 px", "14.5 px"),
+        ] {
+            let parsed = parse_node_style_declarations(input);
+
+            assert_eq!(parsed.style.font_size.as_deref(), Some(expected));
+            assert!(parsed.issues.is_empty(), "{input}: {:?}", parsed.issues);
+        }
+    }
+
+    #[test]
+    fn parse_node_style_rejects_invalid_font_size_values() {
+        for input in ["font-size:1rem", "font-size:+14px", "font-size:1.4e1"] {
+            let parsed = parse_node_style_declarations(input);
+
+            assert_eq!(parsed.style.font_size, None, "{input}");
+            assert!(
+                parsed
+                    .issues
+                    .iter()
+                    .any(|issue| issue.message().contains("font-size")),
+                "{input}: {:?}",
+                parsed.issues
+            );
+        }
+    }
+
+    #[test]
+    fn parse_node_style_keeps_comma_font_family_value_together() {
+        let parsed =
+            parse_node_style_declarations("font-family:Times New Roman, serif,font-size:32px");
+
+        assert_eq!(
+            parsed.style.font_family.as_deref(),
+            Some("Times New Roman, serif")
+        );
+        assert_eq!(parsed.style.font_size.as_deref(), Some("32px"));
+        assert!(parsed.issues.is_empty(), "{:?}", parsed.issues);
+    }
+
     // --- classDef parsing ---
 
     #[test]
@@ -772,7 +947,7 @@ mod tests {
 
     #[test]
     fn parse_classdef_unsupported_property_reported() {
-        let result = parse_classdef_statement("classDef foo fill:#f00,font-size:14px");
+        let result = parse_classdef_statement("classDef foo fill:#f00,shape-padding:14px");
         let parsed = result.unwrap();
         assert!(parsed.style.fill.is_some());
         assert!(!parsed.issues.is_empty());
@@ -861,6 +1036,34 @@ mod tests {
 
         assert_eq!(parsed.target, LinkStyleTarget::Default);
         assert_eq!(parsed.style.stroke.as_ref().unwrap().raw(), "#999");
+    }
+
+    #[test]
+    fn parse_linkstyle_accepts_label_font_properties() {
+        let parsed = parse_linkstyle_statement(
+            "linkStyle 0 font-family:Times New Roman,font-size:32px,font-weight:700",
+        )
+        .unwrap();
+
+        assert_eq!(parsed.style.font_family.as_deref(), Some("Times New Roman"));
+        assert_eq!(parsed.style.font_size.as_deref(), Some("32px"));
+        assert_eq!(parsed.style.font_weight.as_deref(), Some("700"));
+        assert!(parsed.issues.is_empty(), "{:?}", parsed.issues);
+    }
+
+    #[test]
+    fn parse_linkstyle_rejects_invalid_label_font_size() {
+        let parsed = parse_linkstyle_statement("linkStyle 0 font-size:1rem").unwrap();
+
+        assert_eq!(parsed.style.font_size, None);
+        assert!(
+            parsed
+                .issues
+                .iter()
+                .any(|issue| issue.message().contains("font-size")),
+            "{:?}",
+            parsed.issues
+        );
     }
 
     #[test]

--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -6591,7 +6591,8 @@ mod dynamic_text_metrics_topology_smoke_tests {
     };
     use crate::runtime::config::RenderConfig;
     use crate::runtime::dynamic_text_metrics::{
-        DynamicMetricsInput, render_graph_family_svg_with_dynamic_text_metrics,
+        DynamicMetricsInput, DynamicTextStyleInput,
+        render_graph_family_svg_with_dynamic_text_metrics,
     };
 
     #[derive(Clone, Copy)]
@@ -6705,14 +6706,18 @@ mod dynamic_text_metrics_topology_smoke_tests {
             .expect("default recorded text metrics should resolve");
         let metrics = resolved.metrics;
         let dynamic_input = DynamicMetricsInput {
-            css_font: format!("{}px {}", metrics.font_size(), DEFAULT_GRAPH_FONT_FAMILY),
-            font_family: DEFAULT_GRAPH_FONT_FAMILY.to_string(),
-            font_size_px: metrics.font_size(),
-            line_height_px: metrics.line_height(),
+            default_style: "s0".to_string(),
+            text_styles: vec![DynamicTextStyleInput {
+                id: "s0".to_string(),
+                font_family: DEFAULT_GRAPH_FONT_FAMILY.to_string(),
+                font_size: metrics.font_size(),
+                font_style: "normal".to_string(),
+                font_weight: "400".to_string(),
+                line_height: metrics.line_height(),
+                css_font: format!("{}px {}", metrics.font_size(), DEFAULT_GRAPH_FONT_FAMILY),
+            }],
             profile_id: None,
             profile_version: None,
-            font_style: None,
-            font_weight: None,
         };
         let text_scales = text_scales
             .iter()

--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -12,8 +12,8 @@ use crate::engines::graph::flux::FluxLayeredEngine;
 use crate::format::{CornerStyle, Curve, RoutingStyle};
 use crate::graph::Stroke;
 use crate::graph::measure::{
-    COMPATIBILITY_TEXT_METRICS_PROFILE_ID, TextMetricsProvider, default_proportional_text_metrics,
-    default_proportional_text_metrics_provider,
+    COMPATIBILITY_TEXT_METRICS_PROFILE_ID, GraphTextStyleKey, TextMetricsProvider,
+    default_proportional_text_metrics, default_proportional_text_metrics_provider,
 };
 use crate::graph::routing::{EdgeRouting, route_graph_geometry};
 use crate::internal_tests::stub_metrics::WideMProvider;
@@ -113,6 +113,111 @@ fn svg_label_background_uses_provider_widths() {
         max_width > 160.0,
         "provider should drive SVG label background width; max={max_width}, svg={svg}"
     );
+}
+
+#[test]
+fn svg_node_and_edge_labels_emit_effective_font_attributes() {
+    let input = r#"graph TD
+        A[Regular] -->|link| B(Styled Node)
+        style A font-family:Verdana,font-size:8px
+        style B font-family:Courier New,font-size:20px
+        linkStyle 0 font-family:Times New Roman,font-size:32px
+    "#;
+
+    let svg = render_svg_with_provider_for_test(input, &StyleSvgProvider);
+
+    assert!(svg.contains("font-family=\"Verdana\""), "{svg}");
+    assert!(
+        regex::Regex::new(r#"font-size="8(?:\.\d+)?""#)
+            .unwrap()
+            .is_match(&svg),
+        "{svg}"
+    );
+    assert!(svg.contains("font-family=\"Courier New\""), "{svg}");
+    assert!(
+        regex::Regex::new(r#"font-size="20(?:\.\d+)?""#)
+            .unwrap()
+            .is_match(&svg),
+        "{svg}"
+    );
+    assert!(svg.contains("font-family=\"Times New Roman\""), "{svg}");
+    assert!(
+        regex::Regex::new(r#"font-size="32(?:\.\d+)?""#)
+            .unwrap()
+            .is_match(&svg),
+        "{svg}"
+    );
+
+    let widest_bg = extract_label_bg_rects(&svg)
+        .iter()
+        .map(|(_, _, width, _)| *width)
+        .fold(0.0, f64::max);
+    assert!(
+        widest_bg > 120.0,
+        "edge label background should use Times New Roman style width; max={widest_bg}, svg={svg}"
+    );
+}
+
+struct StyleSvgProvider;
+
+impl TextMetricsProvider for StyleSvgProvider {
+    fn measure_line_width(&self, text: &str) -> f64 {
+        text.chars().map(|ch| self.measure_scalar_width(ch)).sum()
+    }
+
+    fn measure_scalar_width(&self, _ch: char) -> f64 {
+        8.0
+    }
+
+    fn measure_line_width_for_style(&self, style: &GraphTextStyleKey, text: &str) -> f64 {
+        match (style.font_family.as_str(), text) {
+            ("Verdana", "Regular") => 40.0,
+            ("Courier New", "Styled Node") => 160.0,
+            ("Times New Roman", "link") => 128.0,
+            _ => self.measure_line_width(text),
+        }
+    }
+
+    fn measure_scalar_width_for_style(&self, style: &GraphTextStyleKey, ch: char) -> f64 {
+        match style.font_family.as_str() {
+            "Verdana" => 5.0,
+            "Courier New" => 12.0,
+            "Times New Roman" => 32.0,
+            _ => self.measure_scalar_width(ch),
+        }
+    }
+
+    fn font_size_for_style(&self, style: &GraphTextStyleKey) -> f64 {
+        style.font_size_px()
+    }
+
+    fn line_height_for_style(&self, style: &GraphTextStyleKey) -> f64 {
+        style.line_height_px()
+    }
+
+    fn font_size(&self) -> f64 {
+        16.0
+    }
+
+    fn line_height(&self) -> f64 {
+        24.0
+    }
+
+    fn node_padding_x(&self) -> f64 {
+        15.0
+    }
+
+    fn node_padding_y(&self) -> f64 {
+        15.0
+    }
+
+    fn label_padding_x(&self) -> f64 {
+        4.0
+    }
+
+    fn label_padding_y(&self) -> f64 {
+        2.0
+    }
 }
 
 fn solve_visual_geometry(

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -856,7 +856,7 @@ fn text_measurements_extension(
     let line_widths = measurements
         .line_widths
         .iter()
-        .map(|(text, width)| {
+        .map(|((_style_id, text), width)| {
             let mut entry = Map::new();
             entry.insert("text".to_string(), Value::String(text.clone()));
             entry.insert(
@@ -869,7 +869,7 @@ fn text_measurements_extension(
     let scalar_widths = measurements
         .scalar_widths
         .iter()
-        .map(|(ch, width)| {
+        .map(|((_style_id, ch), width)| {
             let mut entry = Map::new();
             entry.insert("text".to_string(), Value::String(ch.to_string()));
             entry.insert(

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -22,7 +22,7 @@ use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
 use crate::graph::routing::{
     EdgeRouting, route_graph_geometry, route_graph_geometry_with_provider,
 };
-use crate::graph::style::NodeStyle;
+use crate::graph::style::{EdgeStyle, NodeStyle};
 use crate::graph::{Arrow, Direction, GeometryLevel, Graph, Shape, Stroke};
 use crate::simplification::PathSimplification;
 
@@ -409,6 +409,7 @@ fn build_document(
         GeometryLevel::Layout
     };
     let styled_nodes = collect_styled_nodes(diagram);
+    let styled_edges = collect_styled_edges(diagram);
 
     // At routed level, use the recomputed routed bounds (which cover all
     // routed edge paths) instead of stale layout bounds.
@@ -536,12 +537,12 @@ fn build_document(
             grid_projection_extension(grid_projection),
         );
     }
-    if !styled_nodes.is_empty() {
+    if !styled_nodes.is_empty() || !styled_edges.is_empty() {
         push_profile(&mut profiles, CORE_PROFILE);
         push_profile(&mut profiles, NODE_STYLE_PROFILE);
         extensions.insert(
             NODE_STYLE_EXTENSION_NAMESPACE.to_string(),
-            node_style_extension(styled_nodes),
+            style_extension(styled_nodes, styled_edges),
         );
     }
     if let Some(text_metrics_descriptor) = options.text_metrics_descriptor {
@@ -579,6 +580,16 @@ fn collect_styled_nodes(diagram: &Graph) -> BTreeMap<String, NodeStyle> {
         .iter()
         .filter(|(_, node)| !node.style.is_empty())
         .map(|(node_id, node)| (node_id.clone(), node.style.clone()))
+        .collect()
+}
+
+fn collect_styled_edges(diagram: &Graph) -> BTreeMap<String, EdgeStyle> {
+    diagram
+        .edges
+        .iter()
+        .enumerate()
+        .filter(|(_, edge)| !edge.style.is_empty())
+        .map(|(index, edge)| (format!("e{index}"), edge.style.clone()))
         .collect()
 }
 
@@ -715,18 +726,35 @@ fn rect_value(rect: crate::graph::geometry::FRect) -> Value {
     Value::Object(value)
 }
 
-fn node_style_extension(styled_nodes: BTreeMap<String, NodeStyle>) -> Map<String, Value> {
-    let nodes = styled_nodes
-        .iter()
-        .map(|(node_id, style)| {
-            (
-                node_id.clone(),
-                Value::Object(serialize_node_style_extension(style)),
-            )
-        })
-        .collect();
+fn style_extension(
+    styled_nodes: BTreeMap<String, NodeStyle>,
+    styled_edges: BTreeMap<String, EdgeStyle>,
+) -> Map<String, Value> {
     let mut extension = Map::new();
-    extension.insert("nodes".to_string(), Value::Object(nodes));
+    if !styled_nodes.is_empty() {
+        let nodes = styled_nodes
+            .iter()
+            .map(|(node_id, style)| {
+                (
+                    node_id.clone(),
+                    Value::Object(serialize_node_style_extension(style)),
+                )
+            })
+            .collect();
+        extension.insert("nodes".to_string(), Value::Object(nodes));
+    }
+    if !styled_edges.is_empty() {
+        let edges = styled_edges
+            .iter()
+            .map(|(edge_id, style)| {
+                (
+                    edge_id.clone(),
+                    Value::Object(serialize_edge_style_extension(style)),
+                )
+            })
+            .collect();
+        extension.insert("edges".to_string(), Value::Object(edges));
+    }
     extension
 }
 
@@ -764,6 +792,26 @@ fn serialize_node_style_extension(style: &NodeStyle) -> Map<String, Value> {
     }
     if let Some(v) = &style.rx {
         payload.insert("rx".to_string(), Value::String(v.clone()));
+    }
+    payload
+}
+
+fn serialize_edge_style_extension(style: &EdgeStyle) -> Map<String, Value> {
+    let mut payload = Map::new();
+    if let Some(v) = &style.stroke_width {
+        payload.insert("stroke-width".to_string(), Value::String(v.clone()));
+    }
+    if let Some(v) = &style.font_family {
+        payload.insert("font-family".to_string(), Value::String(v.clone()));
+    }
+    if let Some(v) = &style.font_size {
+        payload.insert("font-size".to_string(), Value::String(v.clone()));
+    }
+    if let Some(v) = &style.font_style {
+        payload.insert("font-style".to_string(), Value::String(v.clone()));
+    }
+    if let Some(v) = &style.font_weight {
+        payload.insert("font-weight".to_string(), Value::String(v.clone()));
     }
     payload
 }

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -744,6 +744,12 @@ fn serialize_node_style_extension(style: &NodeStyle) -> Map<String, Value> {
     if let Some(color) = &style.color {
         payload.insert("color".to_string(), Value::String(color.raw().to_string()));
     }
+    if let Some(v) = &style.font_family {
+        payload.insert("font-family".to_string(), Value::String(v.clone()));
+    }
+    if let Some(v) = &style.font_size {
+        payload.insert("font-size".to_string(), Value::String(v.clone()));
+    }
     if let Some(v) = &style.font_style {
         payload.insert("font-style".to_string(), Value::String(v.clone()));
     }
@@ -853,11 +859,42 @@ fn text_measurements_extension(
         Value::Number(Number::from(descriptor.version)),
     );
 
+    let text_styles = measurements
+        .text_styles
+        .values()
+        .map(|style| {
+            let mut entry = Map::new();
+            entry.insert("id".to_string(), Value::String(style.id.clone()));
+            entry.insert(
+                "fontFamily".to_string(),
+                Value::String(style.style.font_family.clone()),
+            );
+            entry.insert(
+                "fontSize".to_string(),
+                finite_number_value(style.style.font_size_px(), "textStyles.fontSize"),
+            );
+            entry.insert(
+                "fontStyle".to_string(),
+                Value::String(style.style.font_style.clone()),
+            );
+            entry.insert(
+                "fontWeight".to_string(),
+                Value::String(style.style.font_weight.clone()),
+            );
+            entry.insert(
+                "lineHeight".to_string(),
+                finite_number_value(style.style.line_height_px(), "textStyles.lineHeight"),
+            );
+            entry.insert("cssFont".to_string(), Value::String(style.css_font.clone()));
+            Value::Object(entry)
+        })
+        .collect();
     let line_widths = measurements
         .line_widths
         .iter()
-        .map(|((_style_id, text), width)| {
+        .map(|((style_id, text), width)| {
             let mut entry = Map::new();
+            entry.insert("style".to_string(), Value::String(style_id.clone()));
             entry.insert("text".to_string(), Value::String(text.clone()));
             entry.insert(
                 "width".to_string(),
@@ -869,8 +906,9 @@ fn text_measurements_extension(
     let scalar_widths = measurements
         .scalar_widths
         .iter()
-        .map(|((_style_id, ch), width)| {
+        .map(|((style_id, ch), width)| {
             let mut entry = Map::new();
+            entry.insert("style".to_string(), Value::String(style_id.clone()));
             entry.insert("text".to_string(), Value::String(ch.to_string()));
             entry.insert(
                 "width".to_string(),
@@ -882,6 +920,7 @@ fn text_measurements_extension(
 
     let mut extension = Map::new();
     extension.insert("profileRef".to_string(), Value::Object(profile_ref));
+    extension.insert("textStyles".to_string(), Value::Array(text_styles));
     extension.insert("lineWidths".to_string(), Value::Array(line_widths));
     extension.insert("scalarWidths".to_string(), Value::Array(scalar_widths));
     extension

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -18,7 +18,7 @@ use crate::graph::measure::{TextMetricsProvider, default_proportional_text_metri
 use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
 use crate::graph::routing::{EdgeRouting, route_graph_geometry_with_provider};
 use crate::graph::space::{FPoint, FRect};
-use crate::graph::style::{ColorToken, NodeStyle};
+use crate::graph::style::{ColorToken, EdgeStyle, NodeStyle};
 use crate::graph::{Edge as GraphEdge, GeometryLevel, Graph, Node, Subgraph};
 use crate::mmds::{
     Document, Edge, NODE_STYLE_EXTENSION_NAMESPACE, TEXT_EXTENSION_NAMESPACE, parse_input,
@@ -174,6 +174,10 @@ pub fn from_document(output: &Document) -> Result<Graph, HydrationError> {
         if let Some(label) = &edge.label {
             hydrated = hydrated.with_label(label.clone());
         }
+        let style = parse_edge_style_from_extension(&output.extensions, &edge.id);
+        if !style.is_empty() {
+            hydrated.style = hydrated.style.merge(&style);
+        }
         hydrated.from_subgraph = edge.from_subgraph.clone();
         hydrated.to_subgraph = edge.to_subgraph.clone();
         diagram.add_edge(hydrated);
@@ -247,6 +251,46 @@ fn parse_node_style_extension(style_object: &Map<String, Value>) -> NodeStyle {
             "stroke_dasharray",
         ),
         rx: parse_node_style_string(style_object, "rx"),
+    }
+}
+
+fn parse_edge_style_from_extension(
+    extensions: &std::collections::BTreeMap<String, Map<String, Value>>,
+    edge_id: &str,
+) -> EdgeStyle {
+    let Some(extension) = extensions.get(NODE_STYLE_EXTENSION_NAMESPACE) else {
+        return EdgeStyle::default();
+    };
+    let Some(edges) = extension.get("edges").and_then(Value::as_object) else {
+        return EdgeStyle::default();
+    };
+    let Some(style_object) = edges.get(edge_id).and_then(Value::as_object) else {
+        return EdgeStyle::default();
+    };
+
+    EdgeStyle {
+        stroke: None,
+        stroke_width: parse_node_style_string_with_legacy_key(
+            style_object,
+            "stroke-width",
+            "stroke_width",
+        ),
+        font_family: parse_node_style_string_with_legacy_key(
+            style_object,
+            "font-family",
+            "font_family",
+        ),
+        font_size: parse_node_style_string_with_legacy_key(style_object, "font-size", "font_size"),
+        font_style: parse_node_style_string_with_legacy_key(
+            style_object,
+            "font-style",
+            "font_style",
+        ),
+        font_weight: parse_node_style_string_with_legacy_key(
+            style_object,
+            "font-weight",
+            "font_weight",
+        ),
     }
 }
 

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -220,6 +220,12 @@ fn parse_node_style_extension(style_object: &Map<String, Value>) -> NodeStyle {
         fill: parse_node_style_color(style_object, "fill"),
         stroke: parse_node_style_color(style_object, "stroke"),
         color: parse_node_style_color(style_object, "color"),
+        font_family: parse_node_style_string_with_legacy_key(
+            style_object,
+            "font-family",
+            "font_family",
+        ),
+        font_size: parse_node_style_string_with_legacy_key(style_object, "font-size", "font_size"),
         font_style: parse_node_style_string_with_legacy_key(
             style_object,
             "font-style",

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -224,33 +224,21 @@ fn parse_node_style_extension(style_object: &Map<String, Value>) -> NodeStyle {
         fill: parse_node_style_color(style_object, "fill"),
         stroke: parse_node_style_color(style_object, "stroke"),
         color: parse_node_style_color(style_object, "color"),
-        font_family: parse_node_style_string_with_legacy_key(
-            style_object,
-            "font-family",
-            "font_family",
-        ),
-        font_size: parse_node_style_string_with_legacy_key(style_object, "font-size", "font_size"),
-        font_style: parse_node_style_string_with_legacy_key(
-            style_object,
-            "font-style",
-            "font_style",
-        ),
-        font_weight: parse_node_style_string_with_legacy_key(
-            style_object,
-            "font-weight",
-            "font_weight",
-        ),
-        stroke_width: parse_node_style_string_with_legacy_key(
+        font_family: parse_style_string_with_legacy_key(style_object, "font-family", "font_family"),
+        font_size: parse_style_string_with_legacy_key(style_object, "font-size", "font_size"),
+        font_style: parse_style_string_with_legacy_key(style_object, "font-style", "font_style"),
+        font_weight: parse_style_string_with_legacy_key(style_object, "font-weight", "font_weight"),
+        stroke_width: parse_style_string_with_legacy_key(
             style_object,
             "stroke-width",
             "stroke_width",
         ),
-        stroke_dasharray: parse_node_style_string_with_legacy_key(
+        stroke_dasharray: parse_style_string_with_legacy_key(
             style_object,
             "stroke-dasharray",
             "stroke_dasharray",
         ),
-        rx: parse_node_style_string(style_object, "rx"),
+        rx: parse_style_string(style_object, "rx"),
     }
 }
 
@@ -270,40 +258,27 @@ fn parse_edge_style_from_extension(
 
     EdgeStyle {
         stroke: None,
-        stroke_width: parse_node_style_string_with_legacy_key(
+        stroke_width: parse_style_string_with_legacy_key(
             style_object,
             "stroke-width",
             "stroke_width",
         ),
-        font_family: parse_node_style_string_with_legacy_key(
-            style_object,
-            "font-family",
-            "font_family",
-        ),
-        font_size: parse_node_style_string_with_legacy_key(style_object, "font-size", "font_size"),
-        font_style: parse_node_style_string_with_legacy_key(
-            style_object,
-            "font-style",
-            "font_style",
-        ),
-        font_weight: parse_node_style_string_with_legacy_key(
-            style_object,
-            "font-weight",
-            "font_weight",
-        ),
+        font_family: parse_style_string_with_legacy_key(style_object, "font-family", "font_family"),
+        font_size: parse_style_string_with_legacy_key(style_object, "font-size", "font_size"),
+        font_style: parse_style_string_with_legacy_key(style_object, "font-style", "font_style"),
+        font_weight: parse_style_string_with_legacy_key(style_object, "font-weight", "font_weight"),
     }
 }
 
-fn parse_node_style_string_with_legacy_key(
+fn parse_style_string_with_legacy_key(
     style_object: &Map<String, Value>,
     key: &str,
     legacy_key: &str,
 ) -> Option<String> {
-    parse_node_style_string(style_object, key)
-        .or_else(|| parse_node_style_string(style_object, legacy_key))
+    parse_style_string(style_object, key).or_else(|| parse_style_string(style_object, legacy_key))
 }
 
-fn parse_node_style_string(style_object: &Map<String, Value>, key: &str) -> Option<String> {
+fn parse_style_string(style_object: &Map<String, Value>, key: &str) -> Option<String> {
     style_object.get(key)?.as_str().map(|s| s.to_string())
 }
 

--- a/src/render/graph/svg/bounds.rs
+++ b/src/render/graph/svg/bounds.rs
@@ -5,7 +5,9 @@ use std::collections::HashMap;
 use super::labels::{fallback_label_position, precomputed_label_positions};
 use super::{Point, Rect};
 use crate::graph::geometry::GraphGeometry;
-use crate::graph::measure::{TextMetricsProvider, edge_label_dimensions_for_provider};
+use crate::graph::measure::{
+    TextMetricsProvider, edge_label_dimensions_for_provider_and_style, edge_text_style_key,
+};
 use crate::graph::{Graph, Stroke};
 
 pub(super) struct SvgBounds {
@@ -147,7 +149,8 @@ pub(super) fn compute_svg_bounds(
         let Some(point) = position else {
             continue;
         };
-        let (w, h) = edge_label_dimensions_for_provider(metrics, label);
+        let style = edge_text_style_key(metrics, edge);
+        let (w, h) = edge_label_dimensions_for_provider_and_style(metrics, &style, label);
         let rect = Rect {
             x: point.x - w / 2.0,
             y: point.y - h / 2.0,

--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -8,7 +8,7 @@ use super::text::{
 };
 use super::{GraphSvgPalette, Point, dynamic_css_attrs};
 use crate::graph::geometry::GraphGeometry;
-use crate::graph::measure::{TextMetricsProvider, edge_text_style_key};
+use crate::graph::measure::{GraphTextStyleKey, TextMetricsProvider, edge_text_style_key};
 use crate::graph::routing::compute_end_label_positions;
 use crate::graph::{Graph, Stroke};
 use crate::render::svg::SvgWriter;
@@ -108,6 +108,7 @@ pub(super) fn render_edge_labels(
     rendered_edge_paths: &HashMap<usize, Vec<Point>>,
     override_nodes: &HashMap<String, String>,
     metrics: &dyn TextMetricsProvider,
+    default_text_style: &GraphTextStyleKey,
     scale: f64,
     palette: &GraphSvgPalette,
 ) {
@@ -224,7 +225,8 @@ pub(super) fn render_edge_labels(
             .and_then(|e| e.effective_wrapped_lines.as_deref())
             .or(edge.wrapped_label_lines.as_deref());
         let text_style = edge_text_style_key(metrics, edge);
-        let text_attrs = dynamic_attrs.clone() + &font_attrs_for_style(metrics, &text_style);
+        let text_attrs =
+            dynamic_attrs.clone() + &font_attrs_for_style(default_text_style, &text_style);
         render_text_centered_with_wrap(
             writer,
             Point {
@@ -265,7 +267,8 @@ pub(super) fn render_edge_labels(
         }
         let (head_pos, tail_pos) = compute_end_label_positions(&path);
         let text_style = edge_text_style_key(metrics, edge);
-        let text_attrs = dynamic_attrs.clone() + &font_attrs_for_style(metrics, &text_style);
+        let text_attrs =
+            dynamic_attrs.clone() + &font_attrs_for_style(default_text_style, &text_style);
         if let (Some(label), Some(pos)) = (&edge.head_label, head_pos) {
             render_text_centered(
                 writer,

--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -125,6 +125,7 @@ pub(super) fn render_edge_labels(
     let bg_style = BackgroundStyle {
         fill: &palette.edge_label_background,
         extra_attrs: bg_dynamic_attrs.as_str(),
+        size: None,
     };
 
     writer.start_group("edgeLabels");
@@ -241,6 +242,7 @@ pub(super) fn render_edge_labels(
                 background: Some(BackgroundStyle {
                     fill: bg_style.fill,
                     extra_attrs: bg_style.extra_attrs,
+                    size: label_geom.map(|g| (g.rect.width, g.rect.height)),
                 }),
             },
         );
@@ -281,6 +283,7 @@ pub(super) fn render_edge_labels(
                     background: Some(BackgroundStyle {
                         fill: bg_style.fill,
                         extra_attrs: bg_style.extra_attrs,
+                        size: None,
                     }),
                 },
             );
@@ -302,6 +305,7 @@ pub(super) fn render_edge_labels(
                     background: Some(BackgroundStyle {
                         fill: bg_style.fill,
                         extra_attrs: bg_style.extra_attrs,
+                        size: None,
                     }),
                 },
             );

--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -3,11 +3,12 @@
 use std::collections::HashMap;
 
 use super::text::{
-    BackgroundStyle, TextRenderStyle, render_text_centered, render_text_centered_with_wrap,
+    BackgroundStyle, TextRenderStyle, font_attrs_for_style, render_text_centered,
+    render_text_centered_with_wrap,
 };
 use super::{GraphSvgPalette, Point, dynamic_css_attrs};
 use crate::graph::geometry::GraphGeometry;
-use crate::graph::measure::TextMetricsProvider;
+use crate::graph::measure::{TextMetricsProvider, edge_text_style_key};
 use crate::graph::routing::compute_end_label_positions;
 use crate::graph::{Graph, Stroke};
 use crate::render::svg::SvgWriter;
@@ -221,6 +222,8 @@ pub(super) fn render_edge_labels(
         let wrap_lines = layout_edge
             .and_then(|e| e.effective_wrapped_lines.as_deref())
             .or(edge.wrapped_label_lines.as_deref());
+        let text_style = edge_text_style_key(metrics, edge);
+        let text_attrs = dynamic_attrs.clone() + &font_attrs_for_style(metrics, &text_style);
         render_text_centered_with_wrap(
             writer,
             Point {
@@ -233,7 +236,8 @@ pub(super) fn render_edge_labels(
             scale,
             TextRenderStyle {
                 color: &palette.edge_label_text,
-                extra_attrs: dynamic_attrs.as_str(),
+                extra_attrs: text_attrs.as_str(),
+                text_style: Some(&text_style),
                 background: Some(BackgroundStyle {
                     fill: bg_style.fill,
                     extra_attrs: bg_style.extra_attrs,
@@ -258,6 +262,8 @@ pub(super) fn render_edge_labels(
             continue;
         }
         let (head_pos, tail_pos) = compute_end_label_positions(&path);
+        let text_style = edge_text_style_key(metrics, edge);
+        let text_attrs = dynamic_attrs.clone() + &font_attrs_for_style(metrics, &text_style);
         if let (Some(label), Some(pos)) = (&edge.head_label, head_pos) {
             render_text_centered(
                 writer,
@@ -270,7 +276,8 @@ pub(super) fn render_edge_labels(
                 scale,
                 TextRenderStyle {
                     color: &palette.edge_label_text,
-                    extra_attrs: dynamic_attrs.as_str(),
+                    extra_attrs: text_attrs.as_str(),
+                    text_style: Some(&text_style),
                     background: Some(BackgroundStyle {
                         fill: bg_style.fill,
                         extra_attrs: bg_style.extra_attrs,
@@ -290,7 +297,8 @@ pub(super) fn render_edge_labels(
                 scale,
                 TextRenderStyle {
                     color: &palette.edge_label_text,
-                    extra_attrs: dynamic_attrs.as_str(),
+                    extra_attrs: text_attrs.as_str(),
+                    text_style: Some(&text_style),
                     background: Some(BackgroundStyle {
                         fill: bg_style.fill,
                         extra_attrs: bg_style.extra_attrs,

--- a/src/render/graph/svg/mod.rs
+++ b/src/render/graph/svg/mod.rs
@@ -21,8 +21,8 @@ use crate::format::{Curve, RoutingStyle};
 use crate::graph::direction_policy::build_override_node_map;
 use crate::graph::geometry::{FPoint, FRect, GraphGeometry};
 use crate::graph::measure::{
-    DEFAULT_GRAPH_FONT_FAMILY, DEFAULT_PROPORTIONAL_FONT_SIZE, ProportionalTextMetrics,
-    TextMetricsProvider,
+    DEFAULT_GRAPH_FONT_FAMILY, DEFAULT_PROPORTIONAL_FONT_SIZE, GraphTextStyleKey,
+    ProportionalTextMetrics, TextMetricsProvider,
 };
 use crate::graph::routing::EdgeRouting;
 use crate::graph::{Graph, Stroke};
@@ -252,6 +252,7 @@ fn render_svg_with_geometry_context(
     let offset_y = (-min_y + padding) * scale;
     let palette = GraphSvgPalette::from_theme(theme);
     let used_markers = collect_used_markers(diagram);
+    let default_text_style = GraphTextStyleKey::default_provider_style(metrics);
 
     let mut writer = SvgWriter::new();
     writer.start_svg_with_root_style(
@@ -276,7 +277,15 @@ fn render_svg_with_geometry_context(
         scale,
         &palette,
     );
-    render_nodes(&mut writer, diagram, geom, metrics, scale, &palette);
+    render_nodes(
+        &mut writer,
+        diagram,
+        geom,
+        metrics,
+        &default_text_style,
+        scale,
+        &palette,
+    );
     render_edge_labels(
         &mut writer,
         diagram,
@@ -285,6 +294,7 @@ fn render_svg_with_geometry_context(
         &prepared_edges.paths,
         context.override_nodes,
         metrics,
+        &default_text_style,
         scale,
         &palette,
     );

--- a/src/render/graph/svg/nodes.rs
+++ b/src/render/graph/svg/nodes.rs
@@ -4,10 +4,10 @@ use std::fmt::Write;
 
 use super::bounds::scale_rect;
 use super::edges::{document_svg_path, polygon_points};
-use super::text::{TextRenderStyle, render_text_centered};
+use super::text::{TextRenderStyle, font_attrs_for_style, render_text_centered};
 use super::{GraphSvgPalette, Point, Rect, dynamic_css_attrs};
 use crate::graph::geometry::{FRect, GraphGeometry};
-use crate::graph::measure::TextMetricsProvider;
+use crate::graph::measure::{GraphTextStyleKey, TextMetricsProvider, node_text_style_key};
 use crate::graph::routing::hexagon_vertices;
 use crate::graph::{Direction, Graph, Node, Shape};
 use crate::render::svg::{SvgWriter, escape_text, fmt_f64};
@@ -17,8 +17,6 @@ struct ResolvedSvgNodeStyle<'a> {
     fill: Option<&'a str>,
     stroke: Option<&'a str>,
     text: Option<&'a str>,
-    font_style: Option<&'a str>,
-    font_weight: Option<&'a str>,
     stroke_width: Option<&'a str>,
     stroke_dasharray: Option<&'a str>,
     rx: Option<&'a str>,
@@ -30,8 +28,6 @@ impl<'a> ResolvedSvgNodeStyle<'a> {
             fill: node.style.fill.as_ref().map(|color| color.raw()),
             stroke: node.style.stroke.as_ref().map(|color| color.raw()),
             text: node.style.color.as_ref().map(|color| color.raw()),
-            font_style: node.style.font_style.as_deref(),
-            font_weight: node.style.font_weight.as_deref(),
             stroke_width: node.style.stroke_width.as_deref(),
             stroke_dasharray: node.style.stroke_dasharray.as_deref(),
             rx: node.style.rx.as_deref(),
@@ -63,10 +59,10 @@ impl<'a> ResolvedSvgNodeStyle<'a> {
     }
 }
 
-#[derive(Clone, Copy)]
 struct NodeLabelRenderContext<'a> {
     rect: &'a Rect,
     style: ResolvedSvgNodeStyle<'a>,
+    text_style: GraphTextStyleKey,
     metrics: &'a dyn TextMetricsProvider,
     scale: f64,
     palette: &'a GraphSvgPalette,
@@ -215,6 +211,7 @@ pub(super) fn render_nodes(
         };
         let rect: Rect = pos_node.rect;
         let style = ResolvedSvgNodeStyle::from_node(node);
+        let text_style = node_text_style_key(metrics, node);
         render_node_shape(
             writer,
             node,
@@ -260,6 +257,7 @@ pub(super) fn render_nodes(
             NodeLabelRenderContext {
                 rect: &rect,
                 style,
+                text_style,
                 metrics,
                 scale,
                 palette,
@@ -290,13 +288,8 @@ fn render_node_label(
             &["fill:var(--_text);"],
         )
     };
-    let mut font_attrs = text_dynamic_attrs;
-    if let Some(fw) = context.style.font_weight {
-        write!(font_attrs, " font-weight=\"{fw}\"").unwrap();
-    }
-    if let Some(fs) = context.style.font_style {
-        write!(font_attrs, " font-style=\"{fs}\"").unwrap();
-    }
+    let font_attrs =
+        text_dynamic_attrs + &font_attrs_for_style(context.metrics, &context.text_style);
 
     if !has_separator {
         render_text_centered(
@@ -308,13 +301,14 @@ fn render_node_label(
             TextRenderStyle {
                 color: text_color,
                 extra_attrs: font_attrs.as_str(),
+                text_style: Some(&context.text_style),
                 background: None,
             },
         );
         return;
     }
 
-    let line_height = context.metrics.line_height() * context.scale;
+    let line_height = context.metrics.line_height_for_style(&context.text_style) * context.scale;
     let total_height = line_height * (lines.len().saturating_sub(1) as f64);
     let start_y = center.y - total_height / 2.0;
     let x1 = context.rect.x * context.scale;

--- a/src/render/graph/svg/nodes.rs
+++ b/src/render/graph/svg/nodes.rs
@@ -64,6 +64,7 @@ struct NodeLabelRenderContext<'a> {
     style: ResolvedSvgNodeStyle<'a>,
     text_style: GraphTextStyleKey,
     metrics: &'a dyn TextMetricsProvider,
+    default_text_style: &'a GraphTextStyleKey,
     scale: f64,
     palette: &'a GraphSvgPalette,
 }
@@ -196,6 +197,7 @@ pub(super) fn render_nodes(
     diagram: &Graph,
     geom: &GraphGeometry,
     metrics: &dyn TextMetricsProvider,
+    default_text_style: &GraphTextStyleKey,
     scale: f64,
     palette: &GraphSvgPalette,
 ) {
@@ -259,6 +261,7 @@ pub(super) fn render_nodes(
                 style,
                 text_style,
                 metrics,
+                default_text_style,
                 scale,
                 palette,
             },
@@ -289,7 +292,7 @@ fn render_node_label(
         )
     };
     let font_attrs =
-        text_dynamic_attrs + &font_attrs_for_style(context.metrics, &context.text_style);
+        text_dynamic_attrs + &font_attrs_for_style(context.default_text_style, &context.text_style);
 
     if !has_separator {
         render_text_centered(

--- a/src/render/graph/svg/text.rs
+++ b/src/render/graph/svg/text.rs
@@ -18,6 +18,7 @@ pub(super) struct TextRenderStyle<'a> {
 pub(super) struct BackgroundStyle<'a> {
     pub(super) fill: &'a str,
     pub(super) extra_attrs: &'a str,
+    pub(super) size: Option<(f64, f64)>,
 }
 
 // Label padding defaults live in `graph::measure`.
@@ -54,7 +55,7 @@ pub(super) fn render_text_centered_with_wrap(
         .cloned()
         .unwrap_or_else(|| GraphTextStyleKey::default_provider_style(metrics));
     if let Some(bg) = &style.background {
-        let (w, h) = match wrapped_lines {
+        let (w, h) = bg.size.unwrap_or_else(|| match wrapped_lines {
             Some(lines) => measure_wrapped_with_padding(
                 metrics,
                 &measured_style,
@@ -69,7 +70,7 @@ pub(super) fn render_text_centered_with_wrap(
                 LABEL_BG_PAD_X,
                 LABEL_BG_PAD_Y,
             ),
-        };
+        });
         let rect_w = w * scale;
         let rect_h = h * scale;
         let rect = format!(

--- a/src/render/graph/svg/text.rs
+++ b/src/render/graph/svg/text.rs
@@ -2,14 +2,16 @@
 
 use crate::graph::geometry::FPoint;
 use crate::graph::measure::{
-    DEFAULT_LABEL_PADDING_X, DEFAULT_LABEL_PADDING_Y, TextMetricsProvider,
-    edge_label_dimensions_wrapped_for_provider, measure_text_with_padding_for_provider,
+    DEFAULT_LABEL_PADDING_X, DEFAULT_LABEL_PADDING_Y, GraphTextStyleKey, TextMetricsProvider,
+    edge_label_dimensions_wrapped_for_provider_and_style,
+    measure_text_with_padding_for_provider_and_style,
 };
 use crate::render::svg::{SvgWriter, escape_text, fmt_f64};
 
 pub(super) struct TextRenderStyle<'a> {
     pub(super) color: &'a str,
     pub(super) extra_attrs: &'a str,
+    pub(super) text_style: Option<&'a GraphTextStyleKey>,
     pub(super) background: Option<BackgroundStyle<'a>>,
 }
 
@@ -47,13 +49,22 @@ pub(super) fn render_text_centered_with_wrap(
     scale: f64,
     style: TextRenderStyle<'_>,
 ) {
+    let measured_style = style
+        .text_style
+        .cloned()
+        .unwrap_or_else(|| GraphTextStyleKey::default_provider_style(metrics));
     if let Some(bg) = &style.background {
         let (w, h) = match wrapped_lines {
-            Some(lines) => {
-                measure_wrapped_with_padding(metrics, lines, LABEL_BG_PAD_X, LABEL_BG_PAD_Y)
-            }
-            None => measure_text_with_padding_for_provider(
+            Some(lines) => measure_wrapped_with_padding(
                 metrics,
+                &measured_style,
+                lines,
+                LABEL_BG_PAD_X,
+                LABEL_BG_PAD_Y,
+            ),
+            None => measure_text_with_padding_for_provider_and_style(
+                metrics,
+                &measured_style,
                 text,
                 LABEL_BG_PAD_X,
                 LABEL_BG_PAD_Y,
@@ -100,7 +111,7 @@ pub(super) fn render_text_centered_with_wrap(
         return;
     }
 
-    let line_height = metrics.line_height() * scale;
+    let line_height = metrics.line_height_for_style(&measured_style) * scale;
     let total_height = line_height * (lines.len().saturating_sub(1) as f64);
     let start_y = center.y - total_height / 2.0;
 
@@ -120,17 +131,47 @@ pub(super) fn render_text_centered_with_wrap(
 
 fn measure_wrapped_with_padding(
     metrics: &dyn TextMetricsProvider,
+    style: &GraphTextStyleKey,
     lines: &[String],
     padding_x: f64,
     padding_y: f64,
 ) -> (f64, f64) {
     // Mirrors ProportionalTextMetrics::measure_text_with_padding but sources
     // the line vector from the caller's pre-wrapped artifact.
-    let (w, h) = edge_label_dimensions_wrapped_for_provider(metrics, lines);
+    let (w, h) = edge_label_dimensions_wrapped_for_provider_and_style(metrics, style, lines);
     // `edge_label_dimensions_wrapped` bakes in `metrics.label_padding_*`; peel
     // those off and add the caller-requested padding to match the untreated
     // `measure_text_with_padding` behavior.
     let raw_w = w - 2.0 * metrics.label_padding_x();
     let raw_h = h - 2.0 * metrics.label_padding_y();
     (raw_w + 2.0 * padding_x, raw_h + 2.0 * padding_y)
+}
+
+pub(super) fn font_attrs_for_style(
+    metrics: &dyn TextMetricsProvider,
+    style: &GraphTextStyleKey,
+) -> String {
+    let default = GraphTextStyleKey::default_provider_style(metrics);
+    let mut attrs = String::new();
+    if style.font_family != default.font_family {
+        attrs.push_str(" font-family=\"");
+        attrs.push_str(&escape_text(&style.font_family));
+        attrs.push('"');
+    }
+    if style.font_size_mpx != default.font_size_mpx {
+        attrs.push_str(" font-size=\"");
+        attrs.push_str(&fmt_f64(style.font_size_px()));
+        attrs.push('"');
+    }
+    if style.font_style != default.font_style {
+        attrs.push_str(" font-style=\"");
+        attrs.push_str(&escape_text(&style.font_style));
+        attrs.push('"');
+    }
+    if style.font_weight != default.font_weight {
+        attrs.push_str(" font-weight=\"");
+        attrs.push_str(&escape_text(&style.font_weight));
+        attrs.push('"');
+    }
+    attrs
 }

--- a/src/render/graph/svg/text.rs
+++ b/src/render/graph/svg/text.rs
@@ -149,10 +149,9 @@ fn measure_wrapped_with_padding(
 }
 
 pub(super) fn font_attrs_for_style(
-    metrics: &dyn TextMetricsProvider,
+    default: &GraphTextStyleKey,
     style: &GraphTextStyleKey,
 ) -> String {
-    let default = GraphTextStyleKey::default_provider_style(metrics);
     let mut attrs = String::new();
     if style.font_family != default.font_family {
         attrs.push_str(" font-family=\"");

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -4,7 +4,7 @@
 //! provider API is not part of the stable Rust facade.
 
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 use serde::Deserialize;
@@ -15,8 +15,9 @@ use crate::format::OutputFormat;
 use crate::frontends::{InputFrontend, detect_input_frontend};
 use crate::graph::measure::{
     DEFAULT_LABEL_PADDING_X, DEFAULT_LABEL_PADDING_Y, DEFAULT_PROPORTIONAL_NODE_PADDING_X,
-    DEFAULT_PROPORTIONAL_NODE_PADDING_Y, TextMeasurementCache, TextMetricsLayoutDescriptor,
-    TextMetricsProfileDescriptor, TextMetricsProvider, TextMetricsStyleDescriptor,
+    DEFAULT_PROPORTIONAL_NODE_PADDING_Y, GraphTextStyleKey, TextMeasurementCache,
+    TextMeasurementStyle, TextMetricsLayoutDescriptor, TextMetricsProfileDescriptor,
+    TextMetricsProvider, TextMetricsStyleDescriptor,
 };
 use crate::payload::Diagram;
 use crate::registry::DiagramFamily;
@@ -27,22 +28,32 @@ use crate::runtime::config_input::apply_svg_surface_defaults;
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DynamicMetricsInput {
-    pub css_font: String,
-    pub font_family: String,
-    pub font_size_px: f64,
-    pub line_height_px: f64,
+    pub default_style: String,
+    pub text_styles: Vec<DynamicTextStyleInput>,
     pub profile_id: Option<String>,
     pub profile_version: Option<u32>,
-    pub font_style: Option<String>,
-    pub font_weight: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DynamicTextStyleInput {
+    pub id: String,
+    pub font_family: String,
+    pub font_size: f64,
+    pub font_style: String,
+    pub font_weight: String,
+    pub line_height: f64,
+    pub css_font: String,
 }
 
 impl DynamicMetricsInput {
     pub fn validate(&self) -> Result<(), RenderError> {
-        validate_non_empty("cssFont", &self.css_font)?;
-        validate_non_empty("fontFamily", &self.font_family)?;
-        validate_positive_finite("fontSizePx", self.font_size_px)?;
-        validate_positive_finite("lineHeightPx", self.line_height_px)?;
+        validate_non_empty("defaultStyle", &self.default_style)?;
+        if self.text_styles.is_empty() {
+            return Err(RenderError {
+                message: "dynamic text metrics field `textStyles` must not be empty".to_string(),
+            });
+        }
         if let Some(profile_id) = &self.profile_id {
             validate_non_empty("profileId", profile_id)?;
         }
@@ -52,25 +63,42 @@ impl DynamicMetricsInput {
                     .to_string(),
             });
         }
-        if let Some(font_style) = &self.font_style {
-            validate_non_empty("fontStyle", font_style)?;
+        let mut ids = std::collections::HashSet::new();
+        let mut style_keys = std::collections::HashSet::new();
+        let mut has_default = false;
+        for style in &self.text_styles {
+            style.validate()?;
+            if !ids.insert(style.id.as_str()) {
+                return Err(RenderError {
+                    message: format!(
+                        "dynamic text metrics field `textStyles` contains duplicate id {:?}",
+                        style.id
+                    ),
+                });
+            }
+            let key = style.style_key()?;
+            if !style_keys.insert(key) {
+                return Err(RenderError {
+                    message:
+                        "dynamic text metrics field `textStyles` contains duplicate style identity"
+                            .to_string(),
+                });
+            }
+            has_default |= style.id == self.default_style;
         }
-        if let Some(font_weight) = &self.font_weight {
-            validate_non_empty("fontWeight", font_weight)?;
+        if !has_default {
+            return Err(RenderError {
+                message: format!(
+                    "dynamic text metrics field `defaultStyle` {:?} must reference a textStyles id",
+                    self.default_style
+                ),
+            });
         }
         Ok(())
     }
 
     pub(crate) fn profile_version_or_default(&self) -> u32 {
         self.profile_version.unwrap_or(1)
-    }
-
-    pub(crate) fn font_style_or_default(&self) -> &str {
-        self.font_style.as_deref().unwrap_or("normal")
-    }
-
-    pub(crate) fn font_weight_or_default(&self) -> &str {
-        self.font_weight.as_deref().unwrap_or("400")
     }
 
     pub(crate) fn require_profile_id(&self, operation: &str) -> Result<&str, RenderError> {
@@ -84,6 +112,28 @@ impl DynamicMetricsInput {
         }
     }
 
+    fn default_text_style(&self) -> Result<&DynamicTextStyleInput, RenderError> {
+        self.text_styles
+            .iter()
+            .find(|style| style.id == self.default_style)
+            .ok_or_else(|| RenderError {
+                message: format!(
+                    "dynamic text metrics field `defaultStyle` {:?} must reference a textStyles id",
+                    self.default_style
+                ),
+            })
+    }
+
+    fn style_by_key(
+        &self,
+    ) -> Result<HashMap<GraphTextStyleKey, DynamicTextStyleInput>, RenderError> {
+        let mut styles = HashMap::new();
+        for style in &self.text_styles {
+            styles.insert(style.style_key()?, style.clone());
+        }
+        Ok(styles)
+    }
+
     pub(crate) fn text_metrics_descriptor_for_layout(
         &self,
         node_padding_x: f64,
@@ -92,16 +142,17 @@ impl DynamicMetricsInput {
     ) -> Result<TextMetricsProfileDescriptor, RenderError> {
         self.validate()?;
         let profile_id = self.require_profile_id("dynamic MMDS descriptor")?;
+        let default_style = self.default_text_style()?;
         Ok(TextMetricsProfileDescriptor {
             profile_id: profile_id.to_string(),
             source: "dynamic".to_string(),
             version: self.profile_version_or_default(),
             default_text_style: TextMetricsStyleDescriptor {
-                font_family: self.font_family.clone(),
-                font_size: self.font_size_px,
-                font_style: self.font_style_or_default().to_string(),
-                font_weight: self.font_weight_or_default().to_string(),
-                line_height: self.line_height_px,
+                font_family: default_style.font_family.clone(),
+                font_size: default_style.font_size,
+                font_style: default_style.font_style.clone(),
+                font_weight: default_style.font_weight.clone(),
+                line_height: default_style.line_height,
             },
             layout_text: TextMetricsLayoutDescriptor {
                 node_padding_x,
@@ -110,6 +161,36 @@ impl DynamicMetricsInput {
                 label_padding_y: DEFAULT_LABEL_PADDING_Y,
                 edge_label_max_width,
             },
+        })
+    }
+}
+
+impl DynamicTextStyleInput {
+    fn validate(&self) -> Result<(), RenderError> {
+        validate_non_empty("textStyles.id", &self.id)?;
+        validate_non_empty("textStyles.fontFamily", &self.font_family)?;
+        validate_positive_finite("textStyles.fontSize", self.font_size)?;
+        validate_non_empty("textStyles.fontStyle", &self.font_style)?;
+        validate_non_empty("textStyles.fontWeight", &self.font_weight)?;
+        validate_positive_finite("textStyles.lineHeight", self.line_height)?;
+        validate_non_empty("textStyles.cssFont", &self.css_font)?;
+        self.style_key()?;
+        Ok(())
+    }
+
+    fn style_key(&self) -> Result<GraphTextStyleKey, RenderError> {
+        GraphTextStyleKey::new(
+            &self.font_family,
+            self.font_size,
+            self.line_height,
+            &self.font_style,
+            &self.font_weight,
+        )
+        .map_err(|message| RenderError {
+            message: format!(
+                "dynamic text metrics textStyles entry {:?} is invalid: {message}",
+                self.id
+            ),
         })
     }
 }
@@ -140,9 +221,11 @@ where
     F: FnMut(&str, &str) -> Result<f64, DynamicTextMetricsError>,
 {
     input: DynamicMetricsInput,
+    default_style: GraphTextStyleKey,
+    styles_by_key: HashMap<GraphTextStyleKey, DynamicTextStyleInput>,
     callback: RefCell<F>,
-    line_cache: RefCell<HashMap<String, f64>>,
-    scalar_cache: RefCell<HashMap<char, f64>>,
+    line_cache: RefCell<HashMap<StyleLineCacheKey, f64>>,
+    scalar_cache: RefCell<HashMap<StyleScalarCacheKey, f64>>,
     first_error: RefCell<Option<DynamicTextMetricsError>>,
     in_callback: Cell<bool>,
     node_padding_x: f64,
@@ -168,8 +251,18 @@ where
         node_padding_y: f64,
         callback: F,
     ) -> Self {
+        let default_style = input
+            .default_text_style()
+            .and_then(DynamicTextStyleInput::style_key)
+            .unwrap_or_else(|_| {
+                GraphTextStyleKey::new("invalid dynamic default", 1.0, 1.0, "normal", "400")
+                    .expect("fallback dynamic style key should be valid")
+            });
+        let styles_by_key = input.style_by_key().unwrap_or_default();
         Self {
             input,
+            default_style,
+            styles_by_key,
             callback: RefCell::new(callback),
             line_cache: RefCell::new(HashMap::new()),
             scalar_cache: RefCell::new(HashMap::new()),
@@ -191,30 +284,56 @@ where
 
     pub(crate) fn measurement_cache_snapshot(&self) -> Result<TextMeasurementCache, RenderError> {
         self.finish()?;
+        let mut text_styles = BTreeMap::new();
+        for style in &self.input.text_styles {
+            text_styles.insert(
+                style.id.clone(),
+                TextMeasurementStyle {
+                    id: style.id.clone(),
+                    style: style.style_key().map_err(|error| RenderError {
+                        message: error.to_string(),
+                    })?,
+                    css_font: style.css_font.clone(),
+                },
+            );
+        }
         Ok(TextMeasurementCache {
+            default_style: self.input.default_style.clone(),
+            text_styles,
             line_widths: self
                 .line_cache
                 .borrow()
                 .iter()
-                .map(|(text, width)| (text.clone(), *width))
+                .map(|(key, width)| ((key.style_id.clone(), key.text.clone()), *width))
                 .collect(),
             scalar_widths: self
                 .scalar_cache
                 .borrow()
                 .iter()
-                .map(|(ch, width)| (*ch, *width))
+                .map(|(key, width)| ((key.style_id.clone(), key.ch), *width))
                 .collect(),
         })
     }
 
     fn measure_line_text(&self, text: &str) -> f64 {
-        if let Some(width) = self.line_cache.borrow().get(text).copied() {
+        self.measure_line_text_for_style(&self.default_style.clone(), text)
+    }
+
+    fn measure_line_text_for_style(&self, style: &GraphTextStyleKey, text: &str) -> f64 {
+        let Some(style_input) = self.style_input_for_key(style, Some(text)) else {
+            return 0.0;
+        };
+        let key = StyleLineCacheKey {
+            style_id: style_input.id.clone(),
+            text: text.to_string(),
+        };
+        if let Some(width) = self.line_cache.borrow().get(&key).copied() {
             return width;
         }
 
-        match self.measure_uncached_text(text) {
+        match self.measure_uncached_text(text, style_input) {
             Some(width) => {
-                self.line_cache.borrow_mut().insert(text.to_string(), width);
+                self.line_cache.borrow_mut().insert(key, width);
                 width
             }
             None => 0.0,
@@ -222,26 +341,37 @@ where
     }
 
     fn measure_scalar_char(&self, ch: char) -> f64 {
-        if let Some(width) = self.scalar_cache.borrow().get(&ch).copied() {
+        self.measure_scalar_char_for_style(&self.default_style.clone(), ch)
+    }
+
+    fn measure_scalar_char_for_style(&self, style: &GraphTextStyleKey, ch: char) -> f64 {
+        let mut text = [0_u8; 4];
+        let text = ch.encode_utf8(&mut text);
+        let Some(style_input) = self.style_input_for_key(style, Some(text)) else {
+            return 0.0;
+        };
+        let key = StyleScalarCacheKey {
+            style_id: style_input.id.clone(),
+            ch,
+        };
+        if let Some(width) = self.scalar_cache.borrow().get(&key).copied() {
             return width;
         }
 
-        let mut text = [0_u8; 4];
-        let text = ch.encode_utf8(&mut text);
-        match self.measure_uncached_text(text) {
+        match self.measure_uncached_text(text, style_input) {
             Some(width) => {
-                self.scalar_cache.borrow_mut().insert(ch, width);
+                self.scalar_cache.borrow_mut().insert(key, width);
                 width
             }
             None => 0.0,
         }
     }
 
-    fn measure_uncached_text(&self, text: &str) -> Option<f64> {
+    fn measure_uncached_text(&self, text: &str, style: &DynamicTextStyleInput) -> Option<f64> {
         if self.in_callback.get() {
             self.record_error(DynamicTextMetricsError::new(format!(
                 "dynamic text measurement callback re-entered while measuring {text:?} with font {:?}",
-                self.input.css_font
+                style.css_font
             )));
             return None;
         }
@@ -249,13 +379,13 @@ where
         self.in_callback.set(true);
         let result = {
             let mut callback = self.callback.borrow_mut();
-            callback(text, &self.input.css_font)
+            callback(text, &style.css_font)
         };
         self.in_callback.set(false);
 
         let validated = match result {
-            Ok(width) => self.validate_width(text, width),
-            Err(error) => Err(self.contextualize_callback_error(text, error)),
+            Ok(width) => self.validate_width(text, style, width),
+            Err(error) => Err(self.contextualize_callback_error(text, style, error)),
         };
 
         match validated {
@@ -270,22 +400,46 @@ where
     fn contextualize_callback_error(
         &self,
         text: &str,
+        style: &DynamicTextStyleInput,
         error: DynamicTextMetricsError,
     ) -> DynamicTextMetricsError {
         DynamicTextMetricsError::new(format!(
             "dynamic text measurement callback failed for {text:?} with font {:?}: {error}",
-            self.input.css_font
+            style.css_font
         ))
     }
 
-    fn validate_width(&self, text: &str, width: f64) -> Result<f64, DynamicTextMetricsError> {
+    fn validate_width(
+        &self,
+        text: &str,
+        style: &DynamicTextStyleInput,
+        width: f64,
+    ) -> Result<f64, DynamicTextMetricsError> {
         if !width.is_finite() || width < 0.0 {
             return Err(DynamicTextMetricsError::new(format!(
                 "dynamic text measurement for {text:?} with font {:?} must return a finite non-negative width",
-                self.input.css_font
+                style.css_font
             )));
         }
         Ok(width)
+    }
+
+    fn style_input_for_key(
+        &self,
+        style: &GraphTextStyleKey,
+        text: Option<&str>,
+    ) -> Option<&DynamicTextStyleInput> {
+        match self.styles_by_key.get(style) {
+            Some(style_input) => Some(style_input),
+            None => {
+                let text = text.unwrap_or("");
+                self.record_error(DynamicTextMetricsError::new(format!(
+                    "dynamic text metrics style set has no CSS font for text {text:?} and style {:?}",
+                    style
+                )));
+                None
+            }
+        }
     }
 
     fn record_error(&self, error: DynamicTextMetricsError) {
@@ -294,6 +448,18 @@ where
             *first_error = Some(error);
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct StyleLineCacheKey {
+    style_id: String,
+    text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct StyleScalarCacheKey {
+    style_id: String,
+    ch: char,
 }
 
 impl<F> TextMetricsProvider for CallbackTextMetricsProvider<F>
@@ -308,12 +474,42 @@ where
         self.measure_scalar_char(ch)
     }
 
+    fn default_text_style_key(&self) -> GraphTextStyleKey {
+        self.default_style.clone()
+    }
+
+    fn measure_line_width_for_style(&self, style: &GraphTextStyleKey, text: &str) -> f64 {
+        self.measure_line_text_for_style(style, text)
+    }
+
+    fn measure_scalar_width_for_style(&self, style: &GraphTextStyleKey, ch: char) -> f64 {
+        self.measure_scalar_char_for_style(style, ch)
+    }
+
     fn font_size(&self) -> f64 {
-        self.input.font_size_px
+        self.styles_by_key.get(&self.default_style).map_or_else(
+            || self.default_style.font_size_px(),
+            |style| style.font_size,
+        )
     }
 
     fn line_height(&self) -> f64 {
-        self.input.line_height_px
+        self.styles_by_key.get(&self.default_style).map_or_else(
+            || self.default_style.line_height_px(),
+            |style| style.line_height,
+        )
+    }
+
+    fn font_size_for_style(&self, style: &GraphTextStyleKey) -> f64 {
+        self.styles_by_key
+            .get(style)
+            .map_or_else(|| style.font_size_px(), |style| style.font_size)
+    }
+
+    fn line_height_for_style(&self, style: &GraphTextStyleKey) -> f64 {
+        self.styles_by_key
+            .get(style)
+            .map_or_else(|| style.line_height_px(), |style| style.line_height)
     }
 
     fn node_padding_x(&self) -> f64 {
@@ -443,8 +639,9 @@ where
             if matches!(format, OutputFormat::Svg) {
                 apply_svg_surface_defaults(OutputFormat::Svg, &mut effective_config, true);
             }
-            let font_family = dynamic_input.font_family.clone();
-            let font_size = dynamic_input.font_size_px;
+            let default_style = dynamic_input.default_text_style()?;
+            let font_family = default_style.font_family.clone();
+            let font_size = default_style.font_size;
             let node_padding_x = effective_config
                 .svg_node_padding_x
                 .unwrap_or(DEFAULT_PROPORTIONAL_NODE_PADDING_X);
@@ -523,8 +720,9 @@ where
         // layoutEngine knob.
         apply_svg_surface_defaults(OutputFormat::Svg, &mut effective_config, true);
     }
-    let font_family = dynamic_input.font_family.clone();
-    let font_size = dynamic_input.font_size_px;
+    let default_style = dynamic_input.default_text_style()?;
+    let font_family = default_style.font_family.clone();
+    let font_size = default_style.font_size;
 
     let node_padding_x = effective_config
         .svg_node_padding_x
@@ -634,7 +832,7 @@ mod tests {
     use crate::format::OutputFormat;
     use crate::graph::GeometryLevel;
     use crate::graph::measure::{
-        COMPATIBILITY_TEXT_METRICS_PROFILE_ID, DEFAULT_GRAPH_FONT_FAMILY,
+        COMPATIBILITY_TEXT_METRICS_PROFILE_ID, DEFAULT_GRAPH_FONT_FAMILY, GraphTextStyleKey,
         RECORDED_SANS_TEXT_METRICS_PROFILE_ID, TextMetricsProfileConfig, TextMetricsProvider,
         resolve_text_metrics_profile,
     };
@@ -643,7 +841,20 @@ mod tests {
 
     fn valid_input() -> DynamicMetricsInput {
         serde_json::from_str(
-            r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24}"#,
+            r#"{
+              "defaultStyle":"s0",
+              "textStyles":[
+                {
+                  "id":"s0",
+                  "fontFamily":"Inter",
+                  "fontSize":16,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":24,
+                  "cssFont":"16px Inter"
+                }
+              ]
+            }"#,
         )
         .unwrap()
     }
@@ -651,14 +862,60 @@ mod tests {
     fn profiled_input(profile_id: &str) -> DynamicMetricsInput {
         serde_json::from_str(&format!(
             r#"{{
-              "cssFont":"16px Inter",
-              "fontFamily":"Inter",
-              "fontSizePx":16,
-              "lineHeightPx":24,
+              "defaultStyle":"s0",
+              "textStyles":[
+                {{
+                  "id":"s0",
+                  "fontFamily":"Inter",
+                  "fontSize":16,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":24,
+                  "cssFont":"16px Inter"
+                }}
+              ],
               "profileId":"{profile_id}"
             }}"#
         ))
         .unwrap()
+    }
+
+    fn style_set_input() -> DynamicMetricsInput {
+        serde_json::from_str(
+            r#"{
+              "defaultStyle":"s0",
+              "textStyles":[
+                {
+                  "id":"s0",
+                  "fontFamily":"Inter",
+                  "fontSize":8,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":12,
+                  "cssFont":"400 normal 8px Inter"
+                },
+                {
+                  "id":"s1",
+                  "fontFamily":"Inter",
+                  "fontSize":32,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":48,
+                  "cssFont":"400 normal 32px Inter"
+                }
+              ],
+              "profileId":"browser-test-v1"
+            }"#,
+        )
+        .unwrap()
+    }
+
+    fn style_8px() -> GraphTextStyleKey {
+        GraphTextStyleKey::new("Inter", 8.0, 12.0, "normal", "400").unwrap()
+    }
+
+    fn style_32px() -> GraphTextStyleKey {
+        GraphTextStyleKey::new("Inter", 32.0, 48.0, "normal", "400").unwrap()
     }
 
     fn deterministic_width(text: &str, _css_font: &str) -> Result<f64, DynamicTextMetricsError> {
@@ -688,14 +945,18 @@ mod tests {
             .expect("default recorded text metrics should resolve")
             .metrics;
         DynamicMetricsInput {
-            css_font: format!("{}px {}", metrics.font_size(), DEFAULT_GRAPH_FONT_FAMILY),
-            font_family: DEFAULT_GRAPH_FONT_FAMILY.to_string(),
-            font_size_px: metrics.font_size(),
-            line_height_px: metrics.line_height(),
+            default_style: "s0".to_string(),
+            text_styles: vec![DynamicTextStyleInput {
+                id: "s0".to_string(),
+                font_family: DEFAULT_GRAPH_FONT_FAMILY.to_string(),
+                font_size: metrics.font_size(),
+                font_style: "normal".to_string(),
+                font_weight: "400".to_string(),
+                line_height: metrics.line_height(),
+                css_font: format!("{}px {}", metrics.font_size(), DEFAULT_GRAPH_FONT_FAMILY),
+            }],
             profile_id: None,
             profile_version: None,
-            font_style: None,
-            font_weight: None,
         }
     }
 
@@ -703,14 +964,20 @@ mod tests {
     fn dynamic_metrics_input_accepts_optional_provider_identity_for_svg() {
         let input: DynamicMetricsInput = serde_json::from_str(
             r#"{
-              "cssFont":"16px Inter",
-              "fontFamily":"Inter",
-              "fontSizePx":16,
-              "lineHeightPx":24,
+              "defaultStyle":"s0",
+              "textStyles":[
+                {
+                  "id":"s0",
+                  "fontFamily":"Inter",
+                  "fontSize":16,
+                  "fontStyle":"italic",
+                  "fontWeight":"700",
+                  "lineHeight":24,
+                  "cssFont":"italic 700 16px Inter"
+                }
+              ],
               "profileId":"browser-inter-v1",
-              "profileVersion":2,
-              "fontStyle":"italic",
-              "fontWeight":"700"
+              "profileVersion":2
             }"#,
         )
         .unwrap();
@@ -721,18 +988,20 @@ mod tests {
             "browser-inter-v1"
         );
         assert_eq!(input.profile_version_or_default(), 2);
-        assert_eq!(input.font_style_or_default(), "italic");
-        assert_eq!(input.font_weight_or_default(), "700");
+        let default_style = input.default_text_style().unwrap();
+        assert_eq!(default_style.font_style, "italic");
+        assert_eq!(default_style.font_weight, "700");
     }
 
     #[test]
-    fn dynamic_metrics_input_keeps_existing_svg_metrics_json_valid() {
+    fn dynamic_metrics_input_accepts_style_set_svg_metrics_json() {
         let input = valid_input();
 
         input.validate().unwrap();
         assert_eq!(input.profile_version_or_default(), 1);
-        assert_eq!(input.font_style_or_default(), "normal");
-        assert_eq!(input.font_weight_or_default(), "400");
+        let default_style = input.default_text_style().unwrap();
+        assert_eq!(default_style.font_style, "normal");
+        assert_eq!(default_style.font_weight, "400");
         let err = input
             .require_profile_id("dynamic MMDS")
             .expect_err("profile id should only be required for descriptor operations");
@@ -745,10 +1014,18 @@ mod tests {
     fn dynamic_metrics_input_rejects_zero_profile_version() {
         let input: DynamicMetricsInput = serde_json::from_str(
             r#"{
-              "cssFont":"16px Inter",
-              "fontFamily":"Inter",
-              "fontSizePx":16,
-              "lineHeightPx":24,
+              "defaultStyle":"s0",
+              "textStyles":[
+                {
+                  "id":"s0",
+                  "fontFamily":"Inter",
+                  "fontSize":16,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":24,
+                  "cssFont":"16px Inter"
+                }
+              ],
               "profileVersion":0
             }"#,
         )
@@ -766,15 +1043,15 @@ mod tests {
         for (field, json) in [
             (
                 "profileId",
-                r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"profileId":" "}"#,
+                r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}],"profileId":" "}"#,
             ),
             (
-                "fontStyle",
-                r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"fontStyle":" "}"#,
+                "textStyles.fontStyle",
+                r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":" ","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}]}"#,
             ),
             (
-                "fontWeight",
-                r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"fontWeight":" "}"#,
+                "textStyles.fontWeight",
+                r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":" ","lineHeight":24,"cssFont":"16px Inter"}]}"#,
             ),
         ] {
             let input: DynamicMetricsInput = serde_json::from_str(json).unwrap();
@@ -789,10 +1066,18 @@ mod tests {
     fn dynamic_metrics_input_builds_provider_bound_descriptor() {
         let input: DynamicMetricsInput = serde_json::from_str(
             r#"{
-              "cssFont":"16px Inter",
-              "fontFamily":"Inter",
-              "fontSizePx":16,
-              "lineHeightPx":24,
+              "defaultStyle":"s0",
+              "textStyles":[
+                {
+                  "id":"s0",
+                  "fontFamily":"Inter",
+                  "fontSize":16,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":24,
+                  "cssFont":"16px Inter"
+                }
+              ],
               "profileId":"browser-inter-v1"
             }"#,
         )
@@ -827,14 +1112,20 @@ mod tests {
     fn dynamic_metrics_descriptor_mirrors_adapter_owned_style_and_version() {
         let input: DynamicMetricsInput = serde_json::from_str(
             r#"{
-              "cssFont":"italic 700 16px Inter",
-              "fontFamily":"Inter",
-              "fontSizePx":16,
-              "lineHeightPx":24,
+              "defaultStyle":"s0",
+              "textStyles":[
+                {
+                  "id":"s0",
+                  "fontFamily":"Inter",
+                  "fontSize":16,
+                  "fontStyle":"italic",
+                  "fontWeight":"700",
+                  "lineHeight":24,
+                  "cssFont":"italic 700 16px Inter"
+                }
+              ],
               "profileId":"browser-inter-v2",
-              "profileVersion":2,
-              "fontStyle":"italic",
-              "fontWeight":"700"
+              "profileVersion":2
             }"#,
         )
         .unwrap();
@@ -864,7 +1155,7 @@ mod tests {
     #[test]
     fn dynamic_metrics_input_rejects_unknown_fields() {
         let err = serde_json::from_str::<DynamicMetricsInput>(
-            r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"extra":true}"#,
+            r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}],"extra":true}"#,
         )
         .unwrap_err()
         .to_string();
@@ -878,34 +1169,26 @@ mod tests {
         valid_input().validate().expect("valid input should pass");
 
         for (field, input) in [
-            (
-                "cssFont",
-                DynamicMetricsInput {
-                    css_font: " ".to_string(),
-                    ..valid_input()
-                },
-            ),
-            (
-                "fontFamily",
-                DynamicMetricsInput {
-                    font_family: " ".to_string(),
-                    ..valid_input()
-                },
-            ),
-            (
-                "fontSizePx",
-                DynamicMetricsInput {
-                    font_size_px: 0.0,
-                    ..valid_input()
-                },
-            ),
-            (
-                "lineHeightPx",
-                DynamicMetricsInput {
-                    line_height_px: f64::INFINITY,
-                    ..valid_input()
-                },
-            ),
+            ("textStyles.cssFont", {
+                let mut input = valid_input();
+                input.text_styles[0].css_font = " ".to_string();
+                input
+            }),
+            ("textStyles.fontFamily", {
+                let mut input = valid_input();
+                input.text_styles[0].font_family = " ".to_string();
+                input
+            }),
+            ("textStyles.fontSize", {
+                let mut input = valid_input();
+                input.text_styles[0].font_size = 0.0;
+                input
+            }),
+            ("textStyles.lineHeight", {
+                let mut input = valid_input();
+                input.text_styles[0].line_height = f64::INFINITY;
+                input
+            }),
         ] {
             let err = input.validate().expect_err("invalid field should fail");
             assert!(err.message.contains(field), "{err}");
@@ -925,6 +1208,115 @@ mod tests {
         assert_eq!(provider.measure_line_width("Alpha"), 5.0);
         provider.finish().expect("cached measurements should pass");
         assert_eq!(observed_calls.get(), 1);
+    }
+
+    #[test]
+    fn dynamic_provider_caches_same_text_separately_by_style() {
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        let observed_calls = Rc::clone(&calls);
+        let provider =
+            CallbackTextMetricsProvider::new(style_set_input(), move |text, css_font| {
+                calls
+                    .borrow_mut()
+                    .push((text.to_string(), css_font.to_string()));
+                Ok(if css_font.contains("32px") {
+                    64.0
+                } else {
+                    16.0
+                })
+            });
+
+        assert_eq!(
+            provider.measure_line_width_for_style(&style_8px(), "Same"),
+            16.0
+        );
+        assert_eq!(
+            provider.measure_line_width_for_style(&style_32px(), "Same"),
+            64.0
+        );
+        assert_eq!(
+            provider.measure_line_width_for_style(&style_8px(), "Same"),
+            16.0
+        );
+        provider.finish().expect("style-keyed cache should pass");
+
+        assert_eq!(
+            observed_calls.borrow().as_slice(),
+            [
+                ("Same".to_string(), "400 normal 8px Inter".to_string()),
+                ("Same".to_string(), "400 normal 32px Inter".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn dynamic_provider_snapshot_preserves_style_identity() {
+        let provider = CallbackTextMetricsProvider::new(style_set_input(), |text, css_font| {
+            Ok(if css_font.contains("32px") {
+                text.len() as f64 * 20.0
+            } else {
+                text.len() as f64 * 5.0
+            })
+        });
+
+        assert_eq!(
+            provider.measure_line_width_for_style(&style_8px(), "Same"),
+            20.0
+        );
+        assert_eq!(
+            provider.measure_line_width_for_style(&style_32px(), "Same"),
+            80.0
+        );
+
+        let snapshot = provider
+            .measurement_cache_snapshot()
+            .expect("successful provider should export measurements");
+        assert_eq!(snapshot.line_width_for_style("s0", "Same"), Some(20.0));
+        assert_eq!(snapshot.line_width_for_style("s1", "Same"), Some(80.0));
+    }
+
+    #[test]
+    fn dynamic_provider_errors_name_text_and_css_font_for_style() {
+        let provider = CallbackTextMetricsProvider::new(style_set_input(), |text, css_font| {
+            Err(DynamicTextMetricsError::new(format!(
+                "failed {text} with {css_font}"
+            )))
+        });
+
+        assert_eq!(
+            provider.measure_line_width_for_style(&style_32px(), "Styled"),
+            0.0
+        );
+        let err = provider
+            .finish()
+            .expect_err("callback error should be recorded");
+
+        assert!(err.message.contains("Styled"), "{err}");
+        assert!(err.message.contains("400 normal 32px Inter"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_metrics_rejects_config_graph_text_style_even_with_mermaid_styles() {
+        let config = RenderConfig {
+            graph_text_style: Some(GraphTextStyleConfig::new("Arial", 16.0)),
+            ..RenderConfig::default()
+        };
+
+        let err = render_graph_family_with_dynamic_text_metrics(
+            "graph TD\nA[Alpha] --> B[Beta]\nstyle A font-family:Inter,font-size:16px",
+            OutputFormat::Svg,
+            &config,
+            style_set_input(),
+            |_text, _css_font| Ok(8.0),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.message.contains("graph_text_style")
+                || err.message.contains("graphTextStyle")
+                || err.message.contains("RenderConfig.graph_text_style"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -1534,15 +1926,15 @@ mod tests {
         let mut version = profiled_input("browser-test-v1");
         version.profile_version = Some(2);
         let mut font_family = profiled_input("browser-test-v1");
-        font_family.font_family = "Arial".to_string();
+        font_family.text_styles[0].font_family = "Arial".to_string();
         let mut font_size = profiled_input("browser-test-v1");
-        font_size.font_size_px = 18.0;
+        font_size.text_styles[0].font_size = 18.0;
         let mut font_style = profiled_input("browser-test-v1");
-        font_style.font_style = Some("italic".to_string());
+        font_style.text_styles[0].font_style = "italic".to_string();
         let mut font_weight = profiled_input("browser-test-v1");
-        font_weight.font_weight = Some("700".to_string());
+        font_weight.text_styles[0].font_weight = "700".to_string();
         let mut line_height = profiled_input("browser-test-v1");
-        line_height.line_height_px = 30.0;
+        line_height.text_styles[0].line_height = 30.0;
 
         for (name, metrics, expected_field) in [
             (

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -262,6 +262,9 @@ where
                 GraphTextStyleKey::new("invalid dynamic default", 1.0, 1.0, "normal", "400")
                     .expect("fallback dynamic style key should be valid")
             });
+        // Preserve the first validation error in `finish()`. If validation
+        // failed, the lookup map is intentionally empty so measurement returns
+        // harmless widths until the recorded error is surfaced.
         let styles_by_key = input.style_by_key().unwrap_or_default();
         Self {
             input,
@@ -288,6 +291,8 @@ where
 
     pub(crate) fn measurement_cache_snapshot(&self) -> Result<TextMeasurementCache, RenderError> {
         self.finish()?;
+        // Provider-free replay can need the default space scalar during wrap
+        // reconstruction even if direct rendering did not otherwise query it.
         self.measure_scalar_char_for_style(&self.default_style.clone(), ' ');
         self.finish()?;
         let mut text_styles = BTreeMap::new();
@@ -439,13 +444,36 @@ where
             Some(style_input) => Some(style_input),
             None => {
                 let text = text.unwrap_or("");
-                self.record_error(DynamicTextMetricsError::new(format!(
-                    "dynamic text metrics style set has no CSS font for text {text:?} and style {:?}",
-                    style
-                )));
+                if let Some((registered_style, style_input)) =
+                    self.style_input_for_key_except_line_height(style)
+                {
+                    self.record_error(DynamicTextMetricsError::new(format!(
+                        "dynamic text metrics style set has lineHeight mismatch for text {text:?}: Mermaid font-size-only styles derive lineHeight {:.2}px from the default style ratio, but CSS font {:?} was registered with lineHeight {:.2}px",
+                        style.line_height_px(),
+                        style_input.css_font,
+                        registered_style.line_height_px()
+                    )));
+                } else {
+                    self.record_error(DynamicTextMetricsError::new(format!(
+                        "dynamic text metrics style set has no CSS font for text {text:?} and style {:?}",
+                        style
+                    )));
+                }
                 None
             }
         }
+    }
+
+    fn style_input_for_key_except_line_height(
+        &self,
+        style: &GraphTextStyleKey,
+    ) -> Option<(&GraphTextStyleKey, &DynamicTextStyleInput)> {
+        self.styles_by_key.iter().find(|(registered_style, _)| {
+            registered_style.font_family == style.font_family
+                && registered_style.font_size_mpx == style.font_size_mpx
+                && registered_style.font_style == style.font_style
+                && registered_style.font_weight == style.font_weight
+        })
     }
 
     fn record_error(&self, error: DynamicTextMetricsError) {
@@ -1446,6 +1474,34 @@ mod tests {
 
         assert!(err.message.contains("Styled"), "{err}");
         assert!(err.message.contains("400 normal 32px Inter"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_provider_reports_line_height_mismatches_clearly() {
+        let mut input = multi_font_style_set_input();
+        let small_style = input
+            .text_styles
+            .iter_mut()
+            .find(|style| style.id == "s1")
+            .expect("small style should exist");
+        small_style.line_height = 14.0;
+        let provider = CallbackTextMetricsProvider::new(input, |_text, _css_font| Ok(8.0));
+        let mermaid_style = GraphTextStyleKey::new("Verdana", 8.0, 12.0, "normal", "400")
+            .expect("test style is valid");
+
+        assert_eq!(
+            provider.measure_line_width_for_style(&mermaid_style, "Small"),
+            0.0
+        );
+        let err = provider
+            .finish()
+            .expect_err("line-height mismatch should be recorded");
+
+        assert!(err.message.contains("lineHeight mismatch"), "{err}");
+        assert!(err.message.contains("default style ratio"), "{err}");
+        assert!(err.message.contains("12.00px"), "{err}");
+        assert!(err.message.contains("14.00px"), "{err}");
+        assert!(err.message.contains("8px Verdana"), "{err}");
     }
 
     #[test]

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -251,6 +251,10 @@ where
         node_padding_y: f64,
         callback: F,
     ) -> Self {
+        let validation_error = input
+            .validate()
+            .err()
+            .map(|err| DynamicTextMetricsError::new(err.message));
         let default_style = input
             .default_text_style()
             .and_then(DynamicTextStyleInput::style_key)
@@ -266,7 +270,7 @@ where
             callback: RefCell::new(callback),
             line_cache: RefCell::new(HashMap::new()),
             scalar_cache: RefCell::new(HashMap::new()),
-            first_error: RefCell::new(None),
+            first_error: RefCell::new(validation_error),
             in_callback: Cell::new(false),
             node_padding_x,
             node_padding_y,
@@ -1343,6 +1347,20 @@ mod tests {
         assert_eq!(provider.measure_line_width("Alpha"), 5.0);
         provider.finish().expect("cached measurements should pass");
         assert_eq!(observed_calls.get(), 1);
+    }
+
+    #[test]
+    fn callback_provider_finish_reports_unvalidated_input_errors() {
+        let mut input = valid_input();
+        input.default_style = "missing-style".to_string();
+        let provider = CallbackTextMetricsProvider::new(input, |_text, _css_font| Ok(1.0));
+
+        let err = provider
+            .finish()
+            .expect_err("provider should preserve validation errors");
+
+        assert!(err.message.contains("defaultStyle"), "{err}");
+        assert!(err.message.contains("missing-style"), "{err}");
     }
 
     #[test]

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -910,6 +910,71 @@ mod tests {
         .unwrap()
     }
 
+    fn multi_font_style_set_input() -> DynamicMetricsInput {
+        serde_json::from_str(
+            r#"{
+              "defaultStyle":"s0",
+              "textStyles":[
+                {
+                  "id":"s0",
+                  "fontFamily":"Inter",
+                  "fontSize":16,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":24,
+                  "cssFont":"16px Inter"
+                },
+                {
+                  "id":"s1",
+                  "fontFamily":"Verdana",
+                  "fontSize":8,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":12,
+                  "cssFont":"8px Verdana"
+                },
+                {
+                  "id":"s2",
+                  "fontFamily":"Courier New",
+                  "fontSize":20,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":30,
+                  "cssFont":"20px Courier New"
+                }
+              ],
+              "profileId":"browser-multifont-v1"
+            }"#,
+        )
+        .unwrap()
+    }
+
+    fn multi_font_same_text_input() -> &'static str {
+        "graph TD\nA[Same] --> B[Same]\nstyle A font-family:Verdana,font-size:8px\nstyle B font-family:Courier New,font-size:20px"
+    }
+
+    fn multi_font_width(text: &str, css_font: &str) -> Result<f64, DynamicTextMetricsError> {
+        let per_char = if css_font.contains("Courier New") {
+            18.0
+        } else if css_font.contains("Verdana") {
+            6.0
+        } else {
+            10.0
+        };
+        Ok(text.len() as f64 * per_char)
+    }
+
+    fn multi_font_dynamic_mmds_fixture() -> String {
+        render_graph_family_with_dynamic_text_metrics(
+            multi_font_same_text_input(),
+            OutputFormat::Mmds,
+            &routed_config(),
+            multi_font_style_set_input(),
+            multi_font_width,
+        )
+        .expect("dynamic multi-font MMDS fixture should render")
+    }
+
     fn style_8px() -> GraphTextStyleKey {
         GraphTextStyleKey::new("Inter", 8.0, 12.0, "normal", "400").unwrap()
     }
@@ -1667,6 +1732,68 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_measurement_sidecar_round_trips_same_text_under_two_styles() {
+        let input = multi_font_same_text_input();
+        let config = routed_config();
+        let direct_svg = render_graph_family_with_dynamic_text_metrics(
+            input,
+            OutputFormat::Svg,
+            &config,
+            multi_font_style_set_input(),
+            multi_font_width,
+        )
+        .expect("direct multi-font SVG should render");
+        let dynamic_mmds = render_graph_family_with_dynamic_text_metrics(
+            input,
+            OutputFormat::Mmds,
+            &config,
+            multi_font_style_set_input(),
+            multi_font_width,
+        )
+        .expect("dynamic multi-font MMDS should render");
+
+        let value: serde_json::Value = serde_json::from_str(&dynamic_mmds).unwrap();
+        let sidecar = &value["extensions"]["org.mmdflux.text-measurements.v1"];
+        assert!(
+            sidecar["textStyles"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|style| style["id"] == "s1" && style["fontFamily"] == "Verdana"),
+            "{sidecar}"
+        );
+        assert!(
+            sidecar["textStyles"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|style| style["id"] == "s2" && style["fontFamily"] == "Courier New"),
+            "{sidecar}"
+        );
+        assert!(
+            sidecar["lineWidths"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|entry| entry["style"] == "s1" && entry["text"] == "Same"),
+            "{sidecar}"
+        );
+        assert!(
+            sidecar["lineWidths"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|entry| entry["style"] == "s2" && entry["text"] == "Same"),
+            "{sidecar}"
+        );
+
+        let replay_svg = render_diagram(&dynamic_mmds, OutputFormat::Svg, &RenderConfig::default())
+            .expect("style-keyed sidecar should allow provider-free replay");
+
+        assert_eq!(replay_svg, direct_svg);
+    }
+
+    #[test]
     fn dynamic_mmds_without_measurements_still_requires_provider_free_replay_provider() {
         let dynamic_mmds = dynamic_mmds_fixture();
         let mut value: serde_json::Value = serde_json::from_str(&dynamic_mmds).unwrap();
@@ -1806,6 +1933,45 @@ mod tests {
 
         assert!(err.message.contains("scalarWidths"), "{err}");
         assert!(err.message.contains("missing persisted"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_measurement_sidecar_rejects_duplicate_style_text_entries() {
+        let dynamic_mmds = multi_font_dynamic_mmds_fixture();
+        let mut duplicate: serde_json::Value = serde_json::from_str(&dynamic_mmds).unwrap();
+        let line_widths = duplicate["extensions"]["org.mmdflux.text-measurements.v1"]["lineWidths"]
+            .as_array_mut()
+            .unwrap();
+        let repeated = line_widths
+            .iter()
+            .find(|entry| entry["style"] == "s1" && entry["text"] == "Same")
+            .unwrap()
+            .clone();
+        line_widths.push(repeated);
+        let duplicate = serde_json::to_string_pretty(&duplicate).unwrap();
+
+        let err = render_diagram(&duplicate, OutputFormat::Svg, &RenderConfig::default())
+            .expect_err("duplicate style-keyed line width should reject");
+
+        assert!(err.message.contains("duplicate lineWidths"), "{err}");
+        assert!(err.message.contains("s1"), "{err}");
+        assert!(err.message.contains("Same"), "{err}");
+    }
+
+    #[test]
+    fn dynamic_measurement_sidecar_rejects_unknown_style_references() {
+        let dynamic_mmds = multi_font_dynamic_mmds_fixture();
+        let mut unknown_style: serde_json::Value = serde_json::from_str(&dynamic_mmds).unwrap();
+        unknown_style["extensions"]["org.mmdflux.text-measurements.v1"]["lineWidths"][0]["style"] =
+            serde_json::json!("missing-style");
+        let unknown_style = serde_json::to_string_pretty(&unknown_style).unwrap();
+
+        let err = render_diagram(&unknown_style, OutputFormat::Svg, &RenderConfig::default())
+            .expect_err("unknown sidecar style id should reject");
+
+        assert!(err.message.contains("lineWidths"), "{err}");
+        assert!(err.message.contains("missing-style"), "{err}");
+        assert!(err.message.contains("textStyles"), "{err}");
     }
 
     #[test]

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -284,6 +284,8 @@ where
 
     pub(crate) fn measurement_cache_snapshot(&self) -> Result<TextMeasurementCache, RenderError> {
         self.finish()?;
+        self.measure_scalar_char_for_style(&self.default_style.clone(), ' ');
+        self.finish()?;
         let mut text_styles = BTreeMap::new();
         for style in &self.input.text_styles {
             text_styles.insert(
@@ -953,6 +955,58 @@ mod tests {
         "graph TD\nA[Same] --> B[Same]\nstyle A font-family:Verdana,font-size:8px\nstyle B font-family:Courier New,font-size:20px"
     }
 
+    fn multi_font_mermaid_input() -> &'static str {
+        include_str!("../../tests/fixtures/flowchart/dynamic/multi_font_styles.mmd")
+    }
+
+    fn multi_font_mermaid_style_set_input() -> DynamicMetricsInput {
+        serde_json::from_str(
+            r#"{
+              "defaultStyle":"s0",
+              "textStyles":[
+                {
+                  "id":"s0",
+                  "fontFamily":"Inter",
+                  "fontSize":16,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":24,
+                  "cssFont":"16px Inter"
+                },
+                {
+                  "id":"s1",
+                  "fontFamily":"Verdana",
+                  "fontSize":8,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":12,
+                  "cssFont":"8px Verdana"
+                },
+                {
+                  "id":"s2",
+                  "fontFamily":"Courier New",
+                  "fontSize":20,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":30,
+                  "cssFont":"20px Courier New"
+                },
+                {
+                  "id":"s3",
+                  "fontFamily":"Times New Roman",
+                  "fontSize":32,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":48,
+                  "cssFont":"32px Times New Roman"
+                }
+              ],
+              "profileId":"browser-multifont-v1"
+            }"#,
+        )
+        .unwrap()
+    }
+
     fn multi_font_width(text: &str, css_font: &str) -> Result<f64, DynamicTextMetricsError> {
         let per_char = if css_font.contains("Courier New") {
             18.0
@@ -962,6 +1016,22 @@ mod tests {
             10.0
         };
         Ok(text.len() as f64 * per_char)
+    }
+
+    fn multi_font_mermaid_width(
+        text: &str,
+        css_font: &str,
+    ) -> Result<f64, DynamicTextMetricsError> {
+        let per_char = if css_font.contains("Times New Roman") {
+            30.0
+        } else if css_font.contains("Courier New") {
+            15.0
+        } else if css_font.contains("Verdana") {
+            4.0
+        } else {
+            8.0
+        };
+        Ok(text.chars().count() as f64 * per_char)
     }
 
     fn multi_font_dynamic_mmds_fixture() -> String {
@@ -1492,7 +1562,8 @@ mod tests {
             .expect("successful provider should export measurements");
         assert_eq!(snapshot.line_width("A"), Some(8.0));
         assert_eq!(snapshot.scalar_width('A'), Some(8.0));
-        assert_eq!(observed_calls.get(), 2);
+        assert_eq!(snapshot.scalar_width(' '), Some(8.0));
+        assert_eq!(observed_calls.get(), 3);
     }
 
     #[test]
@@ -1790,6 +1861,91 @@ mod tests {
         let replay_svg = render_diagram(&dynamic_mmds, OutputFormat::Svg, &RenderConfig::default())
             .expect("style-keyed sidecar should allow provider-free replay");
 
+        assert_eq!(replay_svg, direct_svg);
+    }
+
+    #[test]
+    fn dynamic_multifont_mermaid_fixture_round_trips_and_records_all_styles() {
+        use std::cell::RefCell;
+        use std::collections::BTreeMap;
+
+        let calls = Rc::new(RefCell::new(BTreeMap::<(String, String), usize>::new()));
+        let calls_for_svg = Rc::clone(&calls);
+        let direct_svg = render_graph_family_with_dynamic_text_metrics(
+            multi_font_mermaid_input(),
+            OutputFormat::Svg,
+            &routed_config(),
+            multi_font_mermaid_style_set_input(),
+            move |text, css_font| {
+                *calls_for_svg
+                    .borrow_mut()
+                    .entry((css_font.to_string(), text.to_string()))
+                    .or_default() += 1;
+                multi_font_mermaid_width(text, css_font)
+            },
+        )
+        .expect("direct dynamic multi-font SVG should render");
+        assert!(
+            direct_svg.contains("font-family=\"Verdana\""),
+            "{direct_svg}"
+        );
+        assert!(
+            direct_svg.contains("font-family=\"Courier New\""),
+            "{direct_svg}"
+        );
+        assert!(
+            direct_svg.contains("font-family=\"Times New Roman\""),
+            "{direct_svg}"
+        );
+        assert!(
+            direct_svg.contains("width=\"128.00\""),
+            "edge label background should reflect Times New Roman width; {direct_svg}"
+        );
+        assert!(
+            calls.borrow().values().all(|count| *count == 1),
+            "{:?}",
+            calls.borrow()
+        );
+
+        let dynamic_mmds = render_graph_family_with_dynamic_text_metrics(
+            multi_font_mermaid_input(),
+            OutputFormat::Mmds,
+            &routed_config(),
+            multi_font_mermaid_style_set_input(),
+            multi_font_mermaid_width,
+        )
+        .expect("dynamic multi-font MMDS should render");
+        let value: serde_json::Value = serde_json::from_str(&dynamic_mmds).unwrap();
+        let sidecar = &value["extensions"]["org.mmdflux.text-measurements.v1"];
+        for (style, family, text, width) in [
+            ("s1", "Verdana", "Regular", 28.0),
+            ("s2", "Courier New", "Styled Node", 165.0),
+            ("s3", "Times New Roman", "link", 120.0),
+        ] {
+            assert!(
+                sidecar["textStyles"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|entry| entry["id"] == style && entry["fontFamily"] == family),
+                "{sidecar}"
+            );
+            assert!(
+                sidecar["lineWidths"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|entry| {
+                        entry["style"] == style
+                            && entry["text"] == text
+                            && (entry["width"].as_f64().unwrap() - width).abs() < f64::EPSILON
+                    }),
+                "{sidecar}"
+            );
+        }
+
+        let replay_svg = render_diagram(&dynamic_mmds, OutputFormat::Svg, &RenderConfig::default())
+            .expect("provider-free sidecar replay should render");
         assert_eq!(replay_svg, direct_svg);
     }
 

--- a/src/runtime/graph_family.rs
+++ b/src/runtime/graph_family.rs
@@ -10,9 +10,10 @@ use crate::format::OutputFormat;
 use crate::graph::label_wrap::prepare_wrapped_labels_with_provider;
 use crate::graph::measure::{
     COMPATIBILITY_TEXT_METRICS_PROFILE_ID, DEFAULT_PROPORTIONAL_NODE_PADDING_X,
-    DEFAULT_PROPORTIONAL_NODE_PADDING_Y, ResolvedTextMetrics, TextMeasurementCache,
-    TextMetricsProfileConfig, TextMetricsProfileDescriptor, TextMetricsProvider,
-    resolve_text_metrics_profile, text_style_matches_descriptor,
+    DEFAULT_PROPORTIONAL_NODE_PADDING_Y, GraphTextStyleKey, ResolvedTextMetrics,
+    TextMeasurementCache, TextMetricsProfileConfig, TextMetricsProfileDescriptor,
+    TextMetricsProvider, edge_text_style_key, node_text_style_key, resolve_text_metrics_profile,
+    text_style_matches_descriptor,
 };
 use crate::graph::{GeometryLevel, Graph};
 use crate::mmds::Document;
@@ -153,6 +154,12 @@ fn solve_graph_family_for_render(
 ) -> Result<GraphFamilyRenderResult, RenderError> {
     let text_metrics = resolve_text_metrics_for_config(format, config)?;
     validate_provider_free_graph_text_style(format, config, &text_metrics.descriptor)?;
+    validate_provider_free_mermaid_font_styles(
+        format,
+        diagram,
+        &text_metrics.descriptor,
+        &text_metrics.metrics,
+    )?;
     let solve = solve_graph_family_with_provider(
         diagram_id,
         diagram,
@@ -210,6 +217,52 @@ fn provider_free_graph_text_style_error(descriptor: &TextMetricsProfileDescripto
             descriptor.profile_id
         ),
     }
+}
+
+fn validate_provider_free_mermaid_font_styles(
+    format: OutputFormat,
+    diagram: &Graph,
+    descriptor: &TextMetricsProfileDescriptor,
+    provider: &dyn TextMetricsProvider,
+) -> Result<(), RenderError> {
+    if !matches!(
+        format,
+        OutputFormat::Svg | OutputFormat::Mmds | OutputFormat::Text | OutputFormat::Ascii
+    ) {
+        return Ok(());
+    }
+
+    for node in diagram.nodes.values() {
+        let style = node_text_style_key(provider, node);
+        if !text_style_key_matches_descriptor(&style, &descriptor.default_text_style)? {
+            return Err(provider_free_graph_text_style_error(descriptor));
+        }
+    }
+
+    for edge in &diagram.edges {
+        if edge.label.is_none() && edge.head_label.is_none() && edge.tail_label.is_none() {
+            continue;
+        }
+        let style = edge_text_style_key(provider, edge);
+        if !text_style_key_matches_descriptor(&style, &descriptor.default_text_style)? {
+            return Err(provider_free_graph_text_style_error(descriptor));
+        }
+    }
+
+    Ok(())
+}
+
+fn text_style_key_matches_descriptor(
+    style: &GraphTextStyleKey,
+    descriptor: &crate::graph::measure::TextMetricsStyleDescriptor,
+) -> Result<bool, RenderError> {
+    let family_and_size_matches =
+        text_style_matches_descriptor(&style.font_family, style.font_size_px(), descriptor)
+            .map_err(|message| RenderError {
+                message: format!("fontFamily {message}"),
+            })?;
+    Ok(family_and_size_matches
+        && (style.line_height_px() - descriptor.line_height).abs() <= f64::EPSILON)
 }
 
 fn solve_graph_family_with_provider(

--- a/src/runtime/mmds.rs
+++ b/src/runtime/mmds.rs
@@ -4,7 +4,7 @@
 //! This module owns the render dispatch for MMDS input.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 
 use serde_json::{Map, Value};
@@ -13,9 +13,9 @@ use crate::errors::RenderError;
 use crate::format::OutputFormat;
 use crate::graph::GeometryLevel;
 use crate::graph::measure::{
-    LEGACY_MMDS_TEXT_METRICS_PROFILE_ID, ResolvedTextMetrics, TextMetricsLayoutDescriptor,
-    TextMetricsProfileConfig, TextMetricsProfileDescriptor, TextMetricsProvider,
-    TextMetricsStyleDescriptor, resolve_text_metrics_profile,
+    GraphTextStyleKey, LEGACY_MMDS_TEXT_METRICS_PROFILE_ID, ResolvedTextMetrics,
+    TextMetricsLayoutDescriptor, TextMetricsProfileConfig, TextMetricsProfileDescriptor,
+    TextMetricsProvider, TextMetricsStyleDescriptor, resolve_text_metrics_profile,
 };
 use crate::mmds::{
     Document, TEXT_MEASUREMENTS_EXTENSION_NAMESPACE, TEXT_METRICS_EXTENSION_NAMESPACE,
@@ -303,8 +303,16 @@ enum ReplayTextMetrics {
 
 #[derive(Debug)]
 struct PersistedTextMeasurements {
-    line_widths: HashMap<String, f64>,
-    scalar_widths: HashMap<char, f64>,
+    default_style: GraphTextStyleKey,
+    style_ids_by_key: HashMap<GraphTextStyleKey, String>,
+    line_widths: HashMap<(String, String), f64>,
+    scalar_widths: HashMap<(String, char), f64>,
+}
+
+struct ParsedTextMeasurementStyles {
+    default_style: GraphTextStyleKey,
+    ids_by_key: HashMap<GraphTextStyleKey, String>,
+    ids: HashSet<String>,
 }
 
 struct PersistedTextMeasurementsProvider<'a> {
@@ -342,22 +350,65 @@ impl<'a> PersistedTextMeasurementsProvider<'a> {
 
 impl TextMetricsProvider for PersistedTextMeasurementsProvider<'_> {
     fn measure_line_width(&self, text: &str) -> f64 {
-        match self.measurements.line_widths.get(text).copied() {
+        self.measure_line_width_for_style(&self.measurements.default_style, text)
+    }
+
+    fn measure_scalar_width(&self, ch: char) -> f64 {
+        self.measure_scalar_width_for_style(&self.measurements.default_style, ch)
+    }
+
+    fn default_text_style_key(&self) -> GraphTextStyleKey {
+        self.measurements.default_style.clone()
+    }
+
+    fn measure_line_width_for_style(&self, style: &GraphTextStyleKey, text: &str) -> f64 {
+        let Some(style_id) = self.measurements.style_ids_by_key.get(style) else {
+            self.record_error(missing_persisted_text_measurement_style(
+                "lineWidths",
+                style,
+            ));
+            return 0.0;
+        };
+        match self
+            .measurements
+            .line_widths
+            .get(&(style_id.clone(), text.to_string()))
+            .copied()
+        {
             Some(width) => width,
             None => {
-                self.record_error(missing_persisted_text_measurement("lineWidths", text));
+                self.record_error(missing_persisted_text_measurement(
+                    "lineWidths",
+                    style_id,
+                    text,
+                ));
                 0.0
             }
         }
     }
 
-    fn measure_scalar_width(&self, ch: char) -> f64 {
-        match self.measurements.scalar_widths.get(&ch).copied() {
+    fn measure_scalar_width_for_style(&self, style: &GraphTextStyleKey, ch: char) -> f64 {
+        let Some(style_id) = self.measurements.style_ids_by_key.get(style) else {
+            self.record_error(missing_persisted_text_measurement_style(
+                "scalarWidths",
+                style,
+            ));
+            return 0.0;
+        };
+        let mut buffer = [0_u8; 4];
+        let text = ch.encode_utf8(&mut buffer);
+        match self
+            .measurements
+            .scalar_widths
+            .get(&(style_id.clone(), ch))
+            .copied()
+        {
             Some(width) => width,
             None => {
                 self.record_error(missing_persisted_text_measurement(
                     "scalarWidths",
-                    ch.encode_utf8(&mut [0_u8; 4]),
+                    style_id,
+                    text,
                 ));
                 0.0
             }
@@ -588,18 +639,80 @@ fn parse_text_measurements_for_descriptor(
         )));
     }
 
-    let line_widths = parse_line_width_entries(extension)?;
-    let scalar_widths = parse_scalar_width_entries(extension)?;
+    let styles = parse_measurement_text_styles(extension, descriptor)?;
+    let line_widths = parse_line_width_entries(extension, &styles.ids)?;
+    let scalar_widths = parse_scalar_width_entries(extension, &styles.ids)?;
 
     Ok(PersistedTextMeasurements {
+        default_style: styles.default_style,
+        style_ids_by_key: styles.ids_by_key,
         line_widths,
         scalar_widths,
     })
 }
 
+fn parse_measurement_text_styles(
+    extension: &Map<String, Value>,
+    descriptor: &TextMetricsProfileDescriptor,
+) -> Result<ParsedTextMeasurementStyles, RenderError> {
+    let entries = required_measurements_array(extension, "textStyles")?;
+    let default_style = GraphTextStyleKey::from_descriptor(&descriptor.default_text_style)
+        .map_err(invalid_text_measurements_extension)?;
+    let mut style_ids = HashSet::new();
+    let mut style_ids_by_key = HashMap::new();
+    let mut has_default_style = false;
+    for (index, entry) in entries.iter().enumerate() {
+        let object = entry.as_object().ok_or_else(|| {
+            invalid_text_measurements_extension(format!("textStyles[{index}] must be an object"))
+        })?;
+        ensure_text_style_entry_fields(object, index)?;
+        let id = required_measurements_string_field(object, "textStyles", "id")?;
+        if id.trim().is_empty() {
+            return Err(invalid_text_measurements_extension(format!(
+                "textStyles[{index}].id must not be empty"
+            )));
+        }
+        if !style_ids.insert(id.to_string()) {
+            return Err(invalid_text_measurements_extension(format!(
+                "duplicate textStyles id {id:?}"
+            )));
+        }
+        let style_key = GraphTextStyleKey::new(
+            required_measurements_string_field(object, "textStyles", "fontFamily")?,
+            required_measurements_number_field(object, "textStyles", "fontSize")?,
+            required_measurements_number_field(object, "textStyles", "lineHeight")?,
+            required_measurements_string_field(object, "textStyles", "fontStyle")?,
+            required_measurements_string_field(object, "textStyles", "fontWeight")?,
+        )
+        .map_err(|message| {
+            invalid_text_measurements_extension(format!(
+                "textStyles[{index}] is invalid: {message}"
+            ))
+        })?;
+        validate_non_empty_measurement_string(object, "textStyles", "cssFont", index)?;
+        has_default_style |= style_key == default_style;
+        if style_ids_by_key.insert(style_key, id.to_string()).is_some() {
+            return Err(invalid_text_measurements_extension(format!(
+                "duplicate textStyles style identity for id {id:?}"
+            )));
+        }
+    }
+    if !has_default_style {
+        return Err(invalid_text_measurements_extension(
+            "textStyles must include the sibling defaultTextStyle".to_string(),
+        ));
+    }
+    Ok(ParsedTextMeasurementStyles {
+        default_style,
+        ids_by_key: style_ids_by_key,
+        ids: style_ids,
+    })
+}
+
 fn parse_line_width_entries(
     extension: &Map<String, Value>,
-) -> Result<HashMap<String, f64>, RenderError> {
+    known_styles: &HashSet<String>,
+) -> Result<HashMap<(String, String), f64>, RenderError> {
     let entries = required_measurements_array(extension, "lineWidths")?;
     let mut widths = HashMap::new();
     for (index, entry) in entries.iter().enumerate() {
@@ -607,11 +720,15 @@ fn parse_line_width_entries(
             invalid_text_measurements_extension(format!("lineWidths[{index}] must be an object"))
         })?;
         ensure_measurement_entry_fields(object, "lineWidths", index)?;
+        let style = required_measurement_style_field(object, "lineWidths", index, known_styles)?;
         let text = required_measurements_string_field(object, "lineWidths", "text")?;
         let width = required_measurements_width(object, "lineWidths", index)?;
-        if widths.insert(text.to_string(), width).is_some() {
+        if widths
+            .insert((style.to_string(), text.to_string()), width)
+            .is_some()
+        {
             return Err(invalid_text_measurements_extension(format!(
-                "duplicate lineWidths text {text:?}"
+                "duplicate lineWidths style {style:?} text {text:?}"
             )));
         }
     }
@@ -620,7 +737,8 @@ fn parse_line_width_entries(
 
 fn parse_scalar_width_entries(
     extension: &Map<String, Value>,
-) -> Result<HashMap<char, f64>, RenderError> {
+    known_styles: &HashSet<String>,
+) -> Result<HashMap<(String, char), f64>, RenderError> {
     let entries = required_measurements_array(extension, "scalarWidths")?;
     let mut widths = HashMap::new();
     for (index, entry) in entries.iter().enumerate() {
@@ -628,6 +746,7 @@ fn parse_scalar_width_entries(
             invalid_text_measurements_extension(format!("scalarWidths[{index}] must be an object"))
         })?;
         ensure_measurement_entry_fields(object, "scalarWidths", index)?;
+        let style = required_measurement_style_field(object, "scalarWidths", index, known_styles)?;
         let text = required_measurements_string_field(object, "scalarWidths", "text")?;
         let mut chars = text.chars();
         let Some(ch) = chars.next() else {
@@ -641,9 +760,9 @@ fn parse_scalar_width_entries(
             )));
         }
         let width = required_measurements_width(object, "scalarWidths", index)?;
-        if widths.insert(ch, width).is_some() {
+        if widths.insert((style.to_string(), ch), width).is_some() {
             return Err(invalid_text_measurements_extension(format!(
-                "duplicate scalarWidths text {text:?}"
+                "duplicate scalarWidths style {style:?} text {text:?}"
             )));
         }
     }
@@ -656,9 +775,31 @@ fn ensure_measurement_entry_fields(
     index: usize,
 ) -> Result<(), RenderError> {
     for field in object.keys() {
-        if field != "text" && field != "width" {
+        if field != "style" && field != "text" && field != "width" {
             return Err(invalid_text_measurements_extension(format!(
                 "{array_name}[{index}] contains unsupported field {field:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn ensure_text_style_entry_fields(
+    object: &Map<String, Value>,
+    index: usize,
+) -> Result<(), RenderError> {
+    for field in object.keys() {
+        if !matches!(
+            field.as_str(),
+            "id" | "fontFamily"
+                | "fontSize"
+                | "fontStyle"
+                | "fontWeight"
+                | "lineHeight"
+                | "cssFont"
+        ) {
+            return Err(invalid_text_measurements_extension(format!(
+                "textStyles[{index}] contains unsupported field {field:?}"
             )));
         }
     }
@@ -693,6 +834,58 @@ fn required_measurements_string_field<'a>(
     object.get(field).and_then(Value::as_str).ok_or_else(|| {
         invalid_text_measurements_extension(format!("{object_name}.{field} must be a string"))
     })
+}
+
+fn required_measurements_number_field(
+    object: &Map<String, Value>,
+    object_name: &str,
+    field: &str,
+) -> Result<f64, RenderError> {
+    let value = object.get(field).and_then(Value::as_f64).ok_or_else(|| {
+        invalid_text_measurements_extension(format!("{object_name}.{field} must be a number"))
+    })?;
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(invalid_text_measurements_extension(format!(
+            "{object_name}.{field} must be finite"
+        )))
+    }
+}
+
+fn validate_non_empty_measurement_string(
+    object: &Map<String, Value>,
+    object_name: &str,
+    field: &str,
+    index: usize,
+) -> Result<(), RenderError> {
+    let value = required_measurements_string_field(object, object_name, field)?;
+    if value.trim().is_empty() {
+        return Err(invalid_text_measurements_extension(format!(
+            "{object_name}[{index}].{field} must not be empty"
+        )));
+    }
+    Ok(())
+}
+
+fn required_measurement_style_field<'a>(
+    object: &'a Map<String, Value>,
+    array_name: &str,
+    index: usize,
+    known_styles: &HashSet<String>,
+) -> Result<&'a str, RenderError> {
+    let style = required_measurements_string_field(object, array_name, "style")?;
+    if style.trim().is_empty() {
+        return Err(invalid_text_measurements_extension(format!(
+            "{array_name}[{index}].style must not be empty"
+        )));
+    }
+    if !known_styles.contains(style) {
+        return Err(invalid_text_measurements_extension(format!(
+            "{array_name}[{index}].style {style:?} is not present in textStyles"
+        )));
+    }
+    Ok(style)
 }
 
 fn required_measurements_integer_field(
@@ -1044,10 +1237,18 @@ fn invalid_text_measurements_extension(message: impl Into<String>) -> RenderErro
     }
 }
 
-fn missing_persisted_text_measurement(kind: &str, text: &str) -> RenderError {
+fn missing_persisted_text_measurement(kind: &str, style_id: &str, text: &str) -> RenderError {
     RenderError {
         message: format!(
-            "missing persisted dynamic text measurement in {TEXT_MEASUREMENTS_EXTENSION_NAMESPACE}.{kind} for {text:?}"
+            "missing persisted dynamic text measurement in {TEXT_MEASUREMENTS_EXTENSION_NAMESPACE}.{kind} for style {style_id:?} text {text:?}"
+        ),
+    }
+}
+
+fn missing_persisted_text_measurement_style(kind: &str, style: &GraphTextStyleKey) -> RenderError {
+    RenderError {
+        message: format!(
+            "missing persisted dynamic text measurement style in {TEXT_MEASUREMENTS_EXTENSION_NAMESPACE}.textStyles for {kind} style {style:?}"
         ),
     }
 }
@@ -1211,14 +1412,25 @@ mod tests {
                 "source": "dynamic",
                 "version": 1
             },
+            "textStyles": [
+                {
+                    "id": "s0",
+                    "fontFamily": "Inter",
+                    "fontSize": 16.0,
+                    "fontStyle": "normal",
+                    "fontWeight": "400",
+                    "lineHeight": 24.0,
+                    "cssFont": "16px Inter"
+                }
+            ],
             "lineWidths": [
-                { "text": "Alpha", "width": 42.31415926535897 },
-                { "text": "é", "width": 12.5 }
+                { "style": "s0", "text": "Alpha", "width": 42.31415926535897 },
+                { "style": "s0", "text": "é", "width": 12.5 }
             ],
             "scalarWidths": [
-                { "text": "A", "width": 10.671875 },
-                { "text": " ", "width": 4.4453125 },
-                { "text": "é", "width": 12.5 }
+                { "style": "s0", "text": "A", "width": 10.671875 },
+                { "style": "s0", "text": " ", "width": 4.4453125 },
+                { "style": "s0", "text": "é", "width": 12.5 }
             ]
         })
         .as_object()
@@ -1350,6 +1562,38 @@ mod tests {
             err.message
                 .contains("missing persisted dynamic text measurement")
         );
+        assert!(err.message.contains("Alpha"), "{err}");
+    }
+
+    #[test]
+    fn persisted_measurement_provider_rejects_missing_style_keyed_line_query() {
+        let descriptor = dynamic_descriptor();
+        let mut extension = text_measurements_extension();
+        extension
+            .get_mut("textStyles")
+            .unwrap()
+            .as_array_mut()
+            .unwrap()
+            .push(json!({
+                "id": "s1",
+                "fontFamily": "Verdana",
+                "fontSize": 8.0,
+                "fontStyle": "normal",
+                "fontWeight": "400",
+                "lineHeight": 12.0,
+                "cssFont": "8px Verdana"
+            }));
+        let measurements = parse_text_measurements_for_descriptor(&extension, &descriptor).unwrap();
+        let provider = PersistedTextMeasurementsProvider::new(&descriptor, &measurements);
+        let style = GraphTextStyleKey::new("Verdana", 8.0, 12.0, "normal", "400").unwrap();
+
+        assert_eq!(provider.measure_line_width_for_style(&style, "Alpha"), 0.0);
+        let err = provider
+            .finish()
+            .expect_err("missing style-keyed line width should fail");
+
+        assert!(err.message.contains("lineWidths"), "{err}");
+        assert!(err.message.contains("s1"), "{err}");
         assert!(err.message.contains("Alpha"), "{err}");
     }
 }

--- a/tests/fixtures/flowchart/dynamic/multi_font_styles.mmd
+++ b/tests/fixtures/flowchart/dynamic/multi_font_styles.mmd
@@ -1,0 +1,5 @@
+graph TD
+    A[Regular] -->|link| B(Styled Node)
+    style A font-family:Verdana,font-size:8px
+    style B font-family:Courier New,font-size:20px
+    linkStyle 0 font-family:Times New Roman,font-size:32px

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -85,6 +85,21 @@ fn flowchart_fixture(name: &str) -> String {
         .unwrap_or_else(|e| panic!("failed to read flowchart fixture {}: {e}", path.display()))
 }
 
+fn dynamic_flowchart_fixture(name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("flowchart")
+        .join("dynamic")
+        .join(name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "failed to read dynamic flowchart fixture {}: {e}",
+            path.display()
+        )
+    })
+}
+
 fn render_json(input: &str) -> String {
     render_json_with_config(input, &RenderConfig::default())
 }
@@ -532,6 +547,17 @@ fn provider_free_mmds_rejects_custom_graph_font_style() {
 
     let err = render_diagram("graph TD\nA-->B", OutputFormat::Mmds, &config)
         .expect_err("custom provider-free graph font style should fail");
+
+    assert!(err.message.contains("fontFamily"), "{err}");
+    assert!(err.message.contains("dynamic text metrics"), "{err}");
+}
+
+#[test]
+fn provider_free_mmds_rejects_mermaid_graph_font_styles() {
+    let input = dynamic_flowchart_fixture("multi_font_styles.mmd");
+
+    let err = render_diagram(&input, OutputFormat::Mmds, &RenderConfig::default())
+        .expect_err("Mermaid font styles require dynamic text metrics");
 
     assert!(err.message.contains("fontFamily"), "{err}");
     assert!(err.message.contains("dynamic text metrics"), "{err}");

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -228,14 +228,25 @@ fn text_measurements_extension() -> Value {
             "source": "dynamic",
             "version": 1
         },
+        "textStyles": [
+            {
+                "id": "s0",
+                "fontFamily": "Inter",
+                "fontSize": 16.0,
+                "fontStyle": "normal",
+                "fontWeight": "400",
+                "lineHeight": 24.0,
+                "cssFont": "16px Inter"
+            }
+        ],
         "lineWidths": [
-            { "text": "Alpha", "width": 42.31415926535897 },
-            { "text": "edge label", "width": 72.5 }
+            { "style": "s0", "text": "Alpha", "width": 42.31415926535897 },
+            { "style": "s0", "text": "edge label", "width": 72.5 }
         ],
         "scalarWidths": [
-            { "text": "A", "width": 10.671875 },
-            { "text": " ", "width": 4.4453125 },
-            { "text": "🦀", "width": 16.25 }
+            { "style": "s0", "text": "A", "width": 10.671875 },
+            { "style": "s0", "text": " ", "width": 4.4453125 },
+            { "style": "s0", "text": "🦀", "width": 16.25 }
         ]
     })
 }
@@ -1776,7 +1787,7 @@ fn schema_rejects_text_measurements_static_profile_ref_source() {
 
 #[test]
 fn schema_rejects_text_measurements_missing_query_arrays() {
-    for field in ["lineWidths", "scalarWidths"] {
+    for field in ["textStyles", "lineWidths", "scalarWidths"] {
         let mut value = dynamic_mmds_value_with_text_measurements_extension();
         value["extensions"]["org.mmdflux.text-measurements.v1"]
             .as_object_mut()
@@ -1785,6 +1796,14 @@ fn schema_rejects_text_measurements_missing_query_arrays() {
 
         assert_schema_invalid(value);
     }
+}
+
+#[test]
+fn schema_rejects_text_measurements_empty_text_styles() {
+    let mut value = dynamic_mmds_value_with_text_measurements_extension();
+    value["extensions"]["org.mmdflux.text-measurements.v1"]["textStyles"] = json!([]);
+
+    assert_schema_invalid(value);
 }
 
 #[test]
@@ -1834,7 +1853,7 @@ fn schema_rejects_text_measurements_scalar_with_multiple_scalars() {
 fn schema_accepts_text_measurements_non_bmp_scalar_prefilter() {
     let mut value = dynamic_mmds_value_with_text_measurements_extension();
     value["extensions"]["org.mmdflux.text-measurements.v1"]["scalarWidths"] =
-        json!([{ "text": "🦀", "width": 16.25 }]);
+        json!([{ "style": "s0", "text": "🦀", "width": 16.25 }]);
 
     assert_schema_valid(value);
 }

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -481,6 +481,24 @@ fn mmds_output_emits_node_style_extension_when_styles_exist() {
 }
 
 #[test]
+fn schema_accepts_edge_style_extension_entries() {
+    let mut value: Value = serde_json::from_str(STYLED_MMDS_LAYOUT).unwrap();
+    value["extensions"]["org.mmdflux.node-style.v1"] = json!({
+        "edges": {
+            "e0": {
+                "stroke-width": "2px",
+                "font-family": "Times New Roman",
+                "font-size": "32px",
+                "font-style": "italic",
+                "font-weight": "700"
+            }
+        }
+    });
+
+    assert_schema_valid(value);
+}
+
+#[test]
 fn mmds_output_omits_node_style_extension_when_styles_absent() {
     let json = render_json("graph TD\nA-->B");
     let value: Value = serde_json::from_str(&json).unwrap();
@@ -1783,6 +1801,31 @@ fn schema_accepts_dynamic_text_measurements_extension() {
 }
 
 #[test]
+fn schema_accepts_style_keyed_dynamic_text_measurements_multi_style_sidecar() {
+    let mut value = dynamic_mmds_value_with_text_measurements_extension();
+    let sidecar = &mut value["extensions"]["org.mmdflux.text-measurements.v1"];
+    sidecar["textStyles"].as_array_mut().unwrap().push(json!({
+        "id": "s1",
+        "fontFamily": "Times New Roman",
+        "fontSize": 32.0,
+        "fontStyle": "normal",
+        "fontWeight": "400",
+        "lineHeight": 48.0,
+        "cssFont": "32px Times New Roman"
+    }));
+    sidecar["lineWidths"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!({ "style": "s1", "text": "link", "width": 52.25 }));
+    sidecar["scalarWidths"]
+        .as_array_mut()
+        .unwrap()
+        .push(json!({ "style": "s1", "text": "k", "width": 15.5 }));
+
+    assert_schema_valid(value);
+}
+
+#[test]
 fn schema_accepts_empty_text_measurement_query_arrays() {
     let mut value = dynamic_mmds_value_with_text_measurements_extension();
     value["extensions"]["org.mmdflux.text-measurements.v1"]["lineWidths"] = json!([]);
@@ -1828,6 +1871,42 @@ fn schema_rejects_text_measurements_missing_query_arrays() {
 fn schema_rejects_text_measurements_empty_text_styles() {
     let mut value = dynamic_mmds_value_with_text_measurements_extension();
     value["extensions"]["org.mmdflux.text-measurements.v1"]["textStyles"] = json!([]);
+
+    assert_schema_invalid(value);
+}
+
+#[test]
+fn schema_rejects_text_measurements_duplicate_text_style_entries() {
+    let mut value = dynamic_mmds_value_with_text_measurements_extension();
+    let text_styles = value["extensions"]["org.mmdflux.text-measurements.v1"]["textStyles"]
+        .as_array_mut()
+        .unwrap();
+    text_styles.push(text_styles[0].clone());
+
+    assert_schema_invalid(value);
+}
+
+#[test]
+fn schema_rejects_text_measurement_width_entries_without_style_id() {
+    for array_name in ["lineWidths", "scalarWidths"] {
+        let mut value = dynamic_mmds_value_with_text_measurements_extension();
+        value["extensions"]["org.mmdflux.text-measurements.v1"][array_name][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("style");
+
+        assert_schema_invalid(value);
+    }
+}
+
+#[test]
+fn schema_rejects_text_measurement_style_descriptors_with_kebab_case_keys() {
+    let mut value = dynamic_mmds_value_with_text_measurements_extension();
+    let style = value["extensions"]["org.mmdflux.text-measurements.v1"]["textStyles"][0]
+        .as_object_mut()
+        .unwrap();
+    let font_family = style.remove("fontFamily").unwrap();
+    style.insert("font-family".to_string(), font_family);
 
     assert_schema_invalid(value);
 }
@@ -1882,6 +1961,38 @@ fn schema_accepts_text_measurements_non_bmp_scalar_prefilter() {
         json!([{ "style": "s0", "text": "🦀", "width": 16.25 }]);
 
     assert_schema_valid(value);
+}
+
+#[test]
+fn text_measurements_replay_rejects_duplicate_style_ids() {
+    let mut value = dynamic_mmds_value_with_text_measurements_extension();
+    let text_styles = value["extensions"]["org.mmdflux.text-measurements.v1"]["textStyles"]
+        .as_array_mut()
+        .unwrap();
+    let mut duplicate = text_styles[0].clone();
+    duplicate["fontFamily"] = json!("Times New Roman");
+    text_styles.push(duplicate);
+    let input = serde_json::to_string(&value).unwrap();
+
+    let err = render_diagram(&input, OutputFormat::Svg, &RenderConfig::default())
+        .expect_err("duplicate style ids should reject replay");
+
+    assert!(err.message.contains("duplicate textStyles id"), "{err}");
+}
+
+#[test]
+fn text_measurements_replay_rejects_unknown_style_references() {
+    let mut value = dynamic_mmds_value_with_text_measurements_extension();
+    value["extensions"]["org.mmdflux.text-measurements.v1"]["lineWidths"][0]["style"] =
+        json!("missing-style");
+    let input = serde_json::to_string(&value).unwrap();
+
+    let err = render_diagram(&input, OutputFormat::Svg, &RenderConfig::default())
+        .expect_err("unknown style refs should reject replay");
+
+    assert!(err.message.contains("lineWidths"), "{err}");
+    assert!(err.message.contains("missing-style"), "{err}");
+    assert!(err.message.contains("textStyles"), "{err}");
 }
 
 #[test]
@@ -2006,6 +2117,23 @@ fn docs_and_schema_reference_text_metrics_extension_contract() {
     assert!(schema.contains("recorded"));
     assert!(schema.contains("dynamic"));
     assert!(schema.contains("edge-label-max-width"));
+}
+
+#[test]
+fn mmds_docs_describe_style_keyed_dynamic_text_measurements() {
+    let docs = std::fs::read_to_string("docs/mmds.md").unwrap();
+    let section = docs
+        .split("## Style-keyed dynamic text measurements")
+        .nth(1)
+        .expect("style-keyed dynamic text measurements section should exist");
+
+    assert!(docs.contains("org.mmdflux.text-measurements.v1"));
+    assert!(section.contains("textStyles"));
+    assert!(section.contains("fontFamily"));
+    assert!(section.contains("lineWidths"));
+    assert!(section.contains("scalarWidths"));
+    assert!(section.contains("Text/ASCII"));
+    assert!(section.contains("#323"));
 }
 
 #[test]

--- a/tests/svg_render.rs
+++ b/tests/svg_render.rs
@@ -24,6 +24,21 @@ fn load_flowchart_fixture(name: &str) -> String {
         .unwrap_or_else(|e| panic!("failed to read flowchart fixture {}: {e}", path.display()))
 }
 
+fn load_dynamic_flowchart_fixture(name: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("flowchart")
+        .join("dynamic")
+        .join(name);
+    fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "failed to read dynamic flowchart fixture {}: {e}",
+            path.display()
+        )
+    })
+}
+
 fn load_class_fixture(name: &str) -> String {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
@@ -133,6 +148,17 @@ fn provider_free_svg_rejects_custom_graph_font_style() {
     assert!(err.message.contains("fontFamily"), "{err}");
     assert!(err.message.contains("dynamic text metrics"), "{err}");
     assert!(err.message.contains(DEFAULT_GRAPH_FONT_FAMILY), "{err}");
+}
+
+#[test]
+fn provider_free_svg_rejects_mermaid_graph_font_styles() {
+    let input = load_dynamic_flowchart_fixture("multi_font_styles.mmd");
+
+    let err = render_diagram(&input, OutputFormat::Svg, &RenderConfig::default())
+        .expect_err("Mermaid font styles require dynamic text metrics");
+
+    assert!(err.message.contains("fontFamily"), "{err}");
+    assert!(err.message.contains("dynamic text metrics"), "{err}");
 }
 
 #[test]

--- a/tests/wasm_cli_contract.rs
+++ b/tests/wasm_cli_contract.rs
@@ -400,7 +400,7 @@ fn dynamic_metrics_input_rejects_unknown_fields() {
     use mmdflux::dynamic_text_metrics::DynamicMetricsInput;
 
     let err = serde_json::from_str::<DynamicMetricsInput>(
-        r#"{"cssFont":"16px Inter","fontFamily":"Inter","fontSizePx":16,"lineHeightPx":24,"extra":true}"#,
+        r#"{"defaultStyle":"s0","textStyles":[{"id":"s0","fontFamily":"Inter","fontSize":16,"fontStyle":"normal","fontWeight":"400","lineHeight":24,"cssFont":"16px Inter"}],"extra":true}"#,
     )
     .unwrap_err()
     .to_string();

--- a/web/src/browser-text-metrics.test.ts
+++ b/web/src/browser-text-metrics.test.ts
@@ -366,6 +366,44 @@ describe("prepareBrowserTextMetrics", () => {
         environmentFixture().environment,
       ),
     ).rejects.toThrow("lineHeight");
+
+    await expect(
+      prepareBrowserTextMetrics(
+        {
+          defaultStyle: "s0",
+          textStyles: [
+            {
+              id: "s0",
+              fontFamily: "Inter",
+              fontSize: 16,
+              fontSizePx: 18,
+              lineHeight: 24,
+              cssFont: "16px Inter",
+            },
+          ],
+        },
+        environmentFixture().environment,
+      ),
+    ).rejects.toThrow("fontSize");
+
+    await expect(
+      prepareBrowserTextMetrics(
+        {
+          defaultStyle: "s0",
+          textStyles: [
+            {
+              id: "s0",
+              fontFamily: "Inter",
+              fontSize: 16,
+              lineHeight: 24,
+              lineHeightPx: 30,
+              cssFont: "16px Inter",
+            },
+          ],
+        },
+        environmentFixture().environment,
+      ),
+    ).rejects.toThrow("lineHeight");
   });
 });
 

--- a/web/src/browser-text-metrics.test.ts
+++ b/web/src/browser-text-metrics.test.ts
@@ -94,6 +94,30 @@ function fontSetFixture(
   };
 }
 
+function multiStyleRequest() {
+  return {
+    defaultStyle: "s0",
+    textStyles: [
+      {
+        id: "s0",
+        fontFamily: "Inter",
+        fontSize: 16,
+        lineHeight: 24,
+        fontStyle: "normal",
+        fontWeight: "400",
+      },
+      {
+        id: "s1",
+        fontFamily: "Verdana",
+        fontSize: 8,
+        lineHeight: 12,
+        fontStyle: "normal",
+        fontWeight: "400",
+      },
+    ],
+  };
+}
+
 describe("prepareBrowserTextMetrics", () => {
   it("fails honestly without OffscreenCanvas", async () => {
     await expect(
@@ -173,14 +197,20 @@ describe("prepareBrowserTextMetrics", () => {
     expect(fonts.check).toHaveBeenCalledWith('normal 400 16px "Inter"');
     expect(calls).toEqual(["load", "check"]);
     expect(JSON.parse(prepared.metricsJson)).toEqual({
-      cssFont: 'normal 400 16px "Inter"',
-      fontFamily: "Inter",
-      fontSizePx: 16,
-      lineHeightPx: 24,
+      defaultStyle: "s0",
       profileId: "mmdflux-browser-canvas-v1",
       profileVersion: 1,
-      fontStyle: "normal",
-      fontWeight: "400",
+      textStyles: [
+        {
+          id: "s0",
+          cssFont: 'normal 400 16px "Inter"',
+          fontFamily: "Inter",
+          fontSize: 16,
+          lineHeight: 24,
+          fontStyle: "normal",
+          fontWeight: "400",
+        },
+      ],
     });
   });
 
@@ -248,6 +278,64 @@ describe("prepareBrowserTextMetrics", () => {
     expect(context.measureText).toHaveBeenCalledTimes(2);
   });
 
+  it("preflights and caches each css font in a style set", async () => {
+    const fonts = fontSetFixture();
+    const { context, environment } = environmentFixture(fonts);
+
+    const prepared = await prepareBrowserTextMetrics(
+      multiStyleRequest(),
+      environment,
+    );
+
+    expect(fonts.load).toHaveBeenCalledWith('normal 400 16px "Inter"');
+    expect(fonts.load).toHaveBeenCalledWith('normal 400 8px "Verdana"');
+    expect(fonts.check).toHaveBeenCalledWith('normal 400 16px "Inter"');
+    expect(fonts.check).toHaveBeenCalledWith('normal 400 8px "Verdana"');
+    expect(JSON.parse(prepared.metricsJson)).toMatchObject({
+      defaultStyle: "s0",
+      textStyles: [
+        {
+          id: "s0",
+          cssFont: 'normal 400 16px "Inter"',
+          fontFamily: "Inter",
+          fontSize: 16,
+          fontStyle: "normal",
+          fontWeight: "400",
+          lineHeight: 24,
+        },
+        {
+          id: "s1",
+          cssFont: 'normal 400 8px "Verdana"',
+          fontFamily: "Verdana",
+          fontSize: 8,
+          fontStyle: "normal",
+          fontWeight: "400",
+          lineHeight: 12,
+        },
+      ],
+      profileId: "mmdflux-browser-canvas-v1",
+      profileVersion: 1,
+    });
+
+    prepared.measureText("Same", 'normal 400 16px "Inter"');
+    prepared.measureText("Same", 'normal 400 16px "Inter"');
+    prepared.measureText("Same", 'normal 400 8px "Verdana"');
+
+    expect(context.measureText).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when any style-set font is unavailable", async () => {
+    const { environment } = environmentFixture(
+      fontSetFixture({
+        check: vi.fn((cssFont) => !cssFont.includes("Verdana")),
+      }),
+    );
+
+    await expect(
+      prepareBrowserTextMetrics(multiStyleRequest(), environment),
+    ).rejects.toThrow("Verdana");
+  });
+
   it("quotes CSS font families and rejects invalid numeric style fields", async () => {
     expect(
       buildCssFont({
@@ -270,14 +358,14 @@ describe("prepareBrowserTextMetrics", () => {
         { fontFamily: "Inter", fontSizePx: 0, lineHeightPx: 24 },
         environmentFixture().environment,
       ),
-    ).rejects.toThrow("fontSizePx");
+    ).rejects.toThrow("fontSize");
 
     await expect(
       prepareBrowserTextMetrics(
         { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: Number.NaN },
         environmentFixture().environment,
       ),
-    ).rejects.toThrow("lineHeightPx");
+    ).rejects.toThrow("lineHeight");
   });
 });
 
@@ -308,8 +396,12 @@ describe("prepareMainThreadBrowserTextMetrics", () => {
     expect(JSON.parse(prepared.metricsJson)).toMatchObject({
       profileId: "mmdflux-browser-canvas-v1",
       profileVersion: 1,
-      fontStyle: "normal",
-      fontWeight: "400",
+      textStyles: [
+        expect.objectContaining({
+          fontStyle: "normal",
+          fontWeight: "400",
+        }),
+      ],
     });
     expect(prepared.measureText("Alpha", 'normal 400 16px "Inter"')).toBe(15);
     expect(context.font).toBe('normal 400 16px "Inter"');

--- a/web/src/browser-text-metrics.ts
+++ b/web/src/browser-text-metrics.ts
@@ -310,13 +310,17 @@ function prepareTextStyle(
 ): PreparedBrowserTextStyle {
   const id = normalizeNonEmpty("textStyles.id", input.id);
   const fontFamily = normalizeFontFamily(input.fontFamily);
-  const fontSize = positiveFiniteNumber(
+  const fontSize = positiveFiniteNumberWithAlias(
     "textStyles.fontSize",
     input.fontSize ?? input.fontSizePx,
+    "textStyles.fontSizePx",
+    input.fontSizePx,
   );
-  const lineHeight = positiveFiniteNumber(
+  const lineHeight = positiveFiniteNumberWithAlias(
     "textStyles.lineHeight",
     input.lineHeight ?? input.lineHeightPx,
+    "textStyles.lineHeightPx",
+    input.lineHeightPx,
   );
   const fontStyle = fontStyleFor(input);
   const fontWeight = fontWeightFor(input);
@@ -454,4 +458,24 @@ function positiveFiniteNumber(field: string, value: unknown): number {
     throw new Error(`${field} must be a finite positive number.`);
   }
   return value;
+}
+
+function positiveFiniteNumberWithAlias(
+  field: string,
+  value: unknown,
+  aliasField: string,
+  aliasValue: unknown,
+): number {
+  const primary = positiveFiniteNumber(field, value);
+  if (aliasValue === undefined) {
+    return primary;
+  }
+
+  const alias = positiveFiniteNumber(aliasField, aliasValue);
+  if (primary !== alias) {
+    throw new Error(
+      `${field} and ${aliasField} must match when both are provided.`,
+    );
+  }
+  return primary;
 }

--- a/web/src/browser-text-metrics.ts
+++ b/web/src/browser-text-metrics.ts
@@ -1,9 +1,25 @@
 export interface BrowserTextMetricsRequest {
-  fontFamily: string;
-  fontSizePx: number;
-  lineHeightPx: number;
+  fontFamily?: string;
+  fontSizePx?: number;
+  lineHeightPx?: number;
   fontStyle?: string;
   fontWeight?: string;
+  defaultStyle?: string;
+  textStyles?: BrowserTextMetricsStyleRequest[];
+  profileId?: string;
+  profileVersion?: number;
+}
+
+export interface BrowserTextMetricsStyleRequest {
+  id: string;
+  fontFamily: string;
+  fontSize?: number;
+  fontSizePx?: number;
+  lineHeight?: number;
+  lineHeightPx?: number;
+  fontStyle?: string;
+  fontWeight?: string;
+  cssFont?: string;
 }
 
 export const BROWSER_TEXT_METRICS_PROFILE_ID = "mmdflux-browser-canvas-v1";
@@ -88,6 +104,23 @@ export function browserTextMetricsEnvironment(
   };
 }
 
+interface PreparedBrowserTextStyle {
+  id: string;
+  fontFamily: string;
+  fontSize: number;
+  fontStyle: string;
+  fontWeight: string;
+  lineHeight: number;
+  cssFont: string;
+}
+
+interface PreparedBrowserTextStyleSet {
+  defaultStyle: string;
+  textStyles: PreparedBrowserTextStyle[];
+  profileId: string;
+  profileVersion: number;
+}
+
 export function mainThreadBrowserTextMetricsEnvironment(
   scope: unknown = globalThis,
 ): MainThreadBrowserTextMetricsEnvironment {
@@ -101,7 +134,7 @@ export async function prepareBrowserTextMetrics(
   input: BrowserTextMetricsRequest,
   environment = browserTextMetricsEnvironment(),
 ): Promise<PreparedBrowserTextMetrics> {
-  const cssFont = buildCssFont(input);
+  const styleSet = prepareTextStyleSet(input);
   const fontSet = environment.fonts;
   if (!fontSet) {
     throw new BrowserTextMetricsCapabilityError(
@@ -127,16 +160,16 @@ export async function prepareBrowserTextMetrics(
     );
   }
 
-  await loadAndValidateFontSet(fontSet, cssFont, input.fontFamily);
+  await loadAndValidateFontSet(fontSet, styleSet.textStyles);
 
-  return preparedMetrics(input, cssFont, context);
+  return preparedMetrics(styleSet, context);
 }
 
 export async function prepareMainThreadBrowserTextMetrics(
   input: BrowserTextMetricsRequest,
   environment = mainThreadBrowserTextMetricsEnvironment(),
 ): Promise<PreparedBrowserTextMetrics> {
-  const cssFont = buildCssFont(input);
+  const styleSet = prepareTextStyleSet(input);
   const document = environment.document;
   if (!document?.fonts) {
     throw new BrowserTextMetricsCapabilityError(
@@ -173,27 +206,22 @@ export async function prepareMainThreadBrowserTextMetrics(
     );
   }
 
-  await loadAndValidateFontSet(fontSet, cssFont, input.fontFamily);
+  await loadAndValidateFontSet(fontSet, styleSet.textStyles);
 
-  return preparedMetrics(input, cssFont, context);
+  return preparedMetrics(styleSet, context);
 }
 
 function preparedMetrics(
-  input: BrowserTextMetricsRequest,
-  cssFont: string,
+  styleSet: PreparedBrowserTextStyleSet,
   context: CanvasTextMeasureContext,
 ): PreparedBrowserTextMetrics {
   const cache = new Map<string, number>();
   return {
     metricsJson: JSON.stringify({
-      cssFont,
-      fontFamily: normalizeFontFamily(input.fontFamily),
-      fontSizePx: input.fontSizePx,
-      lineHeightPx: input.lineHeightPx,
-      profileId: BROWSER_TEXT_METRICS_PROFILE_ID,
-      profileVersion: 1,
-      fontStyle: fontStyleFor(input),
-      fontWeight: fontWeightFor(input),
+      defaultStyle: styleSet.defaultStyle,
+      textStyles: styleSet.textStyles,
+      profileId: styleSet.profileId,
+      profileVersion: styleSet.profileVersion,
     }),
     measureText: (text: string, measuredCssFont: string): number => {
       const key = `${measuredCssFont}\0${text}`;
@@ -215,38 +243,148 @@ function preparedMetrics(
 
 async function loadAndValidateFontSet(
   fontSet: BrowserFontFaceSet,
-  cssFont: string,
-  fontFamily: string,
+  textStyles: PreparedBrowserTextStyle[],
 ): Promise<void> {
   // Do not await FontFaceSet.ready here. Chrome worker FontFaceSet.ready can
   // stay pending for system-font stacks even after load resolves and check
   // passes; load plus post-load check is the requested-font contract.
-  await fontSet.load(cssFont);
-  if (!fontSet.check(cssFont)) {
-    throw new Error(`Dynamic text metrics unavailable for font ${fontFamily}.`);
+  for (const style of textStyles) {
+    await fontSet.load(style.cssFont);
+    if (!fontSet.check(style.cssFont)) {
+      throw new Error(
+        `Dynamic text metrics unavailable for font ${style.fontFamily}.`,
+      );
+    }
   }
 }
 
 export function buildCssFont(input: BrowserTextMetricsRequest): string {
-  const fontFamily = fontFamilyStackToCss(input.fontFamily);
-  validatePositiveFinite("fontSizePx", input.fontSizePx);
-  validatePositiveFinite("lineHeightPx", input.lineHeightPx);
+  const style = legacyTextStyleInput(input);
+  const fontFamily = fontFamilyStackToCss(style.fontFamily);
+  validatePositiveFinite("fontSizePx", style.fontSizePx);
+  validatePositiveFinite("lineHeightPx", style.lineHeightPx);
 
-  return `${fontStyleFor(input)} ${fontWeightFor(input)} ${input.fontSizePx}px ${fontFamily}`;
+  return `${fontStyleFor(style)} ${fontWeightFor(style)} ${style.fontSizePx}px ${fontFamily}`;
 }
 
-function fontStyleFor(input: BrowserTextMetricsRequest): string {
+function prepareTextStyleSet(
+  input: BrowserTextMetricsRequest,
+): PreparedBrowserTextStyleSet {
+  if (input.textStyles && input.textStyles.length === 0) {
+    throw new Error("textStyles must not be empty.");
+  }
+  const textStyles = input.textStyles
+    ? input.textStyles.map(prepareTextStyle)
+    : [prepareTextStyle({ id: "s0", ...legacyTextStyleInput(input) })];
+  const defaultStyle =
+    input.defaultStyle === undefined
+      ? textStyles[0]?.id
+      : normalizeNonEmpty("defaultStyle", input.defaultStyle);
+  if (!defaultStyle) {
+    throw new Error("defaultStyle must reference a textStyles id.");
+  }
+  if (!textStyles.some((style) => style.id === defaultStyle)) {
+    throw new Error(
+      `defaultStyle ${defaultStyle} must reference a textStyles id.`,
+    );
+  }
+
+  const styleIds = new Set<string>();
+  for (const style of textStyles) {
+    if (styleIds.has(style.id)) {
+      throw new Error(`textStyles contains duplicate id ${style.id}.`);
+    }
+    styleIds.add(style.id);
+  }
+
+  return {
+    defaultStyle,
+    textStyles,
+    profileId: normalizedProfileId(input.profileId),
+    profileVersion: normalizedProfileVersion(input.profileVersion),
+  };
+}
+
+function prepareTextStyle(
+  input: BrowserTextMetricsStyleRequest,
+): PreparedBrowserTextStyle {
+  const id = normalizeNonEmpty("textStyles.id", input.id);
+  const fontFamily = normalizeFontFamily(input.fontFamily);
+  const fontSize = positiveFiniteNumber(
+    "textStyles.fontSize",
+    input.fontSize ?? input.fontSizePx,
+  );
+  const lineHeight = positiveFiniteNumber(
+    "textStyles.lineHeight",
+    input.lineHeight ?? input.lineHeightPx,
+  );
+  const fontStyle = fontStyleFor(input);
+  const fontWeight = fontWeightFor(input);
+  const cssFont =
+    input.cssFont === undefined
+      ? `${fontStyle} ${fontWeight} ${fontSize}px ${fontFamilyStackToCss(fontFamily)}`
+      : normalizeNonEmpty("textStyles.cssFont", input.cssFont);
+
+  return {
+    id,
+    fontFamily,
+    fontSize,
+    fontStyle,
+    fontWeight,
+    lineHeight,
+    cssFont,
+  };
+}
+
+function legacyTextStyleInput(
+  input: BrowserTextMetricsRequest,
+): Required<
+  Pick<BrowserTextMetricsRequest, "fontFamily" | "fontSizePx" | "lineHeightPx">
+> &
+  Pick<BrowserTextMetricsRequest, "fontStyle" | "fontWeight"> {
+  return {
+    fontFamily: input.fontFamily ?? "",
+    fontSizePx: input.fontSizePx ?? Number.NaN,
+    lineHeightPx: input.lineHeightPx ?? Number.NaN,
+    fontStyle: input.fontStyle,
+    fontWeight: input.fontWeight,
+  };
+}
+
+function normalizedProfileId(profileId: string | undefined): string {
+  return profileId?.trim() || BROWSER_TEXT_METRICS_PROFILE_ID;
+}
+
+function normalizedProfileVersion(profileVersion: number | undefined): number {
+  if (profileVersion === undefined) {
+    return 1;
+  }
+  if (!Number.isInteger(profileVersion) || profileVersion <= 0) {
+    throw new Error("profileVersion must be a positive integer.");
+  }
+  return profileVersion;
+}
+
+function fontStyleFor(
+  input: Pick<BrowserTextMetricsStyleRequest, "fontStyle">,
+): string {
   return input.fontStyle?.trim() || "normal";
 }
 
-function fontWeightFor(input: BrowserTextMetricsRequest): string {
+function fontWeightFor(
+  input: Pick<BrowserTextMetricsStyleRequest, "fontWeight">,
+): string {
   return input.fontWeight?.trim() || "400";
 }
 
 function normalizeFontFamily(fontFamily: string): string {
-  const normalized = fontFamily.trim();
+  return normalizeNonEmpty("fontFamily", fontFamily);
+}
+
+function normalizeNonEmpty(field: string, value: string): string {
+  const normalized = value.trim();
   if (!normalized) {
-    throw new Error("fontFamily must not be empty.");
+    throw new Error(`${field} must not be empty.`);
   }
   return normalized;
 }
@@ -309,4 +447,11 @@ function validatePositiveFinite(field: string, value: number): void {
   if (!Number.isFinite(value) || value <= 0) {
     throw new Error(`${field} must be a finite positive number.`);
   }
+}
+
+function positiveFiniteNumber(field: string, value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${field} must be a finite positive number.`);
+  }
+  return value;
 }

--- a/web/src/mermaid-language.ts
+++ b/web/src/mermaid-language.ts
@@ -316,11 +316,13 @@ function escapeRegExp(value: string): string {
 }
 
 function toPhraseRegexes(values: readonly string[]): RegExp[] {
-  return values
-    .filter((value) => value.includes(" "))
-    .sort((left, right) => right.length - left.length)
-    // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
-    .map((value) => new RegExp(`^${escapeRegExp(value)}(?![\\w-])`));
+  return (
+    values
+      .filter((value) => value.includes(" "))
+      .sort((left, right) => right.length - left.length)
+      // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
+      .map((value) => new RegExp(`^${escapeRegExp(value)}(?![\\w-])`))
+  );
 }
 
 function matchAnyRegex(

--- a/web/src/wasm-diagnostics.ts
+++ b/web/src/wasm-diagnostics.ts
@@ -140,7 +140,8 @@ export function createWasmLintExtension(
   validateWithWorker: ValidateWithWorker,
 ): Extension {
   return linter(
-    async (view) => lintWithWorker(view.state.doc.toString(), validateWithWorker),
+    async (view) =>
+      lintWithWorker(view.state.doc.toString(), validateWithWorker),
     { delay: 350 },
   );
 }


### PR DESCRIPTION
## Summary

- resolve Mermaid graph font declarations into style keys for nodes and edge labels, including `font-family`, `font-size`, `font-style`, and `font-weight`
- thread style-aware text metrics through graph measurement, wrapping, routing, SVG render, and dynamic callback providers without changing unstyled output
- persist style-keyed dynamic measurement caches in MMDS and replay provider-free dynamic SVG from those sidecars
- update the Wasm/web browser metrics contract to preflight and measure multiple CSS font identities per render
- add end-to-end canaries for the Mermaid multi-font example, browser metrics style sets, and provider-free MMDS replay

Closes #321
Closes #322

## Non-goals

- playground UI controls for Mermaid font settings remain deferred to #323
- dynamic metrics for Text, ASCII, and sequence diagrams remain unsupported by design
- subgraph title font styling stays on the default graph text style until Mermaid behavior is pinned separately
- no public exposure of the internal `TextMetricsProvider` trait
- no fallback from requested dynamic measurements to recorded/static profiles

## Validation

- `cargo nextest run --features unstable-text-metrics-provider --no-fail-fast` — 3131/3131 passing, 8 skipped
- `npm run test` — 109/109 passing
- `npm run check`
- `just lint`
- `just architecture-check`
- `cog check origin/main..HEAD`
- `git diff --check`
