### PR TITLE
feat: align subgraph default fill with mermaid clusterBkg

### DIFF
--- a/src/render/graph/svg/mod.rs
+++ b/src/render/graph/svg/mod.rs
@@ -35,6 +35,10 @@ type Rect = FRect;
 
 const UNTHEMED_STROKE_COLOR: &str = "#333";
 const UNTHEMED_SUBGRAPH_STROKE: &str = "#888";
+/// Preserves the historic subgraph default rendering when no SVG theme is
+/// applied — Mermaid parity (`clusterBkg`) only kicks in when a theme is in
+/// scope, so un-themed snapshots stay byte-identical.
+const UNTHEMED_SUBGRAPH_FILL: &str = "none";
 const UNTHEMED_NODE_FILL: &str = "white";
 const UNTHEMED_TEXT_COLOR: &str = "#333";
 const MIN_BASIS_VISIBLE_STEM_PX: f64 = 8.0;
@@ -47,6 +51,7 @@ pub(super) struct GraphSvgPalette {
     pub(super) node_text: String,
     pub(super) edge_stroke: String,
     pub(super) edge_label_text: String,
+    pub(super) subgraph_fill: String,
     pub(super) subgraph_stroke: String,
     pub(super) subgraph_title_text: String,
     pub(super) edge_label_background: String,
@@ -79,6 +84,7 @@ impl GraphSvgPalette {
                 edge_stroke: theme.roles.line.clone(),
                 edge_label_text: theme.roles.text.clone(),
                 edge_label_background: theme.roles.background.clone(),
+                subgraph_fill: theme.roles.cluster_bkg.clone(),
                 subgraph_stroke: theme.roles.node_stroke.clone(),
                 subgraph_title_text: theme.roles.text.clone(),
                 marker_color: theme.roles.arrow.clone(),
@@ -92,6 +98,7 @@ impl GraphSvgPalette {
                 edge_stroke: UNTHEMED_STROKE_COLOR.to_string(),
                 edge_label_text: UNTHEMED_TEXT_COLOR.to_string(),
                 edge_label_background: UNTHEMED_NODE_FILL.to_string(),
+                subgraph_fill: UNTHEMED_SUBGRAPH_FILL.to_string(),
                 subgraph_stroke: UNTHEMED_SUBGRAPH_STROKE.to_string(),
                 subgraph_title_text: UNTHEMED_TEXT_COLOR.to_string(),
                 marker_color: UNTHEMED_STROKE_COLOR.to_string(),

--- a/src/render/graph/svg/nodes.rs
+++ b/src/render/graph/svg/nodes.rs
@@ -105,6 +105,10 @@ impl<'a> ResolvedSvgSubgraphStyle<'a> {
         self.text.unwrap_or(default)
     }
 
+    fn fill_is_overridden(self) -> bool {
+        self.fill.is_some()
+    }
+
     fn stroke_is_overridden(self) -> bool {
         self.stroke.is_some()
     }
@@ -171,17 +175,23 @@ pub(super) fn render_subgraphs(
 
         let rect = scale_rect(&sg_geom.rect, scale);
         let style = ResolvedSvgSubgraphStyle::from_subgraph(subgraph);
-        let fill = style.fill_or("none");
+        // Default subgraph fill follows Mermaid `clusterBkg` parity. The palette
+        // seeds the themed default; un-themed renders stay on `"none"` for
+        // snapshot byte-stability. Explicit `style`/`classDef` fill always wins.
+        let fill = style.fill_or(&palette.subgraph_fill);
         let stroke = style.stroke_or(&palette.subgraph_stroke);
         let default_stroke_width = fmt_f64(1.0 * scale);
         let stroke_width = style.stroke_width.unwrap_or(&default_stroke_width);
         let mut dynamic_declarations = Vec::new();
+        if !style.fill_is_overridden() {
+            dynamic_declarations.push("fill:var(--_cluster-bkg);");
+        }
         if !style.stroke_is_overridden() {
             dynamic_declarations.push("stroke:var(--_node-stroke);");
         }
         let dynamic_attrs = dynamic_css_attrs(
             palette.dynamic_css,
-            "graph-subgraph-stroke",
+            "graph-subgraph-rect",
             &dynamic_declarations,
         );
         let dasharray_attr = style

--- a/src/render/svg/theme.rs
+++ b/src/render/svg/theme.rs
@@ -74,6 +74,7 @@ pub(crate) struct ResolvedThemeSlots {
     pub muted: String,
     pub surface: String,
     pub border: String,
+    pub cluster_bkg: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -88,6 +89,7 @@ pub(crate) struct DerivedThemeRoles {
     pub node_fill: String,
     pub node_stroke: String,
     pub group_fill: String,
+    pub cluster_bkg: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -111,6 +113,10 @@ pub(crate) struct ThemeSeed {
     pub muted: Option<&'static str>,
     pub surface: Option<&'static str>,
     pub border: Option<&'static str>,
+    /// Mermaid `clusterBkg` parity — background fill for subgraph cluster rects.
+    /// `None` falls back to `surface` (matching node fill) inside
+    /// `resolve_optional_slot`.
+    pub cluster_bkg: Option<&'static str>,
 }
 
 const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
@@ -124,6 +130,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: None,
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -136,6 +143,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: None,
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -148,6 +156,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#565f89"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -160,6 +169,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#565f89"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -172,6 +182,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#9699a3"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -184,6 +195,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#6c7086"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -196,6 +208,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#9ca0b0"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -208,6 +221,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#616e88"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -220,6 +234,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#7b88a1"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -232,6 +247,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#6272a4"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -244,6 +260,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#59636e"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -256,6 +273,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#9198a1"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -268,6 +286,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#93a1a1"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -280,6 +299,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#586e75"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
     named_theme(
@@ -292,6 +312,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#5c6370"),
             surface: None,
             border: None,
+            cluster_bkg: None,
         },
     ),
 ];
@@ -307,6 +328,8 @@ const MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#666666"),
             surface: Some("#ececff"),
             border: Some("#9370db"),
+            // Mermaid base theme: clusterBkg = tertiaryColor (#ECECFF).
+            cluster_bkg: Some("#ececff"),
         },
     ),
     named_theme(
@@ -319,6 +342,8 @@ const MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#cccccc"),
             surface: Some("#1f2020"),
             border: Some("#cccccc"),
+            // Mermaid dark theme: clusterBkg = '#302F3D' (explicit).
+            cluster_bkg: Some("#302f3d"),
         },
     ),
     named_theme(
@@ -331,6 +356,8 @@ const MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#333333"),
             surface: Some("#cde498"),
             border: Some("#13540c"),
+            // Mermaid forest theme: clusterBkg = secondBkg = '#cdffb2'.
+            cluster_bkg: Some("#cdffb2"),
         },
     ),
     named_theme(
@@ -343,6 +370,9 @@ const MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             muted: Some("#333333"),
             surface: Some("#eeeeee"),
             border: Some("#999999"),
+            // Mermaid neutral theme: clusterBkg = secondBkg, calculated from
+            // contrast (#707070) via lighten(.., 55); resolves to ~#eeeeee.
+            cluster_bkg: Some("#eeeeee"),
         },
     ),
 ];
@@ -385,44 +415,60 @@ pub(crate) fn resolve_svg_theme(config: &SvgThemeSpec) -> Result<ResolvedSvgThem
         DEFAULT_FG,
     )?;
 
+    let line = resolve_optional_slot(
+        config.line.as_deref(),
+        named.and_then(|theme| theme.seed.line),
+        &fg,
+        &bg,
+        MIX_LINE,
+    )?;
+    let accent = resolve_optional_slot(
+        config.accent.as_deref(),
+        named.and_then(|theme| theme.seed.accent),
+        &fg,
+        &bg,
+        MIX_ARROW,
+    )?;
+    let muted = resolve_optional_slot(
+        config.muted.as_deref(),
+        named.and_then(|theme| theme.seed.muted),
+        &fg,
+        &bg,
+        MIX_TEXT_MUTED,
+    )?;
+    let surface = resolve_optional_slot(
+        config.surface.as_deref(),
+        named.and_then(|theme| theme.seed.surface),
+        &fg,
+        &bg,
+        MIX_NODE_FILL,
+    )?;
+    let border = resolve_optional_slot(
+        config.border.as_deref(),
+        named.and_then(|theme| theme.seed.border),
+        &fg,
+        &bg,
+        MIX_NODE_STROKE,
+    )?;
+    // `cluster_bkg` mirrors Mermaid's `clusterBkg` theme variable. There is no
+    // direct public override hook on `SvgThemeSpec`; the seed comes from the
+    // named theme, and otherwise falls back to the resolved `surface` slot so
+    // unseeded themes (beautiful palettes, custom slot overrides) keep behaving
+    // like a tinted node background instead of leaking `bg` through.
+    let cluster_bkg = match named.and_then(|theme| theme.seed.cluster_bkg) {
+        Some(color) => normalize_hex_color(color)?,
+        None => surface.clone(),
+    };
+
     let slots = ResolvedThemeSlots {
         bg: bg.clone(),
         fg: fg.clone(),
-        line: resolve_optional_slot(
-            config.line.as_deref(),
-            named.and_then(|theme| theme.seed.line),
-            &fg,
-            &bg,
-            MIX_LINE,
-        )?,
-        accent: resolve_optional_slot(
-            config.accent.as_deref(),
-            named.and_then(|theme| theme.seed.accent),
-            &fg,
-            &bg,
-            MIX_ARROW,
-        )?,
-        muted: resolve_optional_slot(
-            config.muted.as_deref(),
-            named.and_then(|theme| theme.seed.muted),
-            &fg,
-            &bg,
-            MIX_TEXT_MUTED,
-        )?,
-        surface: resolve_optional_slot(
-            config.surface.as_deref(),
-            named.and_then(|theme| theme.seed.surface),
-            &fg,
-            &bg,
-            MIX_NODE_FILL,
-        )?,
-        border: resolve_optional_slot(
-            config.border.as_deref(),
-            named.and_then(|theme| theme.seed.border),
-            &fg,
-            &bg,
-            MIX_NODE_STROKE,
-        )?,
+        line,
+        accent,
+        muted,
+        surface,
+        border,
+        cluster_bkg,
     };
 
     let roles = DerivedThemeRoles {
@@ -436,6 +482,7 @@ pub(crate) fn resolve_svg_theme(config: &SvgThemeSpec) -> Result<ResolvedSvgThem
         node_fill: slots.surface.clone(),
         node_stroke: slots.border.clone(),
         group_fill: slots.bg.clone(),
+        cluster_bkg: slots.cluster_bkg.clone(),
     };
 
     let dynamic = if matches!(config.mode, SvgThemeRenderMode::Dynamic) {
@@ -451,6 +498,7 @@ pub(crate) fn resolve_svg_theme(config: &SvgThemeSpec) -> Result<ResolvedSvgThem
                     ("--muted".into(), slots.muted.clone()),
                     ("--surface".into(), slots.surface.clone()),
                     ("--border".into(), slots.border.clone()),
+                    ("--cluster-bkg".into(), slots.cluster_bkg.clone()),
                 ],
                 style_block: Some(style_block.clone()),
             },
@@ -558,6 +606,7 @@ fn build_dynamic_style_block() -> String {
         "  --_node-fill: var(--surface);",
         "  --_node-stroke: var(--border);",
         "  --_group-fill: var(--bg);",
+        "  --_cluster-bkg: var(--cluster-bkg);",
         "}",
     ]
     .join("\n")
@@ -670,6 +719,9 @@ mod tests {
         assert!(root_vars.contains(&"--muted:#a9a9aa".to_string()));
         assert!(root_vars.contains(&"--surface:#f9f9f9".to_string()));
         assert!(root_vars.contains(&"--border:#d4d4d4".to_string()));
+        // Unseeded themes fall the cluster_bkg slot back to `surface` so the
+        // dynamic CSS payload still surfaces a value (no surprise blanks).
+        assert!(root_vars.contains(&"--cluster-bkg:#f9f9f9".to_string()));
         assert!(dynamic.style_block.contains("--_text: var(--fg);"));
         assert!(dynamic.style_block.contains("--_line: var(--line);"));
         assert!(
@@ -682,5 +734,62 @@ mod tests {
                 .style_block
                 .contains("--_node-stroke: var(--border);")
         );
+        assert!(
+            dynamic
+                .style_block
+                .contains("--_cluster-bkg: var(--cluster-bkg);")
+        );
+    }
+
+    #[test]
+    fn mermaid_named_themes_seed_cluster_bkg_to_documented_values() {
+        // Mermaid base theme: clusterBkg = tertiaryColor (#ECECFF).
+        let base = resolve_svg_theme(&SvgThemeSpec {
+            name: Some("default".into()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(base.slots.cluster_bkg, "#ececff");
+        assert_eq!(base.roles.cluster_bkg, "#ececff");
+
+        // Mermaid dark theme pins clusterBkg explicitly as #302F3D.
+        let dark = resolve_svg_theme(&SvgThemeSpec {
+            name: Some("dark".into()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(dark.slots.cluster_bkg, "#302f3d");
+
+        // Mermaid forest theme: clusterBkg = secondBkg = #cdffb2 (distinct
+        // from the resolved surface slot at #cde498).
+        let forest = resolve_svg_theme(&SvgThemeSpec {
+            name: Some("forest".into()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(forest.slots.cluster_bkg, "#cdffb2");
+        assert_ne!(forest.slots.cluster_bkg, forest.slots.surface);
+
+        // Mermaid neutral theme: clusterBkg derives to a pale gray; mmdflux
+        // seeds #eeeeee to match the established surface tone.
+        let neutral = resolve_svg_theme(&SvgThemeSpec {
+            name: Some("neutral".into()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(neutral.slots.cluster_bkg, "#eeeeee");
+    }
+
+    #[test]
+    fn unseeded_themes_fall_cluster_bkg_back_to_resolved_surface() {
+        // Beautiful palette themes have no Mermaid-style clusterBkg parity
+        // documentation, so the slot inherits the resolved surface fill.
+        let resolved = resolve_svg_theme(&SvgThemeSpec {
+            name: Some("tokyo-night".into()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(resolved.slots.cluster_bkg, resolved.slots.surface);
     }
 }

--- a/tests/svg_render.rs
+++ b/tests/svg_render.rs
@@ -309,6 +309,129 @@ fn unstyled_subgraph_container_rect_stays_byte_stable() {
 }
 
 #[test]
+fn themed_subgraph_default_fill_follows_mermaid_cluster_bkg_not_node_fill() {
+    // Mermaid `dark` theme: clusterBkg = #302F3D, surface (node_fill) = #1f2020.
+    // The subgraph rect must consume cluster_bkg, not node_fill.
+    let input = "flowchart LR\nsubgraph A[Source]\na1\nend\n";
+    let svg = render_svg(
+        input,
+        &RenderConfig {
+            svg_theme: Some(SvgThemeConfig {
+                name: Some("dark".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+
+    let subgraph_lines: Vec<&str> = svg
+        .lines()
+        .filter(|line| line.contains(r#"class="subgraph""#))
+        .collect();
+    assert!(!subgraph_lines.is_empty(), "{svg}");
+    for line in &subgraph_lines {
+        assert!(
+            line.contains(r##"fill="#302f3d""##),
+            "themed subgraph should pick up cluster_bkg #302f3d, got: {line}"
+        );
+        assert!(
+            !line.contains(r##"fill="#1f2020""##),
+            "themed subgraph must not fall back to node_fill #1f2020, got: {line}"
+        );
+    }
+}
+
+#[test]
+fn explicit_subgraph_class_fill_wins_over_theme_cluster_bkg() {
+    // Even when a theme would seed cluster_bkg, an author-specified classDef
+    // fill must take precedence (preserves the precedence guarantee from #328).
+    let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef blue fill:#e1f5fe,stroke:#01579b,stroke-width:2px\nclass A blue\n";
+    let svg = render_svg(
+        input,
+        &RenderConfig {
+            svg_theme: Some(SvgThemeConfig {
+                name: Some("dark".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+
+    assert!(svg.contains(r##"fill="#e1f5fe""##), "{svg}");
+    assert!(
+        !svg.contains(r##"fill="#302f3d""##),
+        "themed cluster_bkg must yield to explicit classDef fill: {svg}"
+    );
+}
+
+#[test]
+fn dynamic_themed_subgraph_emits_cluster_bkg_css_variable() {
+    // Dynamic theme mode wires `--cluster-bkg` so adapters can override the
+    // subgraph default at runtime without re-rendering.
+    let input = "flowchart LR\nsubgraph A[Source]\na1\nend\n";
+    let svg = render_svg(
+        input,
+        &RenderConfig {
+            svg_theme: Some(SvgThemeConfig {
+                name: Some("dark".into()),
+                mode: SvgThemeMode::Dynamic,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+
+    assert!(svg.contains("--cluster-bkg:#302f3d"), "{svg}");
+    assert!(
+        svg.contains("--_cluster-bkg: var(--cluster-bkg);"),
+        "dynamic style block should bridge --cluster-bkg into --_cluster-bkg: {svg}"
+    );
+    assert!(
+        svg.contains("fill:var(--_cluster-bkg);"),
+        "subgraph rect should carry the dynamic fill declaration: {svg}"
+    );
+    assert!(
+        svg.contains(r#"data-svg-role="graph-subgraph-rect""#),
+        "subgraph rect must tag data-svg-role=\"graph-subgraph-rect\" for adapter targeting: {svg}"
+    );
+}
+
+#[test]
+fn named_theme_keeps_cluster_bkg_when_caller_overrides_surface_slot() {
+    // Custom surface override on a named theme must not drag cluster_bkg with
+    // it — the named seed (#302f3d for dark) is the parity contract, and an
+    // ad-hoc surface tweak is for nodes only.
+    let input = "flowchart LR\nsubgraph A[Source]\na1\nend\n";
+    let svg = render_svg(
+        input,
+        &RenderConfig {
+            svg_theme: Some(SvgThemeConfig {
+                name: Some("dark".into()),
+                surface: Some("#123456".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+
+    let subgraph_lines: Vec<&str> = svg
+        .lines()
+        .filter(|line| line.contains(r#"class="subgraph""#))
+        .collect();
+    assert!(!subgraph_lines.is_empty(), "{svg}");
+    for line in &subgraph_lines {
+        assert!(
+            line.contains(r##"fill="#302f3d""##),
+            "named theme cluster_bkg must survive a surface override: {line}"
+        );
+        assert!(
+            !line.contains(r##"fill="#123456""##),
+            "surface override must not bleed into subgraph fill: {line}"
+        );
+    }
+}
+
+#[test]
 fn svg_subgraph_title_uses_visual_font_attrs_from_class_style() {
     let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef title font-style:italic,font-weight:700,color:#123456\nclass A title\n";
     let svg = render_svg(input, &RenderConfig::default());


### PR DESCRIPTION
## Summary

- Adds a `cluster_bkg` slot to `ThemeSeed` / `ResolvedThemeSlots` / `DerivedThemeRoles`, mirroring Mermaid's `clusterBkg` theme variable.
- Per-theme seeds pinned to documented Mermaid values: `default=#ECECFF`, `dark=#302F3D`, `forest=#cdffb2`, `neutral=#eeeeee`. Beautiful palettes fall back to the resolved `surface` slot.
- Un-themed renders keep `fill="none"` via `UNTHEMED_SUBGRAPH_FILL`, so every existing snapshot is byte-identical.
- Explicit `style` / `classDef` fill still wins (preserves the #328 precedence guarantee).
- Dynamic CSS adds `--cluster-bkg` / `--_cluster-bkg` so adapters can recolor at runtime.

## Test plan

- [x] 5 new tests: themed default consumes `cluster_bkg`, classDef fill wins over theme, dynamic CSS variable emits with `data-svg-role="graph-subgraph-rect"`, surface override does not bleed into `cluster_bkg`, named-theme values match Mermaid sources
- [x] `just test` (3187 passed, 8 skipped)
- [x] `just lint`
- [x] `cargo xtask architecture check`
- [x] No snapshot churn

Closes #337