### PR TITLE
ci: switch macOS Rust setup to actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,18 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: false
 
       - name: Install Rust nightly for rustfmt
-        uses: dtolnay/rust-toolchain@nightly
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: nightly
           components: rustfmt
+          cache: false
+          override: false
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -58,7 +64,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: false
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@nextest
@@ -86,7 +95,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          cache: false
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,11 @@ jobs:
           echo "Resolved tag: $TAG"
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          targets: ${{ matrix.target }}
+          toolchain: stable
+          target: ${{ matrix.target }}
+          cache: false
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

The new `macos-15-arm64` runner image (rolled out around 2026-05-11) ships a Homebrew `rustup-init` shim that satisfies `command -v rustup` without putting a real `cargo` on `PATH`. `dtolnay/rust-toolchain@stable` only appends `\$CARGO_HOME/bin` to `\$GITHUB_PATH` when it has to install rustup itself, so on the new image `cargo build --release --locked` resolves to the rustup-init shim and exits with:

```
error: unexpected argument 'build' found
Usage: rustup-init[EXE] [OPTIONS]
```

Retries pass only when the runner pool happens to land on an older image generation, which is why the failures look intermittent.

`actions-rust-lang/setup-rust-toolchain@v1` is the actively-maintained successor and prepends `\$CARGO_HOME/bin` to `PATH` unconditionally.

- Swap the action in `ci.yml` (lint, test, build jobs) and `release.yml` (build matrix)
- Set `cache: false` on every invocation so the existing `Swatinem/rust-cache@v2` steps remain the sole cache layer
- Leave the seven Ubuntu-only workflows on dtolnay — they don't hit the bug, and minimal scope keeps the change reviewable

## Test plan

- [x] CI passes for this PR on all three OS runners (Ubuntu, macOS, Windows)
- [x] `Build macos-latest / Build release binary` no longer prints the `rustup-init` error
- [ ] Cache restore still succeeds on macOS (look for "Cache restored from key" in `Setup Rust cache`)