### PR TITLE
fix: tighten OSC 11 parsing and add $COLORFGBG appearance fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,6 +1472,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "windows-sys 0.52.0",
+ "xterm-color",
 ]
 
 [[package]]
@@ -4173,6 +4174,12 @@ dependencies = [
  "tracing-subscriber",
  "ttf-parser",
 ]
+
+[[package]]
+name = "xterm-color"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7008a9d8ba97a7e47d9b2df63fcdb8dade303010c5a7cd5bf2469d4da6eba673"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1"
 thiserror = "2"
 tracing = { version = "0.1.44", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.23", optional = true, default-features = false, features = ["std", "fmt", "ansi", "env-filter", "json"] }
+xterm-color = { version = "1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = [
@@ -40,7 +41,7 @@ windows-sys = { version = "0.52", features = [
 # Keep CLI behavior by default while allowing library/Wasm users to opt out.
 default = ["cli"]
 # CLI-only dependency surface.
-cli = ["dep:clap", "dep:libc", "dep:tracing-subscriber", "dep:windows-sys"]
+cli = ["dep:clap", "dep:libc", "dep:tracing-subscriber", "dep:windows-sys", "dep:xterm-color"]
 engine-elk = []
 # Experimental bridge for callback-backed browser text measurement. This is
 # intentionally disabled by default and only consumed by mmdflux-wasm.

--- a/README.md
+++ b/README.md
@@ -228,6 +228,22 @@ SVG theming is opt-in and affects SVG output only.
 - **Dynamic mode is additive.** `--svg-theme-mode dynamic` emits the same hex fallbacks plus root CSS variables and a `<style>` block for browser embedding.
 - **Default auto-theme mapping is `light:default,dark:dark`.** Override it with `--svg-theme-auto=light:zinc-light,dark:dracula` when a different light/dark pair is a better fit.
 
+#### Detecting terminal appearance inside tmux/screen
+
+`--svg-theme-auto` probes the terminal's background color via OSC 11. Inside a
+multiplexer (tmux/screen) the query is intercepted by default, so mmdflux falls
+back to `$COLORFGBG` and then to the OS-level theme — none of which track a
+terminal profile switch. For tmux ≥ 3.3, enable passthrough so OSC 11 reaches
+the outer terminal:
+
+```tmux
+set -g allow-passthrough on
+set -as terminal-features ',*:RGB:OSC11'
+```
+
+This fixes background detection for every tool that queries OSC 11, not just
+mmdflux.
+
 ### Built-in themes
 
 | Theme               | Family            |

--- a/src/terminal_appearance.rs
+++ b/src/terminal_appearance.rs
@@ -33,7 +33,37 @@ const OSC_11_READ_DEADLINE: Duration = Duration::from_millis(500);
 const TRACE_POST_LOGICAL_RESTORE_WINDOW: Duration = Duration::from_millis(250);
 
 pub(crate) fn detect_terminal_appearance() -> Option<TerminalAppearance> {
-    detect_osc_terminal_appearance()
+    detect_osc_terminal_appearance().or_else(detect_colorfgbg_appearance)
+}
+
+#[cfg(any(unix, windows))]
+fn detect_colorfgbg_appearance() -> Option<TerminalAppearance> {
+    let value = env::var("COLORFGBG").ok()?;
+    parse_colorfgbg(&value)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn detect_colorfgbg_appearance() -> Option<TerminalAppearance> {
+    None
+}
+
+fn parse_colorfgbg(value: &str) -> Option<TerminalAppearance> {
+    // COLORFGBG is set by xterm/rxvt/urxvt/konsole at startup. Format is
+    // either `<fg>;<bg>` or the urxvt variant `<fg>;default;<bg>`. The last
+    // `;`-separated field is the background palette index; `default` (or any
+    // non-numeric token) yields no verdict. Require at least one `;` so a
+    // stray single-field value can't be misread as a background index.
+    value.find(';')?;
+    let bg = value.rsplit(';').next()?.trim();
+    if bg.is_empty() || bg.eq_ignore_ascii_case("default") {
+        return None;
+    }
+    let bg = bg.parse::<u32>().ok()?;
+    if bg < 8 {
+        Some(TerminalAppearance::Dark)
+    } else {
+        Some(TerminalAppearance::Light)
+    }
 }
 
 pub(crate) fn detect_os_appearance() -> Option<TerminalAppearance> {
@@ -244,48 +274,45 @@ fn read_additional_chunks(
 
 #[cfg(any(unix, windows))]
 fn parse_terminal_appearance(response: &[u8]) -> Option<TerminalAppearance> {
-    let (red, green, blue) = parse_rgb_triplet(response)?;
-    let luminance =
-        ((u32::from(red) * 299) + (u32::from(green) * 587) + (u32::from(blue) * 114)) / 1000;
-    if luminance < 128 {
+    let body = extract_osc_11_payload(response)?;
+    let color = xterm_color::Color::parse(body).ok()?;
+    if color.perceived_lightness() < 0.5 {
         Some(TerminalAppearance::Dark)
     } else {
         Some(TerminalAppearance::Light)
     }
 }
 
+/// Strips the `\x1b]11;` introducer and `\x07` / `\x1b\\` terminator from an
+/// OSC 11 response, returning the color-spec payload. Surrounding ASCII
+/// whitespace is trimmed so `xterm_color::Color::parse` sees only the
+/// color string itself.
 #[cfg(any(unix, windows))]
-fn parse_rgb_triplet(response: &[u8]) -> Option<(u8, u8, u8)> {
-    let response = String::from_utf8_lossy(response);
-    let rgb = response.split_once("rgb:")?.1;
-    let mut components = rgb.split('/');
-    let red = normalize_component(leading_hex_component(components.next()?))?;
-    let green = normalize_component(leading_hex_component(components.next()?))?;
-    let blue = normalize_component(leading_hex_component(components.next()?))?;
-    Some((red, green, blue))
-}
+fn extract_osc_11_payload(response: &[u8]) -> Option<&[u8]> {
+    const PREFIX: &[u8] = b"\x1b]11;";
+    let start = response.windows(PREFIX.len()).position(|w| w == PREFIX)?;
+    let body = &response[start + PREFIX.len()..];
 
-#[cfg(any(unix, windows))]
-fn leading_hex_component(component: &str) -> &str {
-    let len = component
-        .bytes()
-        .take_while(|byte| byte.is_ascii_hexdigit())
-        .count();
-    &component[..len]
-}
+    let bel = body.iter().position(|&b| b == 0x07);
+    let st = body.windows(2).position(|w| w == b"\x1b\\");
+    let end = match (bel, st) {
+        (Some(a), Some(b)) => a.min(b),
+        (Some(a), None) => a,
+        (None, Some(b)) => b,
+        (None, None) => body.len(),
+    };
 
-#[cfg(any(unix, windows))]
-fn normalize_component(component: &str) -> Option<u8> {
-    if component.is_empty() || !component.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return None;
-    }
-
-    let value = u32::from_str_radix(component, 16).ok()?;
-    let max = (16_u32)
-        .checked_pow(component.len() as u32)?
-        .checked_sub(1)?;
-    let normalized = ((value * 255) + (max / 2)) / max;
-    u8::try_from(normalized).ok()
+    let payload = &body[..end];
+    let leading = payload
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .unwrap_or(payload.len());
+    let trailing = payload
+        .iter()
+        .rev()
+        .position(|b| !b.is_ascii_whitespace())
+        .unwrap_or(0);
+    Some(&payload[leading..payload.len() - trailing])
 }
 
 #[cfg(any(unix, windows))]
@@ -1037,4 +1064,150 @@ fn win_read_additional_chunks(
     }
 
     Ok(response.len().saturating_sub(initial_len))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(any(unix, windows))]
+    fn osc_bel(payload: &[u8]) -> Vec<u8> {
+        let mut buffer = Vec::with_capacity(payload.len() + 6);
+        buffer.extend_from_slice(b"\x1b]11;");
+        buffer.extend_from_slice(payload);
+        buffer.push(0x07);
+        buffer
+    }
+
+    #[cfg(any(unix, windows))]
+    fn osc_st(payload: &[u8]) -> Vec<u8> {
+        let mut buffer = Vec::with_capacity(payload.len() + 7);
+        buffer.extend_from_slice(b"\x1b]11;");
+        buffer.extend_from_slice(payload);
+        buffer.extend_from_slice(b"\x1b\\");
+        buffer
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn parses_rgb_with_short_components() {
+        assert_eq!(
+            parse_terminal_appearance(&osc_bel(b"rgb:0/0/0")),
+            Some(TerminalAppearance::Dark)
+        );
+        assert_eq!(
+            parse_terminal_appearance(&osc_bel(b"rgb:f/f/f")),
+            Some(TerminalAppearance::Light)
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn parses_rgb_with_two_three_four_hex_components() {
+        assert_eq!(
+            parse_terminal_appearance(&osc_bel(b"rgb:1e/1e/1e")),
+            Some(TerminalAppearance::Dark)
+        );
+        assert_eq!(
+            parse_terminal_appearance(&osc_bel(b"rgb:fff/fff/fff")),
+            Some(TerminalAppearance::Light)
+        );
+        assert_eq!(
+            parse_terminal_appearance(&osc_bel(b"rgb:1e1e/1e1e/1e1e")),
+            Some(TerminalAppearance::Dark)
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn parses_sharp_form() {
+        assert_eq!(
+            parse_terminal_appearance(&osc_bel(b"#ffffff")),
+            Some(TerminalAppearance::Light)
+        );
+        assert_eq!(
+            parse_terminal_appearance(&osc_bel(b"#000000")),
+            Some(TerminalAppearance::Dark)
+        );
+        // `#RGB` short form is bit-shifted (per xparsecolor): `#222` becomes
+        // `#202020...` in 16-bit space, a clear dark gray.
+        assert_eq!(
+            parse_terminal_appearance(&osc_bel(b"#222")),
+            Some(TerminalAppearance::Dark)
+        );
+        assert_eq!(
+            parse_terminal_appearance(&osc_bel(b"#fff")),
+            Some(TerminalAppearance::Light)
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn parses_rgba_low_alpha_does_not_drop_verdict() {
+        // rxvt-unicode with transparency. The dark RGB triplet must still
+        // produce a Dark verdict even though the alpha component is non-max.
+        assert_eq!(
+            parse_terminal_appearance(&osc_bel(b"rgba:0000/0000/4444/cccc")),
+            Some(TerminalAppearance::Dark)
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn parses_st_terminated_response() {
+        assert_eq!(
+            parse_terminal_appearance(&osc_st(b"rgb:ffff/ffff/ffff")),
+            Some(TerminalAppearance::Light)
+        );
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn rejects_malformed_response() {
+        assert_eq!(parse_terminal_appearance(b""), None);
+        assert_eq!(parse_terminal_appearance(b"\x1b]11;not-a-color\x07"), None);
+        // Missing OSC introducer.
+        assert_eq!(parse_terminal_appearance(b"rgb:00/00/00"), None);
+        assert_eq!(parse_terminal_appearance(&osc_bel(b"rgb:gg/gg/gg")), None);
+        // Empty OSC body must not yield a verdict.
+        assert_eq!(parse_terminal_appearance(b"\x1b]11;\x07"), None);
+        assert_eq!(parse_terminal_appearance(b"\x1b]11;\x1b\\"), None);
+    }
+
+    #[test]
+    fn colorfgbg_two_field_form() {
+        assert_eq!(parse_colorfgbg("15;0"), Some(TerminalAppearance::Dark));
+        assert_eq!(parse_colorfgbg("0;15"), Some(TerminalAppearance::Light));
+        assert_eq!(parse_colorfgbg("7;7"), Some(TerminalAppearance::Dark));
+        assert_eq!(parse_colorfgbg("7;8"), Some(TerminalAppearance::Light));
+    }
+
+    #[test]
+    fn colorfgbg_three_field_form() {
+        // urxvt-style `<fg>;default;<bg>`.
+        assert_eq!(
+            parse_colorfgbg("15;default;0"),
+            Some(TerminalAppearance::Dark)
+        );
+        assert_eq!(
+            parse_colorfgbg("0;default;15"),
+            Some(TerminalAppearance::Light)
+        );
+    }
+
+    #[test]
+    fn colorfgbg_skips_default_or_malformed_bg() {
+        // Background `default` means no verdict.
+        assert_eq!(parse_colorfgbg("7;default"), None);
+        assert_eq!(parse_colorfgbg("15;default;default"), None);
+        // Non-numeric background → no verdict.
+        assert_eq!(parse_colorfgbg("7;banana"), None);
+        // Empty / single-field is rejected.
+        assert_eq!(parse_colorfgbg(""), None);
+        assert_eq!(parse_colorfgbg(";"), None);
+        // A single field with no `;` is not a valid COLORFGBG value even if
+        // it happens to parse as a number — require at least one separator.
+        assert_eq!(parse_colorfgbg("7"), None);
+        assert_eq!(parse_colorfgbg("default"), None);
+    }
 }


### PR DESCRIPTION
## Summary

- Replace the hand-rolled OSC 11 parser with `xterm_color::Color::parse` so `#RRGGBB`, `rgb:` (1–4 hex digit components), and `rgba:` (rxvt-with-transparency) all parse instead of falling through. Verdict now uses gamma-correct sRGB → CIELAB L* via `perceived_lightness` instead of BT.601-on-encoded-bytes, fixing flips in mid-range colors.
- Strip the `\x1b]11;` introducer and `\x07` / `\x1b\\` terminator before parsing.
- Add a `$COLORFGBG` fallback tier between OSC 11 and OS-level detection. The last `;`-separated field is the background palette index (`< 8` → Dark, `≥ 8` → Light); `default` and non-numeric values yield no verdict.
- Document the tmux ≥ 3.3 `allow-passthrough` / `OSC11` knob in the SVG theming section of the README.

Closes #324

## Test plan

- [x] `just lint` (clippy + fmt) clean
- [x] `cargo xtask architecture check` passes
- [x] `just test` — all 3127 tests pass; 12 new unit tests cover `#RRGGBB`, `rgb:` short/long forms, `rgba:` low-alpha, BEL/ST terminators, malformed input, and `$COLORFGBG` two- and three-field variants
- [ ] Manual check inside tmux (with and without `allow-passthrough`) to confirm `$COLORFGBG` fallback engages when OSC 11 is intercepted