### PR TITLE
ci: disable rust-cache cache-bin on macOS-touching jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci-build
+          # macos-15 images (rolled out 2026-05-11) ship rustup state that
+          # collides with cached ~/.cargo/bin contents, leaving `cargo` as
+          # the rustup-init installer. Don't cache rustup binaries.
+          # See Swatinem/rust-cache#341, actions/runner-images#14099.
+          cache-bin: false
 
       - name: Build release binary
         run: cargo build --release --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: release-${{ matrix.target }}
+          # macos-15 images (rolled out 2026-05-11) ship rustup state that
+          # collides with cached ~/.cargo/bin contents, leaving `cargo` as
+          # the rustup-init installer. Don't cache rustup binaries.
+          # See Swatinem/rust-cache#341, actions/runner-images#14099.
+          cache-bin: false
 
       - name: Build binary
         run: cargo build --release --locked --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

Supersedes the PATH-append approach (which didn't actually work) and the prior action-swap (#342) (also didn't actually work). Real root cause traced via [actions/runner-images#14099](https://github.com/actions/runner-images/issues/14099) → [Swatinem/rust-cache#341](https://github.com/Swatinem/rust-cache/issues/341).

The macos-15 and macos-15-arm64 runner images rolled out around 2026-05-11 ship a pre-populated rustup state. `Swatinem/rust-cache@v2` caches `~/.cargo/bin` by default since v2.8 ([PR #325](https://github.com/Swatinem/rust-cache/pull/325)). On the new image, the cache restore step overwrites the freshly-installed rustup proxies with stale binaries that run in installer mode rather than proxy mode. Subsequent `cargo build` calls land on a rustup-init shim and exit with `unexpected argument 'build'`. Retries only pass when the runner pool happens to assign an older image generation — which is why the issue looked intermittent.

The reported workaround is `cache-bin: false`. Apply it to the matrix `build` jobs in `ci.yml` and `release.yml` — the only places that target macOS runners. Lint and Test are Ubuntu-only and not affected.

## Test plan

- [ ] `Build macos-latest / Build release binary` passes on this PR's **first** attempt
- [ ] Cache restore still works (rust-cache log shows the same Cache Paths minus `/Users/runner/.cargo/bin`)
- [ ] Lint and Test jobs still pass