### PR TITLE
fix: surface unfit label overlap diagnostics

### DIFF
--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -295,6 +295,7 @@ mmdflux --format mmds --geometry-level routed diagram.mmd
 | `metadata.direction`    | string                   | `"TD"`, `"TB"`, `"BT"`, `"LR"`, or `"RL"`; `"TB"` deserializes as canonical `"TD"`                                                   |
 | `metadata.bounds`       | object                   | Overall diagram canvas extents (`width`, `height`) in unitless MMDS coordinate space (currently SVG-pixel-aligned in mmdflux output) |
 | `metadata.engine`       | string?                  | Engine+algorithm that produced this output (e.g., `"flux-layered"`). Omitted when not produced via the solve pipeline.               |
+| `metadata.diagnostics`  | object?                  | Optional mmdflux diagnostics emitted from routed geometry. Omitted when empty and only populated for `"routed"` geometry output.     |
 | `subgraphs`             | array                    | Subgraph inventory (omitted when empty)                                                                                              |
 
 ## Profiles and Extensions Governance
@@ -663,6 +664,24 @@ the routed path.
 | `parent`    | string?           | both   | Parent subgraph ID                                    |
 | `direction` | string?           | both   | Direction override: `"TD"`, `"TB"`, `"BT"`, `"LR"`, or `"RL"`; `"TB"` deserializes as canonical `"TD"` |
 | `bounds`    | `{width, height}` | routed | Bounding box dimensions                               |
+
+### Metadata Diagnostics
+
+`metadata.diagnostics` is an optional object for diagnostics that are derived
+from routed geometry. mmdflux omits it when no routed diagnostics are present.
+Layout-level MMDS does not include routed diagnostics because layout output has
+no routed path or routed label rectangle to attach them to.
+
+Current diagnostic fields:
+
+| Field                                             | Type   | Level  | Description                                                                 |
+| ------------------------------------------------- | ------ | ------ | --------------------------------------------------------------------------- |
+| `metadata.diagnostics.unfit_label_overlaps`       | array  | routed | Labels that could not fit in the available edge gap after marker avoidance. |
+| `unfit_label_overlaps[].edge_id`                  | string | routed | MMDS edge ID whose label could not fit.                                      |
+| `unfit_label_overlaps[].label`                    | string | routed | Rendered edge label text.                                                    |
+| `unfit_label_overlaps[].gap_pixels`               | number | routed | Available edge-parallel gap in current mmdflux output coordinates.          |
+| `unfit_label_overlaps[].label_span_pixels`        | number | routed | Padded label span in current mmdflux output coordinates.                    |
+| `unfit_label_overlaps[].attempted_side`           | string | routed | Attempted label side: `"above"`, `"below"`, or `"center"`.                  |
 
 ### Identifier Namespace
 

--- a/docs/mmds.schema.json
+++ b/docs/mmds.schema.json
@@ -207,6 +207,55 @@
         "engine": {
           "type": "string",
           "description": "Engine+algorithm identifier that produced this output (e.g., 'flux-layered', 'mermaid-layered'). Present when the output was produced via the solve pipeline."
+        },
+        "diagnostics": {
+          "$ref": "#/$defs/MetadataDiagnostics",
+          "description": "Optional routed diagnostics emitted by mmdflux. Present only when routed geometry detected reportable conditions."
+        }
+      }
+    },
+    "MetadataDiagnostics": {
+      "type": "object",
+      "properties": {
+        "unfit_label_overlaps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/UnfitLabelOverlapDiagnostic"
+          },
+          "default": [],
+          "description": "Labels that could not fit in the available edge gap after marker avoidance. Routed level only."
+        }
+      }
+    },
+    "UnfitLabelOverlapDiagnostic": {
+      "type": "object",
+      "required": [
+        "edge_id",
+        "label",
+        "gap_pixels",
+        "label_span_pixels",
+        "attempted_side"
+      ],
+      "properties": {
+        "edge_id": {
+          "type": "string",
+          "description": "MMDS edge ID whose label could not fit."
+        },
+        "label": {
+          "type": "string",
+          "description": "Rendered edge label text."
+        },
+        "gap_pixels": {
+          "type": "number",
+          "description": "Available gap along the edge-parallel axis in current mmdflux output coordinates."
+        },
+        "label_span_pixels": {
+          "type": "number",
+          "description": "Padded label span along the edge-parallel axis in current mmdflux output coordinates."
+        },
+        "attempted_side": {
+          "enum": ["above", "below", "center"],
+          "description": "Label side attempted by the routed layout."
         }
       }
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ use mmdflux::graph::measure::validate_text_metrics_profile_id;
 use mmdflux::simplification::PathSimplification;
 use mmdflux::{
     ColorWhen, EngineAlgorithmId, LayoutConfig, OutputFormat, Ranker, RenderConfig, SvgThemeConfig,
-    SvgThemeMode, TextColorMode, apply_svg_surface_defaults, detect_diagram, render_diagram,
-    validate_diagram,
+    SvgThemeMode, TextColorMode, apply_svg_surface_defaults, detect_diagram, materialize_diagram,
+    render_diagram, render_document, validate_diagram,
 };
 use serde::{Deserialize, Serialize};
 use svg_theme_auto::{SVG_THEME_AUTO_DEFAULT_SPEC, SvgThemeAutoMap, select_auto_theme_name};
@@ -54,6 +54,35 @@ struct CliLintJson {
 }
 
 const STRICT_PARSE_WARNING_PREFIX: &str = "Strict parsing would reject this input:";
+
+fn extract_mmds_unfit_warning_lines(document: &mmdflux::mmds::Document) -> Vec<String> {
+    let Some(diag) = document.metadata.diagnostics.as_ref() else {
+        return Vec::new();
+    };
+    diag.unfit_label_overlaps
+        .iter()
+        .map(|overlap| {
+            let label = serde_json::to_string(&overlap.label)
+                .unwrap_or_else(|_| format!("{:?}", overlap.label));
+            format!(
+                "Warning: edge {} label {} could not fit gap (gap={:.2}, span={:.2}, side={})",
+                overlap.edge_id,
+                label,
+                overlap.gap_pixels,
+                overlap.label_span_pixels,
+                edge_label_side_name(overlap.attempted_side)
+            )
+        })
+        .collect()
+}
+
+fn edge_label_side_name(side: mmdflux::graph::geometry::EdgeLabelSide) -> &'static str {
+    match side {
+        mmdflux::graph::geometry::EdgeLabelSide::Above => "above",
+        mmdflux::graph::geometry::EdgeLabelSide::Below => "below",
+        mmdflux::graph::geometry::EdgeLabelSide::Center => "center",
+    }
+}
 
 fn normalize_validation_result(result: ValidationResult) -> CliLintJson {
     let default_severity = if result.valid {
@@ -749,7 +778,24 @@ fn main() -> io::Result<()> {
     }
 
     // Render through the shared facade contract.
-    match render_diagram(&input, format, &config) {
+    let rendered = if format == OutputFormat::Mmds && matches!(diagram_id, "flowchart" | "class") {
+        materialize_diagram(&input, &config).and_then(|document| {
+            let output = render_document(&document, OutputFormat::Mmds, &config)?;
+            if !cli.quiet
+                && document.geometry_level == GeometryLevel::Routed
+                && config.geometry_level == GeometryLevel::Routed
+            {
+                for line in extract_mmds_unfit_warning_lines(&document) {
+                    eprintln!("{line}");
+                }
+            }
+            Ok(output)
+        })
+    } else {
+        render_diagram(&input, format, &config)
+    };
+
+    match rendered {
         Ok(output) => match &cli.output {
             Some(path) => fs::write(path, &output)?,
             None => print!("{}", output),
@@ -931,5 +977,37 @@ mod tests {
         );
 
         assert_eq!(auto_output, explicit_output);
+    }
+
+    #[test]
+    fn extract_mmds_unfit_warning_lines_from_metadata_diagnostics() {
+        let json = r#"{
+          "version": 1,
+          "defaults": {"node": {}, "edge": {}},
+          "geometry_level": "routed",
+          "metadata": {
+            "diagram_type": "flowchart",
+            "direction": "TD",
+            "bounds": {"width": 10.0, "height": 10.0},
+            "diagnostics": {
+              "unfit_label_overlaps": [{
+                "edge_id": "e4",
+                "label": "too\nlong",
+                "gap_pixels": 8.0,
+                "label_span_pixels": 14.0,
+                "attempted_side": "below"
+              }]
+            }
+          },
+          "nodes": [],
+          "edges": [],
+          "subgraphs": []
+        }"#;
+        let document = mmdflux::mmds::parse_input(json).expect("MMDS document should parse");
+        let lines = extract_mmds_unfit_warning_lines(&document);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("edge e4"));
+        assert!(lines[0].contains(r#"label "too\nlong""#));
+        assert!(lines[0].contains("could not fit gap"));
     }
 }

--- a/src/mmds/document.rs
+++ b/src/mmds/document.rs
@@ -423,6 +423,21 @@ fn build_document(
             height: effective_bounds.height,
         },
         engine: options.engine_id.map(|id| id.to_string()),
+        diagnostics: routed.and_then(|r| {
+            (!r.unfit_label_overlaps.is_empty()).then(|| MetadataDiagnostics {
+                unfit_label_overlaps: r
+                    .unfit_label_overlaps
+                    .iter()
+                    .map(|u| UnfitLabelOverlapDiagnostic {
+                        edge_id: format!("e{}", u.edge_index),
+                        label: u.label.clone(),
+                        gap_pixels: u.gap_pixels,
+                        label_span_pixels: u.label_span_pixels,
+                        attempted_side: u.attempted_side,
+                    })
+                    .collect(),
+            })
+        }),
     };
 
     // Build nodes from geometry (float positions)
@@ -1173,6 +1188,28 @@ pub struct Metadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub engine: Option<String>,
+    /// Optional routed diagnostics surfaced for consumers/CLI warnings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub diagnostics: Option<MetadataDiagnostics>,
+}
+
+/// Optional routed diagnostics attached under `metadata.diagnostics`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetadataDiagnostics {
+    /// Labels that could not fit in the available edge gap after marker avoidance.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unfit_label_overlaps: Vec<UnfitLabelOverlapDiagnostic>,
+}
+
+/// One unfit edge-label overlap diagnostic entry for MMDS/CLI surfaces.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnfitLabelOverlapDiagnostic {
+    pub edge_id: String,
+    pub label: String,
+    pub gap_pixels: f64,
+    pub label_span_pixels: f64,
+    pub attempted_side: EdgeLabelSide,
 }
 
 /// Bounding box dimensions.

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -1077,6 +1077,7 @@ mod tests {
                     height: 160.0,
                 },
                 engine: None,
+                diagnostics: None,
             },
             nodes: vec![
                 crate::mmds::Node {

--- a/src/runtime/mmds.rs
+++ b/src/runtime/mmds.rs
@@ -1280,6 +1280,7 @@ fn prefixed_display_error(prefix: &str, error: impl Display) -> RenderError {
 fn strip_routed_fields(payload: &Document) -> Document {
     let mut output = payload.clone();
     output.geometry_level = crate::graph::GeometryLevel::Layout;
+    output.metadata.diagnostics = None;
     for edge in &mut output.edges {
         edge.path = None;
         edge.label_position = None;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1418,6 +1418,30 @@ fn cli_json_routed_level_includes_paths() {
 }
 
 #[test]
+fn cli_mmds_routed_level_warns_for_unfit_label_overlaps() {
+    mmdflux()
+        .args([
+            "--format",
+            "mmds",
+            "--geometry-level",
+            "routed",
+            "--rank-spacing",
+            "1",
+            "--svg-node-padding-x",
+            "300",
+            "--svg-node-padding-y",
+            "20",
+        ])
+        .write_stdin("graph LR\nA -->|this is a deliberately long label that cannot fit| B\n")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"unfit_label_overlaps\""))
+        .stderr(predicate::str::contains(
+            "Warning: edge e0 label \"this is a deliberately long label that cannot fit\" could not fit gap",
+        ));
+}
+
+#[test]
 fn cli_json_routed_level_accepts_path_simplification_lossless() {
     mmdflux()
         .args([

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -22,8 +22,8 @@ use mmdflux::mmds::{
 };
 use mmdflux::simplification::PathSimplification;
 use mmdflux::{
-    EngineAlgorithmId, GraphTextStyleConfig, OutputFormat, RenderConfig, TextColorMode,
-    materialize_diagram, render_diagram,
+    EngineAlgorithmId, GraphTextStyleConfig, LayoutConfig, OutputFormat, RenderConfig,
+    TextColorMode, materialize_diagram, render_diagram,
 };
 use serde_json::{Value, json};
 
@@ -3113,8 +3113,18 @@ fn mmds_schema_rejects_label_side_with_invalid_enum() {
 #[test]
 fn mmds_routed_to_layout_down_conversion_strips_routed_only_edge_fields() {
     let routed_json = render_json_with_level("graph TD\nA -->|forward| B", GeometryLevel::Routed);
+    let mut routed_value: Value = serde_json::from_str(&routed_json).unwrap();
+    routed_value["metadata"]["diagnostics"] = json!({
+        "unfit_label_overlaps": [{
+            "edge_id": "e0",
+            "label": "forward",
+            "gap_pixels": 1.0,
+            "label_span_pixels": 2.0,
+            "attempted_side": "above"
+        }]
+    });
     let layout_output = render_mmds_input(
-        &routed_json,
+        &serde_json::to_string_pretty(&routed_value).unwrap(),
         OutputFormat::Mmds,
         RenderConfig {
             geometry_level: GeometryLevel::Layout,
@@ -3123,6 +3133,10 @@ fn mmds_routed_to_layout_down_conversion_strips_routed_only_edge_fields() {
     );
     let parsed: Document = serde_json::from_str(&layout_output).unwrap();
     assert_eq!(parsed.geometry_level, GeometryLevel::Layout);
+    assert!(
+        parsed.metadata.diagnostics.is_none(),
+        "routed diagnostics must be stripped at layout level"
+    );
     for edge in &parsed.edges {
         assert!(edge.path.is_none(), "path must be stripped at layout level");
         assert!(
@@ -3640,4 +3654,83 @@ mod plan_0151_routed_mmds_replay_contract {
             "replay SVG anchor {anchor:?} must track the authoritative label_rect center {authoritative:?}; drift {drift:.2} px"
         );
     }
+}
+
+#[test]
+fn mmds_parses_metadata_diagnostics_unfit_label_overlaps() {
+    let value = serde_json::json!({
+      "version": 1,
+      "defaults": {"node": {}, "edge": {}},
+      "geometry_level": "routed",
+      "metadata": {
+        "diagram_type": "flowchart",
+        "direction": "TD",
+        "bounds": {"width": 10.0, "height": 10.0},
+        "diagnostics": {
+          "unfit_label_overlaps": [{
+            "edge_id": "e0",
+            "label": "long",
+            "gap_pixels": 10.0,
+            "label_span_pixels": 20.0,
+            "attempted_side": "above"
+          }]
+        }
+      },
+      "nodes": [{"id":"A","label":"A","position":{"x":0.0,"y":0.0},"size":{"width":1.0,"height":1.0}}],
+      "edges": [{"id":"e0","source":"A","target":"A"}],
+      "subgraphs": []
+    });
+    let doc: Document = serde_json::from_value(value).expect("document should parse");
+    let overlaps = doc
+        .metadata
+        .diagnostics
+        .expect("diagnostics should parse")
+        .unfit_label_overlaps;
+    assert_eq!(overlaps.len(), 1);
+    assert_eq!(overlaps[0].edge_id, "e0");
+}
+
+#[test]
+fn mmds_routed_output_populates_unfit_label_overlap_diagnostics() {
+    let input = "graph LR\nA -->|this is a deliberately long label that cannot fit| B\n";
+    let config = |level| RenderConfig {
+        geometry_level: level,
+        layout: LayoutConfig {
+            rank_sep: 1.0,
+            ..LayoutConfig::default()
+        },
+        svg_node_padding_x: Some(300.0),
+        svg_node_padding_y: Some(20.0),
+        ..RenderConfig::default()
+    };
+
+    let layout_output: Document = serde_json::from_str(&render_json_with_config(
+        input,
+        &config(GeometryLevel::Layout),
+    ))
+    .unwrap();
+    assert_eq!(layout_output.geometry_level, GeometryLevel::Layout);
+    assert!(
+        layout_output.metadata.diagnostics.is_none(),
+        "layout MMDS must not carry routed diagnostics"
+    );
+
+    let routed_json = render_json_with_config(input, &config(GeometryLevel::Routed));
+    let routed_value: Value = serde_json::from_str(&routed_json).unwrap();
+    assert_schema_valid(routed_value);
+
+    let routed_output: Document = serde_json::from_str(&routed_json).unwrap();
+    assert_eq!(routed_output.geometry_level, GeometryLevel::Routed);
+    let overlaps = routed_output
+        .metadata
+        .diagnostics
+        .expect("routed diagnostics should be present")
+        .unfit_label_overlaps;
+    assert_eq!(overlaps.len(), 1);
+    assert_eq!(overlaps[0].edge_id, "e0");
+    assert_eq!(
+        overlaps[0].label,
+        "this is a deliberately long label that cannot fit"
+    );
+    assert!(overlaps[0].gap_pixels < overlaps[0].label_span_pixels);
 }

--- a/tests/mmds_views.rs
+++ b/tests/mmds_views.rs
@@ -40,6 +40,7 @@ fn output(nodes: Vec<Node>, edges: Vec<Edge>, subgraphs: Vec<Subgraph>) -> Docum
                 height: 200.0,
             },
             engine: None,
+            diagnostics: None,
         },
         nodes,
         edges,


### PR DESCRIPTION
## Summary

Expose routed unfit label overlap diagnostics through MMDS metadata and surface them as CLI warnings when rendering MMDS output.

## Why

Issue #234 needs the renderer to preserve diagnostic information when labels cannot be fitted without overlap. Without this, MMDS consumers and CLI users lose visibility into overlap conditions that the routing pipeline already detects.

## Impact

- MMDS routed output now includes `metadata.diagnostics.unfit_label_overlaps` when routed geometry records unfit label overlap diagnostics.
- Layout-level MMDS intentionally omits routed diagnostics because it has no routed path or routed label rectangle to attach them to.
- Hydrated MMDS views carry the metadata through the adapter path.
- The CLI emits warnings for MMDS routed output when these diagnostics are present.
- The schema and MMDS docs now document the diagnostics shape.
- Regression coverage locks the JSON contract and CLI warning behavior.

Closes #234

## Validation

- `just test-file mmds_json`
- `just test-file cli`
- `just check`