### PR TITLE
fix: route inline class on subgraph id to subgraph style map

### DIFF
--- a/docs/development/mermaid-style-routing-parity.md
+++ b/docs/development/mermaid-style-routing-parity.md
@@ -1,0 +1,122 @@
+# Mermaid Style Routing Parity
+
+This note captures Mermaid v11's observed behavior when a `style`, `class`,
+or inline `:::` declaration targets an id that is also a subgraph, and how
+mmdflux's style-map routing maps onto it. The scope here is **style routing
+only**. The broader structural collision (mmdflux's IR keeping both
+`nodes["A"]` and `subgraphs["A"]` for an explicit `A[NodeBox] … subgraph A`
+input) affects edge resolution and SVG rendering, is **not** resolved, and is
+tracked separately in #352.
+
+The four inputs below were rendered with `mmdc` (Mermaid v11) and inspected
+for the element that carries the resulting fill. They are reproducible with:
+
+```bash
+mmdc -i input.mmd -o input.svg -q
+```
+
+## Inputs and observed Mermaid output
+
+### 1. Inline `:::` on a subgraph id
+
+```mermaid
+flowchart LR
+subgraph A[Source]
+a1
+end
+classDef blue fill:#e1f5fe
+A:::blue
+```
+
+Mermaid emits `<g class="cluster blue" id="my-svg-A">` for the subgraph; the
+distinctive fill `#e1f5fe` lands on the cluster's `<rect>`. No separate node
+`A` appears under `<g class="nodes">`. The cluster carries the class.
+
+mmdflux now matches: the inline class merges into `subgraph_styles["A"]`,
+and the spurious implicit node created by edge-parsing for `A:::blue` is
+pruned. The two maps stay independent.
+
+### 2. `class` statement on a subgraph id
+
+```mermaid
+flowchart LR
+subgraph A[Source]
+a1
+end
+classDef blue fill:#e1f5fe
+class A blue
+```
+
+Output is identical to case 1: `<g class="cluster blue" id="my-svg-A">`.
+Mermaid treats inline `A:::blue` and `class A blue` as the same routing.
+
+mmdflux already routed `class A blue` to the subgraph via `merge_target_style`;
+the inline path is now aligned with it.
+
+### 3. Explicit node then subgraph with same id (`class` statement)
+
+```mermaid
+flowchart LR
+A[NodeBox]
+subgraph A
+a1
+end
+classDef blue fill:#e1f5fe
+class A blue
+```
+
+Mermaid emits `<g class="cluster blue" id="my-svg-A">`. There is no
+coexisting node `A` under `<g class="nodes">` — Mermaid's unified id
+namespace folds the prior `A[NodeBox]` into the subgraph cluster.
+
+**mmdflux's style routing matches** (the class merges into the subgraph
+style map; the node style map for id `A` stays unstyled), **but** the
+structural collision is unresolved. mmdflux's IR keeps `nodes["A"]` alive
+alongside `subgraphs["A"]`. Tracked in #352.
+
+### 4. Explicit node then subgraph with same id (`style` statement)
+
+```mermaid
+flowchart LR
+A[NodeBox]
+subgraph A
+a1
+end
+style A fill:#ffebee
+```
+
+Mermaid emits `<g class="cluster" id="my-svg-A">` with the cluster `<rect>`
+carrying `fill:#ffebee !important`. Same conclusion as case 3: only the
+cluster carries the style. mmdflux's style routing matches; the structural
+collision is still tracked in #352.
+
+## mmdflux style-routing rule
+
+`compile_to_graph` collects subgraph ids in a first pass, then routes every
+`style`, `class`, and inline `:::` declaration through `merge_target_style`:
+
+- If the target id matches a known subgraph id → merge into
+  `subgraph_styles`.
+- Otherwise → merge into `node_styles`.
+
+The MMDS `styleMap` and `subgraphStyleMap` stay independent: even when a
+target id appears in both maps (because `A[NodeBox]` and `subgraph A` were
+both declared), the subgraph map is the only one that receives the
+class/style; the node map stays unstyled for that id.
+
+## Unresolved: broader structural collision
+
+The cases above pin **style-map routing only**. mmdflux's IR has separate
+`nodes` and `subgraphs` maps, so when input declares both `A[NodeBox]` and
+`subgraph A` mmdflux keeps both alive. Edge endpoint resolution, parent
+assignment, layout positions, and SVG output all see the collision — for
+example a `subgraph C` enclosing `A[NodeBox] --> B[NodeBox2]` after an
+earlier `subgraph A` rewrites the edge from subgraph `A` via child `a1`
+and stacks the explicit node `A` over the cluster. Mermaid's unified id
+namespace does not reproduce that collision. The rule and fix are tracked
+in #352.
+
+The style-routing tests live in `src/diagrams/flowchart/compiler.rs`:
+
+- `inline_triple_colon_class_on_subgraph_id_applies_to_subgraph`
+- `explicit_node_with_same_id_as_subgraph_keeps_style_maps_independent`

--- a/src/diagrams/flowchart/compiler.rs
+++ b/src/diagrams/flowchart/compiler.rs
@@ -83,7 +83,7 @@ fn process_statements(
             Statement::Vertex(vertex) => {
                 resolve_class_annotation(
                     diagram,
-                    style_targets.node_styles,
+                    style_targets,
                     class_defs,
                     &vertex.id,
                     &vertex.class_name,
@@ -98,7 +98,7 @@ fn process_statements(
             Statement::Edge(edge_spec) => {
                 resolve_class_annotation(
                     diagram,
-                    style_targets.node_styles,
+                    style_targets,
                     class_defs,
                     &edge_spec.from.id,
                     &edge_spec.from.class_name,
@@ -111,7 +111,7 @@ fn process_statements(
                 );
                 resolve_class_annotation(
                     diagram,
-                    style_targets.node_styles,
+                    style_targets,
                     class_defs,
                     &edge_spec.to.id,
                     &edge_spec.to.class_name,
@@ -193,18 +193,21 @@ fn collect_subgraph_ids_recursive(statements: &[Statement], ids: &mut HashSet<St
 }
 
 /// Resolve a `:::className` annotation by looking up the class in the registry
-/// and merging its style into the node's accumulated styles.
+/// and merging its style into the target's accumulated styles. When the target
+/// id matches a declared subgraph, the style routes to the subgraph style map
+/// (the same rule used by `class A foo` and `style A …` statements) rather
+/// than being silently absorbed by a soon-to-be-pruned spurious node.
 fn resolve_class_annotation(
     diagram: &mut Graph,
-    node_styles: &mut HashMap<String, NodeStyle>,
+    style_targets: &mut StyleTargets<'_>,
     class_defs: &ClassDefRegistry,
-    node_id: &str,
+    target_id: &str,
     class_name: &Option<String>,
 ) {
     if let Some(cn) = class_name
         && let Some(style) = class_defs.get(cn)
     {
-        merge_node_style(diagram, node_styles, node_id, style);
+        merge_target_style(diagram, style_targets, target_id, style);
     }
 }
 
@@ -303,6 +306,13 @@ fn merge_subgraph_style(
     }
 }
 
+/// Route a style declaration to the appropriate style map.
+///
+/// When `target_id` matches a declared subgraph id, the style merges into the
+/// subgraph style map; otherwise it merges into the node style map. This rule
+/// is shared by `style A …`, `class A foo`, and inline `A:::foo`. The two
+/// style maps are kept independent, so MMDS `styleMap` and `subgraphStyleMap`
+/// never collide on a shared id even when the input declares both.
 fn merge_target_style(
     diagram: &mut Graph,
     style_targets: &mut StyleTargets<'_>,
@@ -868,6 +878,69 @@ mod tests {
         assert_eq!(style.fill.as_ref().map(|c| c.raw()), Some("#e1f5fe"));
         assert_eq!(style.stroke.as_ref().map(|c| c.raw()), Some("#b71c1c"));
         assert_eq!(style.stroke_width.as_deref(), Some("2px"));
+    }
+
+    #[test]
+    fn inline_triple_colon_class_on_subgraph_id_applies_to_subgraph() {
+        // `A:::blue` after `subgraph A …` previously routed through the node
+        // style map and was silently discarded by the spurious-node cleanup.
+        // It now routes the same way as `class A blue` and `style A …`, which
+        // matches Mermaid's observed behavior — see
+        // docs/development/mermaid-style-routing-parity.md.
+        let input =
+            "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef blue fill:#e1f5fe\nA:::blue\n";
+        let flowchart = parse_flowchart(input).unwrap();
+        let diagram = compile_to_graph(&flowchart);
+
+        assert_eq!(
+            diagram.subgraphs["A"].style.fill.as_ref().map(|c| c.raw()),
+            Some("#e1f5fe"),
+        );
+        assert!(!diagram.nodes.contains_key("A"));
+    }
+
+    #[test]
+    fn explicit_node_with_same_id_as_subgraph_keeps_style_maps_independent() {
+        // mmdflux can structurally hold both a node and a subgraph with the
+        // same id when an explicit `A[Box]` precedes `subgraph A`. Mermaid's
+        // unified id namespace does not reproduce this — its parser folds the
+        // node into the cluster. The broader structural collision (edge
+        // resolution, parent assignment, layout overlap) is unresolved and
+        // tracked in issue #352. This test pins the style-map routing slice
+        // only: every style/class declaration targeting a subgraph id routes
+        // to the subgraph, the node style map stays independent, and MMDS
+        // `styleMap` and `subgraphStyleMap` never collide on the shared id.
+        // See docs/development/mermaid-style-routing-parity.md.
+        let input = concat!(
+            "flowchart LR\n",
+            "A[NodeBox]\n",
+            "subgraph A\n",
+            "a1\n",
+            "end\n",
+            "classDef blue fill:#e1f5fe\n",
+            "class A blue\n",
+            "style A stroke:#b71c1c\n",
+        );
+        let flowchart = parse_flowchart(input).unwrap();
+        let diagram = compile_to_graph(&flowchart);
+
+        let sg_style = &diagram.subgraphs["A"].style;
+        assert_eq!(
+            sg_style.fill.as_ref().map(|c| c.raw()),
+            Some("#e1f5fe"),
+            "subgraph receives classDef fill",
+        );
+        assert_eq!(
+            sg_style.stroke.as_ref().map(|c| c.raw()),
+            Some("#b71c1c"),
+            "subgraph receives direct style stroke",
+        );
+
+        let node_style = &diagram.nodes["A"].style;
+        assert!(
+            node_style.fill.is_none() && node_style.stroke.is_none(),
+            "node A keeps its independent (unstyled) entry",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR is the **style-routing slice** of the broader node/subgraph id collision problem.

- Inline `A:::class` now flows through `merge_target_style`, the same router used by `class A foo` and `style A …`. When the target id matches a declared subgraph, the style merges into `subgraph_styles`; otherwise it merges into `node_styles`. Previously, inline class annotations targeting a subgraph id were silently dropped — they merged into the node style map and were then discarded by the spurious-node cleanup in `resolve_subgraph_edges`. That silent drop could have undermined the per-element font-style claim made in #320.
- MMDS `styleMap` and `subgraphStyleMap` stay independent. Even if an explicit `A[NodeBox]` precedes `subgraph A`, the node entry stays unstyled while the subgraph receives the styling.
- Mermaid v11 comparison evidence is captured in `docs/development/mermaid-style-routing-parity.md`. Four collision-case `.mmd` inputs rendered via `mmdc` show that Mermaid applies inline `A:::blue` and `class A blue` identically (both target the cluster). mmdflux now matches Mermaid for the style-map slice.

## Out of scope

The broader **structural** collision is **not** resolved here. mmdflux's IR can simultaneously hold `nodes["A"]` and `subgraphs["A"]` (Mermaid's parser collapses the namespace; mmdflux does not), and that collision affects edge endpoint resolution, parent assignment, layout positions, and SVG render overlap. The structural rule and fix are tracked in #352. The parity note added by this PR explicitly flags the structural collision as unresolved.

This PR uses `Refs #336` rather than `Closes #336` because the original issue's framing (`Define style routing for node and subgraph ID collisions`) is broader than the style-map slice landed here. The maintainer can decide whether to close #336 after #352 lands or use #336 as the umbrella.

## Test plan

- [x] `cargo nextest run -E 'test(/diagrams::flowchart::compiler/)'` — 84/84 passing, including the two new pinning tests:
  - `inline_triple_colon_class_on_subgraph_id_applies_to_subgraph`
  - `explicit_node_with_same_id_as_subgraph_keeps_style_maps_independent`
- [x] `just test` — 3099/3099 passing (run on the pre-amend version; the doc/comment edits in the amend cannot affect tests)
- [x] `just lint` — clean
- [x] `just architecture-check` — clean
- [x] `cog check origin/main..HEAD` — clean
- [x] Mermaid comparison fixtures re-rendered via `mmdc` and the observed cluster/node attributes recorded in the parity note