### PR TITLE
feat: complete subgraph style mmds replay

### DIFF
--- a/docs/development/wasm.md
+++ b/docs/development/wasm.md
@@ -113,7 +113,9 @@ change `render` output.
 The playground routes graph-family SVG font styles through browser text metrics
 when Mermaid `style`, `classDef`/`class`, or `linkStyle` declarations include
 layout-affecting font properties. Static/default SVG renders without font
-styling continue to use the portable `render` path. Text, ASCII, and sequence remain unsupported for dynamic metrics.
+styling continue to use the portable `render` path. Subgraph container visual
+styles can replay provider-free, but custom subgraph title font family or size
+requires dynamic metrics because it changes layout geometry. Text, ASCII, and sequence remain unsupported for dynamic metrics.
 
 `renderWithBrowserTextMetrics(input, format, configJson, metricsJson, measureText)`
 is a separate experimental export for browser-owned font measurement. It

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -333,7 +333,7 @@ MMDS keeps core graph semantics compact while allowing renderer- or adapter-spec
 
 ### Node Style Extension
 
-When at least one node or edge label carries a non-empty internal style,
+When at least one node, edge label, or subgraph carries a non-empty internal style,
 mmdflux emits:
 
 - profile: `mmdflux-node-style-v1`
@@ -360,6 +360,16 @@ Payload shape:
           "font-style": "normal",
           "font-weight": "400"
         }
+      },
+      "subgraphs": {
+        "A": {
+          "fill": "#e1f5fe",
+          "stroke": "#01579b",
+          "stroke-width": "2px",
+          "color": "#123456",
+          "font-style": "italic",
+          "font-weight": "700"
+        }
       }
     }
   }
@@ -368,13 +378,22 @@ Payload shape:
 
 Rules:
 
-- Omit the profile and extension entirely when no node or edge-label styles are
-  present.
+- Omit the profile and extension entirely when no node, edge-label, or subgraph
+  styles are present.
 - `fill`, `stroke`, and `color` preserve the raw Mermaid/MMDS color token.
 - Edge-label entries are keyed by MMDS edge id and preserve Mermaid `linkStyle`
   font tokens for SVG rendering and dynamic text measurement replay.
-- MMDS input hydration replays this extension back into internal node and edge
-  label styles for text and SVG rendering.
+- Subgraph entries live at `org.mmdflux.node-style.v1.subgraphs`; the historical
+  namespace name is retained, but these entries are graph subgraph style
+  overrides. Container visual styles replay provider-free. The rule is:
+  custom subgraph title font family or size requires dynamic metrics because
+  title geometry is layout-affecting.
+- Provider-free replay preserves the persisted style attributes, but MMDS keeps
+  canonical graph geometry. Direct dynamic SVG rendering can use visual SVG
+  geometry, so styled-title replay is not guaranteed to be byte-identical to the
+  original dynamic SVG output.
+- MMDS input hydration replays this extension back into internal node, edge
+  label, and subgraph styles for text and SVG rendering.
 - Mermaid generation from MMDS style extensions is still deferred.
 
 ### Text Metrics Extension

--- a/docs/mmds.schema.json
+++ b/docs/mmds.schema.json
@@ -417,9 +417,20 @@
           "additionalProperties": {
             "$ref": "#/$defs/EdgeLabelStyle"
           }
+        },
+        "subgraphs": {
+          "type": "object",
+          "description": "Subgraph-ID keyed style overrides replayed into renderer-visible subgraph container and title properties.",
+          "additionalProperties": {
+            "$ref": "#/$defs/NodeStyle"
+          }
         }
       },
-      "anyOf": [{ "required": ["nodes"] }, { "required": ["edges"] }],
+      "anyOf": [
+        { "required": ["nodes"] },
+        { "required": ["edges"] },
+        { "required": ["subgraphs"] }
+      ],
       "additionalProperties": false
     },
     "TextMetricsExtension": {

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -410,6 +410,7 @@ fn build_document(
     };
     let styled_nodes = collect_styled_nodes(diagram);
     let styled_edges = collect_styled_edges(diagram);
+    let styled_subgraphs = collect_styled_subgraphs(diagram);
 
     // At routed level, use the recomputed routed bounds (which cover all
     // routed edge paths) instead of stale layout bounds.
@@ -537,12 +538,12 @@ fn build_document(
             grid_projection_extension(grid_projection),
         );
     }
-    if !styled_nodes.is_empty() || !styled_edges.is_empty() {
+    if !styled_nodes.is_empty() || !styled_edges.is_empty() || !styled_subgraphs.is_empty() {
         push_profile(&mut profiles, CORE_PROFILE);
         push_profile(&mut profiles, NODE_STYLE_PROFILE);
         extensions.insert(
             NODE_STYLE_EXTENSION_NAMESPACE.to_string(),
-            style_extension(styled_nodes, styled_edges),
+            style_extension(styled_nodes, styled_edges, styled_subgraphs),
         );
     }
     if let Some(text_metrics_descriptor) = options.text_metrics_descriptor {
@@ -590,6 +591,15 @@ fn collect_styled_edges(diagram: &Graph) -> BTreeMap<String, EdgeStyle> {
         .enumerate()
         .filter(|(_, edge)| !edge.style.is_empty())
         .map(|(index, edge)| (format!("e{index}"), edge.style.clone()))
+        .collect()
+}
+
+fn collect_styled_subgraphs(diagram: &Graph) -> BTreeMap<String, NodeStyle> {
+    diagram
+        .subgraphs
+        .iter()
+        .filter(|(_, subgraph)| !subgraph.style.is_empty())
+        .map(|(subgraph_id, subgraph)| (subgraph_id.clone(), subgraph.style.clone()))
         .collect()
 }
 
@@ -729,6 +739,7 @@ fn rect_value(rect: crate::graph::geometry::FRect) -> Value {
 fn style_extension(
     styled_nodes: BTreeMap<String, NodeStyle>,
     styled_edges: BTreeMap<String, EdgeStyle>,
+    styled_subgraphs: BTreeMap<String, NodeStyle>,
 ) -> Map<String, Value> {
     let mut extension = Map::new();
     if !styled_nodes.is_empty() {
@@ -754,6 +765,18 @@ fn style_extension(
             })
             .collect();
         extension.insert("edges".to_string(), Value::Object(edges));
+    }
+    if !styled_subgraphs.is_empty() {
+        let subgraphs = styled_subgraphs
+            .iter()
+            .map(|(subgraph_id, style)| {
+                (
+                    subgraph_id.clone(),
+                    Value::Object(serialize_node_style_extension(style)),
+                )
+            })
+            .collect();
+        extension.insert("subgraphs".to_string(), Value::Object(subgraphs));
     }
     extension
 }

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -53,9 +53,6 @@ pub fn from_document(output: &Document) -> Result<Graph, HydrationError> {
                 dir: subgraph.direction,
                 invisible: subgraph.invisible,
                 concurrent_regions: subgraph.concurrent_regions.clone(),
-                // Graph subgraph styles are not persisted in MMDS yet. Keep
-                // provider-free replay honest by defaulting until the document
-                // schema carries this field explicitly.
                 style: Default::default(),
             },
         );
@@ -204,21 +201,36 @@ fn hydrate_node_style_extension(
     let Some(extension) = extensions.get(NODE_STYLE_EXTENSION_NAMESPACE) else {
         return;
     };
-    let Some(nodes) = extension.get("nodes").and_then(Value::as_object) else {
-        return;
-    };
 
-    for (node_id, raw_style) in nodes {
-        let Some(style_object) = raw_style.as_object() else {
-            continue;
-        };
-        let Some(node) = diagram.nodes.get_mut(node_id) else {
-            continue;
-        };
+    if let Some(nodes) = extension.get("nodes").and_then(Value::as_object) {
+        for (node_id, raw_style) in nodes {
+            let Some(style_object) = raw_style.as_object() else {
+                continue;
+            };
+            let Some(node) = diagram.nodes.get_mut(node_id) else {
+                continue;
+            };
 
-        let style = parse_node_style_extension(style_object);
-        if !style.is_empty() {
-            node.style = node.style.merge(&style);
+            let style = parse_node_style_extension(style_object);
+            if !style.is_empty() {
+                node.style = node.style.merge(&style);
+            }
+        }
+    }
+
+    if let Some(subgraphs) = extension.get("subgraphs").and_then(Value::as_object) {
+        for (subgraph_id, raw_style) in subgraphs {
+            let Some(style_object) = raw_style.as_object() else {
+                continue;
+            };
+            let Some(subgraph) = diagram.subgraphs.get_mut(subgraph_id) else {
+                continue;
+            };
+
+            let style = parse_node_style_extension(style_object);
+            if !style.is_empty() {
+                subgraph.style = subgraph.style.merge(&style);
+            }
         }
     }
 }

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -2486,6 +2486,44 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_mmds_subgraph_title_style_replays_provider_free() {
+        let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef title font-family:Verdana,font-size:32px,font-style:italic,font-weight:700,color:#123456\nclass A title\n";
+
+        let dynamic_mmds = render_graph_family_with_dynamic_text_metrics(
+            input,
+            OutputFormat::Mmds,
+            &routed_config(),
+            styled_subgraph_title_input(),
+            |text, css_font| {
+                if text == "Source" && css_font.contains("Verdana") {
+                    Ok(320.0)
+                } else {
+                    Ok(text.chars().count() as f64 * 8.0)
+                }
+            },
+        )
+        .expect("dynamic styled subgraph title MMDS should render");
+
+        let value: serde_json::Value =
+            serde_json::from_str(&dynamic_mmds).expect("dynamic MMDS should parse");
+        let style = &value["extensions"]["org.mmdflux.node-style.v1"]["subgraphs"]["A"];
+        assert_eq!(style["font-family"], "Verdana");
+        assert_eq!(style["font-size"], "32px");
+        assert_eq!(style["font-style"], "italic");
+        assert_eq!(style["font-weight"], "700");
+        assert_eq!(style["color"], "#123456");
+
+        let replay_svg = render_diagram(&dynamic_mmds, OutputFormat::Svg, &RenderConfig::default())
+            .expect("provider-free styled subgraph title MMDS replay should render");
+
+        let title = regex::Regex::new(
+            r##"<text [^>]*fill="#123456"[^>]*font-family="Verdana"[^>]*font-size="32(?:\.00)?"[^>]*font-style="italic"[^>]*font-weight="700"[^>]*>Source</text>"##,
+        )
+        .expect("title regex should compile");
+        assert!(title.is_match(&replay_svg), "{replay_svg}");
+    }
+
+    #[test]
     fn dynamic_mmds_without_measurements_still_requires_provider_free_replay_provider() {
         let dynamic_mmds = dynamic_mmds_fixture();
         let mut value: serde_json::Value = serde_json::from_str(&dynamic_mmds).unwrap();

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -481,6 +481,30 @@ fn mmds_output_emits_node_style_extension_when_styles_exist() {
 }
 
 #[test]
+fn mmds_output_emits_subgraph_style_extension_when_styles_exist() {
+    let json = render_json(
+        "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef blue fill:#e1f5fe,stroke:#01579b,stroke-width:2px,color:#123456,font-style:italic,font-weight:700\nclass A blue\n",
+    );
+    let value: Value = serde_json::from_str(&json).unwrap();
+
+    assert!(
+        value["profiles"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|profile| profile == "mmdflux-node-style-v1")
+    );
+    let style = &value["extensions"]["org.mmdflux.node-style.v1"]["subgraphs"]["A"];
+    assert_eq!(style["fill"], "#e1f5fe");
+    assert_eq!(style["stroke"], "#01579b");
+    assert_eq!(style["stroke-width"], "2px");
+    assert_eq!(style["color"], "#123456");
+    assert_eq!(style["font-style"], "italic");
+    assert_eq!(style["font-weight"], "700");
+    assert_schema_valid(value);
+}
+
+#[test]
 fn schema_accepts_edge_style_extension_entries() {
     let mut value: Value = serde_json::from_str(STYLED_MMDS_LAYOUT).unwrap();
     value["extensions"]["org.mmdflux.node-style.v1"] = json!({
@@ -499,8 +523,90 @@ fn schema_accepts_edge_style_extension_entries() {
 }
 
 #[test]
+fn schema_accepts_subgraph_style_extension_entries() {
+    let mut value: Value = serde_json::from_str(STYLED_MMDS_LAYOUT).unwrap();
+    value["extensions"]["org.mmdflux.node-style.v1"] = json!({
+        "subgraphs": {
+            "A": {
+                "fill": "#e1f5fe",
+                "stroke": "#01579b",
+                "stroke-width": "2px",
+                "font-family": "Verdana",
+                "font-size": "20px",
+                "font-style": "italic",
+                "font-weight": "700",
+                "color": "#123456"
+            }
+        }
+    });
+
+    assert_schema_valid(value);
+}
+
+#[test]
+fn schema_accepts_mixed_node_edge_and_subgraph_style_extension_entries() {
+    let mut value: Value = serde_json::from_str(STYLED_MMDS_LAYOUT).unwrap();
+    value["extensions"]["org.mmdflux.node-style.v1"] = json!({
+        "nodes": {
+            "A": {
+                "fill": "#ffeeaa"
+            }
+        },
+        "edges": {
+            "e0": {
+                "font-family": "Times New Roman"
+            }
+        },
+        "subgraphs": {
+            "A": {
+                "stroke": "#01579b"
+            }
+        }
+    });
+
+    assert_schema_valid(value);
+}
+
+#[test]
+fn schema_rejects_unknown_node_style_extension_keys() {
+    let mut value: Value = serde_json::from_str(STYLED_MMDS_LAYOUT).unwrap();
+    value["extensions"]["org.mmdflux.node-style.v1"] = json!({
+        "subgraphs": {
+            "A": {
+                "stroke": "#01579b"
+            }
+        },
+        "groups": {
+            "A": {
+                "stroke": "#01579b"
+            }
+        }
+    });
+
+    assert_schema_invalid(value);
+}
+
+#[test]
 fn mmds_output_omits_node_style_extension_when_styles_absent() {
     let json = render_json("graph TD\nA-->B");
+    let value: Value = serde_json::from_str(&json).unwrap();
+
+    assert!(!value["profiles"].as_array().is_some_and(|profiles| {
+        profiles
+            .iter()
+            .any(|profile| profile == "mmdflux-node-style-v1")
+    }));
+    assert!(
+        value
+            .get("extensions")
+            .and_then(|extensions| extensions.get("org.mmdflux.node-style.v1"))
+            .is_none()
+    );
+}
+
+#[test]
+fn mmds_output_omits_node_style_extension_when_only_unstyled_subgraphs_exist() {
+    let json = render_json("flowchart LR\nsubgraph A[Source]\na1\nend\n");
     let value: Value = serde_json::from_str(&json).unwrap();
 
     assert!(!value["profiles"].as_array().is_some_and(|profiles| {
@@ -1074,6 +1180,100 @@ fn mmds_hydration_replays_hyphenated_node_style_keys_into_svg() {
     assert!(
         svg.contains("stroke-dasharray=\"4 2\""),
         "styled MMDS SVG stroke-dasharray missing: {svg}"
+    );
+}
+
+#[test]
+fn mmds_hydration_replays_subgraph_styles_into_svg() {
+    let mut payload: Value =
+        serde_json::from_str(&render_json("flowchart LR\nsubgraph A[Source]\na1\nend\n"))
+            .expect("subgraph MMDS should parse");
+    payload["profiles"]
+        .as_array_mut()
+        .expect("profiles should be an array")
+        .push(Value::String("mmdflux-node-style-v1".to_string()));
+    payload["extensions"]["org.mmdflux.node-style.v1"] = json!({
+        "subgraphs": {
+            "A": {
+                "fill": "#e1f5fe",
+                "stroke": "#01579b",
+                "stroke-width": "2px",
+                "color": "#123456",
+                "font-style": "italic",
+                "font-weight": "700"
+            }
+        }
+    });
+
+    let input = serde_json::to_string(&payload).expect("MMDS payload should serialize");
+    let svg = render_mmds_input(&input, OutputFormat::Svg, RenderConfig::default());
+
+    assert!(
+        svg.contains(r##"fill="#e1f5fe""##),
+        "styled MMDS subgraph fill missing: {svg}"
+    );
+    assert!(
+        svg.contains(r##"stroke="#01579b""##),
+        "styled MMDS subgraph stroke missing: {svg}"
+    );
+    assert!(
+        svg.contains(r#"stroke-width="2px""#),
+        "styled MMDS subgraph stroke width missing: {svg}"
+    );
+    let title = regex::Regex::new(r##"<text [^>]*fill="#123456"[^>]*font-style="italic"[^>]*font-weight="700"[^>]*>Source</text>"##)
+        .expect("title regex should compile");
+    assert!(title.is_match(&svg), "{svg}");
+}
+
+#[test]
+fn mmds_hydration_keeps_colliding_node_and_subgraph_styles_separate() {
+    let mut payload: Value = serde_json::from_str(STYLED_MMDS_LAYOUT).unwrap();
+    payload["subgraphs"] = json!([
+        {
+            "id": "A",
+            "title": "Group",
+            "children": ["B"]
+        }
+    ]);
+    payload["extensions"]["org.mmdflux.node-style.v1"] = json!({
+        "nodes": {
+            "A": {
+                "fill": "#ffeeaa",
+                "stroke": "#333333"
+            }
+        },
+        "subgraphs": {
+            "A": {
+                "fill": "#e1f5fe",
+                "stroke": "#01579b",
+                "stroke-width": "2px"
+            }
+        }
+    });
+    assert_schema_valid(payload.clone());
+
+    let input = serde_json::to_string(&payload).expect("MMDS payload should serialize");
+    let svg = render_mmds_input(&input, OutputFormat::Svg, RenderConfig::default());
+
+    assert!(
+        svg.contains(r##"fill="#ffeeaa""##),
+        "node style for colliding id missing: {svg}"
+    );
+    assert!(
+        svg.contains(r##"stroke="#333333""##),
+        "node stroke for colliding id missing: {svg}"
+    );
+    assert!(
+        svg.contains(r##"fill="#e1f5fe""##),
+        "subgraph fill for colliding id missing: {svg}"
+    );
+    assert!(
+        svg.contains(r##"stroke="#01579b""##),
+        "subgraph stroke for colliding id missing: {svg}"
+    );
+    assert!(
+        svg.contains(r#"stroke-width="2px""#),
+        "subgraph stroke width for colliding id missing: {svg}"
     );
 }
 
@@ -2076,9 +2276,13 @@ fn docs_and_schema_reference_node_style_extension_contract() {
     let docs = std::fs::read_to_string("docs/mmds.md").unwrap();
     assert!(docs.contains("mmdflux-node-style-v1"));
     assert!(docs.contains("org.mmdflux.node-style.v1"));
+    assert!(docs.contains("org.mmdflux.node-style.v1.subgraphs"));
+    assert!(docs.contains("subgraph style"));
+    assert!(docs.contains("custom subgraph title font family or size requires dynamic metrics"));
 
     let schema = std::fs::read_to_string("docs/mmds.schema.json").unwrap();
     assert!(schema.contains("org.mmdflux.node-style.v1"));
+    assert!(schema.contains("\"subgraphs\""));
 }
 
 #[test]
@@ -2207,6 +2411,7 @@ fn docs_cover_live_style_scope_and_wasm_color_config() {
     assert!(wasm_docs.contains("org.mmdflux.text-measurements.v1"));
     assert!(wasm_docs.contains("static `render` export replay"));
     assert!(wasm_docs.contains("Missing measured queries"));
+    assert!(wasm_docs.contains("custom subgraph title font family or size"));
     assert!(!wasm_docs.contains("currently accepts only"));
 
     let readme = std::fs::read_to_string("README.md").unwrap();

--- a/web/src/dynamic-svg-routing.test.ts
+++ b/web/src/dynamic-svg-routing.test.ts
@@ -89,6 +89,51 @@ describe("renderPlaygroundRequest", () => {
     expect(client.render).not.toHaveBeenCalled();
   });
 
+  it("routes subgraph title font styles through dynamic render", async () => {
+    const client = renderClientFixture({
+      resolveBrowserTextMetricsRequest: vi.fn(async () => ({
+        required: true,
+        browserTextMetrics: {
+          defaultStyle: "s0",
+          textStyles: [
+            {
+              id: "s0",
+              fontFamily: "Verdana",
+              fontSize: 20,
+              lineHeight: 30,
+              fontStyle: "normal",
+              fontWeight: "400",
+            },
+          ],
+        },
+      })),
+    });
+    const request = {
+      seq: 8,
+      input:
+        "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef title font-family:Verdana,font-size:20px\nclass A title",
+      format: "svg" as const,
+      configJson: "{}",
+    };
+
+    await expect(renderPlaygroundRequest(client, request)).resolves.toEqual({
+      seq: 8,
+      format: "svg",
+      output: "dynamic-svg-output",
+    });
+
+    expect(client.resolveBrowserTextMetricsRequest).toHaveBeenCalledWith(
+      request,
+    );
+    expect(client.renderWithBrowserTextMetrics).toHaveBeenCalledWith({
+      seq: 8,
+      input: request.input,
+      configJson: "{}",
+      browserTextMetrics: expect.objectContaining({ defaultStyle: "s0" }),
+    });
+    expect(client.render).not.toHaveBeenCalled();
+  });
+
   it("routes not-required SVG through static render", async () => {
     const client = renderClientFixture();
 
@@ -138,6 +183,27 @@ describe("renderPlaygroundRequest", () => {
       format: "svg",
       configJson: "{}",
     });
+    expect(client.renderWithBrowserTextMetrics).not.toHaveBeenCalled();
+  });
+
+  it("routes visual-only subgraph styles through static render without resolving", async () => {
+    const client = renderClientFixture();
+    const request = {
+      seq: 9,
+      input:
+        "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef blue fill:#e1f5fe,stroke:#01579b\nclass A blue",
+      format: "svg" as const,
+      configJson: "{}",
+    };
+
+    await expect(renderPlaygroundRequest(client, request)).resolves.toEqual({
+      seq: 9,
+      format: "svg",
+      output: "svg-output",
+    });
+
+    expect(client.resolveBrowserTextMetricsRequest).not.toHaveBeenCalled();
+    expect(client.render).toHaveBeenCalledWith(request);
     expect(client.renderWithBrowserTextMetrics).not.toHaveBeenCalled();
   });
 

--- a/web/src/examples.test.ts
+++ b/web/src/examples.test.ts
@@ -16,5 +16,9 @@ describe("PLAYGROUND_EXAMPLES", () => {
     expect(example?.input).toContain(
       "linkStyle 0 font-family:Times New Roman,font-size:32px",
     );
+    expect(example?.input).toContain(
+      "classDef groupTitle font-family:Georgia,font-size:24px,font-style:italic,color:#24476b",
+    );
+    expect(example?.input).toContain("class G groupTitle");
   });
 });

--- a/web/src/examples.ts
+++ b/web/src/examples.ts
@@ -84,10 +84,14 @@ export const PLAYGROUND_EXAMPLES: PlaygroundExample[] = [
     category: "flowchart",
     featured: true,
     input: `graph TD
-    A[Regular] -->|link| B(Styled Node)
+    subgraph G[Styled Group]
+        A[Regular] -->|link| B(Styled Node)
+    end
     style A font-family:Verdana,font-size:8px
     style B font-family:Courier New,font-size:20px
-    linkStyle 0 font-family:Times New Roman,font-size:32px`,
+    linkStyle 0 font-family:Times New Roman,font-size:32px
+    classDef groupTitle font-family:Georgia,font-size:24px,font-style:italic,color:#24476b
+    class G groupTitle`,
   },
   {
     id: "flowchart-direction-bt",


### PR DESCRIPTION
## Summary

- persist subgraph styles under `org.mmdflux.node-style.v1.subgraphs` and hydrate them back into graph-family SVG replay
- update MMDS schema/docs and replay canaries for provider-free subgraph container/title style replay, including node/subgraph ID collision coverage
- extend the Dynamic Fonts playground example with a styled subgraph title and add routing coverage for dynamic title-font vs static visual-only subgraph styles

Closes #328

## Non-goals

- no Text/ASCII or sequence dynamic metrics expansion
- no native font discovery or provider-free custom font measurement
- no broader visual-vs-canonical MMDS geometry contract change; exact byte-equality between direct dynamic SVG and dynamic MMDS replay remains outside this PR and is documented as a replay boundary

## Validation

- `just check` — 3097/3097 default tests passing
- `cargo nextest run --features unstable-text-metrics-provider --no-fail-fast` — 3166/3166 passing
- `cargo test -p mmdflux-wasm` — 35/35 passing
- `cd web && npm run test` — 129/129 passing
- `./scripts/run-wasm-browser-tests.sh` — 36/36 passing
- `just wasm-size` — 1,878,117 raw / 649,503 gzip, PASS
- `git diff --check`
- `cog check origin/main..HEAD`
