### PR TITLE
feat: configure flowchart subgraph title margin

### DIFF
--- a/src/engines/graph/algorithms/layered/float_layout.rs
+++ b/src/engines/graph/algorithms/layered/float_layout.rs
@@ -118,6 +118,7 @@ pub(crate) fn build_float_layout_with_flags(
         layered_config.label_dummy_placement = flags.label_dummy_placement;
         layered_config.label_dummy_routing = flags.label_dummy_routing;
         layered_config.backward_edge_side_grouping = flags.backward_edge_side_grouping;
+        layered_config.subgraph_title_margin = flags.subgraph_title_margin;
     }
     let edge_label_spacing = layered_config.edge_label_spacing;
     let mut layout = build_layered_layout_with_config(
@@ -141,7 +142,14 @@ pub(crate) fn build_float_layout_with_flags(
         },
         skip_non_isolated_overrides,
     );
-    let title_pad_y = metrics.font_size();
+    // Resolve the rank-axis title margin. `Some({top, bottom})` mirrors
+    // Mermaid's `flowchart.subGraphTitleMargin` exactly; `None` preserves
+    // the original measurement-driven default of one font-size of padding
+    // so existing renders stay byte-identical.
+    let title_pad_y = layered_config
+        .subgraph_title_margin
+        .map(|m| m.total())
+        .unwrap_or_else(|| metrics.font_size());
     let content_pad_y = metrics.font_size() * 0.3;
     reconcile_sublayouts(
         diagram,
@@ -153,7 +161,7 @@ pub(crate) fn build_float_layout_with_flags(
 
     // Expand parent subgraph bounds to encompass repositioned children.
     let child_margin = metrics.node_padding_x().max(metrics.node_padding_y());
-    let title_margin = metrics.font_size();
+    let title_margin = title_pad_y;
     expand_parent_bounds(diagram, &mut layout, child_margin, title_margin);
 
     // Push external nodes that now overlap with reconciled subgraph bounds.

--- a/src/engines/graph/algorithms/layered/kernel/types.rs
+++ b/src/engines/graph/algorithms/layered/kernel/types.rs
@@ -188,6 +188,27 @@ pub enum LabelSideStrategy {
     DirectionDown,
 }
 
+/// Pixel margins around a subgraph's title text, mirroring Mermaid's
+/// `flowchart.subGraphTitleMargin: { top, bottom }` configuration.
+///
+/// The two fields are summed and applied as the rank-axis padding between
+/// the subgraph title and its first member row. `top + bottom` matches
+/// Mermaid's `subGraphTitleTotalMargin`.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct SubgraphTitleMargin {
+    /// Pixels above the subgraph title (Mermaid `subGraphTitleMargin.top`).
+    pub top: f64,
+    /// Pixels below the subgraph title (Mermaid `subGraphTitleMargin.bottom`).
+    pub bottom: f64,
+}
+
+impl SubgraphTitleMargin {
+    /// Total rank-axis space reserved for the title (top + bottom).
+    pub fn total(&self) -> f64 {
+        self.top + self.bottom
+    }
+}
+
 /// Metadata for a dummy node inserted during normalization.
 #[derive(Debug, Clone)]
 pub struct DummyNode {
@@ -392,6 +413,13 @@ pub struct LayoutConfig {
     /// Maximum edge-label width in pixels before greedy wrap kicks in.
     /// `None` disables wrap (dagre-parity fallback).
     pub edge_label_max_width: Option<f64>,
+
+    /// Optional override for the rank-axis margin reserved around a
+    /// subgraph's title, mirroring Mermaid's
+    /// `flowchart.subGraphTitleMargin`. `None` preserves the
+    /// measurement-driven default (one font-size of padding) so existing
+    /// renders are byte-identical.
+    pub subgraph_title_margin: Option<SubgraphTitleMargin>,
 }
 
 impl LayoutConfig {
@@ -432,6 +460,7 @@ impl Default for LayoutConfig {
             edge_label_spacing: 2.0,
             backward_edge_side_grouping: false,
             edge_label_max_width: None,
+            subgraph_title_margin: None,
         }
     }
 }

--- a/src/engines/graph/algorithms/layered/measurement.rs
+++ b/src/engines/graph/algorithms/layered/measurement.rs
@@ -148,6 +148,7 @@ pub fn run_layered_layout(
     lc.label_dummy_placement = layered_cfg.label_dummy_placement;
     lc.label_dummy_routing = layered_cfg.label_dummy_routing;
     lc.backward_edge_side_grouping = layered_cfg.backward_edge_side_grouping;
+    lc.subgraph_title_margin = layered_cfg.subgraph_title_margin;
 
     let direction = diagram.direction;
     let edge_label_spacing = lc.edge_label_spacing;

--- a/src/engines/graph/algorithms/layered/mod.rs
+++ b/src/engines/graph/algorithms/layered/mod.rs
@@ -19,7 +19,7 @@ pub use kernel::graph::DiGraph;
 pub(crate) use kernel::pipeline::layout;
 pub use kernel::types::{
     AcyclicPolicy, Direction, LabelDummyPlacement, LabelDummyRouting, LabelSideStrategy,
-    LayoutConfig, Ranker,
+    LayoutConfig, Ranker, SubgraphTitleMargin,
 };
 #[cfg(test)]
 pub use kernel::types::{EdgeLayout, LayoutResult, NodeId, Point, Rect, SelfEdgeLayout};

--- a/src/engines/graph/layout.rs
+++ b/src/engines/graph/layout.rs
@@ -141,6 +141,64 @@ pub enum LabelSideStrategy {
     DirectionDown,
 }
 
+/// Rank-axis margin reserved around a subgraph's title text, mirroring
+/// Mermaid's `flowchart.subGraphTitleMargin: { top, bottom }` knob.
+///
+/// `top` and `bottom` are in pixels. The values are summed (matching
+/// Mermaid's `subGraphTitleTotalMargin`) and applied as the rank-axis
+/// padding between a subgraph's title and its first member row. Both
+/// fields default to `0.0` when an instance is constructed; in
+/// `LayoutConfig` the entire knob defaults to `None`, which preserves
+/// today's measurement-driven default (one font-size of padding).
+///
+/// **Mermaid parity divergence**: Mermaid's defaults are non-zero
+/// (`{top: 8, bottom: 8}` in v9, `{top: 25, bottom: 5}` in v10+), so an
+/// unset `LayoutConfig::subgraph_title_margin` is intentionally NOT
+/// Mermaid-equivalent — it preserves byte-stable existing renders.
+/// Set `Some(SubgraphTitleMargin { top: 0.0, bottom: 0.0 })` to collapse
+/// the gap entirely, matching Mermaid's literal zero default; set the
+/// pair to match the Mermaid version you are targeting otherwise.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[non_exhaustive]
+pub struct SubgraphTitleMargin {
+    /// Pixels above the subgraph title (Mermaid `subGraphTitleMargin.top`).
+    pub top: f64,
+    /// Pixels below the subgraph title (Mermaid `subGraphTitleMargin.bottom`).
+    pub bottom: f64,
+}
+
+impl SubgraphTitleMargin {
+    /// Construct an explicit `{ top, bottom }` margin pair. Required for
+    /// external callers because the struct is `#[non_exhaustive]`.
+    pub fn new(top: f64, bottom: f64) -> Self {
+        Self { top, bottom }
+    }
+
+    /// Total rank-axis space reserved for the title, matching Mermaid's
+    /// `subGraphTitleTotalMargin = top + bottom` semantics.
+    pub fn total(&self) -> f64 {
+        self.top + self.bottom
+    }
+}
+
+impl From<SubgraphTitleMargin> for crate::engines::graph::algorithms::layered::SubgraphTitleMargin {
+    fn from(value: SubgraphTitleMargin) -> Self {
+        Self {
+            top: value.top,
+            bottom: value.bottom,
+        }
+    }
+}
+
+impl From<crate::engines::graph::algorithms::layered::SubgraphTitleMargin> for SubgraphTitleMargin {
+    fn from(value: crate::engines::graph::algorithms::layered::SubgraphTitleMargin) -> Self {
+        Self {
+            top: value.top,
+            bottom: value.bottom,
+        }
+    }
+}
+
 impl From<LabelSideStrategy> for crate::engines::graph::algorithms::layered::LabelSideStrategy {
     fn from(value: LabelSideStrategy) -> Self {
         match value {
@@ -199,6 +257,12 @@ pub struct LayoutConfig {
     /// Maximum edge-label width in pixels before greedy wrap kicks in.
     /// `None` disables wrap (dagre-parity fallback).
     pub edge_label_max_width: Option<f64>,
+    /// Rank-axis margin reserved around a subgraph's title, mirroring
+    /// Mermaid's `flowchart.subGraphTitleMargin`. `None` preserves the
+    /// measurement-driven default (one font-size of padding) so existing
+    /// renders are byte-identical; `Some({top, bottom})` overrides the
+    /// total reservation with `top + bottom`.
+    pub subgraph_title_margin: Option<SubgraphTitleMargin>,
 }
 
 impl Default for LayoutConfig {
@@ -228,6 +292,10 @@ impl Default for LayoutConfig {
             // wrapped out of the box. Set to `None` to opt out (dagre-parity /
             // unwrapped measurement).
             edge_label_max_width: Some(200.0),
+            // Default `None` keeps today's measurement-driven margin
+            // (one font-size of rank-axis padding). Set `Some({top, bottom})`
+            // to match Mermaid's `flowchart.subGraphTitleMargin` knob.
+            subgraph_title_margin: None,
         }
     }
 }
@@ -266,6 +334,7 @@ impl From<LayoutConfig> for crate::engines::graph::algorithms::layered::LayoutCo
             edge_label_spacing: value.edge_label_spacing,
             backward_edge_side_grouping: value.backward_edge_side_grouping,
             edge_label_max_width: value.edge_label_max_width,
+            subgraph_title_margin: value.subgraph_title_margin.map(Into::into),
         }
     }
 }
@@ -300,6 +369,7 @@ impl From<crate::engines::graph::algorithms::layered::LayoutConfig> for LayoutCo
             edge_label_spacing: value.edge_label_spacing,
             backward_edge_side_grouping: value.backward_edge_side_grouping,
             edge_label_max_width: value.edge_label_max_width,
+            subgraph_title_margin: value.subgraph_title_margin.map(Into::into),
         }
     }
 }

--- a/src/engines/graph/mermaid.rs
+++ b/src/engines/graph/mermaid.rs
@@ -176,7 +176,10 @@ impl GraphEngine for MermaidLayeredEngine {
         let EngineConfig::Layered(ref layered_cfg) = *config;
         let mut layout_config = layout_config_from_layered(layered_cfg, diagram);
         layout_config.cluster_rank_sep = 0.0;
-        let mermaid_flags = mermaid_layout_flags();
+        let mut mermaid_flags = mermaid_layout_flags();
+        // Forward the user-configured subgraph title margin onto the Mermaid
+        // profile so `flowchart.subGraphTitleMargin` reaches the kernel.
+        mermaid_flags.subgraph_title_margin = layered_cfg.subgraph_title_margin;
         let geometry = build_float_layout_with_flags(
             diagram,
             &layout_config,

--- a/src/engines/graph/mod.rs
+++ b/src/engines/graph/mod.rs
@@ -30,7 +30,10 @@ pub use contracts::{
     EngineConfig, GraphEngine, GraphGeometryContract, GraphSolveRequest, GraphSolveResult,
     SubgraphDirectionPolicy,
 };
-pub use layout::{LabelDummyPlacement, LabelDummyRouting, LayoutConfig, LayoutDirection, Ranker};
+pub use layout::{
+    LabelDummyPlacement, LabelDummyRouting, LayoutConfig, LayoutDirection, Ranker,
+    SubgraphTitleMargin,
+};
 pub use registry::GraphEngineRegistry;
 pub use selection::{AlgorithmId, EngineAlgorithmCapabilities, EngineAlgorithmId, EngineId};
 pub use solve::solve_graph_family;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,6 +351,7 @@ pub use runtime::config::{GraphTextStyleConfig, RenderConfig, SvgThemeConfig, Sv
 /// Layout configuration for the Sugiyama hierarchical engine.
 pub use runtime::config::{
     LabelDummyPlacement, LabelDummyRouting, LayoutConfig, LayoutDirection, Ranker,
+    SubgraphTitleMargin,
 };
 /// Serde-friendly config input for JSON consumers (Wasm, API).
 pub use runtime::config_input::RuntimeConfigInput;

--- a/src/runtime/config.rs
+++ b/src/runtime/config.rs
@@ -3,6 +3,7 @@
 use crate::engines::graph::{EngineAlgorithmId, EngineId};
 pub use crate::engines::graph::{
     LabelDummyPlacement, LabelDummyRouting, LayoutConfig, LayoutDirection, Ranker,
+    SubgraphTitleMargin,
 };
 use crate::format::{CornerStyle, Curve, EdgePreset, OutputFormat, RoutingStyle, TextColorMode};
 use crate::graph::GeometryLevel;

--- a/src/runtime/config_input.rs
+++ b/src/runtime/config_input.rs
@@ -6,7 +6,7 @@
 
 use serde::Deserialize;
 
-use crate::engines::graph::{EngineAlgorithmId, Ranker};
+use crate::engines::graph::{EngineAlgorithmId, Ranker, SubgraphTitleMargin};
 use crate::errors::RenderError;
 use crate::format::{
     ColorWhen, Curve, EdgePreset, OutputFormat, RoutingStyle, normalize_enum_token,
@@ -59,6 +59,48 @@ pub struct LayoutConfigInput {
     pub rank_sep: Option<f64>,
     pub margin: Option<f64>,
     pub ranker: Option<String>,
+    /// Subgraph title margin in pixels, mirroring Mermaid's
+    /// `flowchart.subGraphTitleMargin: { top, bottom }`. Both fields
+    /// default to `0` when the object is provided. Omit entirely (or set
+    /// to `null`) to keep mmdflux's measurement-driven default.
+    ///
+    /// Accepts Mermaid's `subGraphTitleMargin` (capital `G`) alongside the
+    /// camelCase `subgraphTitleMargin` form produced by `rename_all`.
+    #[serde(alias = "subGraphTitleMargin")]
+    pub subgraph_title_margin: Option<SubgraphTitleMarginInput>,
+}
+
+/// Serde-friendly subgraph title margin, mirroring Mermaid's
+/// `flowchart.subGraphTitleMargin: { top, bottom }`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+pub struct SubgraphTitleMarginInput {
+    /// Pixels above the subgraph title (Mermaid `subGraphTitleMargin.top`).
+    pub top: Option<f64>,
+    /// Pixels below the subgraph title (Mermaid `subGraphTitleMargin.bottom`).
+    pub bottom: Option<f64>,
+}
+
+impl SubgraphTitleMarginInput {
+    fn into_config(self) -> Result<SubgraphTitleMargin, RenderError> {
+        let top = self.top.unwrap_or(0.0);
+        let bottom = self.bottom.unwrap_or(0.0);
+        for (label, value) in [("top", top), ("bottom", bottom)] {
+            if !value.is_finite() {
+                return Err(RenderError {
+                    message: format!("subGraphTitleMargin.{label} must be a finite number"),
+                });
+            }
+            if value < 0.0 {
+                return Err(RenderError {
+                    message: format!(
+                        "subGraphTitleMargin.{label} must be non-negative, got {value}"
+                    ),
+                });
+            }
+        }
+        Ok(SubgraphTitleMargin { top, bottom })
+    }
 }
 
 /// Serde-friendly SVG theme config nested inside [`RuntimeConfigInput`].
@@ -158,6 +200,9 @@ impl RuntimeConfigInput {
             }
             if let Some(ranker) = layout.ranker {
                 config.layout.ranker = parse_ranker(&ranker)?;
+            }
+            if let Some(subgraph_title_margin) = layout.subgraph_title_margin {
+                config.layout.subgraph_title_margin = Some(subgraph_title_margin.into_config()?);
             }
         }
 

--- a/tests/subgraph_title_margin.rs
+++ b/tests/subgraph_title_margin.rs
@@ -1,0 +1,201 @@
+//! Regression tests for the configurable subgraph title margin.
+//!
+//! The knob mirrors Mermaid's `flowchart.subGraphTitleMargin: { top, bottom }`
+//! and adjusts the rank-axis space reserved between a subgraph's title and
+//! its first member row. Defaults preserve the original measurement-driven
+//! value so existing renders stay byte-identical; explicit values widen or
+//! narrow the title gap.
+
+use mmdflux::{
+    EngineAlgorithmId, LayoutConfig, OutputFormat, RenderConfig, RuntimeConfigInput,
+    SubgraphTitleMargin, render_diagram,
+};
+
+const SUBGRAPH_INPUT: &str = "flowchart TD\nsubgraph S [Group]\nA-->B\nend\n";
+
+/// Render the fixture as SVG, where the visual-contract code path consumes
+/// the `subgraph_title_margin` knob.
+fn render_svg(config: RenderConfig) -> String {
+    render_diagram(SUBGRAPH_INPUT, OutputFormat::Svg, &config)
+        .expect("rendering SVG should succeed")
+}
+
+/// Extract the `height` attribute of the first `<rect>` element following
+/// the cluster-class container marker (`class="cluster `). The cluster rect
+/// width/height comes directly from the routed subgraph bounds, so growth
+/// in this number reflects the rank-axis title margin expansion.
+fn cluster_rect_height(svg: &str) -> f64 {
+    let cluster_marker = svg
+        .find("class=\"cluster ")
+        .or_else(|| svg.find("class=\"cluster\""))
+        .expect("SVG should mark the subgraph cluster group");
+    let rect_open = svg[cluster_marker..]
+        .find("<rect")
+        .map(|offset| cluster_marker + offset)
+        .expect("cluster group should embed a <rect>");
+    let height_attr = svg[rect_open..]
+        .find("height=\"")
+        .map(|offset| rect_open + offset + "height=\"".len())
+        .expect("cluster rect should set a height attribute");
+    let height_end = svg[height_attr..]
+        .find('"')
+        .map(|offset| height_attr + offset)
+        .expect("height attribute should close");
+    svg[height_attr..height_end]
+        .parse::<f64>()
+        .expect("height attribute should parse as f64")
+}
+
+#[test]
+fn subgraph_title_margin_defaults_to_none() {
+    let config = RenderConfig::default();
+    assert!(config.layout.subgraph_title_margin.is_none());
+}
+
+#[test]
+fn explicit_subgraph_title_margin_grows_subgraph_height() {
+    let default_svg = render_svg(RenderConfig::default());
+    let widened_svg = render_svg(RenderConfig {
+        layout: LayoutConfig {
+            // Drive the total margin well above the default
+            // measurement-driven value (~font_size, 14-16 px) so the
+            // difference outruns any sub-pixel rounding.
+            subgraph_title_margin: Some(SubgraphTitleMargin::new(40.0, 40.0)),
+            ..LayoutConfig::default()
+        },
+        ..RenderConfig::default()
+    });
+
+    let default_height = cluster_rect_height(&default_svg);
+    let widened_height = cluster_rect_height(&widened_svg);
+
+    assert!(
+        widened_height > default_height,
+        "explicit subgraph_title_margin should grow rank-axis cluster height: \
+         default = {default_height}, widened = {widened_height}"
+    );
+}
+
+#[test]
+fn explicit_subgraph_title_margin_uses_total_of_top_and_bottom() {
+    let split_svg = render_svg(RenderConfig {
+        layout: LayoutConfig {
+            subgraph_title_margin: Some(SubgraphTitleMargin::new(30.0, 30.0)),
+            ..LayoutConfig::default()
+        },
+        ..RenderConfig::default()
+    });
+    let totalled_svg = render_svg(RenderConfig {
+        layout: LayoutConfig {
+            subgraph_title_margin: Some(SubgraphTitleMargin::new(0.0, 60.0)),
+            ..LayoutConfig::default()
+        },
+        ..RenderConfig::default()
+    });
+
+    // Mermaid's `subGraphTitleTotalMargin = top + bottom`; only the sum
+    // matters for rank-axis spacing today, so the two configurations must
+    // produce identical cluster heights.
+    assert_eq!(
+        cluster_rect_height(&split_svg),
+        cluster_rect_height(&totalled_svg),
+    );
+}
+
+#[test]
+fn runtime_config_input_accepts_subgraph_title_margin_json() {
+    let input = serde_json::from_str::<RuntimeConfigInput>(
+        r#"{ "layout": { "subGraphTitleMargin": { "top": 12.5, "bottom": 7.5 } } }"#,
+    )
+    .expect("subGraphTitleMargin JSON should parse");
+    let config = input
+        .into_render_config()
+        .expect("conversion to RenderConfig should succeed");
+
+    let margin = config
+        .layout
+        .subgraph_title_margin
+        .expect("subgraph_title_margin should be configured");
+    assert_eq!(margin.top, 12.5);
+    assert_eq!(margin.bottom, 7.5);
+    assert_eq!(margin.total(), 20.0);
+}
+
+#[test]
+fn runtime_config_input_rejects_negative_subgraph_title_margin() {
+    let input = serde_json::from_str::<RuntimeConfigInput>(
+        r#"{ "layout": { "subGraphTitleMargin": { "top": -1.0 } } }"#,
+    )
+    .expect("subGraphTitleMargin JSON should parse");
+
+    let err = input
+        .into_render_config()
+        .expect_err("negative top margin should be rejected");
+    assert!(
+        err.message.contains("subGraphTitleMargin.top"),
+        "{}",
+        err.message
+    );
+    assert!(err.message.contains("non-negative"), "{}", err.message);
+}
+
+#[test]
+fn runtime_config_input_rejects_non_finite_subgraph_title_margin_at_parse() {
+    // serde_json's f64 parser rejects out-of-range literals (`1e400`,
+    // `-1e400`) before they reach validation, and `NaN`/`Infinity` are
+    // not valid JSON tokens. This pins that defense: the validation in
+    // `SubgraphTitleMarginInput::into_config` is layered safety for
+    // hand-constructed input structs, but no non-finite value can leak
+    // through the JSON entry point in the first place.
+    let parse_overflow = serde_json::from_str::<RuntimeConfigInput>(
+        r#"{ "layout": { "subGraphTitleMargin": { "top": 1e400 } } }"#,
+    );
+    assert!(
+        parse_overflow.is_err(),
+        "overflow literal must not deserialize"
+    );
+
+    let parse_neg_overflow = serde_json::from_str::<RuntimeConfigInput>(
+        r#"{ "layout": { "subGraphTitleMargin": { "bottom": -1e400 } } }"#,
+    );
+    assert!(
+        parse_neg_overflow.is_err(),
+        "negative overflow literal must not deserialize"
+    );
+
+    let parse_nan_token = serde_json::from_str::<RuntimeConfigInput>(
+        r#"{ "layout": { "subGraphTitleMargin": { "top": NaN } } }"#,
+    );
+    assert!(
+        parse_nan_token.is_err(),
+        "NaN token is not legal JSON and must not deserialize"
+    );
+}
+
+#[test]
+fn explicit_subgraph_title_margin_routes_through_mermaid_layered_engine() {
+    // The Flux tests above default to layout_engine = None (Flux). This
+    // pins the Mermaid-layered forwarding path at
+    // `src/engines/graph/mermaid.rs:182`, which copies user margin onto
+    // the engine's profile flags.
+    let mermaid = EngineAlgorithmId::parse("mermaid-layered")
+        .expect("mermaid-layered should be a registered engine algorithm");
+
+    let default_svg = render_svg(RenderConfig {
+        layout_engine: Some(mermaid),
+        ..RenderConfig::default()
+    });
+    let widened_svg = render_svg(RenderConfig {
+        layout_engine: Some(mermaid),
+        layout: LayoutConfig {
+            subgraph_title_margin: Some(SubgraphTitleMargin::new(40.0, 40.0)),
+            ..LayoutConfig::default()
+        },
+        ..RenderConfig::default()
+    });
+
+    assert!(
+        cluster_rect_height(&widened_svg) > cluster_rect_height(&default_svg),
+        "mermaid-layered engine should honor subgraph_title_margin"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a public `SubgraphTitleMargin { top, bottom }` knob on `LayoutConfig`, mirroring Mermaid's `flowchart.subGraphTitleMargin`.
- Default behavior is byte-identical (`Option::None` keeps the current measurement-driven gap).
- Wired through both the Flux and Mermaid-layered engines; JSON consumers can use `subgraphTitleMargin` or Mermaid's `subGraphTitleMargin` spelling.
- `#[non_exhaustive]` with `SubgraphTitleMargin::new(top, bottom)` for forward compatibility.

## Test plan

- [x] 7 unit tests in `tests/subgraph_title_margin.rs` covering default, growth, top/bottom summing, JSON parse, negative rejection, non-finite parse rejection, and Mermaid-layered engine routing
- [x] `just test` (3181 passed, 8 skipped)
- [x] `just lint` (clippy + fmt clean)
- [x] `cargo xtask architecture check` (exit 0)
- [x] No snapshot churn — existing Text/SVG/MMDS renders remain byte-identical

Closes #334