### PR TITLE
test(mmds-browser-text-metrics): migrate adapter tests from playground

### DIFF
--- a/packages/mmds-browser-text-metrics/test/_fixtures.ts
+++ b/packages/mmds-browser-text-metrics/test/_fixtures.ts
@@ -1,0 +1,297 @@
+import { vi } from "vitest";
+import type {
+  BrowserTextMetricsEnvironment,
+  MainThreadBrowserTextMetricsEnvironment,
+} from "../src/prepare.js";
+import type {
+  WorkerRequestMessage,
+  WorkerResponseMessage,
+} from "../src/worker-protocol.js";
+
+export interface FakeTextMetrics {
+  width: number;
+}
+
+export interface FakeCanvasContext {
+  font: string;
+  measureText: (text: string) => FakeTextMetrics;
+}
+
+export interface FakeFontFaceSet {
+  load: (cssFont: string) => Promise<unknown[]>;
+  ready: Promise<unknown>;
+  check: (cssFont: string) => boolean;
+}
+
+export function fontSetFixture(
+  overrides: Partial<FakeFontFaceSet> = {},
+): FakeFontFaceSet {
+  return {
+    load: vi.fn(async () => [{}]),
+    ready: Promise.resolve(),
+    check: vi.fn(() => true),
+    ...overrides,
+  };
+}
+
+export function environmentFixture(
+  fonts: FakeFontFaceSet | undefined = fontSetFixture(),
+) {
+  const context: FakeCanvasContext = {
+    font: "",
+    measureText: vi.fn((text: string) => ({ width: text.length * 3 })),
+  };
+  class FakeOffscreenCanvas {
+    getContext(type: string): FakeCanvasContext | null {
+      return type === "2d" ? context : null;
+    }
+  }
+
+  const environment: BrowserTextMetricsEnvironment = {
+    OffscreenCanvas: FakeOffscreenCanvas,
+    fonts,
+  };
+
+  return { context, environment };
+}
+
+export function mainThreadEnvironmentFixture(
+  fonts: FakeFontFaceSet | undefined = fontSetFixture(),
+) {
+  const context: FakeCanvasContext = {
+    font: "",
+    measureText: vi.fn((text: string) => ({ width: text.length * 3 })),
+  };
+  const canvas = {
+    getContext: (type: "2d"): FakeCanvasContext | null =>
+      type === "2d" ? context : null,
+  };
+  const document = {
+    fonts,
+    createElement: vi.fn(function (
+      this: unknown,
+      tagName: "canvas",
+    ): typeof canvas {
+      if (this !== document) {
+        throw new Error("createElement lost document receiver");
+      }
+      if (tagName !== "canvas") {
+        throw new Error(`unexpected element: ${tagName}`);
+      }
+      return canvas;
+    }),
+  };
+  const environment: MainThreadBrowserTextMetricsEnvironment = { document };
+
+  return { context, environment };
+}
+
+export function multiStyleRequest() {
+  return {
+    defaultStyle: "s0",
+    textStyles: [
+      {
+        id: "s0",
+        fontFamily: "Inter",
+        fontSize: 16,
+        lineHeight: 24,
+        fontStyle: "normal",
+        fontWeight: "400",
+      },
+      {
+        id: "s1",
+        fontFamily: "Verdana",
+        fontSize: 8,
+        lineHeight: 12,
+        fontStyle: "normal",
+        fontWeight: "400",
+      },
+    ],
+  };
+}
+
+export interface MockWasmModule {
+  default: () => Promise<void>;
+  browserTextMetricsRequest: (
+    input: string,
+    format: string,
+    configJson: string,
+  ) => string;
+  render: (input: string, format: string, configJson: string) => string;
+  renderWithBrowserTextMetrics: (
+    input: string,
+    format: string,
+    configJson: string,
+    metricsJson: string,
+    measureText: (text: string, cssFont: string) => number,
+  ) => string;
+  validate: (input: string) => string;
+}
+
+export function wasmModuleFixture(
+  renderWithBrowserTextMetrics = vi.fn(
+    (
+      input: string,
+      format: string,
+      configJson: string,
+      metricsJson: string,
+      callback: (text: string, cssFont: string) => number,
+    ) =>
+      `${format}:${input}:${configJson}:${metricsJson}:${callback("A", "font")}`,
+  ),
+) {
+  const initialize = vi.fn(async () => {});
+  const browserTextMetricsRequest = vi.fn(() => '{"required":false}');
+  const render = vi.fn(() => "static unused");
+  const validate = vi.fn(() => '{"valid":true}');
+  const module: MockWasmModule = {
+    default: initialize,
+    browserTextMetricsRequest,
+    render,
+    renderWithBrowserTextMetrics,
+    validate,
+  };
+
+  return {
+    initialize,
+    module,
+    browserTextMetricsRequest,
+    render,
+    renderWithBrowserTextMetrics,
+    validate,
+  };
+}
+
+export interface MockRenderWorkerOptions {
+  dynamicResponse?: WorkerResponseMessage;
+  resolverResponse?: WorkerResponseMessage;
+  suppressDynamicResponse?: boolean;
+  throwOnDynamicPost?: boolean;
+  throwOnResolverPost?: boolean;
+}
+
+export class MockRenderWorker {
+  onmessage: ((event: MessageEvent<WorkerResponseMessage>) => void) | null =
+    null;
+  messages: WorkerRequestMessage[] = [];
+
+  constructor(private readonly options: MockRenderWorkerOptions = {}) {}
+
+  postMessage(message: WorkerRequestMessage): void {
+    this.messages.push(message);
+    if (
+      message.type === "renderWithBrowserTextMetrics" &&
+      this.options.throwOnDynamicPost
+    ) {
+      throw new Error("worker post failed");
+    }
+    if (
+      message.type === "resolveBrowserTextMetrics" &&
+      this.options.throwOnResolverPost
+    ) {
+      throw new Error("worker post failed");
+    }
+
+    if (!this.onmessage) {
+      throw new Error("worker message handler was not installed");
+    }
+
+    queueMicrotask(() => {
+      if (message.type === "render") {
+        this.onmessage?.({
+          data: {
+            version: 1,
+            type: "result",
+            seq: message.seq,
+            format: message.format,
+            output: `${message.format}:${message.input}:${message.configJson}`,
+          },
+        } as MessageEvent<WorkerResponseMessage>);
+        return;
+      }
+
+      if (message.type === "renderWithBrowserTextMetrics") {
+        if (this.options.suppressDynamicResponse) return;
+        if (this.options.dynamicResponse) {
+          this.onmessage?.({
+            data: { ...this.options.dynamicResponse, seq: message.seq },
+          } as MessageEvent<WorkerResponseMessage>);
+          return;
+        }
+        this.onmessage?.({
+          data: {
+            version: 1,
+            type: "result",
+            seq: message.seq,
+            format: message.format,
+            output: `${message.format}:${message.input}:${message.configJson}:${message.browserTextMetrics.fontFamily}`,
+          },
+        } as MessageEvent<WorkerResponseMessage>);
+        return;
+      }
+
+      if (message.type === "resolveBrowserTextMetrics") {
+        if (this.options.resolverResponse) {
+          this.onmessage?.({
+            data: { ...this.options.resolverResponse, seq: message.seq },
+          } as MessageEvent<WorkerResponseMessage>);
+          return;
+        }
+        this.onmessage?.({
+          data: {
+            version: 1,
+            type: "browserTextMetricsDecision",
+            seq: message.seq,
+            decision: {
+              required: message.input.includes("font-family"),
+              browserTextMetrics: message.input.includes("font-family")
+                ? {
+                    defaultStyle: "s0",
+                    textStyles: [
+                      {
+                        id: "s0",
+                        fontFamily: "Verdana",
+                        fontSize: 8,
+                        fontStyle: "normal",
+                        fontWeight: "400",
+                        lineHeight: 12,
+                        cssFont: "8px Verdana",
+                      },
+                    ],
+                  }
+                : undefined,
+            },
+          },
+        } as MessageEvent<WorkerResponseMessage>);
+        return;
+      }
+
+      this.onmessage?.({
+        data: {
+          version: 1,
+          type: "validation",
+          seq: message.seq,
+          resultJson: '{"valid":true}',
+        },
+      } as MessageEvent<WorkerResponseMessage>);
+    });
+  }
+
+  terminate(): void {}
+}
+
+export function mainThreadRendererFixture(output = "main-thread-svg") {
+  return {
+    renderSvg: vi.fn(
+      async (request: {
+        input: string;
+        browserTextMetrics: unknown;
+        configJson?: string;
+      }) => ({
+        output: `${output}:${request.input}`,
+        format: "svg" as const,
+        source: "main-thread" as const,
+      }),
+    ),
+  };
+}

--- a/packages/mmds-browser-text-metrics/test/playground-browser-text-metrics.test.ts
+++ b/packages/mmds-browser-text-metrics/test/playground-browser-text-metrics.test.ts
@@ -1,35 +1,35 @@
 import { describe, expect, it, vi } from "vitest";
+import { MmdsBrowserTextMetricsCapabilityError } from "../src/capability.js";
+import { buildCssFont } from "../src/css-font.js";
+import {
+  type MainThreadBrowserTextMetricsEnvironment,
+  prepareMainThreadTextMetrics,
+  prepareWorkerTextMetrics,
+} from "../src/prepare.js";
 import {
   environmentFixture,
   fontSetFixture,
   mainThreadEnvironmentFixture,
   multiStyleRequest,
-} from "./__test-fixtures__/browser-text-metrics-fakes";
-import {
-  BrowserTextMetricsCapabilityError,
-  buildCssFont,
-  type MainThreadBrowserTextMetricsEnvironment,
-  prepareBrowserTextMetrics,
-  prepareMainThreadBrowserTextMetrics,
-} from "./browser-text-metrics";
+} from "./_fixtures.js";
 
-describe("prepareBrowserTextMetrics", () => {
+describe("prepareWorkerTextMetrics (migrated playground)", () => {
   it("fails honestly without OffscreenCanvas", async () => {
     await expect(
-      prepareBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
-        { fonts: fontSetFixture() },
-      ),
+      prepareWorkerTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        environment: { fonts: fontSetFixture() },
+      }),
     ).rejects.toMatchObject({
       code: "worker-offscreen-canvas-unavailable",
       fallbackEligible: true,
     });
     await expect(
-      prepareBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
-        { fonts: fontSetFixture() },
-      ),
-    ).rejects.toBeInstanceOf(BrowserTextMetricsCapabilityError);
+      prepareWorkerTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        environment: { fonts: fontSetFixture() },
+      }),
+    ).rejects.toBeInstanceOf(MmdsBrowserTextMetricsCapabilityError);
   });
 
   it("fails honestly without worker FontFaceSet support", async () => {
@@ -37,10 +37,10 @@ describe("prepareBrowserTextMetrics", () => {
     environment.fonts = undefined;
 
     await expect(
-      prepareBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      prepareWorkerTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
         environment,
-      ),
+      }),
     ).rejects.toMatchObject({
       code: "worker-font-face-set-unavailable",
       fallbackEligible: true,
@@ -55,13 +55,13 @@ describe("prepareBrowserTextMetrics", () => {
     }
 
     await expect(
-      prepareBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
-        {
+      prepareWorkerTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+        environment: {
           OffscreenCanvas: FakeOffscreenCanvasWithout2dContext,
           fonts: fontSetFixture(),
         },
-      ),
+      }),
     ).rejects.toMatchObject({
       code: "worker-canvas-2d-context-unavailable",
       fallbackEligible: true,
@@ -83,10 +83,10 @@ describe("prepareBrowserTextMetrics", () => {
     });
     const { environment } = environmentFixture(fonts);
 
-    const prepared = await prepareBrowserTextMetrics(
-      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+    const prepared = await prepareWorkerTextMetrics({
+      request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
       environment,
-    );
+    });
 
     expect(fonts.load).toHaveBeenCalledWith('normal 400 16px "Inter"');
     expect(fonts.check).toHaveBeenCalledWith('normal 400 16px "Inter"');
@@ -118,10 +118,10 @@ describe("prepareBrowserTextMetrics", () => {
     );
 
     await expect(
-      prepareBrowserTextMetrics(
-        { fontFamily: "Arial", fontSizePx: 16, lineHeightPx: 24 },
+      prepareWorkerTextMetrics({
+        request: { fontFamily: "Arial", fontSizePx: 16, lineHeightPx: 24 },
         environment,
-      ),
+      }),
     ).resolves.toMatchObject({
       metricsJson: expect.stringContaining('"fontFamily":"Arial"'),
     });
@@ -129,31 +129,29 @@ describe("prepareBrowserTextMetrics", () => {
 
   it("does not classify failed post-load checks as fallback-eligible", async () => {
     const { environment } = environmentFixture(
-      fontSetFixture({
-        check: vi.fn(() => false),
-      }),
+      fontSetFixture({ check: vi.fn(() => false) }),
     );
 
     await expect(
-      prepareBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      prepareWorkerTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
         environment,
-      ),
+      }),
     ).rejects.toThrow("unavailable");
     await expect(
-      prepareBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      prepareWorkerTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
         environment,
-      ),
+      }),
     ).rejects.not.toMatchObject({ fallbackEligible: true });
   });
 
   it("returns a synchronous finite width from canvas measureText", async () => {
     const { context, environment } = environmentFixture();
-    const prepared = await prepareBrowserTextMetrics(
-      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+    const prepared = await prepareWorkerTextMetrics({
+      request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
       environment,
-    );
+    });
 
     expect(prepared.measureText("Alpha", 'normal 400 16px "Inter"')).toBe(15);
     expect(context.font).toBe('normal 400 16px "Inter"');
@@ -161,10 +159,10 @@ describe("prepareBrowserTextMetrics", () => {
 
   it("caches repeated exact text and font measurements", async () => {
     const { context, environment } = environmentFixture();
-    const prepared = await prepareBrowserTextMetrics(
-      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+    const prepared = await prepareWorkerTextMetrics({
+      request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
       environment,
-    );
+    });
 
     prepared.measureText("Alpha", 'normal 400 16px "Inter"');
     prepared.measureText("Alpha", 'normal 400 16px "Inter"');
@@ -177,10 +175,10 @@ describe("prepareBrowserTextMetrics", () => {
     const fonts = fontSetFixture();
     const { context, environment } = environmentFixture(fonts);
 
-    const prepared = await prepareBrowserTextMetrics(
-      multiStyleRequest(),
+    const prepared = await prepareWorkerTextMetrics({
+      request: multiStyleRequest(),
       environment,
-    );
+    });
 
     expect(fonts.load).toHaveBeenCalledWith('normal 400 16px "Inter"');
     expect(fonts.load).toHaveBeenCalledWith('normal 400 8px "Verdana"');
@@ -227,7 +225,10 @@ describe("prepareBrowserTextMetrics", () => {
     );
 
     await expect(
-      prepareBrowserTextMetrics(multiStyleRequest(), environment),
+      prepareWorkerTextMetrics({
+        request: multiStyleRequest(),
+        environment,
+      }),
     ).rejects.toThrow("Verdana");
   });
 
@@ -249,22 +250,26 @@ describe("prepareBrowserTextMetrics", () => {
     ).toBe('normal 400 16px "Arial", "Trebuchet MS", sans-serif');
 
     await expect(
-      prepareBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 0, lineHeightPx: 24 },
-        environmentFixture().environment,
-      ),
+      prepareWorkerTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 0, lineHeightPx: 24 },
+        environment: environmentFixture().environment,
+      }),
     ).rejects.toThrow("fontSize");
 
     await expect(
-      prepareBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: Number.NaN },
-        environmentFixture().environment,
-      ),
+      prepareWorkerTextMetrics({
+        request: {
+          fontFamily: "Inter",
+          fontSizePx: 16,
+          lineHeightPx: Number.NaN,
+        },
+        environment: environmentFixture().environment,
+      }),
     ).rejects.toThrow("lineHeight");
 
     await expect(
-      prepareBrowserTextMetrics(
-        {
+      prepareWorkerTextMetrics({
+        request: {
           defaultStyle: "s0",
           textStyles: [
             {
@@ -277,13 +282,13 @@ describe("prepareBrowserTextMetrics", () => {
             },
           ],
         },
-        environmentFixture().environment,
-      ),
+        environment: environmentFixture().environment,
+      }),
     ).rejects.toThrow("fontSize");
 
     await expect(
-      prepareBrowserTextMetrics(
-        {
+      prepareWorkerTextMetrics({
+        request: {
           defaultStyle: "s0",
           textStyles: [
             {
@@ -296,13 +301,13 @@ describe("prepareBrowserTextMetrics", () => {
             },
           ],
         },
-        environmentFixture().environment,
-      ),
+        environment: environmentFixture().environment,
+      }),
     ).rejects.toThrow("lineHeight");
   });
 });
 
-describe("prepareMainThreadBrowserTextMetrics", () => {
+describe("prepareMainThreadTextMetrics (migrated playground)", () => {
   it("prepares main-thread metrics with document fonts and a canvas", async () => {
     const calls: string[] = [];
     const fonts = fontSetFixture({
@@ -318,10 +323,10 @@ describe("prepareMainThreadBrowserTextMetrics", () => {
     });
     const { context, environment } = mainThreadEnvironmentFixture(fonts);
 
-    const prepared = await prepareMainThreadBrowserTextMetrics(
-      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+    const prepared = await prepareMainThreadTextMetrics({
+      request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
       environment,
-    );
+    });
 
     expect(calls).toEqual(["load", "check"]);
     expect(fonts.load).toHaveBeenCalledWith('normal 400 16px "Inter"');
@@ -348,10 +353,10 @@ describe("prepareMainThreadBrowserTextMetrics", () => {
     environment.document.fonts = undefined;
 
     await expect(
-      prepareMainThreadBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      prepareMainThreadTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
         environment,
-      ),
+      }),
     ).rejects.toMatchObject({
       code: "main-thread-font-face-set-unavailable",
       fallbackEligible: false,
@@ -369,10 +374,10 @@ describe("prepareMainThreadBrowserTextMetrics", () => {
     };
 
     await expect(
-      prepareMainThreadBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      prepareMainThreadTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
         environment,
-      ),
+      }),
     ).rejects.toMatchObject({
       code: "main-thread-canvas-2d-context-unavailable",
       fallbackEligible: false,
@@ -381,35 +386,33 @@ describe("prepareMainThreadBrowserTextMetrics", () => {
 
   it("does not classify main-thread unavailable fonts as fallback-eligible", async () => {
     const { environment } = mainThreadEnvironmentFixture(
-      fontSetFixture({
-        check: vi.fn(() => false),
-      }),
+      fontSetFixture({ check: vi.fn(() => false) }),
     );
 
     await expect(
-      prepareMainThreadBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      prepareMainThreadTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
         environment,
-      ),
+      }),
     ).rejects.toThrow("unavailable");
     await expect(
-      prepareMainThreadBrowserTextMetrics(
-        { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+      prepareMainThreadTextMetrics({
+        request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
         environment,
-      ),
+      }),
     ).rejects.not.toMatchObject({ fallbackEligible: true });
   });
 
   it("caches repeated main-thread measurements per prepared provider", async () => {
     const { context, environment } = mainThreadEnvironmentFixture();
-    const first = await prepareMainThreadBrowserTextMetrics(
-      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+    const first = await prepareMainThreadTextMetrics({
+      request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
       environment,
-    );
-    const second = await prepareMainThreadBrowserTextMetrics(
-      { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
+    });
+    const second = await prepareMainThreadTextMetrics({
+      request: { fontFamily: "Inter", fontSizePx: 16, lineHeightPx: 24 },
       environment,
-    );
+    });
 
     first.measureText("Alpha", 'normal 400 16px "Inter"');
     first.measureText("Alpha", 'normal 400 16px "Inter"');

--- a/packages/mmds-browser-text-metrics/test/playground-main-thread.test.ts
+++ b/packages/mmds-browser-text-metrics/test/playground-main-thread.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
-import { wasmModuleFixture } from "./__test-fixtures__/wasm-module";
-import { createMainThreadBrowserTextMetricsRenderer } from "./services/main-thread-browser-text-metrics";
-import type { BrowserTextMetricsRenderRequest } from "./services/render-client";
+import { createMmdsMainThreadRenderer } from "../src/main-thread.js";
+import { wasmModuleFixture } from "./_fixtures.js";
 
-function renderRequest(
-  overrides: Partial<BrowserTextMetricsRenderRequest> = {},
-): BrowserTextMetricsRenderRequest {
+interface RequestShape {
+  input: string;
+  configJson?: string;
+  browserTextMetrics: {
+    fontFamily: string;
+    fontSizePx: number;
+    lineHeightPx: number;
+  };
+}
+
+function dynamicRequest(overrides: Partial<RequestShape> = {}): RequestShape {
   return {
-    seq: 13,
     input: "graph TD\nA-->B",
     configJson: "{}",
     browserTextMetrics: {
@@ -19,13 +25,13 @@ function renderRequest(
   };
 }
 
-describe("createMainThreadBrowserTextMetricsRenderer", () => {
-  it("does not import or initialize wasm at service construction time", () => {
+describe("createMmdsMainThreadRenderer (migrated playground)", () => {
+  it("does not import or initialize wasm at construction time", () => {
     const loadWasmModule = vi.fn(async () => wasmModuleFixture().module);
 
-    createMainThreadBrowserTextMetricsRenderer({
+    createMmdsMainThreadRenderer({
       loadWasmModule,
-      prepareMainThreadBrowserTextMetrics: vi.fn(),
+      prepareMainThreadTextMetrics: vi.fn(),
     });
 
     expect(loadWasmModule).not.toHaveBeenCalled();
@@ -33,29 +39,34 @@ describe("createMainThreadBrowserTextMetricsRenderer", () => {
 
   it("prepares main-thread metrics and calls the dynamic wasm export", async () => {
     const measureText = vi.fn(() => 42);
-    const prepareMainThreadBrowserTextMetrics = vi.fn(async () => ({
+    const prepareMainThreadTextMetrics = vi.fn(async () => ({
       metricsJson: '{"cssFont":"16px Inter"}',
       measureText,
     }));
     const fixture = wasmModuleFixture();
     const loadWasmModule = vi.fn(async () => fixture.module);
-    const renderer = createMainThreadBrowserTextMetricsRenderer({
+    const renderer = createMmdsMainThreadRenderer({
       loadWasmModule,
-      prepareMainThreadBrowserTextMetrics,
+      prepareMainThreadTextMetrics,
     });
-    const request = renderRequest();
+    const request = dynamicRequest();
 
     await expect(
-      renderer.renderWithBrowserTextMetrics(request),
+      renderer.renderSvg({
+        input: request.input,
+        browserTextMetrics: request.browserTextMetrics,
+        configJson: request.configJson,
+      }),
     ).resolves.toEqual({
-      seq: request.seq,
-      format: "svg",
       output: 'svg:graph TD\nA-->B:{}:{"cssFont":"16px Inter"}:42',
+      format: "svg",
+      source: "main-thread",
     });
 
-    expect(prepareMainThreadBrowserTextMetrics).toHaveBeenCalledWith(
-      request.browserTextMetrics,
-    );
+    expect(prepareMainThreadTextMetrics).toHaveBeenCalledWith({
+      request: request.browserTextMetrics,
+      environment: undefined,
+    });
     expect(fixture.renderWithBrowserTextMetrics).toHaveBeenCalledWith(
       request.input,
       "svg",
@@ -69,7 +80,7 @@ describe("createMainThreadBrowserTextMetricsRenderer", () => {
   it("initializes wasm once and prepares fresh metrics for each render", async () => {
     const firstMeasure = vi.fn(() => 1);
     const secondMeasure = vi.fn(() => 2);
-    const prepareMainThreadBrowserTextMetrics = vi
+    const prepareMainThreadTextMetrics = vi
       .fn()
       .mockResolvedValueOnce({
         metricsJson: '{"cssFont":"first"}',
@@ -81,32 +92,41 @@ describe("createMainThreadBrowserTextMetricsRenderer", () => {
       });
     const fixture = wasmModuleFixture();
     const loadWasmModule = vi.fn(async () => fixture.module);
-    const renderer = createMainThreadBrowserTextMetricsRenderer({
+    const renderer = createMmdsMainThreadRenderer({
       loadWasmModule,
-      prepareMainThreadBrowserTextMetrics,
+      prepareMainThreadTextMetrics,
     });
 
-    await renderer.renderWithBrowserTextMetrics(renderRequest({ seq: 1 }));
-    await renderer.renderWithBrowserTextMetrics(renderRequest({ seq: 2 }));
+    await renderer.renderSvg({
+      input: dynamicRequest().input,
+      browserTextMetrics: dynamicRequest().browserTextMetrics,
+    });
+    await renderer.renderSvg({
+      input: dynamicRequest().input,
+      browserTextMetrics: dynamicRequest().browserTextMetrics,
+    });
 
     expect(loadWasmModule).toHaveBeenCalledTimes(1);
     expect(fixture.initialize).toHaveBeenCalledTimes(1);
-    expect(prepareMainThreadBrowserTextMetrics).toHaveBeenCalledTimes(2);
+    expect(prepareMainThreadTextMetrics).toHaveBeenCalledTimes(2);
     expect(firstMeasure).toHaveBeenCalledTimes(1);
     expect(secondMeasure).toHaveBeenCalledTimes(1);
   });
 
   it("rejects preparation failures without loading wasm", async () => {
     const loadWasmModule = vi.fn(async () => wasmModuleFixture().module);
-    const renderer = createMainThreadBrowserTextMetricsRenderer({
+    const renderer = createMmdsMainThreadRenderer({
       loadWasmModule,
-      prepareMainThreadBrowserTextMetrics: vi.fn(async () => {
+      prepareMainThreadTextMetrics: vi.fn(async () => {
         throw new Error("Dynamic text metrics require document.fonts");
       }),
     });
 
     await expect(
-      renderer.renderWithBrowserTextMetrics(renderRequest()),
+      renderer.renderSvg({
+        input: dynamicRequest().input,
+        browserTextMetrics: dynamicRequest().browserTextMetrics,
+      }),
     ).rejects.toThrow("document.fonts");
     expect(loadWasmModule).not.toHaveBeenCalled();
   });

--- a/packages/mmds-browser-text-metrics/test/playground-render-client.test.ts
+++ b/packages/mmds-browser-text-metrics/test/playground-render-client.test.ts
@@ -1,18 +1,14 @@
 import { describe, expect, it } from "vitest";
-import {
-  MockWorker,
-  mainThreadRendererFixture,
-} from "./__test-fixtures__/mock-render-worker";
-import { createRenderWorkerClient } from "./services/render-client";
-import { PROTOCOL_VERSION } from "./worker-protocol";
+import { createMmdsBrowserTextMetricsClient } from "../src/client.js";
+import { PROTOCOL_VERSION } from "../src/worker-protocol.js";
+import { MockRenderWorker, mainThreadRendererFixture } from "./_fixtures.js";
 
-describe("createRenderWorkerClient", () => {
+describe("createMmdsBrowserTextMetricsClient (migrated playground)", () => {
   it("routes render and validation requests over the same worker", async () => {
-    const worker = new MockWorker();
-    const client = createRenderWorkerClient(worker as unknown as Worker);
+    const worker = new MockRenderWorker();
+    const client = createMmdsBrowserTextMetricsClient({ worker });
 
-    const renderPromise = client.render({
-      seq: 7,
+    const renderPromise = client.renderStatic({
       input: "graph TD\nA-->B",
       format: "svg",
       configJson: '{"padding":2}',
@@ -20,19 +16,18 @@ describe("createRenderWorkerClient", () => {
     const validatePromise = client.validate("graph TD\nA-->B");
 
     await expect(renderPromise).resolves.toEqual({
-      seq: 7,
       format: "svg",
       output: 'svg:graph TD\nA-->B:{"padding":2}',
+      source: "worker",
     });
     await expect(validatePromise).resolves.toBe('{"valid":true}');
   });
 
-  it("resolves browser text metrics decisions by sequence id", async () => {
-    const worker = new MockWorker();
-    const client = createRenderWorkerClient(worker as unknown as Worker);
+  it("resolves browser text metrics decisions and posts a resolveBrowserTextMetrics message", async () => {
+    const worker = new MockRenderWorker();
+    const client = createMmdsBrowserTextMetricsClient({ worker });
 
     const response = await client.resolveBrowserTextMetricsRequest({
-      seq: 21,
       input: "graph TD\nA[Regular]\nstyle A font-family:Verdana,font-size:8px",
       format: "svg",
       configJson: "{}",
@@ -55,10 +50,9 @@ describe("createRenderWorkerClient", () => {
         ],
       },
     });
-    expect(worker.messages.at(-1)).toEqual({
+    expect(worker.messages.at(-1)).toMatchObject({
       version: PROTOCOL_VERSION,
       type: "resolveBrowserTextMetrics",
-      seq: 21,
       input: "graph TD\nA[Regular]\nstyle A font-family:Verdana,font-size:8px",
       format: "svg",
       configJson: "{}",
@@ -66,19 +60,18 @@ describe("createRenderWorkerClient", () => {
   });
 
   it("propagates browser text metrics resolver errors", async () => {
-    const worker = new MockWorker({
+    const worker = new MockRenderWorker({
       resolverResponse: {
         version: PROTOCOL_VERSION,
         type: "error",
-        seq: 22,
+        seq: 0,
         error: "RenderConfig.graph_text_style is not supported",
       },
     });
-    const client = createRenderWorkerClient(worker as unknown as Worker);
+    const client = createMmdsBrowserTextMetricsClient({ worker });
 
     await expect(
       client.resolveBrowserTextMetricsRequest({
-        seq: 22,
         input: "graph TD\nA-->B",
         format: "svg",
         configJson: '{"fontFamily":"Inter","fontSize":16}',
@@ -87,17 +80,15 @@ describe("createRenderWorkerClient", () => {
   });
 
   it("keeps resolver, render, and validation responses independent", async () => {
-    const worker = new MockWorker();
-    const client = createRenderWorkerClient(worker as unknown as Worker);
+    const worker = new MockRenderWorker();
+    const client = createMmdsBrowserTextMetricsClient({ worker });
 
     const resolverPromise = client.resolveBrowserTextMetricsRequest({
-      seq: 31,
       input: "graph TD\nA[Regular]\nstyle A font-family:Verdana,font-size:8px",
       format: "svg",
       configJson: "{}",
     });
-    const renderPromise = client.render({
-      seq: 32,
+    const renderPromise = client.renderStatic({
       input: "graph TD\nA-->B",
       format: "svg",
       configJson: "{}",
@@ -106,22 +97,19 @@ describe("createRenderWorkerClient", () => {
 
     await expect(resolverPromise).resolves.toMatchObject({ required: true });
     await expect(renderPromise).resolves.toEqual({
-      seq: 32,
       format: "svg",
       output: "svg:graph TD\nA-->B:{}",
+      source: "worker",
     });
     await expect(validatePromise).resolves.toBe('{"valid":true}');
   });
 
   it("posts dynamic browser text metrics render requests separately", async () => {
-    const worker = new MockWorker();
-    const mainThreadRenderer = mainThreadRendererFixture();
-    const client = createRenderWorkerClient(worker as unknown as Worker, {
-      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
-    });
+    const worker = new MockRenderWorker();
+    const fallback = mainThreadRendererFixture();
+    const client = createMmdsBrowserTextMetricsClient({ worker, fallback });
 
-    const response = await client.renderWithBrowserTextMetrics({
-      seq: 11,
+    const response = await client.renderSvg({
       input: "graph TD\nA-->B",
       configJson: "{}",
       browserTextMetrics: {
@@ -131,18 +119,15 @@ describe("createRenderWorkerClient", () => {
       },
     });
 
-    expect(
-      mainThreadRenderer.renderWithBrowserTextMetrics,
-    ).not.toHaveBeenCalled();
+    expect(fallback.renderSvg).not.toHaveBeenCalled();
     expect(response).toEqual({
-      seq: 11,
       format: "svg",
       output: "svg:graph TD\nA-->B:{}:Inter",
+      source: "worker",
     });
-    expect(worker.messages.at(-1)).toEqual({
+    expect(worker.messages.at(-1)).toMatchObject({
       version: PROTOCOL_VERSION,
       type: "renderWithBrowserTextMetrics",
-      seq: 11,
       input: "graph TD\nA-->B",
       format: "svg",
       configJson: "{}",
@@ -155,23 +140,20 @@ describe("createRenderWorkerClient", () => {
   });
 
   it("falls back to main-thread dynamic rendering on worker capability errors", async () => {
-    const worker = new MockWorker({
+    const worker = new MockRenderWorker({
       dynamicResponse: {
         version: PROTOCOL_VERSION,
         type: "error",
-        seq: 11,
+        seq: 0,
         error: "Dynamic text metrics require OffscreenCanvas in the worker.",
         code: "dynamic-metrics-capability",
       },
     });
-    const mainThreadRenderer = mainThreadRendererFixture();
-    const client = createRenderWorkerClient(worker as unknown as Worker, {
-      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
-    });
+    const fallback = mainThreadRendererFixture();
+    const client = createMmdsBrowserTextMetricsClient({ worker, fallback });
 
     await expect(
-      client.renderWithBrowserTextMetrics({
-        seq: 11,
+      client.renderSvg({
         input: "graph TD\nA-->B",
         configJson: "{}",
         browserTextMetrics: {
@@ -180,27 +162,24 @@ describe("createRenderWorkerClient", () => {
           lineHeightPx: 24,
         },
       }),
-    ).resolves.toEqual({
-      seq: 11,
+    ).resolves.toMatchObject({
       format: "svg",
-      output: "main-thread-svg",
+      source: "main-thread",
     });
-    expect(
-      mainThreadRenderer.renderWithBrowserTextMetrics,
-    ).toHaveBeenCalledTimes(1);
+    expect(fallback.renderSvg).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to main-thread dynamic rendering when the worker does not respond", async () => {
-    const worker = new MockWorker({ suppressDynamicResponse: true });
-    const mainThreadRenderer = mainThreadRendererFixture();
-    const client = createRenderWorkerClient(worker as unknown as Worker, {
-      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
+    const worker = new MockRenderWorker({ suppressDynamicResponse: true });
+    const fallback = mainThreadRendererFixture();
+    const client = createMmdsBrowserTextMetricsClient({
+      worker,
+      fallback,
       dynamicMetricsWorkerTimeoutMs: 1,
     });
 
     await expect(
-      client.renderWithBrowserTextMetrics({
-        seq: 14,
+      client.renderSvg({
         input: "graph TD\nA-->B",
         configJson: "{}",
         browserTextMetrics: {
@@ -209,33 +188,27 @@ describe("createRenderWorkerClient", () => {
           lineHeightPx: 24,
         },
       }),
-    ).resolves.toEqual({
-      seq: 14,
+    ).resolves.toMatchObject({
       format: "svg",
-      output: "main-thread-svg",
+      source: "main-thread",
     });
-    expect(
-      mainThreadRenderer.renderWithBrowserTextMetrics,
-    ).toHaveBeenCalledTimes(1);
+    expect(fallback.renderSvg).toHaveBeenCalledTimes(1);
   });
 
   it("does not fallback on ordinary dynamic worker errors", async () => {
-    const worker = new MockWorker({
+    const worker = new MockRenderWorker({
       dynamicResponse: {
         version: PROTOCOL_VERSION,
         type: "error",
-        seq: 12,
+        seq: 0,
         error: "Dynamic text metrics unavailable for font Inter.",
       },
     });
-    const mainThreadRenderer = mainThreadRendererFixture();
-    const client = createRenderWorkerClient(worker as unknown as Worker, {
-      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
-    });
+    const fallback = mainThreadRendererFixture();
+    const client = createMmdsBrowserTextMetricsClient({ worker, fallback });
 
     await expect(
-      client.renderWithBrowserTextMetrics({
-        seq: 12,
+      client.renderSvg({
         input: "graph TD\nA-->B",
         configJson: "{}",
         browserTextMetrics: {
@@ -245,21 +218,16 @@ describe("createRenderWorkerClient", () => {
         },
       }),
     ).rejects.toThrow("unavailable");
-    expect(
-      mainThreadRenderer.renderWithBrowserTextMetrics,
-    ).not.toHaveBeenCalled();
+    expect(fallback.renderSvg).not.toHaveBeenCalled();
   });
 
   it("does not fallback when posting dynamic requests fails", async () => {
-    const worker = new MockWorker({ throwOnDynamicPost: true });
-    const mainThreadRenderer = mainThreadRendererFixture();
-    const client = createRenderWorkerClient(worker as unknown as Worker, {
-      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
-    });
+    const worker = new MockRenderWorker({ throwOnDynamicPost: true });
+    const fallback = mainThreadRendererFixture();
+    const client = createMmdsBrowserTextMetricsClient({ worker, fallback });
 
     await expect(
-      client.renderWithBrowserTextMetrics({
-        seq: 13,
+      client.renderSvg({
         input: "graph TD\nA-->B",
         configJson: "{}",
         browserTextMetrics: {
@@ -268,24 +236,18 @@ describe("createRenderWorkerClient", () => {
           lineHeightPx: 24,
         },
       }),
-    ).rejects.toThrow("failed to post dynamic render request");
-    expect(
-      mainThreadRenderer.renderWithBrowserTextMetrics,
-    ).not.toHaveBeenCalled();
+    ).rejects.toThrow(/post|render/i);
+    expect(fallback.renderSvg).not.toHaveBeenCalled();
   });
 
   it("does not use main-thread dynamic rendering for validation", async () => {
-    const worker = new MockWorker();
-    const mainThreadRenderer = mainThreadRendererFixture();
-    const client = createRenderWorkerClient(worker as unknown as Worker, {
-      mainThreadBrowserTextMetricsRenderer: mainThreadRenderer,
-    });
+    const worker = new MockRenderWorker();
+    const fallback = mainThreadRendererFixture();
+    const client = createMmdsBrowserTextMetricsClient({ worker, fallback });
 
     await expect(client.validate("graph TD\nA-->B")).resolves.toBe(
       '{"valid":true}',
     );
-    expect(
-      mainThreadRenderer.renderWithBrowserTextMetrics,
-    ).not.toHaveBeenCalled();
+    expect(fallback.renderSvg).not.toHaveBeenCalled();
   });
 });

--- a/packages/mmds-browser-text-metrics/test/playground-worker.test.ts
+++ b/packages/mmds-browser-text-metrics/test/playground-worker.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
-import type { MockWasmModule } from "./__test-fixtures__/wasm-module";
-import { BrowserTextMetricsCapabilityError } from "./browser-text-metrics";
-import { createWorkerRequestHandler } from "./worker";
+import { MmdsBrowserTextMetricsCapabilityError } from "../src/capability.js";
+import { createWorkerRequestHandler } from "../src/worker.js";
 import {
   PROTOCOL_VERSION,
   type WorkerRequestMessage,
   type WorkerResponseMessage,
-} from "./worker-protocol";
+} from "../src/worker-protocol.js";
+import type { MockWasmModule } from "./_fixtures.js";
 
-describe("createWorkerRequestHandler", () => {
+describe("createWorkerRequestHandler (migrated playground)", () => {
   it("initializes worker once and returns render results", async () => {
     const initialize = vi.fn(async () => {});
     const render = vi.fn(
@@ -423,7 +423,7 @@ describe("createWorkerRequestHandler", () => {
     const handler = createWorkerRequestHandler({
       loadWasmModule,
       prepareBrowserTextMetrics: vi.fn(async () => {
-        throw new BrowserTextMetricsCapabilityError({
+        throw new MmdsBrowserTextMetricsCapabilityError({
           code: "worker-offscreen-canvas-unavailable",
           message:
             "Dynamic text metrics require OffscreenCanvas in the worker.",
@@ -478,7 +478,7 @@ describe("createWorkerRequestHandler", () => {
     const handler = createWorkerRequestHandler({
       loadWasmModule,
       prepareBrowserTextMetrics: vi.fn(async () => {
-        throw new BrowserTextMetricsCapabilityError({
+        throw new MmdsBrowserTextMetricsCapabilityError({
           code: "main-thread-font-face-set-unavailable",
           message:
             "Dynamic text metrics require document.fonts on the main thread.",


### PR DESCRIPTION
## Summary

- `git mv` the four playground adapter test suites (`browser-text-metrics`, `worker`, `render-client`, `main-thread-browser-text-metrics`) into `packages/mmds-browser-text-metrics/test/playground-*.test.ts` and rebase each onto the package's public APIs.
- Calls switch from the playground-shaped positional signatures (`prepareBrowserTextMetrics(req, env)`) to the package's options envelopes (`prepareWorkerTextMetrics({ request, environment })`); `BrowserTextMetricsCapabilityError` → `MmdsBrowserTextMetricsCapabilityError`; `client.renderWithBrowserTextMetrics(req)` → `createMmdsBrowserTextMetricsClient.renderSvg({...})`; `RenderResponse`-shape assertions become `MmdsRenderResult`-shape (`{ output, format, source }`).
- Render-client tests drop per-call `seq` assertions because `createMmdsBrowserTextMetricsClient` owns its own counter; worker-message assertions use `toMatchObject` so the internal seq is not load-bearing for the migration.
- Add `packages/mmds-browser-text-metrics/test/_fixtures.ts` so the four migrated suites can share `vi.fn`-backed env / font / wasm / worker fakes. Underscore prefix keeps Vitest's `test/**/*.test.ts` glob from picking it up; it's intentionally separate from `src/fixtures.ts` because that file uses a vitest-independent `spy()` factory which doesn't compose with `toHaveBeenCalledWith`.

## Test plan

- [x] `cog check origin/main..HEAD` — no errored commits
- [x] `cd packages && npm test -w @mmds/browser-text-metrics` — 16 files / 173 tests pass, 1 file / 5 tests skipped (packed-wasm, gated on `MMDS_WASM_PACKED=1`)
- [x] `cd web && npm test` — 18 files / 92 tests pass (down from 22 / 131; exactly the 4 migrated files / 39 tests removed)
- [x] `cd web && npm run build` and `npm run check` — clean
- [x] `npx biome check .` in `packages/mmds-browser-text-metrics` — clean