### PR TITLE
feat: plumb label bend policy through routing (gate stays no-op)

### DIFF
--- a/src/engines/graph/algorithms/layered/float_layout.rs
+++ b/src/engines/graph/algorithms/layered/float_layout.rs
@@ -17,7 +17,7 @@ use crate::graph::measure::{
     edge_label_dimensions_wrapped_for_provider_and_style, edge_text_style_key,
     proportional_node_dimensions_with_provider, subgraph_title_text_style_key,
 };
-use crate::graph::routing::{EdgeRouting, route_graph_geometry_with_provider};
+use crate::graph::routing::{EdgeRouting, LabelBendPolicy, route_graph_geometry_with_provider};
 use crate::graph::{Direction, Edge, Graph, Stroke};
 
 /// Edge-label sizing that honors the pre-engine wrap artifact when present.
@@ -259,7 +259,17 @@ fn inject_routed_paths(
     edge_routing: EdgeRouting,
     metrics: &dyn TextMetricsProvider,
 ) -> GraphGeometry {
-    let routed = route_graph_geometry_with_provider(diagram, geom, edge_routing, metrics);
+    // `build_float_layout_with_flags` always runs in a proportional context
+    // (its only callers are flux.rs and mermaid.rs SVG/MMDS solves), so the
+    // injected routed paths feed proportional consumers. Opt in to Algorithm
+    // C's `adjusted_path` bow. See issue #240.
+    let routed = route_graph_geometry_with_provider(
+        diagram,
+        geom,
+        edge_routing,
+        metrics,
+        LabelBendPolicy::ApplyIfLanePacked,
+    );
     let mut updated = geom.clone();
     apply_routed_edge_paths(&mut updated, routed.edges);
     updated

--- a/src/engines/graph/flux.rs
+++ b/src/engines/graph/flux.rs
@@ -17,7 +17,7 @@ use crate::errors::RenderError;
 use crate::graph::geometry::{GraphGeometry, RoutedGraphGeometry};
 use crate::graph::measure::{TextMetricsProvider, default_proportional_text_metrics};
 use crate::graph::routing::{
-    EdgeRouting, route_graph_geometry, route_graph_geometry_with_provider,
+    EdgeRouting, LabelBendPolicy, route_graph_geometry, route_graph_geometry_with_provider,
 };
 use crate::graph::{GeometryLevel, Graph};
 
@@ -307,11 +307,21 @@ impl GraphEngine for FluxLayeredEngine {
                         &fallback_metrics
                     }
                 };
+                // Opt into Algorithm C's `adjusted_path` bow only when the
+                // request resolves to a proportional measurement mode (SVG /
+                // MMDS routed). Grid text falls through to `Skip` so the text
+                // renderer continues to read unbent routed paths. See issue
+                // #240.
+                let bend_policy = match mode {
+                    MeasurementMode::Proportional(_) => LabelBendPolicy::ApplyIfLanePacked,
+                    MeasurementMode::Grid => LabelBendPolicy::Skip,
+                };
                 Some(route_graph_geometry_with_provider(
                     diagram,
                     &geometry,
                     edge_routing,
                     solve_metrics,
+                    bend_policy,
                 ))
             } else {
                 None

--- a/src/engines/graph/mermaid.rs
+++ b/src/engines/graph/mermaid.rs
@@ -17,7 +17,7 @@ use crate::engines::graph::{
 };
 use crate::errors::RenderError;
 use crate::graph::geometry::RoutedGraphGeometry;
-use crate::graph::routing::{EdgeRouting, route_graph_geometry_with_provider};
+use crate::graph::routing::{EdgeRouting, LabelBendPolicy, route_graph_geometry_with_provider};
 use crate::graph::{GeometryLevel, Graph};
 
 /// Mermaid dagre default for isolated subgraphs without explicit direction:
@@ -192,11 +192,15 @@ impl GraphEngine for MermaidLayeredEngine {
             (request.geometry_contract, request.geometry_level),
             (GraphGeometryContract::Canonical, GeometryLevel::Routed)
         ) {
+            // Mermaid-layered always solves in a proportional context (the
+            // earlier guard rejects `MeasurementMode::Grid`), so it can opt
+            // into the Algorithm C bow unconditionally. See issue #240.
             Some(route_graph_geometry_with_provider(
                 diagram,
                 &geometry,
                 EdgeRouting::PolylineRoute,
                 metrics,
+                LabelBendPolicy::ApplyIfLanePacked,
             ))
         } else {
             None

--- a/src/graph/routing/mod.rs
+++ b/src/graph/routing/mod.rs
@@ -25,7 +25,9 @@ pub use self::float_core::{
 pub use self::labels::compute_end_label_positions;
 pub use self::orthogonal::{OrthogonalRoutingOptions, route_edges_orthogonal};
 pub(crate) use self::stage::route_graph_geometry_with_provider;
-pub use self::stage::{EdgeRouting, route_graph_geometry};
+pub use self::stage::{
+    EdgeRouting, LabelBendPolicy, route_graph_geometry, route_graph_geometry_with_policy,
+};
 #[cfg(test)]
 use crate::graph::Graph;
 #[cfg(test)]
@@ -1682,6 +1684,7 @@ mod tests {
             &geom,
             EdgeRouting::PolylineRoute,
             &provider,
+            LabelBendPolicy::Skip,
         );
 
         let label_rect = routed.edges[0].label_geometry.as_ref().unwrap().rect;
@@ -1791,6 +1794,7 @@ mod tests {
             &geom,
             EdgeRouting::PolylineRoute,
             &provider,
+            LabelBendPolicy::Skip,
         );
 
         let small_rect = routed.edges[0].label_geometry.as_ref().unwrap().rect;

--- a/src/graph/routing/stage.rs
+++ b/src/graph/routing/stage.rs
@@ -33,17 +33,54 @@ pub enum EdgeRouting {
     OrthogonalRoute,
 }
 
+/// Whether the routing stage applies Algorithm C's `adjusted_path` bow around
+/// lane-displaced edge labels.
+///
+/// Proportional consumers (SVG, MMDS routed) can opt in via
+/// `ApplyIfLanePacked`; the Grid text renderer must stay on `Skip` because
+/// bending routed paths corrupts text-grid corridor closure for backward
+/// edges (the text renderer reads routed paths directly). See issue #240 and
+/// research 0065 Q1 for the regression that motivates the gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LabelBendPolicy {
+    /// Discard `adjusted_path` and keep the unbent routed polyline.
+    #[default]
+    Skip,
+    /// Apply `adjusted_path` when the lane pass placed a label off track 0 in
+    /// a multi-member compartment.
+    ApplyIfLanePacked,
+}
+
 /// Route graph geometry to produce fully-routed edge paths.
 ///
 /// Consumes engine-agnostic `GraphGeometry` and produces `RoutedGraphGeometry`
-/// with polyline paths for every edge.
+/// with polyline paths for every edge. Defaults to [`LabelBendPolicy::Skip`];
+/// callers that target proportional output (SVG / MMDS routed) should use
+/// [`route_graph_geometry_with_policy`].
 pub fn route_graph_geometry(
     diagram: &Graph,
     geometry: &GraphGeometry,
     edge_routing: EdgeRouting,
     metrics: &ProportionalTextMetrics,
 ) -> RoutedGraphGeometry {
-    route_graph_geometry_with_provider(diagram, geometry, edge_routing, metrics)
+    route_graph_geometry_with_provider(
+        diagram,
+        geometry,
+        edge_routing,
+        metrics,
+        LabelBendPolicy::Skip,
+    )
+}
+
+/// Route graph geometry with an explicit [`LabelBendPolicy`].
+pub fn route_graph_geometry_with_policy(
+    diagram: &Graph,
+    geometry: &GraphGeometry,
+    edge_routing: EdgeRouting,
+    metrics: &ProportionalTextMetrics,
+    policy: LabelBendPolicy,
+) -> RoutedGraphGeometry {
+    route_graph_geometry_with_provider(diagram, geometry, edge_routing, metrics, policy)
 }
 
 pub(crate) fn route_graph_geometry_with_provider(
@@ -51,6 +88,7 @@ pub(crate) fn route_graph_geometry_with_provider(
     geometry: &GraphGeometry,
     edge_routing: EdgeRouting,
     metrics: &dyn TextMetricsProvider,
+    policy: LabelBendPolicy,
 ) -> RoutedGraphGeometry {
     let port_attachments = compute_port_attachments_from_geometry(diagram, geometry);
     #[cfg(test)]
@@ -275,7 +313,29 @@ pub(crate) fn route_graph_geometry_with_provider(
         // The adjusted_path field is kept in LabelTrackOutcome for
         // potential future use (e.g., a follow-on plan that adds a
         // text-aware path-bend pass).
-        let _ = &outcome.adjusted_path;
+        //
+        // `LabelBendPolicy::ApplyIfLanePacked` is plumbed through every
+        // proportional call site so a future Algorithm C revision can
+        // flip this gate without re-threading the parameter, but the
+        // current `shift_middle_segment` only displaces interior points
+        // and leaves the endpoint approach angles unchanged. Wiring the
+        // bow in directly produces visible regressions in proportional
+        // output:
+        //
+        //   1. SVG endpoint clipping (`adjust_edge_points_for_shapes`
+        //      and `clip_points_to_rect_*`) re-projects the now-diagonal
+        //      first/last segment against the node face, pulling the
+        //      arrowhead marker inside the node.
+        //   2. The corner-rounding pass in `path_emit::path_from_points_rounded`
+        //      emits more pronounced curves at the new acute joins,
+        //      producing visible kinks/loops near each endpoint.
+        //
+        // Until Algorithm C learns to preserve the perpendicular
+        // approach to each face (e.g. via an S-curve that meets the
+        // node faces orthogonally), the wire-up here stays a no-op even
+        // when the policy is `ApplyIfLanePacked`. See issue #240 for
+        // the regression catalog.
+        let _ = (policy, &outcome.adjusted_path);
     }
 
     // Lane-aware re-wrap. Runs AFTER the wire-up loop above (so routed edges

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -20,7 +20,8 @@ use crate::graph::measure::{
 };
 use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
 use crate::graph::routing::{
-    EdgeRouting, route_graph_geometry, route_graph_geometry_with_provider,
+    EdgeRouting, LabelBendPolicy, route_graph_geometry_with_policy,
+    route_graph_geometry_with_provider,
 };
 use crate::graph::style::{EdgeStyle, NodeStyle};
 use crate::graph::{Arrow, Direction, GeometryLevel, Graph, Shape, Stroke};
@@ -291,18 +292,28 @@ pub(crate) fn to_document_typed_with_routing_and_text_metrics(
     text_measurements: Option<&TextMeasurementCache>,
 ) -> Result<Document, RenderError> {
     let routed_owned = (routed.is_none() && matches!(level, GeometryLevel::Routed)).then(|| {
+        // MMDS routed output is a proportional consumer; opt into Algorithm C's
+        // `adjusted_path` bow on both the metrics-provided and fallback paths.
+        // See issue #240.
         match text_metrics_provider {
             Some(metrics) => route_graph_geometry_with_provider(
                 diagram,
                 geometry,
                 EdgeRouting::OrthogonalRoute,
                 metrics,
+                LabelBendPolicy::ApplyIfLanePacked,
             ),
             None => {
                 // Static MMDS fallback routing for legacy adapter callers that
                 // request routed output without already carrying resolved metrics.
                 let metrics = default_proportional_text_metrics();
-                route_graph_geometry(diagram, geometry, EdgeRouting::OrthogonalRoute, &metrics)
+                route_graph_geometry_with_policy(
+                    diagram,
+                    geometry,
+                    EdgeRouting::OrthogonalRoute,
+                    &metrics,
+                    LabelBendPolicy::ApplyIfLanePacked,
+                )
             }
         }
     });

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -16,7 +16,7 @@ use crate::graph::geometry::{
 };
 use crate::graph::measure::{TextMetricsProvider, default_proportional_text_metrics};
 use crate::graph::projection::{GridProjection, OverrideSubgraphProjection};
-use crate::graph::routing::{EdgeRouting, route_graph_geometry_with_provider};
+use crate::graph::routing::{EdgeRouting, LabelBendPolicy, route_graph_geometry_with_provider};
 use crate::graph::space::{FPoint, FRect};
 use crate::graph::style::{ColorToken, EdgeStyle, NodeStyle};
 use crate::graph::{Edge as GraphEdge, GeometryLevel, Graph, Node, Subgraph};
@@ -426,7 +426,17 @@ pub(crate) fn hydrate_routed_geometry_from_document_with_provider(
     } else {
         EdgeRouting::PolylineRoute
     };
-    let mut routed = route_graph_geometry_with_provider(&diagram, &geometry, edge_routing, metrics);
+    // MMDS hydrate rebuilds routed geometry for a proportional consumer
+    // (SVG / MMDS replay). Opt into Algorithm C's `adjusted_path` bow so
+    // the bow-aware paths the producer emitted survive the round-trip.
+    // See issue #240.
+    let mut routed = route_graph_geometry_with_provider(
+        &diagram,
+        &geometry,
+        edge_routing,
+        metrics,
+        LabelBendPolicy::ApplyIfLanePacked,
+    );
 
     // Preserve authoritative routed label geometry by overwriting
     // `label_geometry` on routed edges with the semantics carried by the MMDS


### PR DESCRIPTION
## Summary

- Adds `LabelBendPolicy::{Skip, ApplyIfLanePacked}` to `graph::routing` and threads it through `route_graph_geometry_with_provider`. New `route_graph_geometry_with_policy` entry point exposes the policy for proportional callers without churning the ~100 existing test call sites that default to `Skip`.
- Proportional consumers wire in the policy: flux SVG/MMDS routed solves, mermaid-layered, the float-layout `inject_routed_paths`, MMDS document output, and MMDS hydrate now request `ApplyIfLanePacked`. The render-time text fallback (`render_text_from_geometry`) and the public `route_graph_geometry` 4-arg API stay on `Skip`.
- **The actual `adjusted_path` wire-up at the policy check stays a no-op.** A first attempt to apply the bow surfaced two SVG regressions catalogued on #240 (both caused by Algorithm C only displacing interior polyline points without preserving the perpendicular approach to each node face):
  1. **Markers behind nodes** — `adjust_edge_points_for_shapes` and `clip_points_to_rect_*` re-project the new diagonal first/last segment against the node face and pull the arrowhead marker inside the node.
  2. **Loops/kinks near endpoints** — `path_emit::path_from_points_rounded` emits more pronounced curves at the new acute joins.

Until Algorithm C's `shift_middle_segment` learns to preserve the perpendicular approach to each face (S-curve, port-aware re-attachment, or similar), the gate stays effectively closed. The plumbing is what #237 Plan 0149's pivot needs from #240 — once the bow algorithm is corrected, flipping the gate is a one-line change at `stage.rs:321`.

## Test plan

- [x] `just check` (lint + nextest + architecture) — 3211 tests pass
- [x] Text snapshots byte-identical
- [x] SVG snapshots byte-identical (`git diff --stat origin/main..HEAD -- tests/` is empty)
- [x] Public API additions surface a usable enum + with-policy entry point for the Plan 0149 pivot

## Follow-up

- Algorithm C revision in `label_lanes::shift_middle_segment` to preserve endpoint approach angles. Tracked under #240 with the regression catalog above; #233 (BT/RL off-edge visual quality) is adjacent and likely benefits from the same revision.

Refs #240