### PR TITLE
refactor(web): bootstrap worker through @mmds/browser-text-metrics/worker

### DIFF
--- a/web/src/worker.test.ts
+++ b/web/src/worker.test.ts
@@ -113,6 +113,7 @@ describe("createWorkerRequestHandler", () => {
       type: "error",
       seq: 42,
       error: "unknown output format: bad",
+      code: "wasm-render-rejected",
     });
   });
 
@@ -287,6 +288,7 @@ describe("createWorkerRequestHandler", () => {
         type: "error",
         seq: 15,
         error: "RenderConfig.graph_text_style is not supported",
+        code: "wasm-config-rejected",
       },
     ]);
   });
@@ -339,9 +341,12 @@ describe("createWorkerRequestHandler", () => {
     });
 
     expect(prepareBrowserTextMetrics).toHaveBeenCalledWith({
-      fontFamily: "Inter",
-      fontSizePx: 16,
-      lineHeightPx: 24,
+      request: {
+        fontFamily: "Inter",
+        fontSizePx: 16,
+        lineHeightPx: 24,
+      },
+      environment: undefined,
     });
     expect(renderWithBrowserTextMetrics).toHaveBeenCalledWith(
       "graph TD\nA-->B",

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -1,133 +1,12 @@
-import {
-  isBrowserTextMetricsCapabilityError,
-  prepareBrowserTextMetrics,
-} from "./browser-text-metrics";
-import { loadWasmModule, type WasmModule } from "./wasm-module";
-import {
-  PROTOCOL_VERSION,
-  type WorkerBrowserTextMetricsDecision,
-  type WorkerRequestMessage,
-  type WorkerResponseMessage,
-} from "./worker-protocol";
-
-export type {
+import { createWorkerRequestHandler } from "@mmds/browser-text-metrics/worker";
+import type {
   WorkerRequestMessage,
   WorkerResponseMessage,
-} from "./worker-protocol";
+} from "@mmds/browser-text-metrics/worker-protocol";
+import { loadWasmModule } from "./wasm-module";
 
-interface RenderRequestHandlerOptions {
-  loadWasmModule?: () => Promise<WasmModule>;
-  prepareBrowserTextMetrics?: typeof prepareBrowserTextMetrics;
-  postMessage: (message: WorkerResponseMessage) => void;
-}
-
-export function createWorkerRequestHandler(
-  options: RenderRequestHandlerOptions,
-): (message: WorkerRequestMessage) => Promise<void> {
-  const loadModule = options.loadWasmModule ?? loadWasmModule;
-  const prepareMetrics =
-    options.prepareBrowserTextMetrics ?? prepareBrowserTextMetrics;
-  const postMessage = options.postMessage;
-  let modulePromise: Promise<WasmModule> | null = null;
-
-  const getWasmModule = async (): Promise<WasmModule> => {
-    if (!modulePromise) {
-      modulePromise = loadModule().then(async (module) => {
-        await module.default();
-        return module;
-      });
-    }
-
-    return modulePromise;
-  };
-
-  return async (message: WorkerRequestMessage): Promise<void> => {
-    try {
-      const wasmModule = await getWasmModule();
-      if (message.type === "render") {
-        const output = wasmModule.render(
-          message.input,
-          message.format,
-          message.configJson,
-        );
-
-        postMessage({
-          version: PROTOCOL_VERSION,
-          type: "result",
-          seq: message.seq,
-          format: message.format,
-          output,
-        });
-        return;
-      }
-
-      if (message.type === "resolveBrowserTextMetrics") {
-        const decisionJson = wasmModule.browserTextMetricsRequest(
-          message.input,
-          message.format,
-          message.configJson,
-        );
-        const decision = JSON.parse(
-          decisionJson,
-        ) as WorkerBrowserTextMetricsDecision;
-
-        postMessage({
-          version: PROTOCOL_VERSION,
-          type: "browserTextMetricsDecision",
-          seq: message.seq,
-          decision,
-        });
-        return;
-      }
-
-      if (message.type === "renderWithBrowserTextMetrics") {
-        const prepared = await prepareMetrics(message.browserTextMetrics);
-        const output = wasmModule.renderWithBrowserTextMetrics(
-          message.input,
-          message.format,
-          message.configJson,
-          prepared.metricsJson,
-          prepared.measureText,
-        );
-
-        postMessage({
-          version: PROTOCOL_VERSION,
-          type: "result",
-          seq: message.seq,
-          format: message.format,
-          output,
-        });
-        return;
-      }
-
-      const resultJson = wasmModule.validate(message.input);
-      postMessage({
-        version: PROTOCOL_VERSION,
-        type: "validation",
-        seq: message.seq,
-        resultJson,
-      });
-    } catch (error) {
-      postMessage({
-        version: PROTOCOL_VERSION,
-        type: "error",
-        seq: message.seq,
-        error: formatError(error),
-        ...(isBrowserTextMetricsCapabilityError(error) && error.fallbackEligible
-          ? { code: "dynamic-metrics-capability" as const }
-          : {}),
-      });
-    }
-  };
-}
-
-function formatError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return String(error);
-}
+export { createWorkerRequestHandler };
+export type { WorkerRequestMessage, WorkerResponseMessage };
 
 interface WorkerScope {
   postMessage: (message: WorkerResponseMessage) => void;
@@ -158,6 +37,7 @@ function getWorkerScope(scope: unknown): WorkerScope | null {
 const workerScope = getWorkerScope(globalThis);
 if (workerScope) {
   const handler = createWorkerRequestHandler({
+    loadWasmModule,
     postMessage: (message) => {
       workerScope.postMessage(message);
     },

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -18,5 +18,9 @@
       ]
     }
   },
-  "include": ["src", "vite.config.ts"]
+  "include": [
+    "src",
+    "vite.config.ts",
+    "../packages/mmds-browser-text-metrics/src/mmds-wasm-shim.d.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- Collapses `web/src/worker.ts` from an in-tree dispatcher into a Vite worker entry that delegates to `createWorkerRequestHandler` from `@mmds/browser-text-metrics/worker`.
- Preserves the playground-only pieces the package can't own: the `window`-aware `getWorkerScope` bootstrap that wires `globalThis.postMessage`/`onmessage`, the locally-injected `loadWasmModule` from `./wasm-module`, and the file location so Vite's `new Worker(new URL("../worker.ts", import.meta.url))` URL still resolves.
- Re-exports `createWorkerRequestHandler` and the `WorkerRequestMessage`/`WorkerResponseMessage` types so downstream playground modules and tests keep importing from `./worker`.

## Contract drift adjusted in `worker.test.ts`

The package handler exposes two differences from the deleted in-tree copy; three assertions are updated to match the public package surface:

- Wasm-thrown errors now surface a `code` field — `wasm-render-rejected` for the generic render throw, `wasm-config-rejected` for messages prefixed `RenderConfig`.
- The injected `prepareBrowserTextMetrics` callback receives an options envelope (`{ request, environment }`) rather than a positional `BrowserTextMetricsRequest`.

## tsconfig include

The worker subpath transitively imports types from the package's `./loader`, whose ambient module declaration for `@mmds/wasm` lives in `mmds-wasm-shim.d.ts` next to the source. The web project type-checks the package via the path mapping in `tsconfig.json`, so the shim is added to `include` for `tsc --noEmit` to resolve the `import("@mmds/wasm")` in `loader.ts`. The `@mmds/wasm` peer is still loaded at runtime by `./wasm-module`, not by the package.

## Test plan

- [x] `cd web && npm test` — 131 passed (22 files)
- [x] `cd web && npm run build` — vite build clean
- [x] `cd web && npm run check` — biome check clean
- [x] `cog check origin/main..HEAD` — clean