### PR TITLE
test: pin flowchart edge-endpoint invariant and document no-collisions[] mmds decision

### DIFF
--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -662,6 +662,28 @@ subgraph definition wins: the explicit-node reference is collapsed and a
 `ParseDiagnostic` warning is emitted. Nested subgraphs convey membership via
 their own `parent` field; `children` lists direct nodes only.
 
+### Diagnostic surface for id collisions
+
+The disjoint-ids invariant is enforced at compile time, so the MMDS document
+is the post-collapse view. The collapse is **observable through parse
+diagnostics**, not through MMDS:
+
+- `mmdflux <input>` prints a warning per collision to stderr in human-readable
+  form (subject to `--quiet`).
+- `mmdflux --lint <input>` prints the same diagnostics to stderr and exits 0
+  if the input is otherwise valid.
+- `mmdflux --lint -f json <input>` emits a structured JSON report on stdout
+  that includes the warning under `warnings[]`.
+- Library callers can read `DiagramInstance::validation_warnings()` on the
+  flowchart instance for the same per-collision warnings.
+
+MMDS deliberately does **not** include a top-level `collisions[]` field. The
+document is the renderer-facing geometry; routing collision metadata through
+it would couple the renderer to parser concerns. Consumers who need
+collision detail should call the parse path. See issue
+[#352](https://github.com/kevinswiber/mmdflux/issues/352) for the original
+motivation.
+
 ## Schema
 
 The formal JSON Schema is available at [`docs/mmds.schema.json`](./mmds.schema.json).

--- a/src/diagrams/flowchart/compiler.rs
+++ b/src/diagrams/flowchart/compiler.rs
@@ -980,6 +980,62 @@ A[NodeBox]
     }
 
     #[test]
+    fn edge_from_subgraph_id_resolves_to_real_node_with_from_subgraph_set() {
+        let input = "\
+flowchart LR
+
+subgraph A
+a1
+end
+
+A --> B
+";
+        let flowchart = parse_flowchart(input).expect("parses");
+        let graph = compile_to_graph(&flowchart);
+
+        assert_eq!(graph.edges.len(), 1);
+        let edge = &graph.edges[0];
+        assert_eq!(
+            edge.from, "a1",
+            "from must be the real node, not subgraph A"
+        );
+        assert_eq!(edge.from_subgraph.as_deref(), Some("A"));
+        assert_eq!(edge.to, "B");
+        assert!(graph.nodes.contains_key("a1"));
+        assert!(graph.nodes.contains_key("B"));
+        assert!(graph.subgraphs.contains_key("A"));
+        assert!(!graph.nodes.contains_key("A"));
+    }
+
+    #[test]
+    fn edge_to_nested_subgraph_resolves_through_non_cluster_child() {
+        let input = "\
+flowchart LR
+
+top
+
+subgraph Outer
+  subgraph Inner
+    leaf
+  end
+end
+
+top --> Outer
+";
+        let flowchart = parse_flowchart(input).expect("parses");
+        let graph = compile_to_graph(&flowchart);
+
+        assert_eq!(graph.edges.len(), 1);
+        let edge = &graph.edges[0];
+        assert_eq!(edge.from, "top");
+        assert_eq!(edge.to, "leaf", "to must drill through to the real node");
+        assert_eq!(edge.to_subgraph.as_deref(), Some("Outer"));
+        assert!(graph.nodes.contains_key("leaf"));
+        assert!(!graph.nodes.contains_key("Outer"));
+        assert!(!graph.nodes.contains_key("Inner"));
+    }
+
+    #[test]
     fn test_build_simple_diagram() {
         let flowchart = parse_flowchart("graph TD\nA --> B\n").unwrap();
         let diagram = compile_to_graph(&flowchart);

--- a/src/internal_tests/edge_endpoint_invariant.rs
+++ b/src/internal_tests/edge_endpoint_invariant.rs
@@ -1,0 +1,103 @@
+//! Corpus-wide invariant: every compiled flowchart edge's `from`/`to` resolves
+//! to an entry in `Graph.nodes` and never to a `Graph.subgraphs` entry.
+//!
+//! `resolve_subgraph_edges` already satisfies this structurally via
+//! `find_subgraph_sink` and `find_non_cluster_child`; this fixture-walk pins
+//! the property so a future regression to either helper fails loudly without
+//! requiring a render-layer snapshot diff.
+//!
+//! The walker recurses into subdirectories so nested fixtures (e.g.
+//! `dynamic/*.mmd`) are covered, not just the top-level fixture directory.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::diagrams::flowchart::compile_to_graph;
+use crate::mermaid::parse_flowchart;
+
+fn walk_flowchart_fixtures() -> Vec<PathBuf> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("flowchart");
+    let mut out = Vec::new();
+    collect_mmd_recursive(&dir, &mut out);
+    out.sort();
+    out
+}
+
+fn collect_mmd_recursive(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries =
+        fs::read_dir(dir).unwrap_or_else(|e| panic!("failed to read {}: {e}", dir.display()));
+    for entry in entries {
+        let entry =
+            entry.unwrap_or_else(|e| panic!("failed to read entry in {}: {e}", dir.display()));
+        let p = entry.path();
+        if p.is_dir() {
+            collect_mmd_recursive(&p, out);
+        } else if p.extension().and_then(|s| s.to_str()) == Some("mmd") {
+            out.push(p);
+        }
+    }
+}
+
+#[test]
+fn final_edges_never_reference_a_subgraph_id_as_endpoint() {
+    let mut failures: Vec<String> = Vec::new();
+    let paths = walk_flowchart_fixtures();
+    let canary: PathBuf = ["dynamic", "multi_font_styles.mmd"].iter().collect();
+    assert!(
+        paths.iter().any(|p| p.ends_with(&canary)),
+        "walker must recurse into subdirectories (e.g. flowchart/{})",
+        canary.display(),
+    );
+
+    for path in paths {
+        let input = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+        let flowchart = parse_flowchart(&input).unwrap_or_else(|err| {
+            panic!(
+                "fixture {} must parse permissively (the runtime uses permissive parsing); got {err}",
+                path.display(),
+            )
+        });
+        let graph = compile_to_graph(&flowchart);
+
+        for (i, edge) in graph.edges.iter().enumerate() {
+            if !graph.nodes.contains_key(&edge.from) {
+                failures.push(format!(
+                    "{}: edge[{i}].from = {:?} is not in Graph.nodes (subgraph id leak?)",
+                    path.display(),
+                    edge.from,
+                ));
+            }
+            if !graph.nodes.contains_key(&edge.to) {
+                failures.push(format!(
+                    "{}: edge[{i}].to = {:?} is not in Graph.nodes (subgraph id leak?)",
+                    path.display(),
+                    edge.to,
+                ));
+            }
+            if graph.subgraphs.contains_key(&edge.from) {
+                failures.push(format!(
+                    "{}: edge[{i}].from = {:?} matches a subgraph id; resolve_subgraph_edges should have rewritten it",
+                    path.display(),
+                    edge.from,
+                ));
+            }
+            if graph.subgraphs.contains_key(&edge.to) {
+                failures.push(format!(
+                    "{}: edge[{i}].to = {:?} matches a subgraph id; resolve_subgraph_edges should have rewritten it",
+                    path.display(),
+                    edge.to,
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "edge-endpoint invariant violated:\n{}",
+        failures.join("\n"),
+    );
+}

--- a/src/internal_tests/mod.rs
+++ b/src/internal_tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod composition_probe;
 mod cross_pipeline;
+mod edge_endpoint_invariant;
 mod event_change_mapping;
 mod graph_routing_pipeline;
 mod grid_routing_regression;


### PR DESCRIPTION
## Summary

- Adds a recursive corpus-wide invariant test (`src/internal_tests/edge_endpoint_invariant.rs`) asserting every compiled flowchart edge's `from`/`to` resolves to a real `Graph.nodes` entry and never to a `Graph.subgraphs` entry. The walker recurses into subdirectories so nested fixtures like `tests/fixtures/flowchart/dynamic/*.mmd` are covered, with an inline canary pinning that coverage. `resolve_subgraph_edges` already satisfies the invariant structurally; the sweep guards against regression to `find_subgraph_sink` / `find_non_cluster_child`.
- Adds two narrow regression tests in `src/diagrams/flowchart/compiler.rs` pinning the two lookup paths: an edge declared from a subgraph id is rewritten to the sink real node with `from_subgraph` populated, and an edge whose target names a subgraph containing only sub-subgraphs recurses through `find_non_cluster_child` to a real node id.
- Documents in `docs/mmds.md` the explicit decision NOT to add a `collisions[]` field to MMDS. The diagnostic surface for id collisions is the existing `ParseDiagnostic` warnings stream (CLI `--lint`, structured `--lint -f json`, library `DiagramInstance::validation_warnings`).

Refs #352.

## Test plan

- [x] `cargo nextest run -E 'test(final_edges_never_reference_a_subgraph_id_as_endpoint) | test(edge_from_subgraph_id_resolves_to_real_node_with_from_subgraph_set) | test(edge_to_nested_subgraph_resolves_through_non_cluster_child)'` — 3 passed
- [x] Mutation: stubbing `find_subgraph_sink` to return the subgraph id makes the invariant sweep fail on 5 fixtures and the targeted from-side test fail; reverted before commit.
- [x] Mutation: stubbing `find_non_cluster_child` to return its argument makes the targeted to-side test fail; reverted before commit.
- [x] `just lint`, `just test` (3124 passed, 8 skipped), `cargo xtask architecture check` all green.