### PR TITLE
docs: describe playground font style support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,14 @@ SVG-only styling. Provider-free static rendering accepts only values that match
 the selected static profile descriptor; arbitrary browser fonts require the
 separate browser dynamic metrics export.
 
+The web playground uses that browser metrics path automatically for graph-family
+SVG diagrams whose Mermaid `style`, `classDef`/`class`, or `linkStyle`
+declarations set layout-affecting font properties. Node labels, edge labels, and
+subgraph titles can each use their effective `font-family`, `font-size`,
+`font-style`, and `font-weight` while still measuring with the same browser font
+identity used for SVG output. Text, ASCII, sequence diagrams, and provider-free
+static rendering keep the deterministic static-profile behavior.
+
 ## Adapter workflows
 
 mmdflux is not only a one-shot renderer. Advanced Rust integrations can treat


### PR DESCRIPTION
## Summary

- document the playground/browser dynamic metrics path for Mermaid graph font styles in the README
- call out the supported scoped surfaces: node labels, edge labels, and subgraph titles in graph-family SVG
- preserve the static contract wording for Text, ASCII, sequence, and provider-free rendering

Closes #320

## Validation

- `cog check origin/main..HEAD`
- not run: README-only change
