### PR TITLE
feat: render flowchart subgraph container styles

### DIFF
--- a/src/diagrams/class/compiler.rs
+++ b/src/diagrams/class/compiler.rs
@@ -179,6 +179,7 @@ fn apply_namespaces(model: &ClassModel, diagram: &mut Graph) {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         diagram.subgraph_order.push(namespace.id.clone());

--- a/src/diagrams/flowchart/compiler.rs
+++ b/src/diagrams/flowchart/compiler.rs
@@ -11,21 +11,36 @@ use crate::mermaid::{
 
 type ClassDefRegistry = HashMap<String, NodeStyle>;
 
+struct StyleTargets<'a> {
+    node_styles: &'a mut HashMap<String, NodeStyle>,
+    subgraph_styles: &'a mut HashMap<String, NodeStyle>,
+    subgraph_ids: &'a HashSet<String>,
+}
+
 /// Build a Diagram from a parsed Flowchart.
 pub fn compile_to_graph(flowchart: &Flowchart) -> Graph {
     let direction = convert_direction(flowchart.direction);
     let mut diagram = Graph::new(direction);
     let mut node_styles = HashMap::new();
+    let mut subgraph_styles = HashMap::new();
     let mut edge_styles = Vec::new();
     let class_defs = collect_class_defs(&flowchart.statements);
-    process_statements(
-        &mut diagram,
-        &flowchart.statements,
-        None,
-        &mut node_styles,
-        &mut edge_styles,
-        &class_defs,
-    );
+    let subgraph_ids = collect_subgraph_ids(&flowchart.statements);
+    {
+        let mut style_targets = StyleTargets {
+            node_styles: &mut node_styles,
+            subgraph_styles: &mut subgraph_styles,
+            subgraph_ids: &subgraph_ids,
+        };
+        process_statements(
+            &mut diagram,
+            &flowchart.statements,
+            None,
+            &mut style_targets,
+            &mut edge_styles,
+            &class_defs,
+        );
+    }
     apply_default_class(&mut diagram, &node_styles, &class_defs);
     resolve_subgraph_edges(&mut diagram);
     apply_edge_styles(&mut diagram, &edge_styles);
@@ -59,7 +74,7 @@ fn process_statements(
     diagram: &mut Graph,
     statements: &[Statement],
     parent_subgraph: Option<&str>,
-    node_styles: &mut HashMap<String, NodeStyle>,
+    style_targets: &mut StyleTargets<'_>,
     edge_styles: &mut Vec<LinkStyleStatement>,
     class_defs: &ClassDefRegistry,
 ) {
@@ -68,7 +83,7 @@ fn process_statements(
             Statement::Vertex(vertex) => {
                 resolve_class_annotation(
                     diagram,
-                    node_styles,
+                    style_targets.node_styles,
                     class_defs,
                     &vertex.id,
                     &vertex.class_name,
@@ -77,13 +92,13 @@ fn process_statements(
                     diagram,
                     vertex,
                     parent_subgraph,
-                    node_styles.get(&vertex.id),
+                    style_targets.node_styles.get(&vertex.id),
                 );
             }
             Statement::Edge(edge_spec) => {
                 resolve_class_annotation(
                     diagram,
-                    node_styles,
+                    style_targets.node_styles,
                     class_defs,
                     &edge_spec.from.id,
                     &edge_spec.from.class_name,
@@ -92,11 +107,11 @@ fn process_statements(
                     diagram,
                     &edge_spec.from,
                     parent_subgraph,
-                    node_styles.get(&edge_spec.from.id),
+                    style_targets.node_styles.get(&edge_spec.from.id),
                 );
                 resolve_class_annotation(
                     diagram,
-                    node_styles,
+                    style_targets.node_styles,
                     class_defs,
                     &edge_spec.to.id,
                     &edge_spec.to.class_name,
@@ -105,7 +120,7 @@ fn process_statements(
                     diagram,
                     &edge_spec.to,
                     parent_subgraph,
-                    node_styles.get(&edge_spec.to.id),
+                    style_targets.node_styles.get(&edge_spec.to.id),
                 );
                 let edge = convert_edge(edge_spec);
                 diagram.add_edge(edge);
@@ -115,7 +130,7 @@ fn process_statements(
                     diagram,
                     &sg_spec.statements,
                     Some(&sg_spec.id),
-                    node_styles,
+                    style_targets,
                     edge_styles,
                     class_defs,
                 );
@@ -130,12 +145,22 @@ fn process_statements(
                         dir: sg_spec.dir.map(convert_direction),
                         invisible: false,
                         concurrent_regions: Vec::new(),
+                        style: style_targets
+                            .subgraph_styles
+                            .get(&sg_spec.id)
+                            .cloned()
+                            .unwrap_or_default(),
                     },
                 );
                 diagram.subgraph_order.push(sg_spec.id.clone());
             }
             Statement::NodeStyle(style_stmt) => {
-                merge_node_style(diagram, node_styles, &style_stmt.node_id, &style_stmt.style);
+                merge_target_style(
+                    diagram,
+                    style_targets,
+                    &style_stmt.node_id,
+                    &style_stmt.style,
+                );
             }
             Statement::ClassDef(_) => {
                 // Already collected in pass 1.
@@ -143,11 +168,26 @@ fn process_statements(
             Statement::ClassApply(apply) => {
                 if let Some(style) = class_defs.get(&apply.class_name) {
                     for node_id in &apply.node_ids {
-                        merge_node_style(diagram, node_styles, node_id, style);
+                        merge_target_style(diagram, style_targets, node_id, style);
                     }
                 }
             }
             Statement::LinkStyle(link_style) => edge_styles.push(link_style.clone()),
+        }
+    }
+}
+
+fn collect_subgraph_ids(statements: &[Statement]) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    collect_subgraph_ids_recursive(statements, &mut ids);
+    ids
+}
+
+fn collect_subgraph_ids_recursive(statements: &[Statement], ids: &mut HashSet<String>) {
+    for stmt in statements {
+        if let Statement::Subgraph(sg) = stmt {
+            ids.insert(sg.id.clone());
+            collect_subgraph_ids_recursive(&sg.statements, ids);
         }
     }
 }
@@ -244,6 +284,35 @@ fn merge_node_style(
 
     if let Some(node) = diagram.nodes.get_mut(node_id) {
         node.style = merged_style;
+    }
+}
+
+fn merge_subgraph_style(
+    diagram: &mut Graph,
+    subgraph_styles: &mut HashMap<String, NodeStyle>,
+    subgraph_id: &str,
+    style: &NodeStyle,
+) {
+    let merged_style = subgraph_styles
+        .entry(subgraph_id.to_string())
+        .and_modify(|existing| *existing = existing.merge(style))
+        .or_insert_with(|| style.clone());
+
+    if let Some(subgraph) = diagram.subgraphs.get_mut(subgraph_id) {
+        subgraph.style = merged_style.clone();
+    }
+}
+
+fn merge_target_style(
+    diagram: &mut Graph,
+    style_targets: &mut StyleTargets<'_>,
+    target_id: &str,
+    style: &NodeStyle,
+) {
+    if style_targets.subgraph_ids.contains(target_id) {
+        merge_subgraph_style(diagram, style_targets.subgraph_styles, target_id, style);
+    } else {
+        merge_node_style(diagram, style_targets.node_styles, target_id, style);
     }
 }
 
@@ -738,6 +807,80 @@ mod tests {
         assert_eq!(sg.title, "Group");
         assert!(sg.nodes.contains(&"A".to_string()));
         assert!(sg.nodes.contains(&"B".to_string()));
+    }
+
+    #[test]
+    fn subgraph_ir_carries_default_style_storage() {
+        let input = "graph TD\nsubgraph A[Source]\na1\nend\n";
+        let flowchart = parse_flowchart(input).unwrap();
+        let diagram = compile_to_graph(&flowchart);
+
+        assert!(diagram.subgraphs["A"].style.is_empty());
+    }
+
+    #[test]
+    fn class_subgraph_applies_classdef_style_to_subgraph() {
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef blue fill:#e1f5fe,stroke:#01579b,stroke-width:2px\nclass A blue\n";
+        let flowchart = parse_flowchart(input).unwrap();
+        let diagram = compile_to_graph(&flowchart);
+
+        let style = &diagram.subgraphs["A"].style;
+        assert_eq!(style.fill.as_ref().map(|c| c.raw()), Some("#e1f5fe"));
+        assert_eq!(style.stroke.as_ref().map(|c| c.raw()), Some("#01579b"));
+        assert_eq!(style.stroke_width.as_deref(), Some("2px"));
+        assert!(diagram.nodes["a1"].style.fill.is_none());
+    }
+
+    #[test]
+    fn direct_style_statement_can_target_subgraph() {
+        let input =
+            "flowchart LR\nsubgraph A[Source]\na1\nend\nstyle A fill:#ffebee,stroke:#b71c1c\n";
+        let flowchart = parse_flowchart(input).unwrap();
+        let diagram = compile_to_graph(&flowchart);
+
+        let style = &diagram.subgraphs["A"].style;
+        assert_eq!(style.fill.as_ref().map(|c| c.raw()), Some("#ffebee"));
+        assert_eq!(style.stroke.as_ref().map(|c| c.raw()), Some("#b71c1c"));
+        assert!(diagram.nodes["a1"].style.fill.is_none());
+    }
+
+    #[test]
+    fn class_subgraph_before_subgraph_declaration_is_applied() {
+        let input =
+            "flowchart LR\nclassDef blue fill:#e1f5fe\nclass A blue\nsubgraph A[Source]\na1\nend\n";
+        let flowchart = parse_flowchart(input).unwrap();
+        let diagram = compile_to_graph(&flowchart);
+
+        assert_eq!(
+            diagram.subgraphs["A"].style.fill.as_ref().map(|c| c.raw()),
+            Some("#e1f5fe")
+        );
+        assert!(diagram.nodes["a1"].style.fill.is_none());
+    }
+
+    #[test]
+    fn subgraph_class_and_direct_style_merge_by_property() {
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef blue fill:#e1f5fe,stroke:#01579b\nclass A blue\nstyle A stroke:#b71c1c,stroke-width:2px\n";
+        let flowchart = parse_flowchart(input).unwrap();
+        let diagram = compile_to_graph(&flowchart);
+
+        let style = &diagram.subgraphs["A"].style;
+        assert_eq!(style.fill.as_ref().map(|c| c.raw()), Some("#e1f5fe"));
+        assert_eq!(style.stroke.as_ref().map(|c| c.raw()), Some("#b71c1c"));
+        assert_eq!(style.stroke_width.as_deref(), Some("2px"));
+    }
+
+    #[test]
+    fn classdef_default_remains_node_only_not_subgraph_style() {
+        let input = "flowchart LR\nclassDef default fill:#f00\nsubgraph A[Source]\na1\nend\n";
+        let flowchart = parse_flowchart(input).unwrap();
+        let diagram = compile_to_graph(&flowchart);
+
+        assert!(diagram.subgraphs["A"].style.fill.is_none());
+        assert_eq!(
+            diagram.nodes["a1"].style.fill.as_ref().map(|c| c.raw()),
+            Some("#f00")
+        );
     }
 
     #[test]

--- a/src/diagrams/state/compiler.rs
+++ b/src/diagrams/state/compiler.rs
@@ -319,6 +319,7 @@ fn process_state_decl(
                     dir: region_dir,
                     invisible: true,
                     concurrent_regions: Vec::new(),
+                    style: Default::default(),
                 },
             );
             graph.subgraph_order.push(region_sg_id.clone());
@@ -360,6 +361,7 @@ fn process_state_decl(
                 dir: None,
                 invisible: false,
                 concurrent_regions: region_sg_ids,
+                style: Default::default(),
             },
         );
         graph.subgraph_order.push(decl.id.clone());
@@ -398,6 +400,7 @@ fn process_state_decl(
                 dir,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         graph.subgraph_order.push(decl.id.clone());

--- a/src/graph/diagram.rs
+++ b/src/graph/diagram.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::edge::{Edge, Stroke};
 use super::node::Node;
+use super::style::NodeStyle;
 
 /// Direction of the diagram layout.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -27,7 +28,7 @@ pub enum Direction {
 }
 
 /// A subgraph grouping of nodes.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
 pub struct Subgraph {
     /// Unique identifier for this subgraph.
     pub id: String,
@@ -48,6 +49,9 @@ pub struct Subgraph {
     /// adjacent region subgraphs. Empty for non-concurrent composites.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub concurrent_regions: Vec<String>,
+    /// Resolved Mermaid style properties for this subgraph.
+    #[serde(default, skip_serializing_if = "NodeStyle::is_empty")]
+    pub style: NodeStyle,
 }
 
 /// Position of a note annotation relative to its target node.
@@ -265,10 +269,28 @@ mod tests {
             dir: None,
             invisible: false,
             concurrent_regions: Vec::new(),
+            style: Default::default(),
         };
         assert_eq!(sg.id, "sg1");
         assert_eq!(sg.title, "My Group");
         assert_eq!(sg.nodes.len(), 2);
+    }
+
+    #[test]
+    fn empty_subgraph_style_is_not_serialized() {
+        let sg = Subgraph {
+            id: "sg1".to_string(),
+            title: "My Group".to_string(),
+            nodes: vec!["A".to_string()],
+            parent: None,
+            dir: None,
+            invisible: false,
+            concurrent_regions: Vec::new(),
+            style: Default::default(),
+        };
+
+        let value = serde_json::to_value(&sg).expect("subgraph should serialize");
+        assert!(value.get("style").is_none());
     }
 
     #[test]
@@ -281,6 +303,7 @@ mod tests {
             dir: None,
             invisible: false,
             concurrent_regions: Vec::new(),
+            style: Default::default(),
         };
         assert_eq!(sg.parent, Some("outer".to_string()));
     }
@@ -311,6 +334,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         assert!(diagram.has_subgraphs());
@@ -331,6 +355,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         g
@@ -358,6 +383,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         // "inner" is a subgraph, so it should be skipped; "A" or "B" returned.
@@ -379,6 +405,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         assert!(g.find_non_cluster_child("sg1").is_none());
@@ -409,6 +436,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         let sink = g.find_subgraph_sink("sg1");
@@ -433,6 +461,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         let sink = g.find_subgraph_sink("sg1");

--- a/src/graph/grid/derive/tests.rs
+++ b/src/graph/grid/derive/tests.rs
@@ -207,6 +207,7 @@ fn effective_rank_sep_adds_cluster_spacing_for_subgraphs() {
             dir: None,
             invisible: false,
             concurrent_regions: Vec::new(),
+            style: Default::default(),
         },
     );
 
@@ -631,6 +632,7 @@ fn test_build_children_map() {
             dir: None,
             invisible: false,
             concurrent_regions: Vec::new(),
+            style: Default::default(),
         },
     );
     subgraphs.insert(
@@ -643,6 +645,7 @@ fn test_build_children_map() {
             dir: None,
             invisible: false,
             concurrent_regions: Vec::new(),
+            style: Default::default(),
         },
     );
     let children_map = build_children_map(&subgraphs);
@@ -669,6 +672,7 @@ fn test_subgraph_bounds_no_overlap_from_separated_rects() {
             dir: None,
             invisible: false,
             concurrent_regions: Vec::new(),
+            style: Default::default(),
         },
     );
     subgraphs.insert(
@@ -681,6 +685,7 @@ fn test_subgraph_bounds_no_overlap_from_separated_rects() {
             dir: None,
             invisible: false,
             concurrent_regions: Vec::new(),
+            style: Default::default(),
         },
     );
 
@@ -757,6 +762,7 @@ fn test_subgraph_bounds_maps_rects() {
             dir: None,
             invisible: false,
             concurrent_regions: Vec::new(),
+            style: Default::default(),
         },
     );
 

--- a/src/graph/measure.rs
+++ b/src/graph/measure.rs
@@ -13,7 +13,7 @@ use crate::graph::font_metrics::{
     RecordedMetricsProfile,
 };
 use crate::graph::style::{EdgeStyle, NodeStyle, parse_font_size_px};
-use crate::graph::{Direction, Edge, Node, Shape};
+use crate::graph::{Direction, Edge, Node, Shape, Subgraph};
 
 /// Compatibility profile for the existing function-backed proportional heuristic.
 pub const COMPATIBILITY_TEXT_METRICS_PROFILE_ID: &str = "mmdflux-heuristic-proportional-v1";
@@ -165,6 +165,13 @@ pub(crate) fn edge_text_style_key(
     edge: &Edge,
 ) -> GraphTextStyleKey {
     text_style_key_from_edge_style(provider, &edge.style)
+}
+
+pub(crate) fn subgraph_title_text_style_key(
+    provider: &dyn TextMetricsProvider,
+    subgraph: &Subgraph,
+) -> GraphTextStyleKey {
+    text_style_key_from_node_style(provider, &subgraph.style)
 }
 
 fn text_style_key_from_node_style(
@@ -1048,7 +1055,7 @@ pub(crate) fn proportional_node_dimensions_with_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::graph::Node;
+    use crate::graph::{Node, Subgraph};
     use crate::internal_tests::stub_metrics::FixedWidthProvider;
 
     #[test]
@@ -1131,6 +1138,28 @@ mod tests {
         let style = text_style_key_from_parts(&provider, Some(" "), None, None, None);
 
         assert_eq!(style, GraphTextStyleKey::default_provider_style(&provider));
+    }
+
+    #[test]
+    fn subgraph_title_style_key_uses_subgraph_style() {
+        let provider = default_proportional_text_metrics();
+        let mut subgraph = Subgraph {
+            id: "A".to_string(),
+            title: "Source".to_string(),
+            nodes: Vec::new(),
+            parent: None,
+            dir: None,
+            invisible: false,
+            concurrent_regions: Vec::new(),
+            style: Default::default(),
+        };
+        subgraph.style.font_family = Some("Verdana".to_string());
+        subgraph.style.font_size = Some("20px".to_string());
+
+        let style = subgraph_title_text_style_key(&provider, &subgraph);
+
+        assert_eq!(style.font_family, "Verdana");
+        assert_eq!(style.font_size_px(), 20.0);
     }
 
     #[test]

--- a/src/graph/routing/label_lanes.rs
+++ b/src/graph/routing/label_lanes.rs
@@ -912,6 +912,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         diagram.subgraphs.insert(
@@ -924,6 +925,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         diagram.subgraphs.insert(
@@ -936,6 +938,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         diagram.add_edge(crate::graph::Edge::new("A", "B").with_label("shared parent label"));

--- a/src/internal_tests/layered_adapter_pipeline.rs
+++ b/src/internal_tests/layered_adapter_pipeline.rs
@@ -249,6 +249,7 @@ fn layered_adapter_maps_subgraph_bounds() {
             dir: None,
             invisible: false,
             concurrent_regions: Vec::new(),
+            style: Default::default(),
         },
     );
 
@@ -306,6 +307,7 @@ fn layered_adapter_skips_compound_nodes() {
             dir: None,
             invisible: false,
             concurrent_regions: Vec::new(),
+            style: Default::default(),
         },
     );
 

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -53,6 +53,10 @@ pub fn from_document(output: &Document) -> Result<Graph, HydrationError> {
                 dir: subgraph.direction,
                 invisible: subgraph.invisible,
                 concurrent_regions: subgraph.concurrent_regions.clone(),
+                // Graph subgraph styles are not persisted in MMDS yet. Keep
+                // provider-free replay honest by defaulting until the document
+                // schema carries this field explicitly.
+                style: Default::default(),
             },
         );
         diagram.subgraph_order.push(subgraph.id.clone());
@@ -1126,6 +1130,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
         diagram.subgraphs.insert(
@@ -1138,6 +1143,7 @@ mod tests {
                 dir: None,
                 invisible: false,
                 concurrent_regions: Vec::new(),
+                style: Default::default(),
             },
         );
 

--- a/src/render/graph/svg/nodes.rs
+++ b/src/render/graph/svg/nodes.rs
@@ -9,7 +9,7 @@ use super::{GraphSvgPalette, Point, Rect, dynamic_css_attrs};
 use crate::graph::geometry::{FRect, GraphGeometry};
 use crate::graph::measure::{GraphTextStyleKey, TextMetricsProvider, node_text_style_key};
 use crate::graph::routing::hexagon_vertices;
-use crate::graph::{Direction, Graph, Node, Shape};
+use crate::graph::{Direction, Graph, Node, Shape, Subgraph};
 use crate::render::svg::{SvgWriter, escape_text, fmt_f64};
 
 #[derive(Clone, Copy)]
@@ -69,6 +69,39 @@ struct NodeLabelRenderContext<'a> {
     palette: &'a GraphSvgPalette,
 }
 
+#[derive(Clone, Copy)]
+struct ResolvedSvgSubgraphStyle<'a> {
+    fill: Option<&'a str>,
+    stroke: Option<&'a str>,
+    stroke_width: Option<&'a str>,
+    stroke_dasharray: Option<&'a str>,
+    rx: Option<&'a str>,
+}
+
+impl<'a> ResolvedSvgSubgraphStyle<'a> {
+    fn from_subgraph(subgraph: &'a Subgraph) -> Self {
+        Self {
+            fill: subgraph.style.fill.as_ref().map(|color| color.raw()),
+            stroke: subgraph.style.stroke.as_ref().map(|color| color.raw()),
+            stroke_width: subgraph.style.stroke_width.as_deref(),
+            stroke_dasharray: subgraph.style.stroke_dasharray.as_deref(),
+            rx: subgraph.style.rx.as_deref(),
+        }
+    }
+
+    fn fill_or(self, default: &'a str) -> &'a str {
+        self.fill.unwrap_or(default)
+    }
+
+    fn stroke_or(self, default: &'a str) -> &'a str {
+        self.stroke.unwrap_or(default)
+    }
+
+    fn stroke_is_overridden(self) -> bool {
+        self.stroke.is_some()
+    }
+}
+
 pub(super) fn render_subgraphs(
     writer: &mut SvgWriter,
     diagram: &Graph,
@@ -89,30 +122,43 @@ pub(super) fn render_subgraphs(
                 .subgraphs
                 .get(id)
                 .filter(|sg| !sg.invisible)
-                .map(|_| (id, sg_geom))
+                .map(|sg| (id, sg, sg_geom))
         })
         .collect();
 
-    subgraphs.sort_by(|a, b| a.1.depth.cmp(&b.1.depth).then_with(|| a.0.cmp(b.0)));
+    subgraphs.sort_by(|a, b| a.2.depth.cmp(&b.2.depth).then_with(|| a.0.cmp(b.0)));
 
     writer.start_group("clusters");
-    for (_id, sg_geom) in subgraphs {
+    for (_id, subgraph, sg_geom) in subgraphs {
         let rect = scale_rect(&sg_geom.rect, scale);
-        let stroke_width = fmt_f64(1.0 * scale);
+        let style = ResolvedSvgSubgraphStyle::from_subgraph(subgraph);
+        let fill = style.fill_or("none");
+        let stroke = style.stroke_or(&palette.subgraph_stroke);
+        let default_stroke_width = fmt_f64(1.0 * scale);
+        let stroke_width = style.stroke_width.unwrap_or(&default_stroke_width);
+        let mut dynamic_declarations = Vec::new();
+        if !style.stroke_is_overridden() {
+            dynamic_declarations.push("stroke:var(--_inner-stroke);");
+        }
         let dynamic_attrs = dynamic_css_attrs(
             palette.dynamic_css,
             "graph-subgraph-stroke",
-            &["stroke:var(--_inner-stroke);"],
+            &dynamic_declarations,
         );
+        let dasharray_attr = style
+            .stroke_dasharray
+            .map(|v| format!(" stroke-dasharray=\"{v}\""))
+            .unwrap_or_default();
+        let rx_attr = style
+            .rx
+            .map(|v| format!(" rx=\"{v}\" ry=\"{v}\""))
+            .unwrap_or_default();
         let rect_line = format!(
-            "<rect class=\"subgraph\" x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\" fill=\"none\" stroke=\"{stroke}\" stroke-width=\"{stroke_width}\"{dynamic_attrs} />",
+            "<rect class=\"subgraph\" x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\"{rx_attr} fill=\"{fill}\" stroke=\"{stroke}\" stroke-width=\"{stroke_width}\"{dasharray_attr}{dynamic_attrs} />",
             x = fmt_f64(rect.x),
             y = fmt_f64(rect.y),
             w = fmt_f64(rect.width),
             h = fmt_f64(rect.height),
-            stroke = palette.subgraph_stroke,
-            stroke_width = stroke_width,
-            dynamic_attrs = dynamic_attrs
         );
         writer.push_line(&rect_line);
 

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -19,6 +19,7 @@ use crate::graph::measure::{
     TextMeasurementStyle, TextMetricsLayoutDescriptor, TextMetricsProfileConfig,
     TextMetricsProfileDescriptor, TextMetricsProvider, TextMetricsStyleDescriptor,
     edge_text_style_key, node_text_style_key, resolve_text_metrics_profile,
+    subgraph_title_text_style_key,
 };
 use crate::payload::Diagram;
 use crate::registry::DiagramFamily;
@@ -704,9 +705,11 @@ fn collect_graph_browser_text_styles(
     for node in graph.nodes.values() {
         styles.insert(node_text_style_key(provider, node));
     }
-    // Subgraph class styling is not represented in the graph IR yet, so
-    // subgraph titles currently render with the provider default. When
-    // subgraph style parity lands, title styles need to join this set.
+    for subgraph in graph.subgraphs.values() {
+        if !subgraph.invisible && !subgraph.title.is_empty() {
+            styles.insert(subgraph_title_text_style_key(provider, subgraph));
+        }
+    }
     for edge in &graph.edges {
         if edge.label.is_some() || edge.head_label.is_some() || edge.tail_label.is_some() {
             styles.insert(edge_text_style_key(provider, edge));
@@ -1071,12 +1074,12 @@ mod tests {
     use super::*;
     use crate::engines::graph::EngineAlgorithmId;
     use crate::format::OutputFormat;
-    use crate::graph::GeometryLevel;
     use crate::graph::measure::{
         COMPATIBILITY_TEXT_METRICS_PROFILE_ID, DEFAULT_GRAPH_FONT_FAMILY, GraphTextStyleKey,
         RECORDED_SANS_TEXT_METRICS_PROFILE_ID, TextMetricsProfileConfig, TextMetricsProvider,
         resolve_text_metrics_profile,
     };
+    use crate::graph::{Direction, GeometryLevel, Graph, Subgraph};
     use crate::runtime::config::{GraphTextStyleConfig, RenderConfig};
     use crate::runtime::render_diagram;
 
@@ -1361,6 +1364,85 @@ mod tests {
                 && (style.font_size - 32.0).abs() < f64::EPSILON
                 && style.css_font == r#"normal 400 32px "Times New Roman""#
         }));
+    }
+
+    #[test]
+    fn browser_metrics_request_requires_dynamic_for_subgraph_title_font() {
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef big font-family:Verdana,font-size:20px\nclass A big\n";
+
+        let decision = resolve_browser_text_metrics_request(
+            input,
+            OutputFormat::Svg,
+            &RenderConfig::default(),
+        )
+        .expect("resolver should succeed");
+
+        assert!(decision.required);
+        let request = decision.browser_text_metrics.expect("metrics request");
+        assert!(request.text_styles.iter().any(|style| {
+            style.font_family == "Verdana" && (style.font_size - 20.0).abs() < f64::EPSILON
+        }));
+    }
+
+    #[test]
+    fn browser_metrics_request_not_required_for_visual_only_subgraph_style() {
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef blue fill:#e1f5fe,stroke:#01579b\nclass A blue\n";
+
+        let decision = resolve_browser_text_metrics_request(
+            input,
+            OutputFormat::Svg,
+            &RenderConfig::default(),
+        )
+        .expect("resolver should succeed");
+
+        assert!(!decision.required);
+        assert!(decision.browser_text_metrics.is_none());
+    }
+
+    #[test]
+    fn browser_metrics_request_not_required_for_default_equivalent_subgraph_title_font() {
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef defaultSize font-size:16px\nclass A defaultSize\n";
+
+        let decision = resolve_browser_text_metrics_request(
+            input,
+            OutputFormat::Svg,
+            &RenderConfig::default(),
+        )
+        .expect("resolver should succeed");
+
+        assert!(!decision.required);
+        assert!(decision.browser_text_metrics.is_none());
+    }
+
+    #[test]
+    fn browser_metrics_request_ignores_invisible_or_empty_title_subgraphs() {
+        let metrics = resolve_text_metrics_profile(TextMetricsProfileConfig::default())
+            .expect("default text metrics should resolve")
+            .metrics;
+        let mut graph = Graph::new(Direction::TopDown);
+        let mut invisible = Subgraph {
+            id: "hidden".to_string(),
+            title: "Hidden".to_string(),
+            invisible: true,
+            ..Default::default()
+        };
+        invisible.style.font_family = Some("Verdana".to_string());
+        let mut empty_title = Subgraph {
+            id: "empty".to_string(),
+            ..Default::default()
+        };
+        empty_title.style.font_family = Some("Courier New".to_string());
+        graph.subgraphs.insert(invisible.id.clone(), invisible);
+        graph.subgraphs.insert(empty_title.id.clone(), empty_title);
+
+        let styles = collect_graph_browser_text_styles(&graph, &metrics);
+
+        assert!(!styles.iter().any(|style| style.font_family == "Verdana"));
+        assert!(
+            !styles
+                .iter()
+                .any(|style| style.font_family == "Courier New")
+        );
     }
 
     #[test]

--- a/src/runtime/graph_family.rs
+++ b/src/runtime/graph_family.rs
@@ -13,7 +13,7 @@ use crate::graph::measure::{
     DEFAULT_PROPORTIONAL_NODE_PADDING_Y, GraphTextStyleKey, ResolvedTextMetrics,
     TextMeasurementCache, TextMetricsProfileConfig, TextMetricsProfileDescriptor,
     TextMetricsProvider, edge_text_style_key, node_text_style_key, resolve_text_metrics_profile,
-    text_style_matches_descriptor,
+    subgraph_title_text_style_key, text_style_matches_descriptor,
 };
 use crate::graph::{GeometryLevel, Graph};
 use crate::mmds::Document;
@@ -244,6 +244,16 @@ fn validate_provider_free_mermaid_font_styles(
             continue;
         }
         let style = edge_text_style_key(provider, edge);
+        if !text_style_key_matches_descriptor(&style, &descriptor.default_text_style)? {
+            return Err(provider_free_graph_text_style_error(descriptor));
+        }
+    }
+
+    for subgraph in diagram.subgraphs.values() {
+        if subgraph.invisible || subgraph.title.is_empty() {
+            continue;
+        }
+        let style = subgraph_title_text_style_key(provider, subgraph);
         if !text_style_key_matches_descriptor(&style, &descriptor.default_text_style)? {
             return Err(provider_free_graph_text_style_error(descriptor));
         }
@@ -536,6 +546,46 @@ mod tests {
             &text_metrics.metrics,
         )
         .expect("SVG render should succeed");
+        assert!(svg.starts_with("<svg"));
+    }
+
+    #[test]
+    fn provider_free_static_svg_accepts_subgraph_fill_stroke_only_style() {
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef blue fill:#e1f5fe,stroke:#01579b,stroke-width:2px\nclass A blue\n";
+
+        let svg = crate::render_diagram(input, OutputFormat::Svg, &RenderConfig::default())
+            .expect("subgraph visual style should not require dynamic metrics");
+
+        assert!(svg.starts_with("<svg"));
+    }
+
+    #[test]
+    fn provider_free_static_svg_rejects_subgraph_title_font_family() {
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef custom font-family:Inter\nclass A custom\n";
+
+        let error = crate::render_diagram(input, OutputFormat::Svg, &RenderConfig::default())
+            .expect_err("custom subgraph title font family should require dynamic metrics");
+
+        assert!(error.message.contains("dynamic text metrics"));
+    }
+
+    #[test]
+    fn provider_free_static_svg_rejects_subgraph_title_font_size() {
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef custom font-size:32px\nclass A custom\n";
+
+        let error = crate::render_diagram(input, OutputFormat::Svg, &RenderConfig::default())
+            .expect_err("custom subgraph title font size should require dynamic metrics");
+
+        assert!(error.message.contains("dynamic text metrics"));
+    }
+
+    #[test]
+    fn provider_free_static_svg_accepts_subgraph_title_visual_font_style() {
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef custom font-style:italic,font-weight:700\nclass A custom\n";
+
+        let svg = crate::render_diagram(input, OutputFormat::Svg, &RenderConfig::default())
+            .expect("font-style and font-weight do not affect provider-free geometry");
+
         assert!(svg.starts_with("<svg"));
     }
 

--- a/tests/svg-snapshots/flowchart-basis/multi_subgraph_direction_override.svg
+++ b/tests/svg-snapshots/flowchart-basis/multi_subgraph_direction_override.svg
@@ -6,9 +6,9 @@
   </defs>
   <g transform="translate(-25.11,-27.00)">
     <g class="clusters">
-      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="201.01" y="39.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">a</text>
-      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="250.68" y="451.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">g</text>
     </g>
     <g class="edgePaths">

--- a/tests/svg-snapshots/flowchart-curved-step/multi_subgraph_direction_override.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/multi_subgraph_direction_override.svg
@@ -6,9 +6,9 @@
   </defs>
   <g transform="translate(-25.11,-27.00)">
     <g class="clusters">
-      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="201.01" y="39.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">a</text>
-      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="250.68" y="451.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">g</text>
     </g>
     <g class="edgePaths">

--- a/tests/svg-snapshots/flowchart-polyline/multi_subgraph_direction_override.svg
+++ b/tests/svg-snapshots/flowchart-polyline/multi_subgraph_direction_override.svg
@@ -6,9 +6,9 @@
   </defs>
   <g transform="translate(-25.11,-27.00)">
     <g class="clusters">
-      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="201.01" y="39.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">a</text>
-      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="250.68" y="451.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">g</text>
     </g>
     <g class="edgePaths">

--- a/tests/svg-snapshots/flowchart-smooth-step/multi_subgraph_direction_override.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/multi_subgraph_direction_override.svg
@@ -6,9 +6,9 @@
   </defs>
   <g transform="translate(-25.11,-27.00)">
     <g class="clusters">
-      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="201.01" y="39.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">a</text>
-      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="250.68" y="451.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">g</text>
     </g>
     <g class="edgePaths">

--- a/tests/svg-snapshots/flowchart-step/multi_subgraph_direction_override.svg
+++ b/tests/svg-snapshots/flowchart-step/multi_subgraph_direction_override.svg
@@ -6,9 +6,9 @@
   </defs>
   <g transform="translate(-25.11,-27.00)">
     <g class="clusters">
-      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="201.01" y="39.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">a</text>
-      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="250.68" y="451.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">g</text>
     </g>
     <g class="edgePaths">

--- a/tests/svg-snapshots/flowchart-straight/multi_subgraph_direction_override.svg
+++ b/tests/svg-snapshots/flowchart-straight/multi_subgraph_direction_override.svg
@@ -6,9 +6,9 @@
   </defs>
   <g transform="translate(-25.11,-27.00)">
     <g class="clusters">
-      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="201.01" y="39.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">a</text>
-      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="250.68" y="451.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">g</text>
     </g>
     <g class="edgePaths">

--- a/tests/svg-snapshots/flowchart/multi_subgraph_direction_override.svg
+++ b/tests/svg-snapshots/flowchart/multi_subgraph_direction_override.svg
@@ -6,9 +6,9 @@
   </defs>
   <g transform="translate(-25.11,-27.00)">
     <g class="clusters">
-      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="33.11" y="35.00" width="335.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="201.01" y="39.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">a</text>
-      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />
+      <rect class="subgraph" x="141.79" y="447.00" width="217.80" height="100.00" fill="#e9efff" stroke="#1f4fff" stroke-width="1px" />
       <text x="250.68" y="451.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">g</text>
     </g>
     <g class="edgePaths">

--- a/tests/svg_render.rs
+++ b/tests/svg_render.rs
@@ -285,6 +285,30 @@ fn basic_flowchart_svg_has_root_text_and_arrow_marker() {
 }
 
 #[test]
+fn svg_subgraph_class_styles_container_rect() {
+    let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef blue fill:#e1f5fe,stroke:#01579b,stroke-width:2px\nclass A blue\n";
+    let svg = render_svg(input, &RenderConfig::default());
+
+    assert!(svg.contains(r#"class="subgraph""#), "{svg}");
+    assert!(svg.contains(r##"fill="#e1f5fe""##), "{svg}");
+    assert!(svg.contains(r##"stroke="#01579b""##), "{svg}");
+    assert!(svg.contains(r#"stroke-width="2px""#), "{svg}");
+}
+
+#[test]
+fn unstyled_subgraph_container_rect_stays_byte_stable() {
+    let input = "flowchart LR\nsubgraph A[Source]\na1\nend\n";
+    let svg = render_svg(input, &RenderConfig::default());
+
+    assert!(
+        svg.contains(
+            r##"<rect class="subgraph" x="43.00" y="12.00" width="107.80" height="100.00" fill="none" stroke="#888" stroke-width="1.00" />"##
+        ),
+        "{svg}"
+    );
+}
+
+#[test]
 fn simple_arrow_flowchart_only_emits_arrowhead_def() {
     let svg = render_svg("graph TD\nA-->B\n", &RenderConfig::default());
 


### PR DESCRIPTION
## Summary

- add `Subgraph` style storage and route Mermaid flowchart `style` / `class` targets to subgraphs when the target ID is a subgraph
- add the subgraph title font contract: provider-free static SVG rejects layout-affecting custom title font identities, while dynamic browser metrics resolution includes visible titled subgraph styles
- render subgraph container visual styles in SVG, including `fill`, `stroke`, `stroke-width`, `stroke-dasharray`, and corner radius, while preserving unstyled subgraph output
- refresh the bounded `multi_subgraph_direction_override.mmd` SVG snapshots where subgraph class styling now appears

Refs #328

## Non-goals

- subgraph title font-family/font-size SVG geometry and text attribute rendering
- MMDS persistence or replay of subgraph styles
- playground-specific behavior changes
- provider-free fallback for custom title font identities

## Validation

- `just check` — 3088/3088 default tests passing
- `just lint`
- `just architecture-check`
- `cargo nextest run -E 'test(svg_snapshot_all_fixtures)'` — 7/7 passing
- `cargo nextest run --test svg_render` — 51/51 passing
- `cargo nextest run --features unstable-text-metrics-provider -E 'test(runtime::dynamic_text_metrics)'` — 64/64 passing
- `cargo nextest run --no-fail-fast` — 3088/3088 passing
- `cog check origin/main..HEAD`
- `git diff --check`
