### PR TITLE
test(web): pin dynamic-svg-routing as playground policy, not package contract

### DIFF
--- a/web/src/dynamic-svg-routing.test.ts
+++ b/web/src/dynamic-svg-routing.test.ts
@@ -301,3 +301,16 @@ describe("renderPlaygroundRequest", () => {
     expect(client.render).not.toHaveBeenCalled();
   });
 });
+
+describe("playground routing policy", () => {
+  // renderPlaygroundRequest is the playground's product-policy
+  // orchestrator — which inputs trigger a resolver round-trip, when to
+  // short-circuit, and when to fall through. @mmds/browser-text-metrics
+  // ships mayNeedBrowserTextMetrics for downstream consumers who want the
+  // heuristic, but the orchestration (resolver → render → renderSvg) is a
+  // playground concern. This test exists to pin the boundary so future
+  // contributors don't migrate this file alongside the adapter tests.
+  it("dynamic-svg-routing tests playground product policy, not package contract", () => {
+    expect(typeof renderPlaygroundRequest).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a self-documenting `describe("playground routing policy")` block at the end of `web/src/dynamic-svg-routing.test.ts` that asserts `typeof renderPlaygroundRequest === "function"`. The body is a single comment explaining why this file does not move to `packages/mmds-browser-text-metrics/test/` alongside the four adapter suites: the package owns the wasm-side `browserTextMetricsRequest` decision protocol and ships `mayNeedBrowserTextMetrics` for downstream consumers, but the playground orchestrator (`resolver → render → renderSvg`, with seq routing and fallback sequencing) is product policy, not a portable package contract.
- No production-code change. The new smoke test sits alongside the existing 10 routing scenarios so a future migration sweep has a visible reason to leave this file in place.

## Test plan

- [x] `cog check origin/main..HEAD` — no errored commits
- [x] `cd web && npm test` — 18 files / 93 tests pass (post-2.5 baseline + 1 smoke)
- [x] `cd web && npm run build` and `npm run check` — clean