### PR TITLE
feat: add notebkgcolor parity for themed sequence notes

### DIFF
--- a/src/render/svg/theme.rs
+++ b/src/render/svg/theme.rs
@@ -75,6 +75,7 @@ pub(crate) struct ResolvedThemeSlots {
     pub surface: String,
     pub border: String,
     pub cluster_bkg: String,
+    pub note_fill: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,6 +91,7 @@ pub(crate) struct DerivedThemeRoles {
     pub node_stroke: String,
     pub group_fill: String,
     pub cluster_bkg: String,
+    pub note_fill: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -117,6 +119,11 @@ pub(crate) struct ThemeSeed {
     /// `None` falls back to `surface` (matching node fill) inside
     /// `resolve_optional_slot`.
     pub cluster_bkg: Option<&'static str>,
+    /// Optional sticky-note background fill (Mermaid's `noteBkgColor`).
+    /// When `None`, falls back to `surface` so themes without an explicit
+    /// value keep the post-#357 behavior (notes share the participant/node
+    /// fill) instead of regressing to a near-bg mix.
+    pub note_fill: Option<&'static str>,
 }
 
 const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
@@ -131,6 +138,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: Some("#fef9c3"),
         },
     ),
     named_theme(
@@ -144,6 +152,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: Some("#854d0e"),
         },
     ),
     named_theme(
@@ -157,6 +166,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -170,6 +180,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -183,6 +194,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -196,6 +208,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -209,6 +222,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -222,6 +236,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -235,6 +250,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -248,6 +264,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -261,6 +278,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -274,6 +292,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -287,6 +306,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -300,6 +320,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
     named_theme(
@@ -313,6 +334,7 @@ const BEAUTIFUL_MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             surface: None,
             border: None,
             cluster_bkg: None,
+            note_fill: None,
         },
     ),
 ];
@@ -330,6 +352,7 @@ const MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             border: Some("#9370db"),
             // Mermaid base theme: clusterBkg = tertiaryColor (#ECECFF).
             cluster_bkg: Some("#ececff"),
+            note_fill: Some("#fff5ad"),
         },
     ),
     named_theme(
@@ -344,6 +367,7 @@ const MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             border: Some("#cccccc"),
             // Mermaid dark theme: clusterBkg = '#302F3D' (explicit).
             cluster_bkg: Some("#302f3d"),
+            note_fill: Some("#fff5ad"),
         },
     ),
     named_theme(
@@ -358,6 +382,8 @@ const MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             border: Some("#13540c"),
             // Mermaid forest theme: clusterBkg = secondBkg = '#cdffb2'.
             cluster_bkg: Some("#cdffb2"),
+            // Mermaid forest: noteBkgColor = '#fff5ad' (theme-forest.js:59).
+            note_fill: Some("#fff5ad"),
         },
     ),
     named_theme(
@@ -373,6 +399,8 @@ const MERMAID_THEMES: &[NamedSvgThemeDefinition] = &[
             // Mermaid neutral theme: clusterBkg = secondBkg, calculated from
             // contrast (#707070) via lighten(.., 55); resolves to ~#eeeeee.
             cluster_bkg: Some("#eeeeee"),
+            // Mermaid neutral: noteBkgColor = '#666' (theme-neutral.js:145).
+            note_fill: Some("#666666"),
         },
     ),
 ];
@@ -460,6 +488,14 @@ pub(crate) fn resolve_svg_theme(config: &SvgThemeSpec) -> Result<ResolvedSvgThem
         None => surface.clone(),
     };
 
+    // `note_fill` falls back to `surface` so themes without an explicit
+    // sticky-note seed keep the post-#357 behavior (notes share the
+    // participant/node fill) instead of regressing to a near-bg mix.
+    let note_fill = match named.and_then(|theme| theme.seed.note_fill) {
+        Some(value) => normalize_hex_color(value)?,
+        None => surface.clone(),
+    };
+
     let slots = ResolvedThemeSlots {
         bg: bg.clone(),
         fg: fg.clone(),
@@ -469,6 +505,7 @@ pub(crate) fn resolve_svg_theme(config: &SvgThemeSpec) -> Result<ResolvedSvgThem
         surface,
         border,
         cluster_bkg,
+        note_fill,
     };
 
     let roles = DerivedThemeRoles {
@@ -483,6 +520,7 @@ pub(crate) fn resolve_svg_theme(config: &SvgThemeSpec) -> Result<ResolvedSvgThem
         node_stroke: slots.border.clone(),
         group_fill: slots.bg.clone(),
         cluster_bkg: slots.cluster_bkg.clone(),
+        note_fill: slots.note_fill.clone(),
     };
 
     let dynamic = if matches!(config.mode, SvgThemeRenderMode::Dynamic) {
@@ -499,6 +537,7 @@ pub(crate) fn resolve_svg_theme(config: &SvgThemeSpec) -> Result<ResolvedSvgThem
                     ("--surface".into(), slots.surface.clone()),
                     ("--border".into(), slots.border.clone()),
                     ("--cluster-bkg".into(), slots.cluster_bkg.clone()),
+                    ("--note-fill".into(), slots.note_fill.clone()),
                 ],
                 style_block: Some(style_block.clone()),
             },
@@ -607,6 +646,7 @@ fn build_dynamic_style_block() -> String {
         "  --_node-stroke: var(--border);",
         "  --_group-fill: var(--bg);",
         "  --_cluster-bkg: var(--cluster-bkg);",
+        "  --_note-fill: var(--note-fill);",
         "}",
     ]
     .join("\n")

--- a/src/render/timeline/svg.rs
+++ b/src/render/timeline/svg.rs
@@ -67,7 +67,7 @@ impl SequenceSvgPalette {
                 participant_text: theme.roles.text.clone(),
                 lifeline_stroke: theme.roles.line.clone(),
                 marker_color: theme.roles.arrow.clone(),
-                note_fill: theme.roles.node_fill.clone(),
+                note_fill: theme.roles.note_fill.clone(),
                 activation_fill: theme.roles.node_fill.clone(),
                 actor_stroke: theme.roles.node_stroke.clone(),
                 block_stroke: theme.roles.node_stroke.clone(),
@@ -778,7 +778,7 @@ fn render_note(writer: &mut SvgWriter, note: &SvgNote, palette: &SequenceSvgPale
     let note_dynamic_attrs = dynamic_css_attrs(
         palette.dynamic_css,
         "sequence-note",
-        &["fill:var(--_node-fill);", "stroke:var(--_line);"],
+        &["fill:var(--_note-fill);", "stroke:var(--_line);"],
     );
     let note_stroke_dynamic_attrs = dynamic_css_attrs(
         palette.dynamic_css,

--- a/tests/svg_render.rs
+++ b/tests/svg_render.rs
@@ -888,14 +888,114 @@ fn sequence_svg_theme_changes_note_and_activation_colors() {
     );
 
     assert!(svg.contains("background-color: #333333;"), "{svg}");
-    // Two participants + activation rect + note path all draw with the
-    // theme's surface slot (#1f2020) — pre-fix the note and activation
-    // collapsed to the near-bg key_badge/inner_stroke mixes.
-    assert_eq!(svg.matches("fill=\"#1f2020\"").count(), 4, "{svg}");
+    // Two participants + activation rect = three rects at the theme's
+    // surface fill. The note path now resolves through its own `note_fill`
+    // slot (sticky yellow) instead of collapsing onto the surface, which is
+    // the parity behavior #358 restored.
+    assert_eq!(svg.matches("fill=\"#1f2020\"").count(), 3, "{svg}");
+    assert!(svg.contains("fill=\"#fff5ad\""), "{svg}");
     assert!(!svg.contains("#ffffcc"), "{svg}");
     assert!(!svg.contains("#ddd"), "{svg}");
     assert!(!svg.contains("#424242"), "{svg}");
     assert!(!svg.contains("#454545"), "{svg}");
+}
+
+#[test]
+fn sequence_svg_themed_note_fill_is_distinct_from_participant_fill() {
+    // Parity coverage for #358: every themed render must paint notes with a
+    // fill that is visibly distinct from the participant/node fill so the
+    // sticky-note cue survives theming. Checks light and dark Mermaid base
+    // themes so a future seed regression on either side trips the test.
+    let input = "sequenceDiagram\n    Alice->>Bob: Hello\n    Note right of Bob: Important\n";
+
+    // Every named Mermaid theme should produce a note fill that is distinct
+    // from the participant rect fill. Beautiful palettes fall back to surface
+    // and are covered by the broader theme suite once they each grow a tuned
+    // `note_fill`; until then the named Mermaid themes are the parity floor.
+    for theme_name in [
+        "default",
+        "dark",
+        "forest",
+        "neutral",
+        "zinc-light",
+        "zinc-dark",
+    ] {
+        let svg = render_svg(
+            input,
+            &RenderConfig {
+                svg_theme: Some(SvgThemeConfig {
+                    name: Some(theme_name.into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        );
+
+        // Extract the note path fill (the only <path ... Z" fill="..." />).
+        let note_marker = "Z\" fill=\"";
+        let note_idx = svg.find(note_marker).unwrap_or_else(|| {
+            panic!(
+                "expected a closed-path note fill in themed sequence SVG for {theme_name}: {svg}"
+            )
+        });
+        let after = &svg[note_idx + note_marker.len()..];
+        let note_fill = &after[..after.find('"').expect("note fill should be quoted")];
+
+        // Extract a participant rect fill: every theme renders the first
+        // participant via `<rect ... fill="..." stroke=...`.
+        let participant_marker = "<rect x=\"10.00\"";
+        let part_idx = svg
+            .find(participant_marker)
+            .unwrap_or_else(|| panic!("expected participant rect for {theme_name}: {svg}"));
+        let part_slice = &svg[part_idx..];
+        let fill_marker = "fill=\"";
+        let fill_idx = part_slice.find(fill_marker).expect("participant fill");
+        let after_part = &part_slice[fill_idx + fill_marker.len()..];
+        let participant_fill = &after_part[..after_part.find('"').expect("participant fill quote")];
+
+        assert_ne!(
+            note_fill, participant_fill,
+            "{theme_name}: note fill and participant fill collapsed to the same value ({note_fill}); \
+             #357 fixed visibility by routing both through `surface`, #358 restores the distinction"
+        );
+    }
+}
+
+#[test]
+fn sequence_svg_untheme_path_preserves_legacy_sticky_yellow() {
+    // Un-themed renders must keep the historical `#ffffcc` sticky-note fill
+    // byte-identically. This is the byte-stability anchor #358 promises for
+    // every fixture that does not opt into a theme.
+    let input = "sequenceDiagram\n    Alice->>Bob: Hello\n    Note right of Bob: Important\n";
+    let svg = render_svg(input, &RenderConfig::default());
+
+    assert!(svg.contains("fill=\"#ffffcc\""), "{svg}");
+    assert!(!svg.contains("fill=\"#fff5ad\""), "{svg}");
+}
+
+#[test]
+fn sequence_svg_dynamic_theme_emits_note_fill_css_variable() {
+    // Dynamic theme mode must surface `--note-fill` in the root style and
+    // bridge it through `--_note-fill: var(--note-fill);` so adapters can
+    // recolor sticky-notes at runtime without re-rendering.
+    let input = "sequenceDiagram\n    Alice->>Bob: Hello\n    Note right of Bob: Important\n";
+    let svg = render_svg(
+        input,
+        &RenderConfig {
+            svg_theme: Some(SvgThemeConfig {
+                name: Some("default".into()),
+                mode: SvgThemeMode::Dynamic,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    );
+
+    assert!(svg.contains("--note-fill:#fff5ad"), "{svg}");
+    assert!(
+        svg.contains("--_note-fill: var(--note-fill);"),
+        "dynamic style block should bridge --note-fill into --_note-fill: {svg}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adopts Option A from #358: a single `note_fill` slot on `ThemeSeed` / `ResolvedThemeSlots` / `DerivedThemeRoles`, with per-theme defaults.
- Restores the sticky-note visual cue that #357 collapsed when it routed `note_fill` through the `node_fill` (surface) slot.
- Per-theme seeds parity-checked against upstream Mermaid (`packages/mermaid/src/themes/theme-*.js`):
  - `default`, `dark`, `forest`: `#fff5ad` (Mermaid sticky yellow on every backdrop)
  - `neutral`: `#666666` (Mermaid neutral uses gray, not yellow)
  - `zinc-light`: `#fef9c3` (mmdflux-original, no Mermaid parity)
  - `zinc-dark`: `#854d0e` (mmdflux-original, no Mermaid parity)
  - All other Beautiful palettes: fall back to `surface` until each gets a tuned value.
- Wires `--note-fill` / `--_note-fill` through the dynamic CSS pipeline.
- Options B (full triple `note_fill`/`note_text`/`note_border`) and C (public CLI override) are intentionally deferred.

## Test plan

- [x] 3 new tests: themed distinctness across 6 themes, un-themed `#ffffcc` byte-stability, dynamic CSS `--note-fill` variable
- [x] Updated `sequence_svg_theme_changes_note_and_activation_colors` to assert the post-fix distinction
- [x] `just test` (3197 passed, 8 skipped)
- [x] `just lint`
- [x] `cargo xtask architecture check`
- [x] No sequence/class/flowchart snapshot churn (un-themed renders untouched)

Closes #358