### PR TITLE
fix: preserve dashes in mermaid identifier normalization

### DIFF
--- a/src/mmds/mermaid.rs
+++ b/src/mmds/mermaid.rs
@@ -105,10 +105,19 @@ where
 }
 
 fn normalize_identifier(raw: &str, fallback_prefix: &str) -> String {
+    // Interior ASCII dashes are preserved because Mermaid's flowchart lexer
+    // accepts them inside node, subgraph, and class identifiers (the
+    // NODE_STRING / idString tokens include MINUS). Keeping them through
+    // MMDS → Mermaid emission also keeps SVG `id` attributes byte-stable
+    // across the round-trip: see `xml_safe_id` in
+    // src/render/graph/svg/nodes.rs, which already passes dashes through
+    // unchanged. Consecutive dashes are collapsed and leading/trailing
+    // dashes are trimmed because `--` is the edge operator in Mermaid and
+    // would otherwise re-tokenize the identifier.
     let mut normalized: String = raw
         .chars()
         .map(|ch| {
-            if ch.is_ascii_alphanumeric() || ch == '_' {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
                 ch
             } else {
                 '_'
@@ -119,8 +128,13 @@ fn normalize_identifier(raw: &str, fallback_prefix: &str) -> String {
     while normalized.contains("__") {
         normalized = normalized.replace("__", "_");
     }
+    while normalized.contains("--") {
+        normalized = normalized.replace("--", "-");
+    }
 
-    normalized = normalized.trim_matches('_').to_string();
+    normalized = normalized
+        .trim_matches(|ch: char| ch == '_' || ch == '-')
+        .to_string();
     if normalized.is_empty() {
         return fallback_prefix.to_string();
     }

--- a/tests/fixtures/mmds/generation/dash-edge-cases.json
+++ b/tests/fixtures/mmds/generation/dash-edge-cases.json
@@ -17,23 +17,17 @@
   },
   "nodes": [
     {
-      "id": "node 1",
-      "label": "A | B",
+      "id": "-foo--bar-",
+      "label": "First",
       "position": { "x": 40.0, "y": 30.0 },
       "size": { "width": 44.0, "height": 24.0 }
     },
     {
-      "id": "node.1",
+      "id": "foo-bar",
       "label": "Second",
       "position": { "x": 140.0, "y": 30.0 },
-      "size": { "width": 54.0, "height": 24.0 }
+      "size": { "width": 44.0, "height": 24.0 }
     }
   ],
-  "edges": [
-    {
-      "id": "e0",
-      "source": "node 1",
-      "target": "node.1"
-    }
-  ]
+  "edges": []
 }

--- a/tests/fixtures/mmds/generation/dashed-ids.json
+++ b/tests/fixtures/mmds/generation/dashed-ids.json
@@ -13,27 +13,23 @@
   "metadata": {
     "diagram_type": "flowchart",
     "direction": "TD",
-    "bounds": { "width": 220.0, "height": 120.0 }
+    "bounds": { "width": 200.0, "height": 100.0 }
   },
   "nodes": [
     {
-      "id": "node 1",
-      "label": "A | B",
+      "id": "web-server",
+      "label": "Web",
+      "parent": "us-east",
       "position": { "x": 40.0, "y": 30.0 },
       "size": { "width": 44.0, "height": 24.0 }
-    },
-    {
-      "id": "node.1",
-      "label": "Second",
-      "position": { "x": 140.0, "y": 30.0 },
-      "size": { "width": 54.0, "height": 24.0 }
     }
   ],
-  "edges": [
+  "edges": [],
+  "subgraphs": [
     {
-      "id": "e0",
-      "source": "node 1",
-      "target": "node.1"
+      "id": "us-east",
+      "title": "us-east",
+      "children": ["web-server"]
     }
   ]
 }

--- a/tests/mmds_conformance.rs
+++ b/tests/mmds_conformance.rs
@@ -561,14 +561,7 @@ fn sorted_subgraphs(output: &Document) -> Vec<&Subgraph> {
 fn flowchart_visual_uses_replay_smoke(name: &str) -> bool {
     matches!(
         name,
-        "subgraph_as_node_edge.mmd"
-            | "subgraph_to_subgraph_edge.mmd"
-            // SVG wrappers now carry the subgraph id; the Mermaid generator
-            // normalizes non-alphanumeric chars in identifiers (e.g. `-` to `_`),
-            // so byte-identical SVG comparison breaks for fixtures whose source
-            // ids contain such characters. Semantic and layout tiers still
-            // verify the round-trip; visual divergence is the id-attribute only.
-            | "external_node_subgraph.mmd"
+        "subgraph_as_node_edge.mmd" | "subgraph_to_subgraph_edge.mmd"
     )
 }
 

--- a/tests/mmds_mermaid_generation.rs
+++ b/tests/mmds_mermaid_generation.rs
@@ -91,6 +91,47 @@ fn generator_emits_minlen_connector_variants_across_styles() {
 }
 
 #[test]
+fn generator_preserves_dashes_in_subgraph_and_node_ids() {
+    // Mermaid's flowchart lexer accepts interior dashes in node, subgraph,
+    // and class identifiers (NODE_STRING / idString → MINUS). The SVG
+    // emitter's `xml_safe_id` (src/render/graph/svg/nodes.rs) also passes
+    // dashes through unchanged, so the MMDS → Mermaid → SVG round-trip is
+    // byte-stable for dashed ids only when this generator preserves them.
+    // If this assertion regresses, the `external_node_subgraph.mmd` fixture
+    // in tests/mmds_conformance.rs will diverge too — but this test fails
+    // first with a localized message.
+    let mmds = fixture("generation/dashed-ids.json");
+    let mermaid = generate_mermaid_from_str(&mmds).unwrap();
+
+    assert!(
+        mermaid.contains("subgraph us-east"),
+        "expected dashed subgraph id preserved:\n{mermaid}"
+    );
+    assert!(
+        mermaid.contains("web-server[Web]"),
+        "expected dashed node id preserved:\n{mermaid}"
+    );
+}
+
+#[test]
+fn generator_collapses_double_dashes_and_trims_edge_dashes_in_ids() {
+    // Mermaid's `--` token is the edge operator, so the generator must not
+    // emit identifiers containing `--` or starting/ending with `-`. The
+    // collision-suffix path then preserves uniqueness.
+    let mmds = fixture("generation/dash-edge-cases.json");
+    let mermaid = generate_mermaid_from_str(&mmds).unwrap();
+
+    assert!(
+        mermaid.contains("foo-bar[First]"),
+        "expected leading/trailing dashes trimmed and double dashes collapsed:\n{mermaid}"
+    );
+    assert!(
+        mermaid.contains("foo-bar_2[Second]"),
+        "expected collision suffix applied after normalization:\n{mermaid}"
+    );
+}
+
+#[test]
 fn generator_rejects_non_graph_diagram_payloads() {
     let mmds = fixture("generation/non-graph-payload.json");
     let err = generate_mermaid_from_str(&mmds).unwrap_err();


### PR DESCRIPTION
## Summary

- Relax `normalize_identifier` in `src/mmds/mermaid.rs` to preserve interior ASCII dashes (Mermaid's flowchart lexer accepts them in node/subgraph/class ids), collapse `--` (the edge operator) to `-`, and trim leading/trailing dashes so emitted ids remain lexable.
- Re-enable byte-identical visual conformance for `external_node_subgraph.mmd` by dropping it from `flowchart_visual_uses_replay_smoke`.
- Add focused regression tests pinning dash preservation across subgraph + node ids and the edge-case behavior (`--` collapse, leading/trailing dash trim).

Closes #363.

## Test plan

- [x] `just check` (lint + nextest 3170/3170 + architecture gate)
- [x] `flowchart_external_node_subgraph_all_tiers_pass_after_hardening` passes against the byte-identical visual tier
- [x] `generator_preserves_dashes_in_subgraph_and_node_ids` regression test exercises `us-east` / `web-server` ids end-to-end
- [x] `generator_collapses_double_dashes_and_trims_edge_dashes_in_ids` pins the new normalization edge cases