### PR TITLE
feat: preserve independent subgraph ry corner radius

### DIFF
--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -382,6 +382,10 @@ Rules:
 - Omit the profile and extension entirely when no node, edge-label, or subgraph
   styles are present.
 - `fill`, `stroke`, and `color` preserve the raw Mermaid/MMDS color token.
+- `rx` and `ry` carry the SVG horizontal and vertical corner radii. When `ry`
+  is omitted, SVG falls back to `rx`, so single-radius styles emit only `rx`
+  for byte-identical replay; independent vertical curvature requires an
+  explicit `ry` value.
 - Edge-label entries are keyed by MMDS edge id and preserve Mermaid `linkStyle`
   font tokens for SVG rendering and dynamic text measurement replay.
 - Subgraph entries live at `org.mmdflux.node-style.v1.subgraphs`; the historical

--- a/docs/mmds.schema.json
+++ b/docs/mmds.schema.json
@@ -731,7 +731,8 @@
         "font-weight": { "type": "string", "description": "CSS font-weight value (e.g. bold, 700)." },
         "stroke-width": { "type": "string", "description": "CSS stroke-width value (e.g. 4px)." },
         "stroke-dasharray": { "type": "string", "description": "SVG stroke-dasharray value (e.g. 5,3)." },
-        "rx": { "type": "string", "description": "SVG rx (border-radius) value." },
+        "rx": { "type": "string", "description": "SVG rx (horizontal border-radius) value." },
+        "ry": { "type": "string", "description": "SVG ry (vertical border-radius) value. When omitted, SVG falls back to rx." },
         "classNames": {
           "type": "array",
           "items": { "type": "string" },
@@ -782,7 +783,11 @@
         },
         "rx": {
           "type": "string",
-          "description": "SVG rx (border-radius) value."
+          "description": "SVG rx (horizontal border-radius) value."
+        },
+        "ry": {
+          "type": "string",
+          "description": "SVG ry (vertical border-radius) value. When omitted, SVG falls back to rx."
         }
       },
       "additionalProperties": false

--- a/src/graph/style.rs
+++ b/src/graph/style.rs
@@ -29,6 +29,8 @@ pub struct NodeStyle {
     pub stroke_dasharray: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rx: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ry: Option<String>,
 }
 
 impl NodeStyle {
@@ -43,6 +45,7 @@ impl NodeStyle {
             && self.stroke_width.is_none()
             && self.stroke_dasharray.is_none()
             && self.rx.is_none()
+            && self.ry.is_none()
     }
 
     pub fn with_fill(mut self, fill: ColorToken) -> Self {
@@ -87,6 +90,7 @@ impl NodeStyle {
                 .clone()
                 .or_else(|| self.stroke_dasharray.clone()),
             rx: overlay.rx.clone().or_else(|| self.rx.clone()),
+            ry: overlay.ry.clone().or_else(|| self.ry.clone()),
         }
     }
 }
@@ -226,7 +230,7 @@ impl NodeStyleIssue {
     pub fn message(&self) -> String {
         match self {
             NodeStyleIssue::UnsupportedProperty { property } => format!(
-                "style property '{}' is not supported; supported properties are fill, stroke, color, font-family, font-size, font-style, font-weight, stroke-width, stroke-dasharray, and rx",
+                "style property '{}' is not supported; supported properties are fill, stroke, color, font-family, font-size, font-style, font-weight, stroke-width, stroke-dasharray, rx, and ry",
                 property
             ),
             NodeStyleIssue::UnsupportedColorSyntax { property, value } => format!(
@@ -439,6 +443,10 @@ pub(crate) fn parse_node_style_declarations(raw: &str) -> ParsedNodeStyleDeclara
             }
             "rx" => {
                 style.rx = Some(value.to_string());
+                continue;
+            }
+            "ry" => {
+                style.ry = Some(value.to_string());
                 continue;
             }
             _ => {}
@@ -880,6 +888,15 @@ mod tests {
                 parsed.issues
             );
         }
+    }
+
+    #[test]
+    fn parse_node_style_accepts_independent_rx_and_ry() {
+        let parsed = parse_node_style_declarations("rx:8,ry:14");
+
+        assert_eq!(parsed.style.rx.as_deref(), Some("8"));
+        assert_eq!(parsed.style.ry.as_deref(), Some("14"));
+        assert!(parsed.issues.is_empty(), "{:?}", parsed.issues);
     }
 
     #[test]

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -840,6 +840,9 @@ fn serialize_node_style_extension(style: &NodeStyle) -> Map<String, Value> {
     if let Some(v) = &style.rx {
         payload.insert("rx".to_string(), Value::String(v.clone()));
     }
+    if let Some(v) = &style.ry {
+        payload.insert("ry".to_string(), Value::String(v.clone()));
+    }
     payload
 }
 

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -264,6 +264,7 @@ fn parse_node_style_extension(style_object: &Map<String, Value>) -> NodeStyle {
             "stroke_dasharray",
         ),
         rx: parse_style_string(style_object, "rx"),
+        ry: parse_style_string(style_object, "ry"),
     }
 }
 

--- a/src/render/graph/svg/nodes.rs
+++ b/src/render/graph/svg/nodes.rs
@@ -22,6 +22,7 @@ struct ResolvedSvgNodeStyle<'a> {
     stroke_width: Option<&'a str>,
     stroke_dasharray: Option<&'a str>,
     rx: Option<&'a str>,
+    ry: Option<&'a str>,
 }
 
 impl<'a> ResolvedSvgNodeStyle<'a> {
@@ -33,6 +34,7 @@ impl<'a> ResolvedSvgNodeStyle<'a> {
             stroke_width: node.style.stroke_width.as_deref(),
             stroke_dasharray: node.style.stroke_dasharray.as_deref(),
             rx: node.style.rx.as_deref(),
+            ry: node.style.ry.as_deref(),
         }
     }
 
@@ -79,6 +81,7 @@ struct ResolvedSvgSubgraphStyle<'a> {
     stroke_width: Option<&'a str>,
     stroke_dasharray: Option<&'a str>,
     rx: Option<&'a str>,
+    ry: Option<&'a str>,
 }
 
 impl<'a> ResolvedSvgSubgraphStyle<'a> {
@@ -90,6 +93,7 @@ impl<'a> ResolvedSvgSubgraphStyle<'a> {
             stroke_width: subgraph.style.stroke_width.as_deref(),
             stroke_dasharray: subgraph.style.stroke_dasharray.as_deref(),
             rx: subgraph.style.rx.as_deref(),
+            ry: subgraph.style.ry.as_deref(),
         }
     }
 
@@ -115,6 +119,22 @@ impl<'a> ResolvedSvgSubgraphStyle<'a> {
 
     fn text_is_overridden(self) -> bool {
         self.text.is_some()
+    }
+}
+
+/// Format the optional `rx`/`ry` SVG corner-radius attributes.
+///
+/// Preserves byte-identical output for the historical single-radius case:
+/// `(Some(rx), None)` emits `rx=".." ry=".."` with the same value for both
+/// axes, matching SVG's implicit fallback. When `ry` is explicitly set and
+/// differs from `rx`, both attributes are emitted independently. When only
+/// `ry` is set, just `ry` is emitted and `rx` falls back to SVG defaults.
+fn format_rx_ry_attrs(rx: Option<&str>, ry: Option<&str>) -> String {
+    match (rx, ry) {
+        (None, None) => String::new(),
+        (Some(rx_val), None) => format!(" rx=\"{rx_val}\" ry=\"{rx_val}\""),
+        (None, Some(ry_val)) => format!(" ry=\"{ry_val}\""),
+        (Some(rx_val), Some(ry_val)) => format!(" rx=\"{rx_val}\" ry=\"{ry_val}\""),
     }
 }
 
@@ -198,10 +218,7 @@ pub(super) fn render_subgraphs(
             .stroke_dasharray
             .map(|v| format!(" stroke-dasharray=\"{v}\""))
             .unwrap_or_default();
-        let rx_attr = style
-            .rx
-            .map(|v| format!(" rx=\"{v}\" ry=\"{v}\""))
-            .unwrap_or_default();
+        let rx_attr = format_rx_ry_attrs(style.rx, style.ry);
         let rect_line = format!(
             "<rect class=\"subgraph\" x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\"{rx_attr} fill=\"{fill}\" stroke=\"{stroke}\" stroke-width=\"{stroke_width}\"{dasharray_attr}{dynamic_attrs} />",
             x = fmt_f64(rect.x),
@@ -509,10 +526,7 @@ fn render_node_shape(
 
     match node.shape {
         Shape::Rectangle => {
-            let rx_attr = node_style
-                .rx
-                .map(|v| format!(" rx=\"{v}\" ry=\"{v}\""))
-                .unwrap_or_default();
+            let rx_attr = format_rx_ry_attrs(node_style.rx, node_style.ry);
             let line = format!(
                 "<rect x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\"{rx_attr}{style} />",
                 x = fmt_f64(rect.x),
@@ -527,6 +541,7 @@ fn render_node_shape(
         Shape::Round => {
             let default_radius = fmt_f64(5.0 * scale);
             let rx_val = node_style.rx.unwrap_or(&default_radius);
+            let ry_val = node_style.ry.unwrap_or(rx_val);
             let line = format!(
                 "<rect x=\"{x}\" y=\"{y}\" width=\"{w}\" height=\"{h}\" rx=\"{rx}\" ry=\"{ry}\"{style} />",
                 x = fmt_f64(rect.x),
@@ -534,7 +549,7 @@ fn render_node_shape(
                 w = fmt_f64(rect.width),
                 h = fmt_f64(rect.height),
                 rx = rx_val,
-                ry = rx_val,
+                ry = ry_val,
                 style = style
             );
             writer.push_line(&line);

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -505,6 +505,39 @@ fn mmds_output_emits_subgraph_style_extension_when_styles_exist() {
 }
 
 #[test]
+fn mmds_output_round_trips_independent_subgraph_corner_radii() {
+    let json = render_json(
+        "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef rounded rx:10,ry:24\nclass A rounded\n",
+    );
+    let value: Value = serde_json::from_str(&json).unwrap();
+    let style = &value["extensions"]["org.mmdflux.node-style.v1"]["subgraphs"]["A"];
+    assert_eq!(style["rx"], "10");
+    assert_eq!(style["ry"], "24");
+    assert_schema_valid(value.clone());
+
+    let input = serde_json::to_string(&value).expect("MMDS payload should serialize");
+    let svg = render_mmds_input(&input, OutputFormat::Svg, RenderConfig::default());
+    assert!(
+        svg.contains("rx=\"10\" ry=\"24\""),
+        "expected independent rx/ry on subgraph after MMDS replay: {svg}"
+    );
+}
+
+#[test]
+fn mmds_output_round_trips_subgraph_rx_only_without_emitting_ry() {
+    let json = render_json(
+        "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef rounded rx:10\nclass A rounded\n",
+    );
+    let value: Value = serde_json::from_str(&json).unwrap();
+    let style = &value["extensions"]["org.mmdflux.node-style.v1"]["subgraphs"]["A"];
+    assert_eq!(style["rx"], "10");
+    assert!(
+        style.get("ry").is_none(),
+        "single-radius subgraph styles must not emit ry to keep MMDS payloads stable: {value}"
+    );
+}
+
+#[test]
 fn schema_accepts_edge_style_extension_entries() {
     let mut value: Value = serde_json::from_str(STYLED_MMDS_LAYOUT).unwrap();
     value["extensions"]["org.mmdflux.node-style.v1"] = json!({

--- a/tests/svg_render.rs
+++ b/tests/svg_render.rs
@@ -1031,6 +1031,51 @@ fn svg_node_with_rx() {
 }
 
 #[test]
+fn svg_node_with_rx_only_mirrors_ry_for_backwards_compatibility() {
+    // Historical single-radius behaviour: when only `rx` is supplied, the SVG
+    // emits `rx=<v> ry=<v>` so the rect renders as a uniform rounded corner.
+    let input = "graph TD\n  classDef rounded rx:10\n  A[Box]:::rounded\n";
+    let svg = render_svg(input, &RenderConfig::default());
+    assert!(
+        svg.contains("rx=\"10\" ry=\"10\""),
+        "expected mirrored rx/ry in SVG: {svg}"
+    );
+}
+
+#[test]
+fn svg_node_with_independent_ry_emits_distinct_radius() {
+    let input = "graph TD\n  classDef ovalish rx:10,ry:20\n  A[Box]:::ovalish\n";
+    let svg = render_svg(input, &RenderConfig::default());
+    assert!(
+        svg.contains("rx=\"10\" ry=\"20\""),
+        "expected independent rx and ry in SVG: {svg}"
+    );
+}
+
+#[test]
+fn svg_subgraph_with_independent_ry_emits_distinct_radius() {
+    let input = "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef rounded rx:10,ry:24\nclass A rounded\n";
+    let svg = render_svg(input, &RenderConfig::default());
+    assert!(
+        svg.contains("rx=\"10\" ry=\"24\""),
+        "expected independent rx/ry on subgraph rect: {svg}"
+    );
+}
+
+#[test]
+fn svg_subgraph_with_rx_only_keeps_single_radius() {
+    // Default subgraph styles (no explicit ry) MUST keep the historical
+    // single-radius output for byte-identical replay.
+    let input =
+        "flowchart LR\nsubgraph A[Source]\na1\nend\nclassDef rounded rx:10\nclass A rounded\n";
+    let svg = render_svg(input, &RenderConfig::default());
+    assert!(
+        svg.contains("rx=\"10\" ry=\"10\""),
+        "expected mirrored rx/ry on subgraph rect: {svg}"
+    );
+}
+
+#[test]
 fn svg_node_with_stroke_dasharray() {
     let input = "graph TD\n  classDef dashed stroke-dasharray:5,3\n  A:::dashed\n";
     let svg = render_svg(input, &RenderConfig::default());


### PR DESCRIPTION
## Summary

- Adds optional `ry` to `NodeStyle` (covers both subgraphs and nodes — the parser and style storage are shared in mmdflux, matching Mermaid where `classDef` applies to either).
- Mermaid emits both `rx` and `ry` on cluster rects and pipes inline `ry:` style declarations through to the rendered SVG; mmdflux now does the same.
- New shared `format_rx_ry_attrs` helper emits `rx="X" ry="X"` for single-radius (byte-identical to pre-change output) and `rx="X" ry="Y"` for independent radii.
- Round-trips through MMDS: optional `ry` field added to `SubgraphStyle` and `NodeStyle` schema definitions, document/hydrate paths emit `ry` only when present.

## Test plan

- [x] 4 new SVG tests (single-radius byte-identity for nodes + subgraphs; independent radii for nodes + subgraphs)
- [x] 2 MMDS round-trip tests (independent rx/ry survives serialize→hydrate→re-render; rx-only omits `ry` from JSON)
- [x] `just test` (3194 passed, 8 skipped)
- [x] `just lint`
- [x] `cargo xtask architecture check`
- [x] No snapshot churn — single-radius output preserved byte-identically

## Mermaid parity

- `packages/mermaid/src/rendering-util/rendering-elements/clusters.js` emits both `.attr('rx', node.rx).attr('ry', node.ry)`.
- `packages/mermaid/src/rendering-util/rendering-elements/shapes/handDrawnShapeStyles.ts` passes user `ry:` declarations through to the cluster's inline `style` attribute.
- `packages/mermaid/src/rendering-util/types.ts` declares both `rx?: number` and `ry?: number` as independent node properties.

Closes #335