### PR TITLE
refactor(web): wrap @mmds/browser-text-metrics/main-thread for playground response shape

### DIFF
--- a/web/src/services/main-thread-browser-text-metrics.ts
+++ b/web/src/services/main-thread-browser-text-metrics.ts
@@ -1,4 +1,5 @@
-import { prepareMainThreadBrowserTextMetrics } from "../browser-text-metrics";
+import { createMmdsMainThreadRenderer } from "@mmds/browser-text-metrics/main-thread";
+import type { prepareMainThreadBrowserTextMetrics as defaultPrepareMainThreadBrowserTextMetrics } from "../browser-text-metrics";
 import { loadWasmModule, type WasmModule } from "../wasm-module";
 import type {
   BrowserTextMetricsRenderRequest,
@@ -13,45 +14,31 @@ export interface MainThreadBrowserTextMetricsRenderer {
 
 export interface MainThreadBrowserTextMetricsRendererOptions {
   loadWasmModule?: () => Promise<WasmModule>;
-  prepareMainThreadBrowserTextMetrics?: typeof prepareMainThreadBrowserTextMetrics;
+  prepareMainThreadBrowserTextMetrics?: typeof defaultPrepareMainThreadBrowserTextMetrics;
 }
 
 export function createMainThreadBrowserTextMetricsRenderer(
   options: MainThreadBrowserTextMetricsRendererOptions = {},
 ): MainThreadBrowserTextMetricsRenderer {
-  const loadModule = options.loadWasmModule ?? loadWasmModule;
-  const prepareMetrics =
-    options.prepareMainThreadBrowserTextMetrics ??
-    prepareMainThreadBrowserTextMetrics;
-  let modulePromise: Promise<WasmModule> | null = null;
-
-  const getWasmModule = async (): Promise<WasmModule> => {
-    if (!modulePromise) {
-      modulePromise = loadModule().then(async (module) => {
-        await module.default();
-        return module;
-      });
-    }
-
-    return modulePromise;
-  };
+  const prepareLegacy = options.prepareMainThreadBrowserTextMetrics;
+  const renderer = createMmdsMainThreadRenderer({
+    loadWasmModule: options.loadWasmModule ?? loadWasmModule,
+    prepareMainThreadTextMetrics: prepareLegacy
+      ? ({ request }) => prepareLegacy(request)
+      : undefined,
+  });
 
   return {
     renderWithBrowserTextMetrics: async (request) => {
-      const prepared = await prepareMetrics(request.browserTextMetrics);
-      const wasmModule = await getWasmModule();
-      const output = wasmModule.renderWithBrowserTextMetrics(
-        request.input,
-        "svg",
-        request.configJson ?? "{}",
-        prepared.metricsJson,
-        prepared.measureText,
-      );
-
+      const result = await renderer.renderSvg({
+        input: request.input,
+        browserTextMetrics: request.browserTextMetrics,
+        configJson: request.configJson ?? "{}",
+      });
       return {
         seq: request.seq,
         format: "svg",
-        output,
+        output: result.output,
       };
     },
   };

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -5,6 +5,9 @@ import wasm from "vite-plugin-wasm";
 const browserTextMetricsRoot = fileURLToPath(
   new URL("../packages/mmds-browser-text-metrics/src/", import.meta.url),
 );
+const localMmdsWasm = fileURLToPath(
+  new URL("./src/wasm-pkg/mmdflux_wasm.js", import.meta.url),
+);
 
 export default defineConfig({
   plugins: [wasm()],
@@ -17,6 +20,10 @@ export default defineConfig({
       {
         find: /^@mmds\/browser-text-metrics\/(.+)$/,
         replacement: `${browserTextMetricsRoot}$1.ts`,
+      },
+      {
+        find: /^@mmds\/wasm$/,
+        replacement: localMmdsWasm,
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Replace `web/src/services/main-thread-browser-text-metrics.ts` with a thin adapter over `createMmdsMainThreadRenderer` from `@mmds/browser-text-metrics/main-thread`. The wrapper continues to accept the playground's `loadWasmModule` and `prepareMainThreadBrowserTextMetrics` overrides — forwarded through the package's loader and prepare seams — and converts the package's `MmdsRenderResult` into the existing `RenderResponse` shape (`seq` + `format` + `output`) so `render-client.ts` and `bootstrap.ts` stay untouched.
- Add a vite resolve alias from `@mmds/wasm` to the playground's local `src/wasm-pkg/mmdflux_wasm.js`. The package's `loader.ts` holds a static `import("@mmds/wasm")` reference even when callers inject their own `loadWasmModule`, so without the alias Vite cannot resolve the package graph from the web app. Same Rust source builds both the package peer and the playground's `wasm-pkg`, so the shape matches.

## Test plan

- [x] `cog check origin/main..HEAD` — no errored commits
- [x] `cd web && ./node_modules/.bin/vitest run` — 22 files / 131 tests pass, including the four existing regressions in `src/main-thread-browser-text-metrics.test.ts`
- [x] `cd web && npm run build` — tsc + vite build clean
- [x] `cd web && npm run check` — biome clean
- [ ] Manual smoke: playground main-thread fallback still renders dynamic SVG when the worker reports a `dynamic-metrics-capability` error