### PR TITLE
feat: route playground font styles through browser metrics

### DIFF
--- a/crates/mmdflux-wasm/src/lib.rs
+++ b/crates/mmdflux-wasm/src/lib.rs
@@ -2,6 +2,7 @@ use std::cell::Cell;
 
 use mmdflux::dynamic_text_metrics::{
     DynamicMetricsInput, DynamicTextMetricsError, render_graph_family_with_dynamic_text_metrics,
+    resolve_browser_text_metrics_request,
 };
 use mmdflux::errors::RenderError;
 use mmdflux::format::OutputFormat;
@@ -23,6 +24,24 @@ pub fn render(input: &str, format: &str, config_json: &str) -> Result<String, Js
     let config = parse_render_config(format, config_json)?;
 
     render_diagram(input, format, &config).map_err(|err| js_error(err.message))
+}
+
+#[wasm_bindgen(js_name = browserTextMetricsRequest)]
+pub fn browser_text_metrics_request(
+    input: &str,
+    format: &str,
+    config_json: &str,
+) -> Result<String, JsError> {
+    let format = parse_output_format(format)?;
+    let config = parse_resolver_config(config_json)?;
+    let decision = resolve_browser_text_metrics_request(input, format, &config)
+        .map_err(|err| js_error(err.message))?;
+
+    serde_json::to_string(&decision).map_err(|error| {
+        js_error(format!(
+            "failed to serialize browser metrics decision: {error}"
+        ))
+    })
 }
 
 #[wasm_bindgen(js_name = renderWithBrowserTextMetrics)]
@@ -90,6 +109,18 @@ fn parse_render_config(format: OutputFormat, config_json: &str) -> Result<Render
     // Wasm forces flux-layered for SVG.
     apply_svg_surface_defaults(format, &mut config, true);
     Ok(config)
+}
+
+fn parse_resolver_config(config_json: &str) -> Result<RenderConfig, JsError> {
+    if config_json.trim().is_empty() {
+        return Ok(RenderConfig::default());
+    }
+
+    let input: RuntimeConfigInput = serde_json::from_str(config_json)
+        .map_err(|error| js_error(format!("invalid config_json: {error}")))?;
+    input
+        .into_render_config()
+        .map_err(|err| js_error(err.message))
 }
 
 fn parse_dynamic_render_config(config_json: &str) -> Result<RenderConfig, JsError> {

--- a/crates/mmdflux-wasm/tests/web.rs
+++ b/crates/mmdflux-wasm/tests/web.rs
@@ -1,4 +1,7 @@
-use mmdflux_wasm::{detect, render, render_with_browser_text_metrics, validate, version};
+use mmdflux_wasm::{
+    browser_text_metrics_request, detect, render, render_with_browser_text_metrics, validate,
+    version,
+};
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
@@ -61,6 +64,46 @@ fn dynamic_metrics_json_with_profile_fields(
 
 fn callback(body: &str) -> js_sys::Function {
     js_sys::Function::new_with_args("text, cssFont", body)
+}
+
+#[wasm_bindgen_test]
+fn browser_text_metrics_request_returns_style_set_for_multi_font_graph() {
+    let input = include_str!("../../../tests/fixtures/flowchart/dynamic/multi_font_styles.mmd");
+    let decision =
+        browser_text_metrics_request(input, "svg", "{}").expect("resolver export should succeed");
+    let value: serde_json::Value =
+        serde_json::from_str(&decision).expect("decision should be JSON");
+
+    assert_eq!(value["required"], true);
+    let styles = value["browserTextMetrics"]["textStyles"]
+        .as_array()
+        .expect("styles should be an array");
+    assert!(styles.iter().any(|style| {
+        style["fontFamily"] == "Verdana" && style["cssFont"] == r#"normal 400 8px "Verdana""#
+    }));
+    assert!(
+        styles
+            .iter()
+            .any(|style| style["fontFamily"] == "Courier New"
+                && style["cssFont"] == r#"normal 400 20px "Courier New""#)
+    );
+    assert!(
+        styles
+            .iter()
+            .any(|style| style["fontFamily"] == "Times New Roman"
+                && style["cssFont"] == r#"normal 400 32px "Times New Roman""#)
+    );
+}
+
+#[wasm_bindgen_test]
+fn browser_text_metrics_request_returns_not_required_for_unstyled_svg() {
+    let decision = browser_text_metrics_request("graph TD\nA-->B", "svg", "{}")
+        .expect("resolver export should succeed");
+    let value: serde_json::Value =
+        serde_json::from_str(&decision).expect("decision should be JSON");
+
+    assert_eq!(value["required"], false);
+    assert!(value.get("browserTextMetrics").is_none());
 }
 
 #[wasm_bindgen_test]

--- a/docs/development/wasm.md
+++ b/docs/development/wasm.md
@@ -84,9 +84,8 @@ Notes:
 - `fontMetricsProfile` defaults to `mmdflux-sans-v1` for direct graph-family
   rendering. The compatibility profile `mmdflux-heuristic-proportional-v1`
   remains available for callers that need the previous heuristic geometry.
-  Text and ASCII output ignore this setting and remain pinned to
-  compatibility metrics for wrap preparation. Unsupported profile IDs are
-  rejected.
+  Text and ASCII output ignore this setting and remain pinned to compatibility
+  metrics for wrap preparation. Unsupported profile IDs are rejected.
 - Wasm uses the same static profile tables as native rendering; browser
   `measureText` is not used by these profiles.
 - `fontFamily` and `fontSize` are graph text-style inputs, not styling-only SVG
@@ -110,6 +109,11 @@ Notes:
 The existing `render` export remains static and deterministic. It never calls
 browser measurement APIs, and importing the browser metrics export does not
 change `render` output.
+
+The playground routes graph-family SVG font styles through browser text metrics
+when Mermaid `style`, `classDef`/`class`, or `linkStyle` declarations include
+layout-affecting font properties. Static/default SVG renders without font
+styling continue to use the portable `render` path. Text, ASCII, and sequence remain unsupported for dynamic metrics.
 
 `renderWithBrowserTextMetrics(input, format, configJson, metricsJson, measureText)`
 is a separate experimental export for browser-owned font measurement. It
@@ -173,7 +177,7 @@ Main-thread fallback is used only when worker dynamic metrics fail because the
 worker lacks font or canvas capabilities. Missing fonts, failed post-load
 `check()`, invalid `measureText` output, and Rust render errors remain explicit
 failures; they do not retry through another mode or fall back to static
-profiles.
+profiles. When the requested font is unavailable, rendering fails instead of measuring a fallback font and pretending it matched the request.
 
 The `measureText` callback itself is synchronous from Rust's perspective and
 must return a finite non-negative width number for each `(text, cssFont)`

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -4,10 +4,10 @@
 //! provider API is not part of the stable Rust facade.
 
 use std::cell::{Cell, RefCell};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::builtins::default_registry;
 use crate::errors::RenderError;
@@ -16,8 +16,9 @@ use crate::frontends::{InputFrontend, detect_input_frontend};
 use crate::graph::measure::{
     DEFAULT_LABEL_PADDING_X, DEFAULT_LABEL_PADDING_Y, DEFAULT_PROPORTIONAL_NODE_PADDING_X,
     DEFAULT_PROPORTIONAL_NODE_PADDING_Y, GraphTextStyleKey, TextMeasurementCache,
-    TextMeasurementStyle, TextMetricsLayoutDescriptor, TextMetricsProfileDescriptor,
-    TextMetricsProvider, TextMetricsStyleDescriptor,
+    TextMeasurementStyle, TextMetricsLayoutDescriptor, TextMetricsProfileConfig,
+    TextMetricsProfileDescriptor, TextMetricsProvider, TextMetricsStyleDescriptor,
+    edge_text_style_key, node_text_style_key, resolve_text_metrics_profile,
 };
 use crate::payload::Diagram;
 use crate::registry::DiagramFamily;
@@ -25,16 +26,18 @@ use crate::render::graph::SvgRenderOptions;
 use crate::runtime::config::RenderConfig;
 use crate::runtime::config_input::apply_svg_surface_defaults;
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DynamicMetricsInput {
     pub default_style: String,
     pub text_styles: Vec<DynamicTextStyleInput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub profile_version: Option<u32>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DynamicTextStyleInput {
     pub id: String,
@@ -44,6 +47,14 @@ pub struct DynamicTextStyleInput {
     pub font_weight: String,
     pub line_height: f64,
     pub css_font: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserTextMetricsDecision {
+    pub required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub browser_text_metrics: Option<DynamicMetricsInput>,
 }
 
 impl DynamicMetricsInput {
@@ -613,6 +624,202 @@ fn mmds_input_diagram_type(input: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+pub fn resolve_browser_text_metrics_request(
+    input: &str,
+    format: OutputFormat,
+    config: &RenderConfig,
+) -> Result<BrowserTextMetricsDecision, RenderError> {
+    if !matches!(format, OutputFormat::Svg) {
+        return Ok(browser_text_metrics_not_required());
+    }
+    if config.graph_text_style.is_some() {
+        return Err(RenderError {
+            message: "browser text metrics resolution uses resolved Mermaid styles; do not pass RenderConfig.graph_text_style"
+                .to_string(),
+        });
+    }
+    if !matches!(detect_input_frontend(input), Some(InputFrontend::Mermaid)) {
+        return Ok(browser_text_metrics_not_required());
+    }
+
+    let registry = default_registry();
+    let resolved = registry.resolve(input).ok_or_else(|| RenderError {
+        message: "unknown diagram type".to_string(),
+    })?;
+    if !matches!(resolved.family(), DiagramFamily::Graph) {
+        return Ok(browser_text_metrics_not_required());
+    }
+    if !resolved.supported_formats().contains(&format) {
+        return Ok(browser_text_metrics_not_required());
+    }
+
+    let instance = registry
+        .create(resolved.diagram_id())
+        .ok_or_else(|| RenderError {
+            message: format!(
+                "no implementation for diagram type: {}",
+                resolved.diagram_id()
+            ),
+        })?;
+    let parsed = instance.parse(input).map_err(|error| RenderError {
+        message: format!("parse error: {error}"),
+    })?;
+    let effective_config = super::effective_render_config(input, format, config);
+    let payload =
+        super::payload::prepare_payload_for_render(parsed.into_payload()?, &effective_config);
+    let graph = match &payload {
+        Diagram::Flowchart(graph) | Diagram::Class(graph) | Diagram::State(graph) => graph,
+        Diagram::Sequence(_) => return Ok(browser_text_metrics_not_required()),
+    };
+
+    let metrics = resolve_text_metrics_profile(TextMetricsProfileConfig::default())
+        .map_err(|error| RenderError {
+            message: error.to_string(),
+        })?
+        .metrics;
+    let default_style = GraphTextStyleKey::default_provider_style(&metrics);
+    let styles = collect_graph_browser_text_styles(graph, &metrics);
+    if styles.iter().all(|style| style == &default_style) {
+        return Ok(browser_text_metrics_not_required());
+    }
+
+    Ok(BrowserTextMetricsDecision {
+        required: true,
+        browser_text_metrics: Some(browser_text_metrics_input(default_style, styles)),
+    })
+}
+
+fn browser_text_metrics_not_required() -> BrowserTextMetricsDecision {
+    BrowserTextMetricsDecision {
+        required: false,
+        browser_text_metrics: None,
+    }
+}
+
+fn collect_graph_browser_text_styles(
+    graph: &crate::graph::Graph,
+    provider: &dyn TextMetricsProvider,
+) -> BTreeSet<GraphTextStyleKey> {
+    let mut styles = BTreeSet::new();
+    for node in graph.nodes.values() {
+        styles.insert(node_text_style_key(provider, node));
+    }
+    // Subgraph class styling is not represented in the graph IR yet, so
+    // subgraph titles currently render with the provider default. When
+    // subgraph style parity lands, title styles need to join this set.
+    for edge in &graph.edges {
+        if edge.label.is_some() || edge.head_label.is_some() || edge.tail_label.is_some() {
+            styles.insert(edge_text_style_key(provider, edge));
+        }
+    }
+    styles
+}
+
+fn browser_text_metrics_input(
+    default_style: GraphTextStyleKey,
+    styles: BTreeSet<GraphTextStyleKey>,
+) -> DynamicMetricsInput {
+    let mut text_styles = Vec::with_capacity(styles.len().max(1));
+    // The dynamic provider requires a declared default style even when every
+    // measured node/edge label uses an explicit non-default style.
+    text_styles.push(dynamic_text_style_input_for_key("s0", &default_style));
+    for (index, style) in styles
+        .into_iter()
+        .filter(|style| style != &default_style)
+        .enumerate()
+    {
+        text_styles.push(dynamic_text_style_input_for_key(
+            &format!("s{}", index + 1),
+            &style,
+        ));
+    }
+
+    DynamicMetricsInput {
+        default_style: "s0".to_string(),
+        text_styles,
+        profile_id: None,
+        profile_version: None,
+    }
+}
+
+fn dynamic_text_style_input_for_key(id: &str, style: &GraphTextStyleKey) -> DynamicTextStyleInput {
+    let font_size = style.font_size_px();
+    let line_height = style.line_height_px();
+    DynamicTextStyleInput {
+        id: id.to_string(),
+        font_family: style.font_family.clone(),
+        font_size,
+        font_style: style.font_style.clone(),
+        font_weight: style.font_weight.clone(),
+        line_height,
+        css_font: format!(
+            "{} {} {}px {}",
+            style.font_style,
+            style.font_weight,
+            css_number(font_size),
+            css_font_family_stack(&style.font_family)
+        ),
+    }
+}
+
+fn css_number(value: f64) -> String {
+    if (value.fract()).abs() < f64::EPSILON {
+        format!("{value:.0}")
+    } else {
+        value.to_string()
+    }
+}
+
+fn css_font_family_stack(font_family: &str) -> String {
+    font_family
+        .split(',')
+        .map(css_font_family_token)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn css_font_family_token(family: &str) -> String {
+    let unquoted = strip_one_quote_layer(family.trim());
+    if is_css_generic_family(unquoted) {
+        return unquoted.to_ascii_lowercase();
+    }
+
+    format!(
+        "\"{}\"",
+        unquoted.replace('\\', "\\\\").replace('"', "\\\"")
+    )
+}
+
+fn strip_one_quote_layer(value: &str) -> &str {
+    if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        value[1..value.len() - 1].trim()
+    } else {
+        value
+    }
+}
+
+fn is_css_generic_family(family: &str) -> bool {
+    matches!(
+        family.to_ascii_lowercase().as_str(),
+        "serif"
+            | "sans-serif"
+            | "monospace"
+            | "cursive"
+            | "fantasy"
+            | "system-ui"
+            | "ui-serif"
+            | "ui-sans-serif"
+            | "ui-monospace"
+            | "ui-rounded"
+            | "emoji"
+            | "math"
+            | "fangsong"
+    )
+}
+
 pub fn render_graph_family_svg_with_dynamic_text_metrics<F>(
     input: &str,
     config: &RenderConfig,
@@ -1125,6 +1332,97 @@ mod tests {
             profile_id: None,
             profile_version: None,
         }
+    }
+
+    #[test]
+    fn browser_metrics_request_resolves_multi_font_graph_styles() {
+        let decision = resolve_browser_text_metrics_request(
+            multi_font_mermaid_input(),
+            OutputFormat::Svg,
+            &RenderConfig::default(),
+        )
+        .expect("resolver should parse graph input");
+
+        assert!(decision.required);
+        let request = decision.browser_text_metrics.expect("metrics request");
+        assert_eq!(request.default_style, "s0");
+        assert!(request.text_styles.iter().any(|style| {
+            style.font_family == "Verdana"
+                && (style.font_size - 8.0).abs() < f64::EPSILON
+                && style.css_font == r#"normal 400 8px "Verdana""#
+        }));
+        assert!(request.text_styles.iter().any(|style| {
+            style.font_family == "Courier New"
+                && (style.font_size - 20.0).abs() < f64::EPSILON
+                && style.css_font == r#"normal 400 20px "Courier New""#
+        }));
+        assert!(request.text_styles.iter().any(|style| {
+            style.font_family == "Times New Roman"
+                && (style.font_size - 32.0).abs() < f64::EPSILON
+                && style.css_font == r#"normal 400 32px "Times New Roman""#
+        }));
+    }
+
+    #[test]
+    fn browser_metrics_request_not_required_for_unstyled_graph_svg() {
+        let decision = resolve_browser_text_metrics_request(
+            "graph TD\nA-->B",
+            OutputFormat::Svg,
+            &RenderConfig::default(),
+        )
+        .expect("unstyled graph should resolve");
+
+        assert!(!decision.required);
+        assert!(decision.browser_text_metrics.is_none());
+    }
+
+    #[test]
+    fn browser_metrics_request_not_required_for_terminal_formats() {
+        for format in [OutputFormat::Text, OutputFormat::Ascii] {
+            let decision = resolve_browser_text_metrics_request(
+                multi_font_mermaid_input(),
+                format,
+                &RenderConfig::default(),
+            )
+            .expect("terminal formats should not require browser metrics");
+
+            assert!(!decision.required);
+            assert!(decision.browser_text_metrics.is_none());
+        }
+    }
+
+    #[test]
+    fn browser_metrics_request_not_required_for_sequence_svg() {
+        let decision = resolve_browser_text_metrics_request(
+            "sequenceDiagram\nAlice->>Bob: hello",
+            OutputFormat::Svg,
+            &RenderConfig::default(),
+        )
+        .expect("sequence input should resolve without dynamic metrics");
+
+        assert!(!decision.required);
+        assert!(decision.browser_text_metrics.is_none());
+    }
+
+    #[test]
+    fn browser_metrics_request_rejects_render_config_graph_text_style() {
+        let config = RenderConfig {
+            graph_text_style: Some(GraphTextStyleConfig::new("Inter", 16.0)),
+            ..RenderConfig::default()
+        };
+
+        let err = resolve_browser_text_metrics_request(
+            multi_font_mermaid_input(),
+            OutputFormat::Svg,
+            &config,
+        )
+        .expect_err("render-level graph text style should be rejected");
+
+        assert!(
+            err.message.contains("graph_text_style"),
+            "error should name rejected graph_text_style field: {}",
+            err.message
+        );
     }
 
     #[test]

--- a/web/src/app/bootstrap.ts
+++ b/web/src/app/bootstrap.ts
@@ -1,3 +1,4 @@
+import type { BrowserTextMetricsRequest } from "../browser-text-metrics";
 import { createEditorController } from "../editor";
 import {
   DEFAULT_EXAMPLE_ID,
@@ -22,6 +23,7 @@ import {
   type TextPreviewMode,
 } from "../preview";
 import { createPreviewControls } from "../preview-controls";
+import { renderPlaygroundRequest } from "../services/dynamic-svg-routing";
 import {
   createMainThreadBrowserTextMetricsRenderer,
   type MainThreadBrowserTextMetricsRenderer,
@@ -74,6 +76,7 @@ type SearchLocation = URL | Pick<Location, "search">;
 
 interface BrowserMetricsDebugOptions {
   input?: string;
+  browserTextMetrics?: BrowserTextMetricsRequest;
   fontFamily?: string;
   fontSizePx?: number;
   lineHeightPx?: number;
@@ -137,6 +140,30 @@ function positiveFiniteNumber(value: number, label: string): number {
   }
 
   return value;
+}
+
+function legacyBrowserMetricsDebugRequest(
+  options: BrowserMetricsDebugOptions,
+): BrowserTextMetricsRequest {
+  const fontFamily = (options.fontFamily ?? "Arial, sans-serif").trim();
+  if (fontFamily.length === 0) {
+    throw new Error("fontFamily must not be empty");
+  }
+
+  const fontSizePx = positiveFiniteNumber(
+    options.fontSizePx ?? 16,
+    "fontSizePx",
+  );
+  const lineHeightPx = positiveFiniteNumber(
+    options.lineHeightPx ?? fontSizePx * 1.5,
+    "lineHeightPx",
+  );
+
+  return {
+    fontFamily,
+    fontSizePx,
+    lineHeightPx,
+  };
 }
 
 function toErrorMessage(error: unknown): string {
@@ -922,7 +949,7 @@ export function renderApp(
     debounceMs:
       options.debounceMs ??
       ((request) => defaultAdaptiveDebounce(request.input)),
-    render: (request) => workerClient.render(request),
+    render: (request) => renderPlaygroundRequest(workerClient, request),
     onResult: (response) => {
       preview.showResult({
         format: response.format,
@@ -949,28 +976,13 @@ export function renderApp(
   const renderBrowserMetricsDebug = async (
     options: BrowserMetricsDebugOptions = {},
   ): Promise<BrowserMetricsDebugResult> => {
-    const fontFamily = (options.fontFamily ?? "Arial, sans-serif").trim();
-    if (fontFamily.length === 0) {
-      throw new Error("fontFamily must not be empty");
-    }
-
-    const fontSizePx = positiveFiniteNumber(
-      options.fontSizePx ?? 16,
-      "fontSizePx",
-    );
-    const lineHeightPx = positiveFiniteNumber(
-      options.lineHeightPx ?? fontSizePx * 1.5,
-      "lineHeightPx",
-    );
+    const browserTextMetrics =
+      options.browserTextMetrics ?? legacyBrowserMetricsDebugRequest(options);
     const request = {
       seq: nextBrowserMetricsDebugSeq,
       input: options.input ?? editor.getValue(),
       configJson: options.configJson ?? currentSvgConfigJson(),
-      browserTextMetrics: {
-        fontFamily,
-        fontSizePx,
-        lineHeightPx,
-      },
+      browserTextMetrics,
     };
     nextBrowserMetricsDebugSeq -= 1;
 

--- a/web/src/docs-boundary.test.ts
+++ b/web/src/docs-boundary.test.ts
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("dynamic font docs", () => {
+  it("describe the playground dynamic font boundary", async () => {
+    const docs = await readFile(
+      path.resolve(process.cwd(), "../docs/development/wasm.md"),
+      "utf8",
+    );
+
+    expect(docs).toContain(
+      "playground routes graph-family SVG font styles through browser text metrics",
+    );
+    expect(docs).toContain("Text, ASCII, and sequence remain unsupported");
+    expect(docs).toContain(
+      "requested font is unavailable, rendering fails instead of measuring a fallback font",
+    );
+  });
+});

--- a/web/src/dynamic-svg-routing.test.ts
+++ b/web/src/dynamic-svg-routing.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderPlaygroundRequest } from "./services/dynamic-svg-routing";
+import type {
+  BrowserTextMetricsRenderRequest,
+  RenderRequest,
+  RenderResponse,
+  RenderWorkerClient,
+} from "./services/render-client";
+
+function responseFor(
+  request: Pick<RenderRequest, "seq" | "format">,
+): RenderResponse {
+  return {
+    seq: request.seq,
+    format: request.format,
+    output: `${request.format}-output`,
+  };
+}
+
+function renderClientFixture(
+  overrides: Partial<RenderWorkerClient> = {},
+): RenderWorkerClient {
+  return {
+    render: vi.fn(async (request: RenderRequest) => responseFor(request)),
+    renderWithBrowserTextMetrics: vi.fn(
+      async (
+        request: BrowserTextMetricsRenderRequest,
+      ): Promise<RenderResponse> => ({
+        seq: request.seq,
+        format: "svg",
+        output: "dynamic-svg-output",
+      }),
+    ),
+    resolveBrowserTextMetricsRequest: vi.fn(async () => ({
+      required: false,
+    })),
+    validate: vi.fn(async () => '{"valid":true}'),
+    terminate: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("renderPlaygroundRequest", () => {
+  it("routes required browser metrics through dynamic render", async () => {
+    const client = renderClientFixture({
+      resolveBrowserTextMetricsRequest: vi.fn(async () => ({
+        required: true,
+        browserTextMetrics: {
+          defaultStyle: "s0",
+          textStyles: [
+            {
+              id: "s0",
+              fontFamily: "Inter",
+              fontSize: 16,
+              lineHeight: 24,
+              fontStyle: "normal",
+              fontWeight: "400",
+            },
+          ],
+        },
+      })),
+    });
+
+    await expect(
+      renderPlaygroundRequest(client, {
+        seq: 1,
+        input: "graph TD\nA[Regular]-->B\nstyle A font-family:Verdana",
+        format: "svg",
+        configJson: "{}",
+      }),
+    ).resolves.toEqual({
+      seq: 1,
+      format: "svg",
+      output: "dynamic-svg-output",
+    });
+
+    expect(client.resolveBrowserTextMetricsRequest).toHaveBeenCalledWith({
+      seq: 1,
+      input: "graph TD\nA[Regular]-->B\nstyle A font-family:Verdana",
+      format: "svg",
+      configJson: "{}",
+    });
+    expect(client.renderWithBrowserTextMetrics).toHaveBeenCalledWith({
+      seq: 1,
+      input: "graph TD\nA[Regular]-->B\nstyle A font-family:Verdana",
+      configJson: "{}",
+      browserTextMetrics: expect.objectContaining({ defaultStyle: "s0" }),
+    });
+    expect(client.render).not.toHaveBeenCalled();
+  });
+
+  it("routes not-required SVG through static render", async () => {
+    const client = renderClientFixture();
+
+    await expect(
+      renderPlaygroundRequest(client, {
+        seq: 2,
+        input: "graph TD\nA-->B",
+        format: "svg",
+        configJson: "{}",
+      }),
+    ).resolves.toEqual({
+      seq: 2,
+      format: "svg",
+      output: "svg-output",
+    });
+
+    expect(client.resolveBrowserTextMetricsRequest).not.toHaveBeenCalled();
+    expect(client.render).toHaveBeenCalledWith({
+      seq: 2,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: "{}",
+    });
+    expect(client.renderWithBrowserTextMetrics).not.toHaveBeenCalled();
+  });
+
+  it("routes non-font SVG styles through static render without resolving", async () => {
+    const client = renderClientFixture();
+
+    await expect(
+      renderPlaygroundRequest(client, {
+        seq: 6,
+        input: "graph TD\nA-->B\nstyle A fill:#f00",
+        format: "svg",
+        configJson: "{}",
+      }),
+    ).resolves.toEqual({
+      seq: 6,
+      format: "svg",
+      output: "svg-output",
+    });
+
+    expect(client.resolveBrowserTextMetricsRequest).not.toHaveBeenCalled();
+    expect(client.render).toHaveBeenCalledWith({
+      seq: 6,
+      input: "graph TD\nA-->B\nstyle A fill:#f00",
+      format: "svg",
+      configJson: "{}",
+    });
+    expect(client.renderWithBrowserTextMetrics).not.toHaveBeenCalled();
+  });
+
+  it("resolves SVG requests when config JSON carries graph font fields", async () => {
+    const client = renderClientFixture();
+
+    await renderPlaygroundRequest(client, {
+      seq: 7,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: '{"fontFamily":"Inter"}',
+    });
+
+    expect(client.resolveBrowserTextMetricsRequest).toHaveBeenCalledWith({
+      seq: 7,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: '{"fontFamily":"Inter"}',
+    });
+    expect(client.render).toHaveBeenCalledWith({
+      seq: 7,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: '{"fontFamily":"Inter"}',
+    });
+  });
+
+  it.each([
+    "text",
+    "mmds",
+  ] as const)("routes %s without resolving browser metrics", async (format) => {
+    const client = renderClientFixture();
+
+    await renderPlaygroundRequest(client, {
+      seq: 3,
+      input: "graph TD\nA-->B",
+      format,
+      configJson: "{}",
+    });
+
+    expect(client.resolveBrowserTextMetricsRequest).not.toHaveBeenCalled();
+    expect(client.render).toHaveBeenCalledWith({
+      seq: 3,
+      input: "graph TD\nA-->B",
+      format,
+      configJson: "{}",
+    });
+    expect(client.renderWithBrowserTextMetrics).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to static render when resolver fails", async () => {
+    const client = renderClientFixture({
+      resolveBrowserTextMetricsRequest: vi.fn(async () => {
+        throw new Error("resolver failed");
+      }),
+    });
+
+    await expect(
+      renderPlaygroundRequest(client, {
+        seq: 4,
+        input: "graph TD\nA[Regular]-->B\nstyle A font-family:Verdana",
+        format: "svg",
+        configJson: "{}",
+      }),
+    ).rejects.toThrow("resolver failed");
+
+    expect(client.render).not.toHaveBeenCalled();
+    expect(client.renderWithBrowserTextMetrics).not.toHaveBeenCalled();
+  });
+
+  it("propagates dynamic render errors", async () => {
+    const client = renderClientFixture({
+      resolveBrowserTextMetricsRequest: vi.fn(async () => ({
+        required: true,
+        browserTextMetrics: {
+          fontFamily: "Inter",
+          fontSizePx: 16,
+          lineHeightPx: 24,
+        },
+      })),
+      renderWithBrowserTextMetrics: vi.fn(async () => {
+        throw new Error("dynamic render failed");
+      }),
+    });
+
+    await expect(
+      renderPlaygroundRequest(client, {
+        seq: 5,
+        input: "graph TD\nA[Regular]-->B\nstyle A font-family:Verdana",
+        format: "svg",
+        configJson: "{}",
+      }),
+    ).rejects.toThrow("dynamic render failed");
+
+    expect(client.render).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/examples.test.ts
+++ b/web/src/examples.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { PLAYGROUND_EXAMPLES } from "./examples";
+
+describe("PLAYGROUND_EXAMPLES", () => {
+  it("includes a multi-font flowchart example", () => {
+    const example = PLAYGROUND_EXAMPLES.find(
+      (candidate) => candidate.id === "flowchart-dynamic-fonts",
+    );
+
+    expect(example?.input).toContain(
+      "style A font-family:Verdana,font-size:8px",
+    );
+    expect(example?.input).toContain(
+      "style B font-family:Courier New,font-size:20px",
+    );
+    expect(example?.input).toContain(
+      "linkStyle 0 font-family:Times New Roman,font-size:32px",
+    );
+  });
+});

--- a/web/src/examples.ts
+++ b/web/src/examples.ts
@@ -78,6 +78,18 @@ export const PLAYGROUND_EXAMPLES: PlaygroundExample[] = [
     Error -.->|retry| Setup`,
   },
   {
+    id: "flowchart-dynamic-fonts",
+    name: "Dynamic Fonts",
+    description: "Mermaid font-family and font-size styles",
+    category: "flowchart",
+    featured: true,
+    input: `graph TD
+    A[Regular] -->|link| B(Styled Node)
+    style A font-family:Verdana,font-size:8px
+    style B font-family:Courier New,font-size:20px
+    linkStyle 0 font-family:Times New Roman,font-size:32px`,
+  },
+  {
     id: "flowchart-direction-bt",
     name: "Bottom to Top",
     description: "Direction override using BT layout",

--- a/web/src/main-thread-browser-text-metrics.test.ts
+++ b/web/src/main-thread-browser-text-metrics.test.ts
@@ -4,6 +4,11 @@ import type { BrowserTextMetricsRenderRequest } from "./services/render-client";
 
 interface MockWasmModule {
   default: () => Promise<void>;
+  browserTextMetricsRequest: (
+    input: string,
+    format: string,
+    configJson: string,
+  ) => string;
   render: (input: string, format: string, configJson: string) => string;
   renderWithBrowserTextMetrics: (
     input: string,
@@ -44,10 +49,12 @@ function wasmModuleFixture(
   ),
 ) {
   const initialize = vi.fn(async () => {});
+  const browserTextMetricsRequest = vi.fn(() => '{"required":false}');
   const render = vi.fn(() => "static unused");
   const validate = vi.fn(() => '{"valid":true}');
   const module: MockWasmModule = {
     default: initialize,
+    browserTextMetricsRequest,
     render,
     renderWithBrowserTextMetrics,
     validate,
@@ -56,6 +63,7 @@ function wasmModuleFixture(
   return {
     initialize,
     module,
+    browserTextMetricsRequest,
     render,
     renderWithBrowserTextMetrics,
     validate,

--- a/web/src/main.test.ts
+++ b/web/src/main.test.ts
@@ -1,10 +1,49 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import type { BrowserTextMetricsRequest } from "./browser-text-metrics";
 import { createDefaultRenderWorkerClient, renderApp } from "./main";
 import type { BrowserTextMetricsRenderRequest } from "./services/render-client";
 
+function multiStyleBrowserMetricsRequest(): BrowserTextMetricsRequest {
+  return {
+    defaultStyle: "s0",
+    textStyles: [
+      {
+        id: "s0",
+        fontFamily: "Verdana",
+        fontSize: 8,
+        lineHeight: 12,
+        fontStyle: "normal",
+        fontWeight: "400",
+        cssFont: "8px Verdana",
+      },
+      {
+        id: "s1",
+        fontFamily: "Courier New",
+        fontSize: 20,
+        lineHeight: 30,
+        fontStyle: "normal",
+        fontWeight: "400",
+        cssFont: "20px Courier New",
+      },
+      {
+        id: "s2",
+        fontFamily: "Times New Roman",
+        fontSize: 32,
+        lineHeight: 48,
+        fontStyle: "normal",
+        fontWeight: "400",
+        cssFont: "32px Times New Roman",
+      },
+    ],
+  };
+}
+
 describe("renderApp", () => {
+  const fontStyledInput =
+    "graph TD\nA[Regular]-->B\nstyle A font-family:Verdana";
+
   it("main bootstraps the app without owning render or persistence logic", async () => {
     const source = await readFile(
       path.resolve(process.cwd(), "src/main.ts"),
@@ -20,6 +59,7 @@ describe("renderApp", () => {
     const client = {
       render: vi.fn(),
       renderWithBrowserTextMetrics: vi.fn(),
+      resolveBrowserTextMetricsRequest: vi.fn(),
       validate: vi.fn(),
       terminate: vi.fn(),
     };
@@ -61,6 +101,7 @@ describe("renderApp", () => {
             format: "svg",
             output: `svg:${request.input}`,
           }),
+          resolveBrowserTextMetricsRequest: async () => ({ required: false }),
           validate: async () => '{"valid":true}',
           terminate: () => {},
         }),
@@ -87,6 +128,129 @@ describe("renderApp", () => {
     } finally {
       history.replaceState(null, "", window.location.pathname);
       delete window.__mmdfluxDebug;
+    }
+  });
+
+  it("routes live svg renders with font styles through browser metrics", async () => {
+    try {
+      history.replaceState(null, "", window.location.pathname);
+
+      const render = vi.fn(async (request) => ({
+        seq: request.seq,
+        format: request.format,
+        output: `${request.format}:static`,
+      }));
+      const renderWithBrowserTextMetrics = vi.fn(async (request) => ({
+        seq: request.seq,
+        format: "svg" as const,
+        output: `<svg>${request.browserTextMetrics.textStyles?.length}</svg>`,
+      }));
+      const resolveBrowserTextMetricsRequest = vi.fn(async () => ({
+        required: true,
+        browserTextMetrics: {
+          defaultStyle: "s0",
+          textStyles: [
+            {
+              id: "s0",
+              fontFamily: "Verdana",
+              fontSize: 8,
+              lineHeight: 12,
+              fontStyle: "normal",
+              fontWeight: "400",
+            },
+          ],
+        },
+      }));
+
+      const root = document.createElement("div");
+      renderApp(root, {
+        renderClientFactory: () => ({
+          render,
+          renderWithBrowserTextMetrics,
+          resolveBrowserTextMetricsRequest,
+          validate: async () => '{"valid":true}',
+          terminate: () => {},
+        }),
+        debounceMs: 0,
+        stateStorage: {
+          getItem: () =>
+            JSON.stringify({
+              v: 4,
+              input: fontStyledInput,
+              format: "svg",
+              renderSettings: {},
+              textPreviewMode: "plain",
+              selectedExampleId: "__draft__",
+              customInput: fontStyledInput,
+            }),
+          setItem: () => {},
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(renderWithBrowserTextMetrics).toHaveBeenCalledTimes(1);
+      });
+
+      expect(resolveBrowserTextMetricsRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ format: "svg", input: fontStyledInput }),
+      );
+      expect(renderWithBrowserTextMetrics).toHaveBeenCalledWith({
+        seq: expect.any(Number),
+        input: expect.any(String),
+        configJson: expect.any(String),
+        browserTextMetrics: expect.objectContaining({ defaultStyle: "s0" }),
+      });
+      expect(render).not.toHaveBeenCalled();
+      expect(root.querySelector("[data-preview-output]")?.textContent).toBe(
+        "1",
+      );
+    } finally {
+      history.replaceState(null, "", window.location.pathname);
+    }
+  });
+
+  it("keeps unstyled svg live renders on the static path", async () => {
+    try {
+      history.replaceState(null, "", window.location.pathname);
+
+      const render = vi.fn(async (request) => ({
+        seq: request.seq,
+        format: request.format,
+        output: `${request.format}:static`,
+      }));
+      const renderWithBrowserTextMetrics = vi.fn(async (request) => ({
+        seq: request.seq,
+        format: "svg" as const,
+        output: `<svg>${request.browserTextMetrics.textStyles?.length}</svg>`,
+      }));
+      const resolveBrowserTextMetricsRequest = vi.fn(async () => ({
+        required: false,
+      }));
+
+      const root = document.createElement("div");
+      renderApp(root, {
+        renderClientFactory: () => ({
+          render,
+          renderWithBrowserTextMetrics,
+          resolveBrowserTextMetricsRequest,
+          validate: async () => '{"valid":true}',
+          terminate: () => {},
+        }),
+        debounceMs: 0,
+        stateStorage: {
+          getItem: () => null,
+          setItem: () => {},
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(render).toHaveBeenCalledTimes(1);
+      });
+
+      expect(resolveBrowserTextMetricsRequest).not.toHaveBeenCalled();
+      expect(renderWithBrowserTextMetrics).not.toHaveBeenCalled();
+    } finally {
+      history.replaceState(null, "", window.location.pathname);
     }
   });
 
@@ -118,6 +282,7 @@ describe("renderApp", () => {
             output: `${request.format}:${request.input}`,
           }),
           renderWithBrowserTextMetrics,
+          resolveBrowserTextMetricsRequest: async () => ({ required: false }),
           validate: async () => '{"valid":true}',
           terminate: () => {},
         }),
@@ -176,6 +341,113 @@ describe("renderApp", () => {
         },
       });
       expect(renderWithBrowserTextMetrics).toHaveBeenCalledTimes(1);
+    } finally {
+      history.replaceState(null, "", window.location.pathname);
+      delete window.__mmdfluxDebug;
+    }
+  });
+
+  it("debug console helper accepts worker and main-thread style-set metrics", async () => {
+    const renderWithBrowserTextMetrics = vi.fn(
+      async (request: BrowserTextMetricsRenderRequest) => ({
+        seq: request.seq,
+        format: "svg" as const,
+        output: `<span>worker:${request.browserTextMetrics.textStyles?.length}</span>`,
+      }),
+    );
+    const mainThreadRenderWithBrowserTextMetrics = vi.fn(
+      async (request: BrowserTextMetricsRenderRequest) => ({
+        seq: request.seq,
+        format: "svg" as const,
+        output: `<span>main-thread:${request.browserTextMetrics.textStyles?.length}</span>`,
+      }),
+    );
+    const multiFontInput = `graph TD
+    A[Regular] -->|link| B(Styled Node)
+    style A font-family:Verdana,font-size:8px
+    style B font-family:Courier New,font-size:20px
+    linkStyle 0 font-family:Times New Roman,font-size:32px`;
+    const browserTextMetrics = multiStyleBrowserMetricsRequest();
+
+    try {
+      history.replaceState(null, "", "?debugBrowserMetrics=1");
+
+      const root = document.createElement("div");
+      renderApp(root, {
+        renderClientFactory: () => ({
+          render: async (request) => ({
+            seq: request.seq,
+            format: request.format,
+            output: `${request.format}:${request.input}`,
+          }),
+          renderWithBrowserTextMetrics,
+          resolveBrowserTextMetricsRequest: async () => ({ required: false }),
+          validate: async () => '{"valid":true}',
+          terminate: () => {},
+        }),
+        mainThreadBrowserTextMetricsRendererFactory: () => ({
+          renderWithBrowserTextMetrics: mainThreadRenderWithBrowserTextMetrics,
+        }),
+        debounceMs: 10_000,
+        stateStorage: {
+          getItem: () => null,
+          setItem: () => {},
+        },
+      });
+
+      const debug = window.__mmdfluxDebug;
+      const workerResult = await debug?.renderBrowserMetrics({
+        input: multiFontInput,
+        browserTextMetrics,
+      });
+      const mainThreadResult = await debug?.renderBrowserMetricsMainThread({
+        input: multiFontInput,
+        browserTextMetrics,
+        show: false,
+      });
+
+      expect(workerResult?.source).toBe("worker-client");
+      expect(mainThreadResult?.source).toBe("main-thread");
+      expect(renderWithBrowserTextMetrics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          browserTextMetrics: expect.objectContaining({
+            textStyles: expect.arrayContaining([
+              expect.objectContaining({
+                fontFamily: "Verdana",
+                cssFont: expect.stringContaining("Verdana"),
+              }),
+              expect.objectContaining({
+                fontFamily: "Courier New",
+                cssFont: expect.stringContaining("Courier New"),
+              }),
+              expect.objectContaining({
+                fontFamily: "Times New Roman",
+                cssFont: expect.stringContaining("Times New Roman"),
+              }),
+            ]),
+          }),
+        }),
+      );
+      expect(mainThreadRenderWithBrowserTextMetrics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          browserTextMetrics: expect.objectContaining({
+            textStyles: expect.arrayContaining([
+              expect.objectContaining({
+                fontFamily: "Verdana",
+                cssFont: expect.stringContaining("Verdana"),
+              }),
+              expect.objectContaining({
+                fontFamily: "Courier New",
+                cssFont: expect.stringContaining("Courier New"),
+              }),
+              expect.objectContaining({
+                fontFamily: "Times New Roman",
+                cssFont: expect.stringContaining("Times New Roman"),
+              }),
+            ]),
+          }),
+        }),
+      );
     } finally {
       history.replaceState(null, "", window.location.pathname);
       delete window.__mmdfluxDebug;

--- a/web/src/render-client.test.ts
+++ b/web/src/render-client.test.ts
@@ -8,8 +8,10 @@ import type {
 
 interface MockWorkerOptions {
   dynamicResponse?: WorkerResponseMessage;
+  resolverResponse?: WorkerResponseMessage;
   suppressDynamicResponse?: boolean;
   throwOnDynamicPost?: boolean;
+  throwOnResolverPost?: boolean;
 }
 
 class MockWorker {
@@ -24,6 +26,12 @@ class MockWorker {
     if (
       message.type === "renderWithBrowserTextMetrics" &&
       this.options.throwOnDynamicPost
+    ) {
+      throw new Error("worker post failed");
+    }
+    if (
+      message.type === "resolveBrowserTextMetrics" &&
+      this.options.throwOnResolverPost
     ) {
       throw new Error("worker post failed");
     }
@@ -63,6 +71,42 @@ class MockWorker {
             seq: message.seq,
             format: message.format,
             output: `${message.format}:${message.input}:${message.configJson}:${message.browserTextMetrics.fontFamily}`,
+          },
+        } as MessageEvent<WorkerResponseMessage>);
+        return;
+      }
+
+      if (message.type === "resolveBrowserTextMetrics") {
+        if (this.options.resolverResponse) {
+          this.onmessage?.({
+            data: this.options.resolverResponse,
+          } as MessageEvent<WorkerResponseMessage>);
+          return;
+        }
+
+        this.onmessage?.({
+          data: {
+            type: "browserTextMetricsDecision",
+            seq: message.seq,
+            decision: {
+              required: message.input.includes("font-family"),
+              browserTextMetrics: message.input.includes("font-family")
+                ? {
+                    defaultStyle: "s0",
+                    textStyles: [
+                      {
+                        id: "s0",
+                        fontFamily: "Verdana",
+                        fontSize: 8,
+                        fontStyle: "normal",
+                        fontWeight: "400",
+                        lineHeight: 12,
+                        cssFont: "8px Verdana",
+                      },
+                    ],
+                  }
+                : undefined,
+            },
           },
         } as MessageEvent<WorkerResponseMessage>);
         return;
@@ -110,6 +154,90 @@ describe("createRenderWorkerClient", () => {
       seq: 7,
       format: "svg",
       output: 'svg:graph TD\nA-->B:{"padding":2}',
+    });
+    await expect(validatePromise).resolves.toBe('{"valid":true}');
+  });
+
+  it("resolves browser text metrics decisions by sequence id", async () => {
+    const worker = new MockWorker();
+    const client = createRenderWorkerClient(worker as unknown as Worker);
+
+    const response = await client.resolveBrowserTextMetricsRequest({
+      seq: 21,
+      input: "graph TD\nA[Regular]\nstyle A font-family:Verdana,font-size:8px",
+      format: "svg",
+      configJson: "{}",
+    });
+
+    expect(response).toEqual({
+      required: true,
+      browserTextMetrics: {
+        defaultStyle: "s0",
+        textStyles: [
+          {
+            id: "s0",
+            fontFamily: "Verdana",
+            fontSize: 8,
+            fontStyle: "normal",
+            fontWeight: "400",
+            lineHeight: 12,
+            cssFont: "8px Verdana",
+          },
+        ],
+      },
+    });
+    expect(worker.messages.at(-1)).toEqual({
+      type: "resolveBrowserTextMetrics",
+      seq: 21,
+      input: "graph TD\nA[Regular]\nstyle A font-family:Verdana,font-size:8px",
+      format: "svg",
+      configJson: "{}",
+    });
+  });
+
+  it("propagates browser text metrics resolver errors", async () => {
+    const worker = new MockWorker({
+      resolverResponse: {
+        type: "error",
+        seq: 22,
+        error: "RenderConfig.graph_text_style is not supported",
+      },
+    });
+    const client = createRenderWorkerClient(worker as unknown as Worker);
+
+    await expect(
+      client.resolveBrowserTextMetricsRequest({
+        seq: 22,
+        input: "graph TD\nA-->B",
+        format: "svg",
+        configJson: '{"fontFamily":"Inter","fontSize":16}',
+      }),
+    ).rejects.toThrow("graph_text_style");
+  });
+
+  it("keeps resolver, render, and validation responses independent", async () => {
+    const worker = new MockWorker();
+    const client = createRenderWorkerClient(worker as unknown as Worker);
+
+    const resolverPromise = client.resolveBrowserTextMetricsRequest({
+      seq: 31,
+      input: "graph TD\nA[Regular]\nstyle A font-family:Verdana,font-size:8px",
+      format: "svg",
+      configJson: "{}",
+    });
+    const renderPromise = client.render({
+      seq: 32,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: "{}",
+    });
+    const validatePromise = client.validate("graph TD\nA-->B");
+
+    await expect(resolverPromise).resolves.toMatchObject({ required: true });
+    await expect(renderPromise).resolves.toEqual({
+      seq: 32,
+      format: "svg",
+      output: "svg:graph TD\nA-->B:{}",
     });
     await expect(validatePromise).resolves.toBe('{"valid":true}');
   });

--- a/web/src/services/dynamic-svg-routing.ts
+++ b/web/src/services/dynamic-svg-routing.ts
@@ -1,0 +1,52 @@
+import type {
+  RenderRequest,
+  RenderResponse,
+  RenderWorkerClient,
+} from "./render-client";
+
+export async function renderPlaygroundRequest(
+  client: RenderWorkerClient,
+  request: RenderRequest,
+): Promise<RenderResponse> {
+  if (request.format !== "svg" || !mayNeedBrowserTextMetrics(request)) {
+    return client.render(request);
+  }
+
+  const decision = await client.resolveBrowserTextMetricsRequest(request);
+  if (!decision.required) {
+    return client.render(request);
+  }
+  if (!decision.browserTextMetrics) {
+    throw new Error(
+      "browser text metrics decision required metrics but omitted the request",
+    );
+  }
+
+  // Reuse the live-render seq only after the awaited resolver call has freed
+  // its worker pending slot.
+  return client.renderWithBrowserTextMetrics({
+    seq: request.seq,
+    input: request.input,
+    configJson: request.configJson,
+    browserTextMetrics: decision.browserTextMetrics,
+  });
+}
+
+function mayNeedBrowserTextMetrics(request: RenderRequest): boolean {
+  const input = request.input.toLowerCase();
+  if (
+    input.includes("font-family") ||
+    input.includes("font-size") ||
+    input.includes("font-style") ||
+    input.includes("font-weight")
+  ) {
+    return true;
+  }
+
+  const configJson = request.configJson?.toLowerCase() ?? "";
+  return (
+    configJson.includes("fontfamily") ||
+    configJson.includes("fontsize") ||
+    configJson.includes("themevariables")
+  );
+}

--- a/web/src/services/render-client.ts
+++ b/web/src/services/render-client.ts
@@ -1,5 +1,6 @@
 import type { BrowserTextMetricsRequest } from "../browser-text-metrics";
 import type {
+  BrowserTextMetricsDecision,
   WorkerOutputFormat,
   WorkerRequestMessage,
   WorkerResponseMessage,
@@ -26,6 +27,13 @@ export interface BrowserTextMetricsRenderRequest {
   browserTextMetrics: BrowserTextMetricsRequest;
 }
 
+export interface BrowserTextMetricsDecisionRequest {
+  seq: number;
+  input: string;
+  format: WorkerOutputFormat;
+  configJson?: string;
+}
+
 interface PendingRenderRequest {
   kind: "render";
   resolve: (response: RenderResponse) => void;
@@ -40,13 +48,25 @@ interface PendingValidateRequest {
   reject: (error: Error) => void;
 }
 
-type PendingRequest = PendingRenderRequest | PendingValidateRequest;
+interface PendingBrowserTextMetricsDecisionRequest {
+  kind: "resolveBrowserTextMetrics";
+  resolve: (decision: BrowserTextMetricsDecision) => void;
+  reject: (error: Error) => void;
+}
+
+type PendingRequest =
+  | PendingRenderRequest
+  | PendingValidateRequest
+  | PendingBrowserTextMetricsDecisionRequest;
 
 export interface RenderWorkerClient {
   render: (request: RenderRequest) => Promise<RenderResponse>;
   renderWithBrowserTextMetrics: (
     request: BrowserTextMetricsRenderRequest,
   ) => Promise<RenderResponse>;
+  resolveBrowserTextMetricsRequest: (
+    request: BrowserTextMetricsDecisionRequest,
+  ) => Promise<BrowserTextMetricsDecision>;
   validate: (input: string) => Promise<string>;
   terminate: () => void;
 }
@@ -104,6 +124,20 @@ export function createRenderWorkerClient(
       return;
     }
 
+    if (response.type === "browserTextMetricsDecision") {
+      if (pendingRequest.kind !== "resolveBrowserTextMetrics") {
+        pendingRequest.reject(
+          new Error(
+            "worker returned browser metrics output for another request",
+          ),
+        );
+        return;
+      }
+
+      pendingRequest.resolve(response.decision);
+      return;
+    }
+
     if (response.type === "validation") {
       if (pendingRequest.kind !== "validate") {
         pendingRequest.reject(
@@ -151,6 +185,36 @@ export function createRenderWorkerClient(
           pending.delete(currentSeq);
           reject(
             new Error(`failed to post render request: ${toMessage(error)}`),
+          );
+        }
+      });
+    },
+    resolveBrowserTextMetricsRequest: (request) => {
+      const currentSeq = request.seq;
+
+      return new Promise<BrowserTextMetricsDecision>((resolve, reject) => {
+        const message: WorkerRequestMessage = {
+          type: "resolveBrowserTextMetrics",
+          seq: currentSeq,
+          input: request.input,
+          format: request.format,
+          configJson: request.configJson ?? "{}",
+        };
+
+        pending.set(currentSeq, {
+          kind: "resolveBrowserTextMetrics",
+          resolve,
+          reject,
+        });
+
+        try {
+          worker.postMessage(message);
+        } catch (error) {
+          pending.delete(currentSeq);
+          reject(
+            new Error(
+              `failed to post browser text metrics request: ${toMessage(error)}`,
+            ),
           );
         }
       });

--- a/web/src/wasm-module.ts
+++ b/web/src/wasm-module.ts
@@ -1,5 +1,10 @@
 export interface WasmModule {
   default: () => Promise<void>;
+  browserTextMetricsRequest: (
+    input: string,
+    format: string,
+    configJson: string,
+  ) => string;
   render: (input: string, format: string, configJson: string) => string;
   renderWithBrowserTextMetrics: (
     input: string,

--- a/web/src/worker-protocol.ts
+++ b/web/src/worker-protocol.ts
@@ -25,9 +25,23 @@ export interface WorkerDynamicTextMetricsRenderRequestMessage {
   browserTextMetrics: BrowserTextMetricsRequest;
 }
 
+export interface BrowserTextMetricsDecision {
+  required: boolean;
+  browserTextMetrics?: BrowserTextMetricsRequest;
+}
+
+export interface WorkerBrowserTextMetricsRequestMessage {
+  type: "resolveBrowserTextMetrics";
+  seq: number;
+  input: string;
+  format: WorkerOutputFormat;
+  configJson: string;
+}
+
 export type WorkerRequestMessage =
   | WorkerRenderRequestMessage
   | WorkerDynamicTextMetricsRenderRequestMessage
+  | WorkerBrowserTextMetricsRequestMessage
   | WorkerValidateRequestMessage;
 
 export interface WorkerResultMessage {
@@ -43,6 +57,12 @@ export interface WorkerValidationMessage {
   resultJson: string;
 }
 
+export interface WorkerBrowserTextMetricsDecisionMessage {
+  type: "browserTextMetricsDecision";
+  seq: number;
+  decision: BrowserTextMetricsDecision;
+}
+
 export interface WorkerErrorMessage {
   type: "error";
   seq: number;
@@ -53,4 +73,5 @@ export interface WorkerErrorMessage {
 export type WorkerResponseMessage =
   | WorkerResultMessage
   | WorkerValidationMessage
+  | WorkerBrowserTextMetricsDecisionMessage
   | WorkerErrorMessage;

--- a/web/src/worker.test.ts
+++ b/web/src/worker.test.ts
@@ -8,6 +8,11 @@ import type {
 
 interface MockWasmModule {
   default: () => Promise<void>;
+  browserTextMetricsRequest: (
+    input: string,
+    format: string,
+    configJson: string,
+  ) => string;
   render: (input: string, format: string, configJson: string) => string;
   renderWithBrowserTextMetrics: (
     input: string,
@@ -33,6 +38,7 @@ describe("createWorkerRequestHandler", () => {
     const loadWasmModule = vi.fn(
       async (): Promise<MockWasmModule> => ({
         default: initialize,
+        browserTextMetricsRequest: () => "unused",
         render,
         renderWithBrowserTextMetrics: () => "unused",
         validate,
@@ -87,6 +93,7 @@ describe("createWorkerRequestHandler", () => {
     const loadWasmModule = vi.fn(
       async (): Promise<MockWasmModule> => ({
         default: async () => {},
+        browserTextMetricsRequest: () => "unused",
         render: () => {
           throw new Error("unknown output format: bad");
         },
@@ -124,6 +131,7 @@ describe("createWorkerRequestHandler", () => {
     const loadWasmModule = vi.fn(
       async (): Promise<MockWasmModule> => ({
         default: initialize,
+        browserTextMetricsRequest: () => "unused",
         render: () => "unused",
         renderWithBrowserTextMetrics: () => "unused",
         validate: (input) =>
@@ -161,6 +169,132 @@ describe("createWorkerRequestHandler", () => {
     ]);
   });
 
+  it("returns browser text metrics decisions without rendering or measuring", async () => {
+    const browserTextMetricsRequest = vi.fn(
+      (input: string, format: string, configJson: string) =>
+        JSON.stringify({
+          required: true,
+          browserTextMetrics: {
+            defaultStyle: "s0",
+            textStyles: [
+              {
+                id: "s0",
+                fontFamily: "Verdana",
+                fontSize: 8,
+                fontStyle: "normal",
+                fontWeight: "400",
+                lineHeight: 12,
+                cssFont: "8px Verdana",
+              },
+            ],
+          },
+          input,
+          format,
+          configJson,
+        }),
+    );
+    const render = vi.fn(() => "static unused");
+    const renderWithBrowserTextMetrics = vi.fn(() => "dynamic unused");
+    const prepareBrowserTextMetrics = vi.fn(async () => {
+      throw new Error("should not prepare metrics for resolver");
+    });
+    const loadWasmModule = vi.fn(
+      async (): Promise<MockWasmModule> => ({
+        default: async () => {},
+        browserTextMetricsRequest,
+        render,
+        renderWithBrowserTextMetrics,
+        validate: () => '{"valid":true}',
+      }),
+    );
+
+    const responses: WorkerResponseMessage[] = [];
+    const handler = createWorkerRequestHandler({
+      loadWasmModule,
+      prepareBrowserTextMetrics,
+      postMessage: (message) => responses.push(message),
+    });
+
+    await handler({
+      type: "resolveBrowserTextMetrics",
+      seq: 8,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: "{}",
+    });
+
+    expect(browserTextMetricsRequest).toHaveBeenCalledWith(
+      "graph TD\nA-->B",
+      "svg",
+      "{}",
+    );
+    expect(render).not.toHaveBeenCalled();
+    expect(renderWithBrowserTextMetrics).not.toHaveBeenCalled();
+    expect(prepareBrowserTextMetrics).not.toHaveBeenCalled();
+    expect(responses).toEqual([
+      {
+        type: "browserTextMetricsDecision",
+        seq: 8,
+        decision: {
+          required: true,
+          browserTextMetrics: {
+            defaultStyle: "s0",
+            textStyles: [
+              {
+                id: "s0",
+                fontFamily: "Verdana",
+                fontSize: 8,
+                fontStyle: "normal",
+                fontWeight: "400",
+                lineHeight: 12,
+                cssFont: "8px Verdana",
+              },
+            ],
+          },
+          input: "graph TD\nA-->B",
+          format: "svg",
+          configJson: "{}",
+        },
+      },
+    ]);
+  });
+
+  it("returns structured errors for browser text metrics resolver failures", async () => {
+    const loadWasmModule = vi.fn(
+      async (): Promise<MockWasmModule> => ({
+        default: async () => {},
+        browserTextMetricsRequest: () => {
+          throw new Error("RenderConfig.graph_text_style is not supported");
+        },
+        render: () => "static unused",
+        renderWithBrowserTextMetrics: () => "dynamic unused",
+        validate: () => '{"valid":true}',
+      }),
+    );
+
+    const responses: WorkerResponseMessage[] = [];
+    const handler = createWorkerRequestHandler({
+      loadWasmModule,
+      postMessage: (message) => responses.push(message),
+    });
+
+    await handler({
+      type: "resolveBrowserTextMetrics",
+      seq: 15,
+      input: "graph TD\nA-->B",
+      format: "svg",
+      configJson: '{"fontFamily":"Inter","fontSize":16}',
+    });
+
+    expect(responses).toEqual([
+      {
+        type: "error",
+        seq: 15,
+        error: "RenderConfig.graph_text_style is not supported",
+      },
+    ]);
+  });
+
   it("prepares browser metrics and invokes the dynamic wasm export", async () => {
     const measureText = vi.fn(() => 42);
     const prepareBrowserTextMetrics = vi.fn(async () => ({
@@ -180,6 +314,7 @@ describe("createWorkerRequestHandler", () => {
     const loadWasmModule = vi.fn(
       async (): Promise<MockWasmModule> => ({
         default: async () => {},
+        browserTextMetricsRequest: () => "unused",
         render: () => "static unused",
         renderWithBrowserTextMetrics,
         validate: () => '{"valid":true}',
@@ -232,6 +367,7 @@ describe("createWorkerRequestHandler", () => {
     const loadWasmModule = vi.fn(
       async (): Promise<MockWasmModule> => ({
         default: async () => {},
+        browserTextMetricsRequest: () => "unused",
         render: () => "static unused",
         renderWithBrowserTextMetrics: () => "dynamic unused",
         validate: () => '{"valid":true}',
@@ -272,6 +408,7 @@ describe("createWorkerRequestHandler", () => {
     const loadWasmModule = vi.fn(
       async (): Promise<MockWasmModule> => ({
         default: async () => {},
+        browserTextMetricsRequest: () => "unused",
         render: () => "static unused",
         renderWithBrowserTextMetrics: () => "dynamic unused",
         validate: () => '{"valid":true}',
@@ -323,6 +460,7 @@ describe("createWorkerRequestHandler", () => {
     const loadWasmModule = vi.fn(
       async (): Promise<MockWasmModule> => ({
         default: async () => {},
+        browserTextMetricsRequest: () => "unused",
         render: () => "static unused",
         renderWithBrowserTextMetrics: () => "dynamic unused",
         validate: () => '{"valid":true}',

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -4,6 +4,7 @@ import {
 } from "./browser-text-metrics";
 import { loadWasmModule, type WasmModule } from "./wasm-module";
 import type {
+  BrowserTextMetricsDecision,
   WorkerRequestMessage,
   WorkerResponseMessage,
 } from "./worker-protocol";
@@ -54,6 +55,22 @@ export function createWorkerRequestHandler(
           seq: message.seq,
           format: message.format,
           output,
+        });
+        return;
+      }
+
+      if (message.type === "resolveBrowserTextMetrics") {
+        const decisionJson = wasmModule.browserTextMetricsRequest(
+          message.input,
+          message.format,
+          message.configJson,
+        );
+        const decision = JSON.parse(decisionJson) as BrowserTextMetricsDecision;
+
+        postMessage({
+          type: "browserTextMetricsDecision",
+          seq: message.seq,
+          decision,
         });
         return;
       }

--- a/web/tests/examples.test.ts
+++ b/web/tests/examples.test.ts
@@ -15,6 +15,7 @@ function createFakeRenderClient() {
       format: "svg",
       output: `svg:${request.input}`,
     })),
+    resolveBrowserTextMetricsRequest: vi.fn(async () => ({ required: false })),
     validate: vi.fn(async () => '{"valid":true}'),
     terminate: vi.fn(),
   } satisfies RenderWorkerClient;


### PR DESCRIPTION
## Summary

- add a graph-family SVG resolver that derives browser text metrics style sets from resolved Mermaid `style`, `classDef`/`class`, and `linkStyle` font declarations
- expose the resolver through the Wasm worker protocol and route eligible playground SVG renders through the existing browser dynamic metrics path
- pre-screen SVG requests so unstyled diagrams and non-font styles stay on the static path without an extra resolver round-trip
- keep unstyled/default SVG, Text, ASCII, MMDS, and non-graph renders on the static `render` path
- add a multi-font playground example plus debug coverage for worker and main-thread dynamic rendering
- document the playground boundary and pin it with Rust, Wasm, worker/client, bootstrap, and docs tests

Closes #323

## Non-goals

- no dynamic browser metrics for Text, ASCII, sequence, or non-graph families
- no provider-free fallback from requested dynamic metrics to recorded/static profiles
- no broad UI config surface for graph fonts across every output format
- no change to provider-free static rendering behavior
- no Mermaid subgraph class styling yet; tracked separately in #328 because subgraph styles are not represented in the graph IR

## Validation

- `cd web && npm run build`
- `cargo nextest run --features unstable-text-metrics-provider --no-fail-fast` — 3138/3138 passing
- `cargo nextest run --features unstable-text-metrics-provider -E 'test(browser_metrics_request)'` — 5/5 passing
- `cargo test -p mmdflux-wasm` — 35/35 passing
- `./scripts/run-wasm-browser-tests.sh` — 36/36 passing
- `cd web && npm run test` — 127/127 passing
- focused `cd web && npm run test -- render-client.test.ts dynamic-svg-routing.test.ts main.test.ts worker.test.ts` — 34/34 passing after resolver pre-screen changes
- focused `cd web && npm run test -- dynamic-svg-routing.test.ts main-thread-browser-text-metrics.test.ts` — 10/10 passing after build fix
- `cd web && npm run check`
- `just lint`
- `just architecture-check`
- `just wasm-size` — 1,869,018 raw / 646,121 gzip, PASS
- `cog check origin/main..HEAD`

