### PR TITLE
feat: render styled subgraph title fonts

### DIFF
--- a/src/engines/graph/algorithms/layered/float_layout.rs
+++ b/src/engines/graph/algorithms/layered/float_layout.rs
@@ -15,7 +15,7 @@ use crate::graph::grid::GridLayoutConfig;
 use crate::graph::measure::{
     TextMetricsProvider, edge_label_dimensions_for_provider_and_style,
     edge_label_dimensions_wrapped_for_provider_and_style, edge_text_style_key,
-    proportional_node_dimensions_with_provider,
+    proportional_node_dimensions_with_provider, subgraph_title_text_style_key,
 };
 use crate::graph::routing::{EdgeRouting, route_graph_geometry_with_provider};
 use crate::graph::{Direction, Edge, Graph, Stroke};
@@ -202,6 +202,8 @@ pub(crate) fn build_float_layout_with_flags(
         metrics.node_padding_x(),
         metrics.node_padding_y(),
     );
+    apply_subgraph_title_metric_minimums(diagram, &mut layout, metrics, metrics.node_padding_x());
+    expand_parent_bounds(diagram, &mut layout, 0.0, 0.0);
 
     // Push external nodes away from subgraph borders so that subgraph-as-node
     // edges have visible length comparable to normal edges.
@@ -307,6 +309,52 @@ fn apply_subgraph_float_padding(
     for (id, rect) in layout.subgraph_bounds.iter() {
         if !layout.nodes.contains_key(&NodeId(id.clone())) && diagram.subgraphs.contains_key(id) {
             layout.nodes.insert(NodeId(id.clone()), *rect);
+        }
+    }
+}
+
+fn apply_subgraph_title_metric_minimums(
+    diagram: &Graph,
+    layout: &mut LayoutResult,
+    metrics: &dyn TextMetricsProvider,
+    pad_x: f64,
+) {
+    for (id, subgraph) in &diagram.subgraphs {
+        if subgraph.invisible || subgraph.title.trim().is_empty() {
+            continue;
+        }
+
+        let Some(rect) = layout.subgraph_bounds.get_mut(id) else {
+            continue;
+        };
+
+        let title_style = subgraph_title_text_style_key(metrics, subgraph);
+        let default_style = metrics.default_text_style_key();
+        // Only family and size change title reservation. Weight, style, and
+        // color are emitted as SVG attrs without shifting existing geometry.
+        let layout_affecting_style = title_style.font_family != default_style.font_family
+            || title_style.font_size_mpx != default_style.font_size_mpx;
+        if !layout_affecting_style {
+            continue;
+        }
+
+        let title_width = metrics.measure_line_width_for_style(&title_style, &subgraph.title);
+        let min_width = title_width + pad_x * 2.0;
+        if min_width.is_finite() && min_width > rect.width {
+            let delta = min_width - rect.width;
+            rect.x -= delta / 2.0;
+            rect.width = min_width;
+        }
+
+        let extra_title_height =
+            (metrics.font_size_for_style(&title_style) - metrics.font_size()).max(0.0);
+        if extra_title_height.is_finite() && extra_title_height > 0.0 {
+            rect.y -= extra_title_height;
+            rect.height += extra_title_height;
+        }
+
+        if let Some(node_rect) = layout.nodes.get_mut(&NodeId(id.clone())) {
+            *node_rect = *rect;
         }
     }
 }

--- a/src/render/graph/svg/mod.rs
+++ b/src/render/graph/svg/mod.rs
@@ -265,7 +265,15 @@ fn render_svg_with_geometry_context(
 
     render_defs(&mut writer, scale, &palette, &used_markers);
     writer.start_group_transform(offset_x, offset_y);
-    render_subgraphs(&mut writer, diagram, geom, metrics, scale, &palette);
+    render_subgraphs(
+        &mut writer,
+        diagram,
+        geom,
+        metrics,
+        &default_text_style,
+        scale,
+        &palette,
+    );
     // Keep node fills and borders above edge paths so crossing routes are
     // visually occluded instead of drawing through node bodies.
     render_edges(

--- a/src/render/graph/svg/nodes.rs
+++ b/src/render/graph/svg/nodes.rs
@@ -7,7 +7,9 @@ use super::edges::{document_svg_path, polygon_points};
 use super::text::{TextRenderStyle, font_attrs_for_style, render_text_centered};
 use super::{GraphSvgPalette, Point, Rect, dynamic_css_attrs};
 use crate::graph::geometry::{FRect, GraphGeometry};
-use crate::graph::measure::{GraphTextStyleKey, TextMetricsProvider, node_text_style_key};
+use crate::graph::measure::{
+    GraphTextStyleKey, TextMetricsProvider, node_text_style_key, subgraph_title_text_style_key,
+};
 use crate::graph::routing::hexagon_vertices;
 use crate::graph::{Direction, Graph, Node, Shape, Subgraph};
 use crate::render::svg::{SvgWriter, escape_text, fmt_f64};
@@ -73,6 +75,7 @@ struct NodeLabelRenderContext<'a> {
 struct ResolvedSvgSubgraphStyle<'a> {
     fill: Option<&'a str>,
     stroke: Option<&'a str>,
+    text: Option<&'a str>,
     stroke_width: Option<&'a str>,
     stroke_dasharray: Option<&'a str>,
     rx: Option<&'a str>,
@@ -83,6 +86,7 @@ impl<'a> ResolvedSvgSubgraphStyle<'a> {
         Self {
             fill: subgraph.style.fill.as_ref().map(|color| color.raw()),
             stroke: subgraph.style.stroke.as_ref().map(|color| color.raw()),
+            text: subgraph.style.color.as_ref().map(|color| color.raw()),
             stroke_width: subgraph.style.stroke_width.as_deref(),
             stroke_dasharray: subgraph.style.stroke_dasharray.as_deref(),
             rx: subgraph.style.rx.as_deref(),
@@ -97,8 +101,16 @@ impl<'a> ResolvedSvgSubgraphStyle<'a> {
         self.stroke.unwrap_or(default)
     }
 
+    fn text_or(self, default: &'a str) -> &'a str {
+        self.text.unwrap_or(default)
+    }
+
     fn stroke_is_overridden(self) -> bool {
         self.stroke.is_some()
+    }
+
+    fn text_is_overridden(self) -> bool {
+        self.text.is_some()
     }
 }
 
@@ -107,6 +119,7 @@ pub(super) fn render_subgraphs(
     diagram: &Graph,
     geom: &GraphGeometry,
     metrics: &dyn TextMetricsProvider,
+    default_text_style: &GraphTextStyleKey,
     scale: f64,
     palette: &GraphSvgPalette,
 ) {
@@ -164,18 +177,22 @@ pub(super) fn render_subgraphs(
 
         if !sg_geom.title.trim().is_empty() {
             let title_x = rect.x + rect.width / 2.0;
-            let title_y = rect.y + metrics.font_size() * 0.25;
-            let dynamic_attrs = dynamic_css_attrs(
-                palette.dynamic_css,
-                "graph-subgraph-text",
-                &["fill:var(--_group-hdr);"],
-            );
+            let title_style = subgraph_title_text_style_key(metrics, subgraph);
+            let title_y = rect.y + metrics.font_size_for_style(&title_style) * scale * 0.25;
+            let mut declarations = Vec::new();
+            if !style.text_is_overridden() {
+                declarations.push("fill:var(--_group-hdr);");
+            }
+            let dynamic_attrs =
+                dynamic_css_attrs(palette.dynamic_css, "graph-subgraph-text", &declarations);
+            let extra_attrs =
+                dynamic_attrs + &font_attrs_for_style(default_text_style, &title_style);
             let text = format!(
-                "<text x=\"{x}\" y=\"{y}\" text-anchor=\"middle\" dominant-baseline=\"hanging\" fill=\"{color}\"{dynamic_attrs}>{label}</text>",
+                "<text x=\"{x}\" y=\"{y}\" text-anchor=\"middle\" dominant-baseline=\"hanging\" fill=\"{color}\"{extra_attrs}>{label}</text>",
                 x = fmt_f64(title_x),
                 y = fmt_f64(title_y),
-                color = palette.subgraph_title_text,
-                dynamic_attrs = dynamic_attrs,
+                color = style.text_or(&palette.subgraph_title_text),
+                extra_attrs = extra_attrs,
                 label = escape_text(&sg_geom.title)
             );
             writer.push_line(&text);

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -1249,6 +1249,36 @@ mod tests {
         .unwrap()
     }
 
+    fn styled_subgraph_title_input() -> DynamicMetricsInput {
+        serde_json::from_str(
+            r#"{
+              "defaultStyle":"s0",
+              "textStyles":[
+                {
+                  "id":"s0",
+                  "fontFamily":"Inter",
+                  "fontSize":16,
+                  "fontStyle":"normal",
+                  "fontWeight":"400",
+                  "lineHeight":24,
+                  "cssFont":"16px Inter"
+                },
+                {
+                  "id":"s1",
+                  "fontFamily":"Verdana",
+                  "fontSize":32,
+                  "fontStyle":"italic",
+                  "fontWeight":"700",
+                  "lineHeight":48,
+                  "cssFont":"italic 700 32px Verdana"
+                }
+              ],
+              "profileId":"browser-subgraph-title-v1"
+            }"#,
+        )
+        .unwrap()
+    }
+
     fn multi_font_width(text: &str, css_font: &str) -> Result<f64, DynamicTextMetricsError> {
         let per_char = if css_font.contains("Courier New") {
             18.0
@@ -2401,6 +2431,58 @@ mod tests {
         let replay_svg = render_diagram(&dynamic_mmds, OutputFormat::Svg, &RenderConfig::default())
             .expect("provider-free sidecar replay should render");
         assert_eq!(replay_svg, direct_svg);
+    }
+
+    #[test]
+    fn dynamic_svg_subgraph_title_uses_class_font_attrs_and_geometry() {
+        use std::cell::RefCell;
+
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef title font-family:Verdana,font-size:32px,font-style:italic,font-weight:700,color:#123456\nclass A title\n";
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        let observed_calls = Rc::clone(&calls);
+
+        let svg = render_graph_family_with_dynamic_text_metrics(
+            input,
+            OutputFormat::Svg,
+            &routed_config(),
+            styled_subgraph_title_input(),
+            move |text, css_font| {
+                observed_calls
+                    .borrow_mut()
+                    .push((text.to_string(), css_font.to_string()));
+                if text == "Source" && css_font.contains("Verdana") {
+                    Ok(320.0)
+                } else {
+                    Ok(text.chars().count() as f64 * 8.0)
+                }
+            },
+        )
+        .expect("dynamic styled subgraph title SVG should render");
+
+        let title = regex::Regex::new(
+            r##"<text [^>]*fill="#123456"[^>]*font-family="Verdana"[^>]*font-size="32(?:\.00)?"[^>]*font-style="italic"[^>]*font-weight="700"[^>]*>Source</text>"##,
+        )
+        .expect("title regex should compile");
+        assert!(title.is_match(&svg), "{svg}");
+        assert!(
+            calls.borrow().iter().any(|(text, css_font)| {
+                text == "Source" && css_font == r#"italic 700 32px Verdana"#
+            }),
+            "{:?}",
+            calls.borrow()
+        );
+
+        let rect = regex::Regex::new(r#"<rect class="subgraph" [^>]*\swidth="([0-9.]+)""#)
+            .expect("rect regex should compile");
+        let subgraph_width: f64 = rect
+            .captures(&svg)
+            .and_then(|captures| captures.get(1))
+            .and_then(|width| width.as_str().parse().ok())
+            .expect("subgraph rect width should parse");
+        assert!(
+            subgraph_width > 320.0,
+            "subgraph width should include styled title measurement: {subgraph_width}; {svg}"
+        );
     }
 
     #[test]

--- a/tests/svg_render.rs
+++ b/tests/svg_render.rs
@@ -309,6 +309,48 @@ fn unstyled_subgraph_container_rect_stays_byte_stable() {
 }
 
 #[test]
+fn svg_subgraph_title_uses_visual_font_attrs_from_class_style() {
+    let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef title font-style:italic,font-weight:700,color:#123456\nclass A title\n";
+    let svg = render_svg(input, &RenderConfig::default());
+
+    let title = regex::Regex::new(r##"<text [^>]*fill="#123456"[^>]*font-style="italic"[^>]*font-weight="700"[^>]*>Source</text>"##)
+        .expect("title regex should compile");
+    assert!(title.is_match(&svg), "{svg}");
+}
+
+#[test]
+fn svg_subgraph_title_position_honors_svg_scale() {
+    let input = "flowchart LR\nsubgraph A[Source]\na1\nend\n";
+    let svg = render_svg(
+        input,
+        &RenderConfig {
+            svg_scale: Some(2.0),
+            ..RenderConfig::default()
+        },
+    );
+
+    let rect = regex::Regex::new(r#"<rect class="subgraph" [^>]*\sy="([0-9.]+)""#)
+        .expect("rect regex should compile");
+    let text = regex::Regex::new(r#"<text [^>]*\sy="([0-9.]+)"[^>]*>Source</text>"#)
+        .expect("text regex should compile");
+    let rect_y: f64 = rect
+        .captures(&svg)
+        .and_then(|captures| captures.get(1))
+        .and_then(|value| value.as_str().parse().ok())
+        .expect("subgraph rect y should parse");
+    let title_y: f64 = text
+        .captures(&svg)
+        .and_then(|captures| captures.get(1))
+        .and_then(|value| value.as_str().parse().ok())
+        .expect("subgraph title y should parse");
+
+    assert!(
+        (title_y - rect_y - 8.0).abs() < f64::EPSILON,
+        "scaled title offset should be 16px * 2.0 * 0.25: {svg}"
+    );
+}
+
+#[test]
 fn simple_arrow_flowchart_only_emits_arrowhead_def() {
     let svg = render_svg("graph TD\nA-->B\n", &RenderConfig::default());
 


### PR DESCRIPTION
## Summary

- render effective SVG font attrs on flowchart subgraph titles, including color, family, size, style, and weight
- make dynamic font-family/font-size title styles reserve subgraph title geometry while visual-only title styles render without shifting layout
- add static and dynamic regression coverage, with the dynamic test proving styled title measurement expands the subgraph rect and a scale regression pinning title y-offset under `svgScale != 1.0`

Refs #328

## Non-goals

- MMDS persistence/hydration/replay for subgraph styles
- playground dynamic-metrics routing changes for this subgraph title slice
- broad Mermaid subgraph style parity beyond the title font geometry covered here

## Validation

- `cargo nextest run --test svg_render -E 'test(svg_subgraph_title)'` — 2/2 passing
- `cargo nextest run --test svg_render` — 53/53 passing
- `cargo nextest run -E 'test(svg_snapshot_all_fixtures)'` — 7/7 passing
- `just lint`
- `cargo nextest run --no-fail-fast` — 3089/3089 passing
- `cargo nextest run --features unstable-text-metrics-provider --no-fail-fast` — 3158/3158 passing
- `just architecture-check`
- `cog check origin/main..HEAD`