### PR TITLE
fix: trust svg label geometry centers

### DIFF
--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -53,6 +53,32 @@ fn render_svg(diagram: &crate::graph::Graph, config: &RenderConfig) -> String {
     }
 }
 
+fn render_svg_with_geometry(
+    diagram: &crate::graph::Graph,
+    config: &RenderConfig,
+) -> (String, crate::graph::geometry::GraphGeometry) {
+    let engine = FluxLayeredEngine::text();
+    let metrics = default_proportional_text_metrics();
+    let request = GraphSolveRequest::new(
+        MeasurementMode::Proportional(&metrics),
+        GraphGeometryContract::Visual,
+        config.geometry_level,
+        config
+            .routing_style
+            .or_else(|| config.edge_preset.map(|preset| preset.expand().0)),
+        Default::default(),
+    );
+    let result = engine
+        .solve(
+            diagram,
+            &EngineConfig::Layered(config.layout.clone().into()),
+            &request,
+        )
+        .expect("SVG render should succeed");
+    let svg = render_svg_from_geometry(diagram, &result.geometry, &config.svg_render_options());
+    (svg, result.geometry)
+}
+
 fn render_svg_with_provider_for_test(input: &str, provider: &dyn TextMetricsProvider) -> String {
     let flowchart = parse_flowchart(input).expect("fixture parses");
     let diagram = compile_to_graph(&flowchart);
@@ -600,65 +626,72 @@ fn euclidean_distance(a: (f64, f64), b: (f64, f64)) -> f64 {
     ((a.0 - b.0).powi(2) + (a.1 - b.1).powi(2)).sqrt()
 }
 
-fn distance_point_to_svg_segment(point: (f64, f64), a: (f64, f64), b: (f64, f64)) -> f64 {
-    let dx = b.0 - a.0;
-    let dy = b.1 - a.1;
-    let seg_len_sq = dx * dx + dy * dy;
-    if seg_len_sq <= 0.000_001 {
-        return euclidean_distance(point, a);
-    }
-
-    let projection = ((point.0 - a.0) * dx + (point.1 - a.1) * dy) / seg_len_sq;
-    let t = projection.clamp(0.0, 1.0);
-    let closest = (a.0 + t * dx, a.1 + t * dy);
-    euclidean_distance(point, closest)
-}
-
-fn distance_point_to_svg_path(point: (f64, f64), path: &[(f64, f64)]) -> f64 {
-    if path.is_empty() {
-        return f64::INFINITY;
-    }
-    if path.len() == 1 {
-        return euclidean_distance(point, path[0]);
-    }
-    path.windows(2)
-        .map(|segment| distance_point_to_svg_segment(point, segment[0], segment[1]))
-        .fold(f64::INFINITY, f64::min)
-}
-
-fn svg_label_drift_failures(
+fn svg_label_geometry_center_failures(
     svg: &str,
     diagram: &crate::graph::Graph,
-    max_distance: f64,
+    geom: &crate::graph::geometry::GraphGeometry,
 ) -> Vec<String> {
-    let expected_labels = diagram
-        .edges
-        .iter()
-        .filter(|edge| edge.label.is_some())
-        .count();
     let label_positions = extract_edge_label_positions(svg, diagram);
-    let paths: Vec<Vec<(f64, f64)>> = edge_path_data(svg)
-        .iter()
-        .map(|path| parse_svg_path_points(path))
-        .collect();
+    let mut expected_by_label: HashMap<String, Vec<(f64, f64)>> = HashMap::new();
+    for edge in &diagram.edges {
+        let Some(label) = &edge.label else {
+            continue;
+        };
+        let Some(label_geometry) = geom
+            .edges
+            .iter()
+            .find(|layout_edge| layout_edge.index == edge.index)
+            .and_then(|layout_edge| layout_edge.label_geometry.as_ref())
+        else {
+            continue;
+        };
+        expected_by_label
+            .entry(label.clone())
+            .or_default()
+            .push((label_geometry.center.x, label_geometry.center.y));
+    }
 
+    let expected_count: usize = expected_by_label.values().map(Vec::len).sum();
     let mut failures = Vec::new();
-    if label_positions.len() != expected_labels {
+    if label_positions.len() != expected_count {
         failures.push(format!(
-            "edge-label extraction mismatch: expected={expected_labels}, extracted={}",
+            "edge-label extraction mismatch: expected={expected_count}, extracted={}",
             label_positions.len()
         ));
     }
 
-    for (label, point) in label_positions {
-        let drift = paths
+    for (label, actual) in label_positions {
+        let Some(candidates) = expected_by_label.get_mut(&label) else {
+            failures.push(format!("unexpected rendered edge label {label:?}"));
+            continue;
+        };
+        let Some((best_index, best_distance)) = candidates
             .iter()
-            .map(|path| distance_point_to_svg_path(point, path))
-            .fold(f64::INFINITY, f64::min);
-        if drift > max_distance {
+            .enumerate()
+            .map(|(index, expected)| (index, euclidean_distance(actual, *expected)))
+            .min_by(|(_, a), (_, b)| a.total_cmp(b))
+        else {
+            failures.push(format!("no remaining label_geometry center for {label:?}"));
+            continue;
+        };
+        let expected = candidates.remove(best_index);
+        if best_distance > SVG_LABEL_GEOMETRY_CENTER_TOLERANCE {
             failures.push(format!(
-                "label {label:?} at ({:.2}, {:.2}) drift={drift:.2} exceeds {max_distance:.2}",
-                point.0, point.1
+                "label {label:?} at ({:.2}, {:.2}) expected ({:.2}, {:.2}) distance={best_distance:.2} exceeds {:.2}",
+                actual.0,
+                actual.1,
+                expected.0,
+                expected.1,
+                SVG_LABEL_GEOMETRY_CENTER_TOLERANCE
+            ));
+        }
+    }
+
+    for (label, remaining) in expected_by_label {
+        for expected in remaining {
+            failures.push(format!(
+                "missing rendered edge label {label:?} for label_geometry center ({:.2}, {:.2})",
+                expected.0, expected.1
             ));
         }
     }
@@ -2363,17 +2396,10 @@ fn routed_svg_defaults_to_none_path_simplification() {
     }
 }
 
-// Tolerance for SVG label drift from rendered active path segments.
-// Plan 0145 PR 3 lane shifts intentionally place labels off-path by
-// `track * label_step` (typically 16-32 px) to resolve compartment
-// overlap. The lane-shifted labels are excluded from this assertion
-// in `labeled_edge_label_drift_failures_for_svg`. Non-lane-shifted
-// labels (singletons, `track == 0`) should still attach tightly to
-// their edge, so the original 2.0 px gate stays.
-const SVG_LABEL_REVALIDATION_MAX_DISTANCE_TO_ACTIVE_SEGMENT: f64 = 2.0;
+const SVG_LABEL_GEOMETRY_CENTER_TOLERANCE: f64 = 1.0;
 
 #[test]
-fn svg_orthogonal_orthogonal_route_labeled_edges_labels_remain_attached_to_active_segments() {
+fn svg_orthogonal_orthogonal_route_labeled_edges_labels_use_label_geometry_centers() {
     let diagram = load_flowchart_fixture_diagram("labeled_edges.mmd");
     let options = RenderConfig {
         routing_style: Some(RoutingStyle::Orthogonal),
@@ -2381,23 +2407,18 @@ fn svg_orthogonal_orthogonal_route_labeled_edges_labels_remain_attached_to_activ
         path_simplification: PathSimplification::None,
         ..Default::default()
     };
-    let svg = render_svg(&diagram, &options);
+    let (svg, geom) = render_svg_with_geometry(&diagram, &options);
 
-    let failures = svg_label_drift_failures(
-        &svg,
-        &diagram,
-        SVG_LABEL_REVALIDATION_MAX_DISTANCE_TO_ACTIVE_SEGMENT,
-    );
+    let failures = svg_label_geometry_center_failures(&svg, &diagram, &geom);
     assert!(
         failures.is_empty(),
-        "Label revalidation regression: labeled_edges rendered off-path edge labels:\n{}",
+        "labeled_edges SVG labels diverged from label_geometry centers:\n{}",
         failures.join("\n")
     );
 }
 
 #[test]
-fn svg_orthogonal_orthogonal_route_inline_label_flowchart_labels_remain_attached_to_active_segments()
- {
+fn svg_orthogonal_orthogonal_route_inline_label_flowchart_labels_use_label_geometry_centers() {
     let diagram = load_flowchart_fixture_diagram("inline_label_flowchart.mmd");
     let options = RenderConfig {
         routing_style: Some(RoutingStyle::Orthogonal),
@@ -2405,16 +2426,12 @@ fn svg_orthogonal_orthogonal_route_inline_label_flowchart_labels_remain_attached
         path_simplification: PathSimplification::None,
         ..Default::default()
     };
-    let svg = render_svg(&diagram, &options);
+    let (svg, geom) = render_svg_with_geometry(&diagram, &options);
 
-    let failures = svg_label_drift_failures(
-        &svg,
-        &diagram,
-        SVG_LABEL_REVALIDATION_MAX_DISTANCE_TO_ACTIVE_SEGMENT,
-    );
+    let failures = svg_label_geometry_center_failures(&svg, &diagram, &geom);
     assert!(
         failures.is_empty(),
-        "Label revalidation regression: inline_label_flowchart rendered off-path edge labels:\n{}",
+        "inline_label_flowchart SVG labels diverged from label_geometry centers:\n{}",
         failures.join("\n")
     );
 }
@@ -6304,6 +6321,22 @@ mod plan_0145_q9_red {
     #[test]
     fn svg_viewbox_covers_all_label_background_rects_multi_edge() {
         let input = load_flowchart_fixture("multi_edge_labeled.mmd");
+        let svg = render_svg_default(&input);
+        let failures = svg_viewbox_contains_rects(&svg);
+        assert!(failures.is_empty(), "viewBox violations: {failures:?}");
+    }
+
+    #[test]
+    fn svg_viewbox_covers_git_workflow_lr_backward_label() {
+        let input = load_flowchart_fixture("git_workflow.mmd");
+        let svg = render_svg_default(&input);
+        let failures = svg_viewbox_contains_rects(&svg);
+        assert!(failures.is_empty(), "viewBox violations: {failures:?}");
+    }
+
+    #[test]
+    fn svg_viewbox_covers_git_workflow_td_backward_label() {
+        let input = load_flowchart_fixture("git_workflow_td.mmd");
         let svg = render_svg_default(&input);
         let failures = svg_viewbox_contains_rects(&svg);
         assert!(failures.is_empty(), "viewBox violations: {failures:?}");

--- a/src/render/graph/svg/bounds.rs
+++ b/src/render/graph/svg/bounds.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use super::labels::{fallback_label_position, precomputed_label_positions};
+use super::labels::resolve_edge_label;
 use super::{Point, Rect};
 use crate::graph::geometry::GraphGeometry;
 use crate::graph::measure::{
@@ -57,6 +57,7 @@ pub(super) fn compute_svg_bounds(
     metrics: &dyn TextMetricsProvider,
     self_edge_paths: &HashMap<usize, Vec<Point>>,
     rendered_edge_paths: &HashMap<usize, Vec<Point>>,
+    override_nodes: &HashMap<String, String>,
 ) -> SvgBounds {
     let mut bounds = SvgBounds::new();
 
@@ -109,8 +110,6 @@ pub(super) fn compute_svg_bounds(
         }
     }
 
-    let label_positions = precomputed_label_positions(geom);
-
     for edge in diagram.edges.iter() {
         if edge.stroke == Stroke::Invisible {
             continue;
@@ -118,42 +117,24 @@ pub(super) fn compute_svg_bounds(
         let Some(label) = edge.label.as_ref() else {
             continue;
         };
-        let edge_idx = edge.index;
-        // Use precomputed label positions only when the edge was NOT re-routed.
-        // Re-routed edges (e.g. backward edges with channel detours) have their
-        // labels placed on the rendered path, which can differ from the
-        // precomputed geometry position.
-        let use_precomputed = edge.from_subgraph.is_none()
-            && edge.to_subgraph.is_none()
-            && !rendered_edge_paths.contains_key(&edge.index);
-
-        // Prefer label_geometry.rect when precomputed positions would be used.
-        // label_geometry is the authoritative source populated by the routing
-        // label-lane pass; it carries both center and padded rect.
-        // TODO: remove precomputed/revalidate fallback once label_lanes
-        // populates label_geometry for all edges.
-        let layout_edge = geom.edges.iter().find(|e| e.index == edge_idx);
-        if let Some(g) = layout_edge.and_then(|e| e.label_geometry.as_ref())
-            && use_precomputed
-        {
-            bounds.update_rect(&g.rect);
-            continue;
-        }
-
-        let position = if use_precomputed {
-            label_positions.get(&edge_idx).copied()
-        } else {
-            None
-        }
-        .or_else(|| fallback_label_position(geom, edge_idx, self_edge_paths, rendered_edge_paths));
-        let Some(point) = position else {
+        let Some(resolved_label) = resolve_edge_label(
+            edge,
+            geom,
+            self_edge_paths,
+            rendered_edge_paths,
+            override_nodes,
+        ) else {
             continue;
         };
-        let style = edge_text_style_key(metrics, edge);
-        let (w, h) = edge_label_dimensions_for_provider_and_style(metrics, &style, label);
+        let (w, h) = if let Some(g) = resolved_label.geometry {
+            (g.rect.width, g.rect.height)
+        } else {
+            let style = edge_text_style_key(metrics, edge);
+            edge_label_dimensions_for_provider_and_style(metrics, &style, label)
+        };
         let rect = Rect {
-            x: point.x - w / 2.0,
-            y: point.y - h / 2.0,
+            x: resolved_label.center.x - w / 2.0,
+            y: resolved_label.center.y - h / 2.0,
             width: w,
             height: h,
         };
@@ -227,6 +208,7 @@ mod tests {
         let (diagram, mut geom) = minimal_labeled_edge_fixtures();
         let metrics = default_proportional_text_metrics();
         let empty_map = HashMap::new();
+        let empty_overrides = HashMap::new();
 
         // Set label_geometry with a rect far outside the normal layout bounds.
         geom.edges[0].label_geometry = Some(EdgeLabelGeometry {
@@ -238,7 +220,14 @@ mod tests {
             compartment_size: 1,
         });
 
-        let bounds = compute_svg_bounds(&diagram, &geom, &metrics, &empty_map, &empty_map);
+        let bounds = compute_svg_bounds(
+            &diagram,
+            &geom,
+            &metrics,
+            &empty_map,
+            &empty_map,
+            &empty_overrides,
+        );
         let (min_x, min_y, max_x, max_y) = bounds.finalize(200.0, 200.0);
 
         // The bounds must include the label_geometry rect (490..510, 495..505).

--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -7,14 +7,19 @@ use super::text::{
     render_text_centered_with_wrap,
 };
 use super::{GraphSvgPalette, Point, dynamic_css_attrs};
-use crate::graph::geometry::GraphGeometry;
+use crate::graph::geometry::{EdgeLabelGeometry, GraphGeometry};
 use crate::graph::measure::{GraphTextStyleKey, TextMetricsProvider, edge_text_style_key};
 use crate::graph::routing::compute_end_label_positions;
-use crate::graph::{Graph, Stroke};
+use crate::graph::{Edge, Graph, Stroke};
 use crate::render::svg::SvgWriter;
 
 const LABEL_ANCHOR_REVALIDATION_MAX_DISTANCE: f64 = 2.0;
 const LABEL_POINT_EPS: f64 = 0.000_001;
+
+pub(super) struct ResolvedEdgeLabel<'a> {
+    pub(super) center: Point,
+    pub(super) geometry: Option<&'a EdgeLabelGeometry>,
+}
 
 fn revalidate_svg_label_anchor(candidate: Point, rendered_path: Option<&[Point]>) -> Point {
     let Some(path) = rendered_path else {
@@ -112,7 +117,6 @@ pub(super) fn render_edge_labels(
     scale: f64,
     palette: &GraphSvgPalette,
 ) {
-    let label_positions = precomputed_label_positions(geom);
     let dynamic_attrs = dynamic_css_attrs(
         palette.dynamic_css,
         "graph-edge-text",
@@ -138,77 +142,16 @@ pub(super) fn render_edge_labels(
         let Some(label) = edge.label.as_ref() else {
             continue;
         };
-        let edge_idx = edge.index;
-        let cross_boundary = if edge.from_subgraph.is_none() && edge.to_subgraph.is_none() {
-            let from_override = override_nodes.get(&edge.from);
-            let to_override = override_nodes.get(&edge.to);
-            matches!(
-                (from_override, to_override),
-                (Some(a), Some(b)) if a != b
-            ) || matches!(
-                (from_override, to_override),
-                (Some(_), None) | (None, Some(_))
-            )
-        } else {
-            false
-        };
-        let use_precomputed =
-            edge.from_subgraph.is_none() && edge.to_subgraph.is_none() && !cross_boundary;
-
-        // Prefer label_geometry.center (populated by the routing label-lane pass)
-        // over the precomputed label_position when available. Falls through to
-        // fallback + revalidation when label_geometry is None.
-        // TODO: remove precomputed/revalidate fallback once label_lanes
-        // populates label_geometry for all edges.
-        let layout_edge = geom.edges.iter().find(|e| e.index == edge_idx);
-        let label_geom = layout_edge.and_then(|e| e.label_geometry.as_ref());
-        // The lane-assignment pass writes `label_geometry` with either
-        // `track != 0` (numerical displacement) or `compartment_size > 1`
-        // (coordinated placement inside a multi-edge group, even when the
-        // member happens to sit on track 0 relative to the shared anchor).
-        // For either signal, trust the center directly — re-validating
-        // would snap the coordinated label back to this edge's own path
-        // midpoint and undo the shared-anchor placement. For singleton
-        // track-0 edges (`compartment_size == 1`), the center is just the
-        // engine-supplied label_position, which can be off-path due to
-        // upstream side-adjustment passes; keep the revalidation fallback
-        // so those labels render attached to their edge.
-        //
-        // Exception: labels crossing between sibling subgraphs intentionally
-        // use the compound label-dummy slot, even when they are not lane-
-        // shifted. Re-validating those against a rendered direct path can snap
-        // them from the inter-sibling gap back to a child boundary.
-        let sibling_compound_center = label_geom
-            .filter(|_| edge_crosses_sibling_subgraphs(diagram, geom, edge))
-            .map(|g| g.center);
-        let lane_shifted_center = label_geom
-            .filter(|g| (g.track != 0 || g.compartment_size > 1) && use_precomputed)
-            .map(|g| g.center);
-        let position = if let Some(center) = sibling_compound_center.or(lane_shifted_center) {
-            Some(center)
-        } else {
-            let candidate = if use_precomputed {
-                label_geom
-                    .map(|g| g.center)
-                    .or_else(|| label_positions.get(&edge_idx).copied())
-            } else {
-                None
-            }
-            .or_else(|| {
-                fallback_label_position(geom, edge_idx, self_edge_paths, rendered_edge_paths)
-            });
-            candidate.map(|candidate| {
-                revalidate_svg_label_anchor(
-                    candidate,
-                    rendered_edge_paths
-                        .get(&edge_idx)
-                        .map(|path| path.as_slice()),
-                )
-            })
-        };
-        let Some(point) = position else {
+        let Some(resolved_label) = resolve_edge_label(
+            edge,
+            geom,
+            self_edge_paths,
+            rendered_edge_paths,
+            override_nodes,
+        ) else {
             continue;
         };
+        let layout_edge = geom.edges.iter().find(|e| e.index == edge.index);
         // Prefer the post-lane re-wrap output when the routing pass decided
         // to narrow this edge's label. Falling back to
         // `edge.wrapped_label_lines` (pre-engine wrap) when no re-wrap
@@ -230,8 +173,8 @@ pub(super) fn render_edge_labels(
         render_text_centered_with_wrap(
             writer,
             Point {
-                x: point.x * scale,
-                y: point.y * scale,
+                x: resolved_label.center.x * scale,
+                y: resolved_label.center.y * scale,
             },
             label,
             wrap_lines,
@@ -244,7 +187,9 @@ pub(super) fn render_edge_labels(
                 background: Some(BackgroundStyle {
                     fill: bg_style.fill,
                     extra_attrs: bg_style.extra_attrs,
-                    size: label_geom.map(|g| (g.rect.width, g.rect.height)),
+                    size: resolved_label
+                        .geometry
+                        .map(|g| (g.rect.width, g.rect.height)),
                 }),
             },
         );
@@ -318,47 +263,6 @@ pub(super) fn render_edge_labels(
     writer.end_group();
 }
 
-fn edge_crosses_sibling_subgraphs(
-    diagram: &Graph,
-    geom: &GraphGeometry,
-    edge: &crate::graph::Edge,
-) -> bool {
-    let Some(from_parent) = node_parent_id(diagram, geom, &edge.from) else {
-        return false;
-    };
-    let Some(to_parent) = node_parent_id(diagram, geom, &edge.to) else {
-        return false;
-    };
-    if from_parent == to_parent {
-        return false;
-    }
-
-    let from_grandparent = diagram
-        .subgraphs
-        .get(&from_parent)
-        .and_then(|sg| sg.parent.as_deref());
-    let to_grandparent = diagram
-        .subgraphs
-        .get(&to_parent)
-        .and_then(|sg| sg.parent.as_deref());
-    from_grandparent.is_some() && from_grandparent == to_grandparent
-}
-
-fn node_parent_id(diagram: &Graph, geom: &GraphGeometry, node_id: &str) -> Option<String> {
-    if let Some(parent) = geom
-        .nodes
-        .get(node_id)
-        .and_then(|node| node.parent.as_deref())
-    {
-        return Some(parent.to_string());
-    }
-    diagram
-        .subgraphs
-        .values()
-        .find(|subgraph| subgraph.nodes.iter().any(|member| member == node_id))
-        .map(|subgraph| subgraph.id.clone())
-}
-
 pub(super) fn fallback_label_position(
     geom: &GraphGeometry,
     edge_index: usize,
@@ -388,40 +292,65 @@ pub(super) fn fallback_label_position(
     None
 }
 
-pub(super) fn precomputed_label_positions(geom: &GraphGeometry) -> HashMap<usize, Point> {
-    geom.edges
-        .iter()
-        .filter_map(|edge| edge.label_position.map(|point| (edge.index, point)))
-        .collect()
-}
-
-/// Resolve the label center for a given edge index, preferring
-/// `label_geometry.center` when present, falling back to `label_position`
-/// (precomputed by the layout engine), then to path-based midpoint fallbacks.
-// TODO: once label_lanes populates label_geometry for all edges, the
-// precomputed/fallback paths may be simplified.
-#[cfg(test)]
-fn resolve_edge_label_center(
-    geom: &GraphGeometry,
-    edge_index: usize,
+pub(super) fn resolve_edge_label<'a>(
+    edge: &Edge,
+    geom: &'a GraphGeometry,
     self_edge_paths: &HashMap<usize, Vec<Point>>,
     rendered_edge_paths: &HashMap<usize, Vec<Point>>,
-) -> Option<Point> {
-    // Prefer label_geometry.center (populated by the routing label-lane pass).
-    if let Some(layout_edge) = geom.edges.iter().find(|e| e.index == edge_index)
-        && let Some(g) = &layout_edge.label_geometry
-    {
-        return Some(g.center);
+    override_nodes: &HashMap<String, String>,
+) -> Option<ResolvedEdgeLabel<'a>> {
+    let edge_idx = edge.index;
+    let cross_boundary = if edge.from_subgraph.is_none() && edge.to_subgraph.is_none() {
+        let from_override = override_nodes.get(&edge.from);
+        let to_override = override_nodes.get(&edge.to);
+        matches!(
+            (from_override, to_override),
+            (Some(a), Some(b)) if a != b
+        ) || matches!(
+            (from_override, to_override),
+            (Some(_), None) | (None, Some(_))
+        )
+    } else {
+        false
+    };
+    let use_precomputed =
+        edge.from_subgraph.is_none() && edge.to_subgraph.is_none() && !cross_boundary;
+
+    let layout_edge = geom.edges.iter().find(|e| e.index == edge_idx);
+    let label_geom = layout_edge.and_then(|e| e.label_geometry.as_ref());
+
+    // The lane-assignment pass owns SVG edge-label anchors via
+    // `label_geometry.center`, including singleton track-0 labels that
+    // previously relied on renderer-side midpoint revalidation. Trust any
+    // populated lane output directly to avoid undoing coordinated placement
+    // and to keep SVG aligned with Text/MMDS anchor ownership.
+    if let Some(geometry) = label_geom.filter(|_| use_precomputed) {
+        return Some(ResolvedEdgeLabel {
+            center: geometry.center,
+            geometry: Some(geometry),
+        });
     }
 
-    // Fall back to precomputed label_position from the layout engine.
-    let label_positions = precomputed_label_positions(geom);
-    if let Some(&pos) = label_positions.get(&edge_index) {
-        return Some(pos);
+    let candidate = if use_precomputed {
+        label_geom
+            .map(|g| g.center)
+            .or_else(|| layout_edge.and_then(|e| e.label_position))
+    } else {
+        None
     }
-
-    // Final fallback: path-based midpoint.
-    fallback_label_position(geom, edge_index, self_edge_paths, rendered_edge_paths)
+    .or_else(|| fallback_label_position(geom, edge_idx, self_edge_paths, rendered_edge_paths));
+    let center = candidate.map(|candidate| {
+        revalidate_svg_label_anchor(
+            candidate,
+            rendered_edge_paths
+                .get(&edge_idx)
+                .map(|path| path.as_slice()),
+        )
+    })?;
+    Some(ResolvedEdgeLabel {
+        center,
+        geometry: label_geom,
+    })
 }
 
 #[cfg(test)]
@@ -429,9 +358,9 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use super::{Point, revalidate_svg_label_anchor, svg_path_midpoint};
-    use crate::graph::Direction;
     use crate::graph::geometry::{EdgeLabelGeometry, EdgeLabelSide, GraphGeometry, LayoutEdge};
     use crate::graph::space::{FPoint, FRect};
+    use crate::graph::{Direction, Edge};
 
     #[test]
     fn revalidate_svg_label_anchor_keeps_nearby_anchor() {
@@ -498,10 +427,17 @@ mod tests {
         }
     }
 
+    fn minimal_labeled_edge() -> Edge {
+        let mut edge = Edge::new("A", "B").with_label("yes");
+        edge.index = 0;
+        edge
+    }
+
     #[test]
     fn svg_labels_uses_label_geometry_center_when_present() {
         let mut geom = minimal_geom_with_labeled_edge();
         let empty_map: HashMap<usize, Vec<Point>> = HashMap::new();
+        let empty_overrides: HashMap<String, String> = HashMap::new();
 
         // Set label_geometry with a center far from the normal label_position.
         geom.edges[0].label_geometry = Some(EdgeLabelGeometry {
@@ -513,8 +449,15 @@ mod tests {
             compartment_size: 1,
         });
 
-        // resolve_edge_label_center should prefer label_geometry.center.
-        let center = super::resolve_edge_label_center(&geom, 0, &empty_map, &empty_map);
+        // resolve_edge_label should prefer label_geometry.center.
+        let center = super::resolve_edge_label(
+            &minimal_labeled_edge(),
+            &geom,
+            &empty_map,
+            &empty_map,
+            &empty_overrides,
+        )
+        .map(|label| label.center);
         assert_eq!(
             center,
             Some(FPoint::new(123.0, 456.0)),
@@ -526,9 +469,17 @@ mod tests {
     fn svg_labels_falls_back_to_label_position_when_no_label_geometry() {
         let geom = minimal_geom_with_labeled_edge();
         let empty_map: HashMap<usize, Vec<Point>> = HashMap::new();
+        let empty_overrides: HashMap<String, String> = HashMap::new();
 
         // label_geometry is None, so it should fall back to precomputed label_position.
-        let center = super::resolve_edge_label_center(&geom, 0, &empty_map, &empty_map);
+        let center = super::resolve_edge_label(
+            &minimal_labeled_edge(),
+            &geom,
+            &empty_map,
+            &empty_map,
+            &empty_overrides,
+        )
+        .map(|label| label.center);
         assert_eq!(
             center,
             Some(FPoint::new(50.0, 50.0)),

--- a/src/render/graph/svg/mod.rs
+++ b/src/render/graph/svg/mod.rs
@@ -249,6 +249,7 @@ fn render_svg_with_geometry_context(
         metrics,
         &self_edge_paths,
         &prepared_edges.paths,
+        context.override_nodes,
     );
     let padding = options.diagram_padding;
     let (min_x, min_y, max_x, max_y) = bounds.finalize(geom.bounds.width, geom.bounds.height);

--- a/tests/svg-snapshots/flowchart-basis/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-basis/ci_pipeline.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 174.00" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 177.50" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M129.36,87.00 L132.14,87.00 C134.91,87.00 140.47,87.00 146.03,87.00 C151.58,87.00 157.14,87.00 162.03,87.00 C166.91,87.00 171.14,87.00 173.25,87.00 L175.36,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M274.94,87.00 L277.72,87.00 C280.49,87.00 286.05,87.00 291.60,87.00 C297.16,87.00 302.72,87.00 307.60,87.00 C312.49,87.00 316.72,87.00 318.83,87.00 L320.94,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -44,10 +44,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="839.34" y="21.00" width="59.59" height="28.00" fill="white" />
-      <text x="869.13" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
-      <rect x="827.77" y="125.00" width="82.72" height="28.00" fill="white" />
-      <text x="869.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
+      <rect x="832.65" y="4.50" width="59.59" height="28.00" fill="white" />
+      <text x="862.45" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="832.65" y="108.50" width="82.72" height="28.00" fill="white" />
+      <text x="874.01" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/cjk_labels.svg
+++ b/tests/svg-snapshots/flowchart-basis/cjk_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 196.00" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 199.50" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M100.00,55.32 L101.39,55.32 C102.78,55.32 105.56,55.32 108.33,54.99 C111.11,54.65 113.89,53.99 116.00,53.65 C118.11,53.32 119.56,53.32 120.28,53.32 L121.00,53.32" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M233.00,39.43 L240.88,38.03 L243.73,37.53 C246.58,37.02 252.29,36.01 262.31,35.51 C272.33,35.00 286.67,35.00 300.17,35.00 C313.67,35.00 326.33,35.00 332.67,35.00 L339.00,35.00 L347.00,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -30,10 +30,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="269.81" y="21.00" width="40.00" height="28.00" fill="white" />
-      <text x="289.81" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
-      <rect x="269.71" y="80.00" width="40.00" height="28.00" fill="white" />
-      <text x="289.71" y="94.00" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
+      <rect x="259.50" y="4.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
+      <rect x="259.50" y="63.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="77.50" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
       <rect x="165.50" y="160.00" width="40.00" height="28.00" fill="white" />
       <text x="185.50" y="174.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
     </g>

--- a/tests/svg-snapshots/flowchart-basis/complex.svg
+++ b/tests/svg-snapshots/flowchart-basis/complex.svg
@@ -57,8 +57,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="370.51" y="212.79" width="40.91" height="28.00" fill="white" />
-      <text x="390.96" y="226.79" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="382.40" y="227.40" width="40.91" height="28.00" fill="white" />
+      <text x="402.85" y="241.40" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
       <rect x="514.54" y="130.54" width="32.90" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-basis/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-basis/compound_backward_cross_boundary.svg
@@ -77,8 +77,8 @@
       <text x="237.04" y="502.09" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
       <rect x="325.36" y="432.09" width="69.38" height="28.00" fill="white" />
       <text x="360.05" y="446.09" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
-      <rect x="135.39" y="414.70" width="41.78" height="28.00" fill="white" />
-      <text x="156.28" y="428.70" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
+      <rect x="91.63" y="432.09" width="41.78" height="28.00" fill="white" />
+      <text x="112.52" y="446.09" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
       <rect x="213.48" y="657.11" width="47.12" height="28.00" fill="white" />
       <text x="237.04" y="671.11" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
       <rect x="347.60" y="740.32" width="24.90" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-basis/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-basis/crossing_minimize.svg
@@ -57,8 +57,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="370.51" y="212.79" width="40.91" height="28.00" fill="white" />
-      <text x="390.96" y="226.79" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="382.40" y="227.40" width="40.91" height="28.00" fill="white" />
+      <text x="402.85" y="241.40" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
       <rect x="514.54" y="130.54" width="32.90" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-basis/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-basis/git_workflow.svg
@@ -36,8 +36,8 @@
       <text x="492.56" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="751.95" y="21.00" width="64.04" height="28.00" fill="white" />
       <text x="783.97" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="481.94" y="62.00" width="54.25" height="28.00" fill="white" />
-      <text x="509.07" y="76.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="479.94" y="56.00" width="54.25" height="28.00" fill="white" />
+      <text x="507.07" y="70.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/http_request.svg
+++ b/tests/svg-snapshots/flowchart-basis/http_request.svg
@@ -43,8 +43,8 @@
     <g class="edgeLabels">
       <rect x="200.17" y="70.50" width="113.81" height="28.00" fill="white" />
       <text x="257.08" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
-      <rect x="114.46" y="421.55" width="35.57" height="28.00" fill="white" />
-      <text x="132.24" y="435.55" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="81.13" y="441.25" width="35.57" height="28.00" fill="white" />
+      <text x="98.92" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="318.77" y="441.25" width="28.45" height="28.00" fill="white" />
       <text x="332.99" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
       <rect x="371.02" y="307.64" width="126.27" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-basis/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-basis/inline_label_flowchart.svg
@@ -116,12 +116,12 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="320.86" y="596.47" width="25.80" height="28.00" fill="white" />
-      <text x="333.76" y="610.47" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="256.63" y="616.77" width="25.80" height="28.00" fill="white" />
+      <text x="269.53" y="630.77" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <rect x="599.90" y="624.94" width="32.90" height="28.00" fill="white" />
       <text x="616.35" y="638.94" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="453.14" y="874.69" width="40.90" height="28.00" fill="white" />
-      <text x="473.59" y="888.69" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <rect x="429.87" y="889.48" width="40.90" height="28.00" fill="white" />
+      <text x="450.31" y="903.48" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
       <rect x="694.27" y="908.18" width="49.80" height="28.00" fill="white" />
       <text x="719.16" y="922.18" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <rect x="622.54" y="1572.25" width="25.80" height="28.00" fill="white" />
@@ -130,8 +130,8 @@
       <text x="571.35" y="1542.84" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <rect x="77.14" y="402.29" width="24.90" height="28.00" fill="white" />
       <text x="89.59" y="416.29" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="265.52" y="462.16" width="40.88" height="28.00" fill="white" />
-      <text x="285.96" y="476.16" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="185.56" y="402.29" width="40.88" height="28.00" fill="white" />
+      <text x="206.01" y="416.29" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
       <rect x="728.95" y="1387.49" width="42.68" height="28.00" fill="white" />
       <text x="750.29" y="1401.49" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>

--- a/tests/svg-snapshots/flowchart-basis/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-basis/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 116.00" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 106.50" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-2.50)">
+  <g transform="translate(0.00,14.00)">
     <g class="edgePaths">
       <path d="M209.12,39.31 L201.54,36.76 L195.47,34.72 C189.40,32.67 177.26,28.59 174.36,26.54 C171.46,24.50 177.79,24.50 168.59,27.33 C159.39,30.16 134.66,35.83 122.29,38.66 L109.92,41.49 L102.13,43.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,67.27 L201.43,69.45 L192.56,71.95 C183.69,74.46 165.96,79.48 163.08,81.99 C160.19,84.50 172.16,84.50 165.78,81.67 C159.39,78.84 134.66,73.17 122.29,70.34 L109.92,67.51 L102.13,65.72" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -20,11 +20,11 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="167.01" y="12.59" width="16.00" height="28.00" fill="white" />
-      <text x="175.01" y="26.59" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="160.14" y="58.50" width="32.90" height="52.00" fill="white" />
-      <text x="176.59" y="72.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="176.59" y="96.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="166.62" y="-6.00" width="16.00" height="28.00" fill="white" />
+      <text x="174.62" y="8.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="149.73" y="30.00" width="32.90" height="52.00" fill="white" />
+      <text x="166.18" y="44.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="166.18" y="68.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-basis/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-basis/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 277.04 318.00" style="max-width: 277.04px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 219.22 318.00" style="max-width: 219.22px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M43.34,62.00 L43.34,70.00 L43.34,72.83 C43.34,75.67 43.34,81.33 43.34,93.33 C43.34,105.33 43.34,123.67 43.34,149.83 C43.34,176.00 43.34,210.00 43.34,227.00 L43.34,244.00 L43.34,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M47.69,256.00 L48.96,248.10 L51.36,233.25 C53.76,218.40 58.55,188.70 58.65,159.66 C58.76,130.62 54.18,102.23 51.89,88.04 L49.60,73.85 L48.33,65.95" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-curved-step/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/backward_label_asymmetric_markers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 225.88 246.00" style="max-width: 225.88px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 198.86 246.00" style="max-width: 198.86px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-curved-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/backward_loop_lr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 200.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 214.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -53,8 +53,8 @@
     <g class="edgeLabels">
       <rect x="1087.70" y="178.00" width="33.78" height="28.00" fill="white" />
       <text x="1104.59" y="192.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <rect x="1365.07" y="125.00" width="43.57" height="28.00" fill="white" />
-      <text x="1386.86" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <rect x="1354.57" y="108.50" width="43.57" height="28.00" fill="white" />
+      <text x="1376.36" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/ci_pipeline.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 174.00" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 177.50" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M129.36,87.00 L132.14,87.00 C134.91,87.00 140.47,87.00 145.47,87.00 C150.47,87.00 154.91,87.00 159.80,87.00 C164.69,87.00 170.03,87.00 172.69,87.00 L175.36,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M274.94,87.00 L277.72,87.00 C280.49,87.00 286.05,87.00 291.05,87.00 C296.05,87.00 300.49,87.00 305.38,87.00 C310.27,87.00 315.60,87.00 318.27,87.00 L320.94,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -44,10 +44,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="828.71" y="21.00" width="59.59" height="28.00" fill="white" />
-      <text x="858.51" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
-      <rect x="817.15" y="125.00" width="82.72" height="28.00" fill="white" />
-      <text x="858.51" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
+      <rect x="832.65" y="4.50" width="59.59" height="28.00" fill="white" />
+      <text x="862.45" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="832.65" y="108.50" width="82.72" height="28.00" fill="white" />
+      <text x="874.01" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/cjk_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/cjk_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 200.00" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 217.50" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M100.00,54.32 L100.83,54.32 C101.67,54.32 103.33,54.32 106.83,54.32 C110.33,54.32 115.67,54.32 118.33,54.32 L121.00,54.32" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M233.00,30.00 L233.00,39.43 L236.03,39.43 C239.07,39.43 245.13,39.43 248.17,38.69 C251.20,37.95 251.20,36.48 251.20,35.74 L251.20,35.00 L347.00,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -30,12 +30,12 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="265.02" y="21.00" width="40.00" height="28.00" fill="white" />
-      <text x="285.02" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
-      <rect x="248.60" y="106.00" width="40.00" height="28.00" fill="white" />
-      <text x="268.60" y="120.00" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
-      <rect x="167.50" y="164.00" width="40.00" height="28.00" fill="white" />
-      <text x="187.50" y="178.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
+      <rect x="259.50" y="4.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
+      <rect x="259.50" y="63.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="77.50" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
+      <rect x="165.50" y="178.00" width="40.00" height="28.00" fill="white" />
+      <text x="185.50" y="192.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/complex.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/complex.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 559.43 737.41" style="max-width: 559.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 573.43 737.41" style="max-width: 573.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -61,10 +61,10 @@
       <text x="443.07" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <rect x="518.54" y="132.54" width="32.90" height="28.00" fill="white" />
-      <text x="534.98" y="146.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="284.77" y="516.65" width="25.80" height="28.00" fill="white" />
-      <text x="297.67" y="530.65" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="532.54" y="130.54" width="32.90" height="28.00" fill="white" />
+      <text x="548.98" y="144.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="441.29" y="554.91" width="25.80" height="28.00" fill="white" />
+      <text x="454.19" y="568.91" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/compound_backward_cross_boundary.svg
@@ -73,8 +73,8 @@
       <text x="133.06" y="184.50" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
       <rect x="319.38" y="231.75" width="51.59" height="28.00" fill="white" />
       <text x="345.18" y="245.75" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
-      <rect x="260.97" y="487.59" width="40.02" height="28.00" fill="white" />
-      <text x="280.98" y="501.59" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="217.03" y="488.09" width="40.02" height="28.00" fill="white" />
+      <text x="237.04" y="502.09" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
       <rect x="325.36" y="432.09" width="69.38" height="28.00" fill="white" />
       <text x="360.05" y="446.09" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
       <rect x="91.63" y="432.09" width="41.78" height="28.00" fill="white" />
@@ -83,8 +83,8 @@
       <text x="237.04" y="671.11" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
       <rect x="347.60" y="748.09" width="24.90" height="28.00" fill="white" />
       <text x="360.05" y="762.09" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="197.00" y="945.61" width="73.82" height="28.00" fill="white" />
-      <text x="233.91" y="959.61" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="200.13" y="917.11" width="73.82" height="28.00" fill="white" />
+      <text x="237.04" y="931.11" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
       <rect x="328.47" y="716.09" width="40.00" height="28.00" fill="white" />
       <text x="348.47" y="730.09" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>

--- a/tests/svg-snapshots/flowchart-curved-step/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/crossing_minimize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 559.43 737.41" style="max-width: 559.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 573.43 737.41" style="max-width: 573.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -61,10 +61,10 @@
       <text x="443.07" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <rect x="518.54" y="132.54" width="32.90" height="28.00" fill="white" />
-      <text x="534.98" y="146.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="284.77" y="516.65" width="25.80" height="28.00" fill="white" />
-      <text x="297.67" y="530.65" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="532.54" y="130.54" width="32.90" height="28.00" fill="white" />
+      <text x="548.98" y="144.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="441.29" y="554.91" width="25.80" height="28.00" fill="white" />
+      <text x="454.19" y="568.91" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/decision.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/decision.svg
@@ -32,8 +32,8 @@
     <g class="edgeLabels">
       <rect x="42.45" y="267.87" width="35.57" height="28.00" fill="white" />
       <text x="60.23" y="281.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="177.61" y="242.34" width="28.45" height="28.00" fill="white" />
-      <text x="191.84" y="256.34" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="132.80" y="267.87" width="28.45" height="28.00" fill="white" />
+      <text x="147.03" y="281.87" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/flowchart_code_flow.svg
@@ -686,12 +686,12 @@
       <text x="9389.78" y="464.41" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
       <rect x="9541.38" y="450.41" width="190.67" height="28.00" fill="white" />
       <text x="9636.72" y="464.41" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
-      <rect x="9208.61" y="742.70" width="35.57" height="28.00" fill="white" />
-      <text x="9226.40" y="756.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9125.04" y="714.20" width="35.57" height="28.00" fill="white" />
+      <text x="9142.83" y="728.20" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="9371.99" y="734.90" width="35.57" height="28.00" fill="white" />
       <text x="9389.78" y="748.90" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="9535.37" y="721.36" width="35.57" height="28.00" fill="white" />
-      <text x="9553.15" y="735.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9593.70" y="773.70" width="35.57" height="28.00" fill="white" />
+      <text x="9611.48" y="787.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="360.42" y="1608.82" width="131.59" height="28.00" fill="white" />
       <text x="426.21" y="1622.82" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>

--- a/tests/svg-snapshots/flowchart-curved-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 96.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 110.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-curved-step/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/git_workflow_td.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 213.84 525.00" style="max-width: 213.84px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 227.84 525.00" style="max-width: 227.84px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -36,8 +36,8 @@
       <text x="87.36" y="250.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="55.34" y="396.00" width="64.04" height="28.00" fill="white" />
       <text x="87.36" y="410.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="156.02" y="246.71" width="54.25" height="28.00" fill="white" />
-      <text x="183.14" y="260.71" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="165.59" y="244.71" width="54.25" height="28.00" fill="white" />
+      <text x="192.72" y="258.71" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/http_request.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/http_request.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 509.28 679.75" style="max-width: 509.28px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 523.28 679.75" style="max-width: 523.28px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -47,8 +47,8 @@
       <text x="98.92" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="318.77" y="441.25" width="28.45" height="28.00" fill="white" />
       <text x="332.99" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <rect x="375.02" y="309.64" width="126.27" height="28.00" fill="white" />
-      <text x="438.15" y="323.64" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <rect x="389.02" y="307.64" width="126.27" height="28.00" fill="white" />
+      <text x="452.15" y="321.64" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/inline_label_flowchart.svg
@@ -116,24 +116,24 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="278.22" y="543.17" width="25.80" height="28.00" fill="white" />
-      <text x="291.12" y="557.17" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="276.22" y="600.27" width="25.80" height="28.00" fill="white" />
+      <text x="289.12" y="614.27" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <rect x="599.90" y="600.27" width="32.90" height="28.00" fill="white" />
       <text x="616.35" y="614.27" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <rect x="429.87" y="889.48" width="40.90" height="28.00" fill="white" />
       <text x="450.31" y="903.48" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
       <rect x="694.27" y="865.07" width="49.80" height="28.00" fill="white" />
       <text x="719.16" y="879.07" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
-      <rect x="661.23" y="1541.99" width="25.80" height="28.00" fill="white" />
-      <text x="674.13" y="1555.99" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <rect x="523.44" y="1525.55" width="32.90" height="28.00" fill="white" />
-      <text x="539.89" y="1539.55" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="40.35" y="425.79" width="24.90" height="28.00" fill="white" />
-      <text x="52.80" y="439.79" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="262.60" y="477.79" width="40.88" height="28.00" fill="white" />
-      <text x="283.04" y="491.79" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
-      <rect x="718.58" y="1397.66" width="42.68" height="28.00" fill="white" />
-      <text x="739.92" y="1411.66" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
+      <rect x="617.27" y="1587.95" width="25.80" height="28.00" fill="white" />
+      <text x="630.17" y="1601.95" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="554.90" y="1528.84" width="32.90" height="28.00" fill="white" />
+      <text x="571.35" y="1542.84" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="77.14" y="402.29" width="24.90" height="28.00" fill="white" />
+      <text x="89.59" y="416.29" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="264.60" y="461.79" width="40.88" height="28.00" fill="white" />
+      <text x="285.04" y="475.79" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="728.95" y="1389.30" width="42.68" height="28.00" fill="white" />
+      <text x="750.29" y="1403.30" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/label_clamp_bt_review.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 110.69 294.00" style="max-width: 110.69px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 106.24 294.00" style="max-width: 106.24px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-curved-step/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 81.52" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 79.33" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-17.31)">
+  <g transform="translate(0.00,-19.50)">
     <g class="edgePaths">
       <path d="M209.12,35.50 L209.12,39.31 L204.96,39.31 C200.79,39.31 192.46,39.31 188.29,41.84 C184.12,44.37 184.12,49.44 184.12,51.97 L184.12,54.50 L102.23,54.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,73.50 L209.12,67.27 L193.98,67.27 C178.83,67.27 148.53,67.27 133.38,68.31 C118.23,69.35 118.23,71.42 118.23,72.46 L118.23,73.50 L102.23,73.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-curved-step/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/label_spacing.svg
@@ -24,10 +24,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="39.49" y="99.00" width="40.91" height="28.00" fill="white" />
-      <text x="59.95" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <rect x="121.16" y="99.00" width="53.36" height="28.00" fill="white" />
-      <text x="147.84" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="22.88" y="70.50" width="40.91" height="28.00" fill="white" />
+      <text x="43.34" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="137.77" y="70.50" width="53.36" height="28.00" fill="white" />
+      <text x="164.45" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/labeled_edges.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 366.52 569.48" style="max-width: 366.52px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 380.52 569.48" style="max-width: 380.52px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -41,10 +41,10 @@
       <text x="95.27" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
       <rect x="51.57" y="429.26" width="32.90" height="28.00" fill="white" />
       <text x="68.02" y="443.26" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="214.22" y="370.71" width="25.80" height="28.00" fill="white" />
-      <text x="227.12" y="384.71" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <rect x="318.52" y="268.39" width="40.00" height="28.00" fill="white" />
-      <text x="338.52" y="282.39" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="169.70" y="409.98" width="25.80" height="28.00" fill="white" />
+      <text x="182.60" y="423.98" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="332.52" y="266.39" width="40.00" height="28.00" fill="white" />
+      <text x="352.52" y="280.39" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-curved-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 280.37 318.00" style="max-width: 280.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 216.89 318.00" style="max-width: 216.89px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M43.34,62.00 L43.34,126.67 L43.34,132.06 C43.34,137.44 43.34,148.22 43.34,159.00 C43.34,169.78 43.34,180.56 43.34,185.94 L43.34,191.33 L43.34,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M61.00,256.00 L61.00,86.00 L61.48,86.00 C61.95,86.00 62.89,86.00 63.84,86.00 C64.78,86.00 65.73,86.00 66.20,86.00 L66.67,86.00 L66.67,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-curved-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/multi_edge_labeled.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 132.06 334.00" style="max-width: 132.06px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 121.39 334.00" style="max-width: 121.39px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(26.24,0.00)">
+  <g transform="translate(15.57,0.00)">
     <g class="edgePaths">
       <path d="M16.91,62.00 L16.91,100.00 L21.46,100.00 C26.02,100.00 35.13,100.00 39.69,103.00 C44.24,106.00 44.24,112.00 44.24,115.00 L44.24,118.00 L44.24,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M71.58,62.00 L71.58,71.33 C71.58,80.67 71.58,99.33 71.58,116.33 C71.58,133.33 71.58,148.67 71.58,156.33 L71.58,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-curved-step/three_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/three_parallel_labels.svg
@@ -21,8 +21,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="17.11" y="99.00" width="34.70" height="28.00" fill="white" />
-      <text x="34.46" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
+      <rect x="-9.35" y="70.50" width="34.70" height="28.00" fill="white" />
+      <text x="8.00" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
       <rect x="45.35" y="94.75" width="32.90" height="28.00" fill="white" />
       <text x="61.80" y="108.75" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
       <rect x="66.90" y="126.75" width="44.47" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-polyline/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-polyline/ci_pipeline.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 174.00" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 177.50" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M129.36,87.00 L175.36,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M274.94,87.00 L320.94,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -44,10 +44,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="839.34" y="21.00" width="59.59" height="28.00" fill="white" />
-      <text x="869.13" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
-      <rect x="827.77" y="125.00" width="82.72" height="28.00" fill="white" />
-      <text x="869.13" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
+      <rect x="832.65" y="4.50" width="59.59" height="28.00" fill="white" />
+      <text x="862.45" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="832.65" y="108.50" width="82.72" height="28.00" fill="white" />
+      <text x="874.01" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/cjk_labels.svg
+++ b/tests/svg-snapshots/flowchart-polyline/cjk_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 196.00" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 199.50" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M100.00,55.32 L121.01,53.64" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M233.00,39.43 L258.00,35.00 L301.00,35.00 L347.00,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -30,10 +30,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="269.81" y="21.00" width="40.00" height="28.00" fill="white" />
-      <text x="289.81" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
-      <rect x="269.71" y="80.00" width="40.00" height="28.00" fill="white" />
-      <text x="289.71" y="94.00" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
+      <rect x="259.50" y="4.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
+      <rect x="259.50" y="63.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="77.50" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
       <rect x="165.50" y="160.00" width="40.00" height="28.00" fill="white" />
       <text x="185.50" y="174.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
     </g>

--- a/tests/svg-snapshots/flowchart-polyline/complex.svg
+++ b/tests/svg-snapshots/flowchart-polyline/complex.svg
@@ -57,8 +57,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="370.51" y="212.79" width="40.91" height="28.00" fill="white" />
-      <text x="390.96" y="226.79" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="382.40" y="227.40" width="40.91" height="28.00" fill="white" />
+      <text x="402.85" y="241.40" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
       <rect x="514.54" y="130.54" width="32.90" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-polyline/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-polyline/compound_backward_cross_boundary.svg
@@ -77,8 +77,8 @@
       <text x="237.04" y="502.09" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
       <rect x="325.36" y="432.09" width="69.38" height="28.00" fill="white" />
       <text x="360.05" y="446.09" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
-      <rect x="135.39" y="414.70" width="41.78" height="28.00" fill="white" />
-      <text x="156.28" y="428.70" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
+      <rect x="91.63" y="432.09" width="41.78" height="28.00" fill="white" />
+      <text x="112.52" y="446.09" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
       <rect x="213.48" y="657.11" width="47.12" height="28.00" fill="white" />
       <text x="237.04" y="671.11" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
       <rect x="347.60" y="740.32" width="24.90" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-polyline/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-polyline/crossing_minimize.svg
@@ -57,8 +57,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="370.51" y="212.79" width="40.91" height="28.00" fill="white" />
-      <text x="390.96" y="226.79" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="382.40" y="227.40" width="40.91" height="28.00" fill="white" />
+      <text x="402.85" y="241.40" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
       <rect x="514.54" y="130.54" width="32.90" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-polyline/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-polyline/git_workflow.svg
@@ -36,8 +36,8 @@
       <text x="492.56" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="751.95" y="21.00" width="64.04" height="28.00" fill="white" />
       <text x="783.97" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="481.94" y="62.00" width="54.25" height="28.00" fill="white" />
-      <text x="509.07" y="76.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="479.94" y="56.00" width="54.25" height="28.00" fill="white" />
+      <text x="507.07" y="70.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/http_request.svg
+++ b/tests/svg-snapshots/flowchart-polyline/http_request.svg
@@ -43,8 +43,8 @@
     <g class="edgeLabels">
       <rect x="200.17" y="70.50" width="113.81" height="28.00" fill="white" />
       <text x="257.08" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
-      <rect x="114.46" y="421.55" width="35.57" height="28.00" fill="white" />
-      <text x="132.24" y="435.55" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="81.13" y="441.25" width="35.57" height="28.00" fill="white" />
+      <text x="98.92" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="318.77" y="441.25" width="28.45" height="28.00" fill="white" />
       <text x="332.99" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
       <rect x="371.02" y="307.64" width="126.27" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-polyline/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-polyline/inline_label_flowchart.svg
@@ -116,12 +116,12 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="320.86" y="596.47" width="25.80" height="28.00" fill="white" />
-      <text x="333.76" y="610.47" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="256.63" y="616.77" width="25.80" height="28.00" fill="white" />
+      <text x="269.53" y="630.77" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <rect x="599.90" y="624.94" width="32.90" height="28.00" fill="white" />
       <text x="616.35" y="638.94" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="453.14" y="874.69" width="40.90" height="28.00" fill="white" />
-      <text x="473.59" y="888.69" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <rect x="429.87" y="889.48" width="40.90" height="28.00" fill="white" />
+      <text x="450.31" y="903.48" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
       <rect x="694.27" y="908.18" width="49.80" height="28.00" fill="white" />
       <text x="719.16" y="922.18" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <rect x="622.54" y="1572.25" width="25.80" height="28.00" fill="white" />
@@ -130,8 +130,8 @@
       <text x="571.35" y="1542.84" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <rect x="77.14" y="402.29" width="24.90" height="28.00" fill="white" />
       <text x="89.59" y="416.29" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="265.52" y="462.16" width="40.88" height="28.00" fill="white" />
-      <text x="285.96" y="476.16" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="185.56" y="402.29" width="40.88" height="28.00" fill="white" />
+      <text x="206.01" y="416.29" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
       <rect x="728.95" y="1387.49" width="42.68" height="28.00" fill="white" />
       <text x="750.29" y="1401.49" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>

--- a/tests/svg-snapshots/flowchart-polyline/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-polyline/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 116.00" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 106.50" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-2.50)">
+  <g transform="translate(0.00,14.00)">
     <g class="edgePaths">
       <path d="M209.12,39.31 L165.12,24.50 L184.12,24.50 L102.13,43.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,67.27 L148.23,84.50 L184.12,84.50 L102.13,65.72" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -20,11 +20,11 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="167.01" y="12.59" width="16.00" height="28.00" fill="white" />
-      <text x="175.01" y="26.59" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
-      <rect x="160.14" y="58.50" width="32.90" height="52.00" fill="white" />
-      <text x="176.59" y="72.50" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <text x="176.59" y="96.50" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="166.62" y="-6.00" width="16.00" height="28.00" fill="white" />
+      <text x="174.62" y="8.00" text-anchor="middle" dominant-baseline="middle" fill="#333">x</text>
+      <rect x="149.73" y="30.00" width="32.90" height="52.00" fill="white" />
+      <text x="166.18" y="44.00" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <text x="166.18" y="68.00" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-polyline/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-polyline/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 277.04 318.00" style="max-width: 277.04px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 219.22 318.00" style="max-width: 219.22px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M43.34,62.00 L43.34,87.00 L43.34,142.00 L43.34,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M47.69,256.00 L63.34,159.00 L48.33,65.95" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-smooth-step/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/backward_label_asymmetric_markers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 225.88 246.00" style="max-width: 225.88px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 198.86 246.00" style="max-width: 198.86px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-smooth-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/backward_loop_lr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 200.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 214.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -51,10 +51,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="1089.70" y="168.00" width="33.78" height="28.00" fill="white" />
-      <text x="1106.59" y="182.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <rect x="1365.07" y="125.00" width="43.57" height="28.00" fill="white" />
-      <text x="1386.86" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <rect x="1087.70" y="178.00" width="33.78" height="28.00" fill="white" />
+      <text x="1104.59" y="192.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1354.57" y="108.50" width="43.57" height="28.00" fill="white" />
+      <text x="1376.36" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/ci_pipeline.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 174.00" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 177.50" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M129.36,87.00 L175.36,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M274.94,87.00 L320.94,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -44,10 +44,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="828.71" y="21.00" width="59.59" height="28.00" fill="white" />
-      <text x="858.51" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
-      <rect x="817.15" y="125.00" width="82.72" height="28.00" fill="white" />
-      <text x="858.51" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
+      <rect x="832.65" y="4.50" width="59.59" height="28.00" fill="white" />
+      <text x="862.45" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="832.65" y="108.50" width="82.72" height="28.00" fill="white" />
+      <text x="874.01" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/cjk_labels.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/cjk_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 200.00" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 217.50" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M100.00,54.32 L121.00,54.32" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M233.00,30.00 L248.70,30.00 Q251.20,30.00 251.20,32.50 L251.20,32.50 Q251.20,35.00 253.70,35.00 L347.00,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -30,12 +30,12 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="267.50" y="21.00" width="40.00" height="28.00" fill="white" />
-      <text x="287.50" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
-      <rect x="244.00" y="106.00" width="40.00" height="28.00" fill="white" />
-      <text x="264.00" y="120.00" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
-      <rect x="167.50" y="164.00" width="40.00" height="28.00" fill="white" />
-      <text x="187.50" y="178.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
+      <rect x="259.50" y="4.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
+      <rect x="259.50" y="63.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="77.50" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
+      <rect x="165.50" y="178.00" width="40.00" height="28.00" fill="white" />
+      <text x="185.50" y="192.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/complex.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/complex.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 559.43 737.41" style="max-width: 559.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 573.43 737.41" style="max-width: 573.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -61,10 +61,10 @@
       <text x="443.07" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <rect x="518.54" y="132.54" width="32.90" height="28.00" fill="white" />
-      <text x="534.98" y="146.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="284.77" y="516.65" width="25.80" height="28.00" fill="white" />
-      <text x="297.67" y="530.65" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="532.54" y="130.54" width="32.90" height="28.00" fill="white" />
+      <text x="548.98" y="144.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="441.29" y="554.91" width="25.80" height="28.00" fill="white" />
+      <text x="454.19" y="568.91" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/compound_backward_cross_boundary.svg
@@ -73,8 +73,8 @@
       <text x="133.06" y="184.50" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
       <rect x="319.38" y="231.75" width="51.59" height="28.00" fill="white" />
       <text x="345.18" y="245.75" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
-      <rect x="260.97" y="487.59" width="40.02" height="28.00" fill="white" />
-      <text x="280.98" y="501.59" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="217.03" y="488.09" width="40.02" height="28.00" fill="white" />
+      <text x="237.04" y="502.09" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
       <rect x="325.36" y="432.09" width="69.38" height="28.00" fill="white" />
       <text x="360.05" y="446.09" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
       <rect x="91.63" y="432.09" width="41.78" height="28.00" fill="white" />
@@ -83,8 +83,8 @@
       <text x="237.04" y="671.11" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
       <rect x="347.60" y="748.09" width="24.90" height="28.00" fill="white" />
       <text x="360.05" y="762.09" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="197.00" y="945.61" width="73.82" height="28.00" fill="white" />
-      <text x="233.91" y="959.61" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="200.13" y="917.11" width="73.82" height="28.00" fill="white" />
+      <text x="237.04" y="931.11" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
       <rect x="328.47" y="716.09" width="40.00" height="28.00" fill="white" />
       <text x="348.47" y="730.09" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/crossing_minimize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 559.43 737.41" style="max-width: 559.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 573.43 737.41" style="max-width: 573.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -61,10 +61,10 @@
       <text x="443.07" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <rect x="518.54" y="132.54" width="32.90" height="28.00" fill="white" />
-      <text x="534.98" y="146.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="284.77" y="516.65" width="25.80" height="28.00" fill="white" />
-      <text x="297.67" y="530.65" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="532.54" y="130.54" width="32.90" height="28.00" fill="white" />
+      <text x="548.98" y="144.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="441.29" y="554.91" width="25.80" height="28.00" fill="white" />
+      <text x="454.19" y="568.91" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/decision.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/decision.svg
@@ -32,8 +32,8 @@
     <g class="edgeLabels">
       <rect x="42.45" y="267.87" width="35.57" height="28.00" fill="white" />
       <text x="60.23" y="281.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="177.61" y="242.34" width="28.45" height="28.00" fill="white" />
-      <text x="191.84" y="256.34" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="132.80" y="267.87" width="28.45" height="28.00" fill="white" />
+      <text x="147.03" y="281.87" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/flowchart_code_flow.svg
@@ -686,12 +686,12 @@
       <text x="9389.78" y="464.41" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
       <rect x="9541.38" y="450.41" width="190.67" height="28.00" fill="white" />
       <text x="9636.72" y="464.41" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
-      <rect x="9242.61" y="708.70" width="35.57" height="28.00" fill="white" />
-      <text x="9260.40" y="722.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9125.04" y="714.20" width="35.57" height="28.00" fill="white" />
+      <text x="9142.83" y="728.20" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="9371.99" y="734.90" width="35.57" height="28.00" fill="white" />
       <text x="9389.78" y="748.90" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="9592.70" y="778.70" width="35.57" height="28.00" fill="white" />
-      <text x="9610.48" y="792.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9593.70" y="773.70" width="35.57" height="28.00" fill="white" />
+      <text x="9611.48" y="787.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="360.42" y="1608.82" width="131.59" height="28.00" fill="white" />
       <text x="426.21" y="1622.82" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 96.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 110.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -36,8 +36,8 @@
       <text x="492.56" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="751.95" y="21.00" width="64.04" height="28.00" fill="white" />
       <text x="783.97" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="481.94" y="64.00" width="54.25" height="28.00" fill="white" />
-      <text x="509.07" y="78.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="479.94" y="74.00" width="54.25" height="28.00" fill="white" />
+      <text x="507.07" y="88.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/git_workflow_td.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 213.84 525.00" style="max-width: 213.84px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 227.84 525.00" style="max-width: 227.84px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -36,8 +36,8 @@
       <text x="87.36" y="250.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="55.34" y="396.00" width="64.04" height="28.00" fill="white" />
       <text x="87.36" y="410.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="151.59" y="246.71" width="54.25" height="28.00" fill="white" />
-      <text x="178.72" y="260.71" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="165.59" y="244.71" width="54.25" height="28.00" fill="white" />
+      <text x="192.72" y="258.71" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/http_request.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/http_request.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 509.28 679.75" style="max-width: 509.28px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 523.28 679.75" style="max-width: 523.28px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -47,8 +47,8 @@
       <text x="98.92" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="318.77" y="441.25" width="28.45" height="28.00" fill="white" />
       <text x="332.99" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <rect x="375.02" y="309.64" width="126.27" height="28.00" fill="white" />
-      <text x="438.15" y="323.64" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <rect x="389.02" y="307.64" width="126.27" height="28.00" fill="white" />
+      <text x="452.15" y="321.64" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/inline_label_flowchart.svg
@@ -116,8 +116,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="278.22" y="543.17" width="25.80" height="28.00" fill="white" />
-      <text x="291.12" y="557.17" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="276.22" y="600.27" width="25.80" height="28.00" fill="white" />
+      <text x="289.12" y="614.27" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <rect x="599.90" y="600.27" width="32.90" height="28.00" fill="white" />
       <text x="616.35" y="614.27" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <rect x="429.87" y="889.48" width="40.90" height="28.00" fill="white" />
@@ -126,12 +126,12 @@
       <text x="719.16" y="879.07" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <rect x="617.27" y="1587.95" width="25.80" height="28.00" fill="white" />
       <text x="630.17" y="1601.95" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <rect x="523.44" y="1525.55" width="32.90" height="28.00" fill="white" />
-      <text x="539.89" y="1539.55" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="38.35" y="427.79" width="24.90" height="28.00" fill="white" />
-      <text x="50.80" y="441.79" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="262.60" y="477.79" width="40.88" height="28.00" fill="white" />
-      <text x="283.04" y="491.79" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="554.90" y="1528.84" width="32.90" height="28.00" fill="white" />
+      <text x="571.35" y="1542.84" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="77.14" y="402.29" width="24.90" height="28.00" fill="white" />
+      <text x="89.59" y="416.29" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="264.60" y="461.79" width="40.88" height="28.00" fill="white" />
+      <text x="285.04" y="475.79" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
       <rect x="728.95" y="1389.30" width="42.68" height="28.00" fill="white" />
       <text x="750.29" y="1403.30" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>

--- a/tests/svg-snapshots/flowchart-smooth-step/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/label_clamp_bt_review.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 110.69 294.00" style="max-width: 110.69px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 106.24 294.00" style="max-width: 106.24px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-smooth-step/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 81.52" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 79.33" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-17.31)">
+  <g transform="translate(0.00,-19.50)">
     <g class="edgePaths">
       <path d="M209.12,35.50 L189.12,35.50 Q184.12,35.50 184.12,40.50 L184.12,49.50 Q184.12,54.50 179.12,54.50 L102.23,54.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,73.50 L184.12,73.50 L102.23,73.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-smooth-step/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/labeled_edges.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 366.52 569.48" style="max-width: 366.52px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 380.52 569.48" style="max-width: 380.52px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -41,10 +41,10 @@
       <text x="95.27" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
       <rect x="51.57" y="429.26" width="32.90" height="28.00" fill="white" />
       <text x="68.02" y="443.26" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="214.22" y="370.71" width="25.80" height="28.00" fill="white" />
-      <text x="227.12" y="384.71" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <rect x="318.52" y="268.39" width="40.00" height="28.00" fill="white" />
-      <text x="338.52" y="282.39" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="169.70" y="409.98" width="25.80" height="28.00" fill="white" />
+      <text x="182.60" y="423.98" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="332.52" y="266.39" width="40.00" height="28.00" fill="white" />
+      <text x="352.52" y="280.39" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 280.37 318.00" style="max-width: 280.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 216.89 318.00" style="max-width: 216.89px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M30.62,62.00 L30.62,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M61.00,256.00 L61.00,80.83 Q61.00,78.00 63.84,78.00 L63.84,78.00 Q66.67,78.00 66.67,75.17 L66.67,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-smooth-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/multi_edge_labeled.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 132.06 334.00" style="max-width: 132.06px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 121.39 334.00" style="max-width: 121.39px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(26.24,0.00)">
+  <g transform="translate(15.57,0.00)">
     <g class="edgePaths">
       <path d="M16.91,62.00 L16.91,95.55 Q16.91,100.00 12.45,100.00 L12.45,100.00 Q8.00,100.00 8.00,104.45 L8.00,113.00 Q8.00,118.00 13.00,118.00 L39.24,118.00 Q44.24,118.00 44.24,123.00 L44.24,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M71.58,62.00 L71.58,118.00 L71.58,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-smooth-step/three_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/three_parallel_labels.svg
@@ -21,8 +21,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="-9.35" y="99.00" width="34.70" height="28.00" fill="white" />
-      <text x="8.00" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
+      <rect x="-9.35" y="70.50" width="34.70" height="28.00" fill="white" />
+      <text x="8.00" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
       <rect x="45.35" y="94.75" width="32.90" height="28.00" fill="white" />
       <text x="61.80" y="108.75" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
       <rect x="66.90" y="126.75" width="44.47" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-step/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-step/backward_label_asymmetric_markers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 225.88 246.00" style="max-width: 225.88px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 198.86 246.00" style="max-width: 198.86px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-step/backward_loop_lr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 200.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 214.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -51,10 +51,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="1089.70" y="168.00" width="33.78" height="28.00" fill="white" />
-      <text x="1106.59" y="182.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <rect x="1365.07" y="125.00" width="43.57" height="28.00" fill="white" />
-      <text x="1386.86" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <rect x="1087.70" y="178.00" width="33.78" height="28.00" fill="white" />
+      <text x="1104.59" y="192.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1354.57" y="108.50" width="43.57" height="28.00" fill="white" />
+      <text x="1376.36" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-step/ci_pipeline.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 174.00" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 177.50" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M129.36,87.00 L175.36,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M274.94,87.00 L320.94,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -44,10 +44,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="828.71" y="21.00" width="59.59" height="28.00" fill="white" />
-      <text x="858.51" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
-      <rect x="817.15" y="125.00" width="82.72" height="28.00" fill="white" />
-      <text x="858.51" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
+      <rect x="832.65" y="4.50" width="59.59" height="28.00" fill="white" />
+      <text x="862.45" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="832.65" y="108.50" width="82.72" height="28.00" fill="white" />
+      <text x="874.01" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/cjk_labels.svg
+++ b/tests/svg-snapshots/flowchart-step/cjk_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 200.00" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 217.50" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M100.00,54.32 L121.00,54.32" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M233.00,30.00 L251.20,30.00 L251.20,35.00 L347.00,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -30,12 +30,12 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="267.50" y="21.00" width="40.00" height="28.00" fill="white" />
-      <text x="287.50" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
-      <rect x="244.00" y="106.00" width="40.00" height="28.00" fill="white" />
-      <text x="264.00" y="120.00" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
-      <rect x="167.50" y="164.00" width="40.00" height="28.00" fill="white" />
-      <text x="187.50" y="178.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
+      <rect x="259.50" y="4.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
+      <rect x="259.50" y="63.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="77.50" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
+      <rect x="165.50" y="178.00" width="40.00" height="28.00" fill="white" />
+      <text x="185.50" y="192.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/complex.svg
+++ b/tests/svg-snapshots/flowchart-step/complex.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 559.43 737.41" style="max-width: 559.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 573.43 737.41" style="max-width: 573.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -61,10 +61,10 @@
       <text x="443.07" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <rect x="518.54" y="132.54" width="32.90" height="28.00" fill="white" />
-      <text x="534.98" y="146.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="284.77" y="516.65" width="25.80" height="28.00" fill="white" />
-      <text x="297.67" y="530.65" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="532.54" y="130.54" width="32.90" height="28.00" fill="white" />
+      <text x="548.98" y="144.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="441.29" y="554.91" width="25.80" height="28.00" fill="white" />
+      <text x="454.19" y="568.91" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-step/compound_backward_cross_boundary.svg
@@ -73,8 +73,8 @@
       <text x="133.06" y="184.50" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
       <rect x="319.38" y="231.75" width="51.59" height="28.00" fill="white" />
       <text x="345.18" y="245.75" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
-      <rect x="260.97" y="487.59" width="40.02" height="28.00" fill="white" />
-      <text x="280.98" y="501.59" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="217.03" y="488.09" width="40.02" height="28.00" fill="white" />
+      <text x="237.04" y="502.09" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
       <rect x="325.36" y="432.09" width="69.38" height="28.00" fill="white" />
       <text x="360.05" y="446.09" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
       <rect x="91.63" y="432.09" width="41.78" height="28.00" fill="white" />
@@ -83,8 +83,8 @@
       <text x="237.04" y="671.11" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
       <rect x="347.60" y="748.09" width="24.90" height="28.00" fill="white" />
       <text x="360.05" y="762.09" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="197.00" y="945.61" width="73.82" height="28.00" fill="white" />
-      <text x="233.91" y="959.61" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="200.13" y="917.11" width="73.82" height="28.00" fill="white" />
+      <text x="237.04" y="931.11" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
       <rect x="328.47" y="716.09" width="40.00" height="28.00" fill="white" />
       <text x="348.47" y="730.09" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>

--- a/tests/svg-snapshots/flowchart-step/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-step/crossing_minimize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 559.43 737.41" style="max-width: 559.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 573.43 737.41" style="max-width: 573.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -61,10 +61,10 @@
       <text x="443.07" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <rect x="518.54" y="132.54" width="32.90" height="28.00" fill="white" />
-      <text x="534.98" y="146.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="284.77" y="516.65" width="25.80" height="28.00" fill="white" />
-      <text x="297.67" y="530.65" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="532.54" y="130.54" width="32.90" height="28.00" fill="white" />
+      <text x="548.98" y="144.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="441.29" y="554.91" width="25.80" height="28.00" fill="white" />
+      <text x="454.19" y="568.91" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/decision.svg
+++ b/tests/svg-snapshots/flowchart-step/decision.svg
@@ -32,8 +32,8 @@
     <g class="edgeLabels">
       <rect x="42.45" y="267.87" width="35.57" height="28.00" fill="white" />
       <text x="60.23" y="281.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="177.61" y="242.34" width="28.45" height="28.00" fill="white" />
-      <text x="191.84" y="256.34" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="132.80" y="267.87" width="28.45" height="28.00" fill="white" />
+      <text x="147.03" y="281.87" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-step/flowchart_code_flow.svg
@@ -686,12 +686,12 @@
       <text x="9389.78" y="464.41" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
       <rect x="9541.38" y="450.41" width="190.67" height="28.00" fill="white" />
       <text x="9636.72" y="464.41" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
-      <rect x="9242.61" y="708.70" width="35.57" height="28.00" fill="white" />
-      <text x="9260.40" y="722.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9125.04" y="714.20" width="35.57" height="28.00" fill="white" />
+      <text x="9142.83" y="728.20" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="9371.99" y="734.90" width="35.57" height="28.00" fill="white" />
       <text x="9389.78" y="748.90" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="9595.70" y="781.70" width="35.57" height="28.00" fill="white" />
-      <text x="9613.48" y="795.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9593.70" y="773.70" width="35.57" height="28.00" fill="white" />
+      <text x="9611.48" y="787.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="360.42" y="1608.82" width="131.59" height="28.00" fill="white" />
       <text x="426.21" y="1622.82" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>

--- a/tests/svg-snapshots/flowchart-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-step/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 96.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 110.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -36,8 +36,8 @@
       <text x="492.56" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="751.95" y="21.00" width="64.04" height="28.00" fill="white" />
       <text x="783.97" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="481.94" y="64.00" width="54.25" height="28.00" fill="white" />
-      <text x="509.07" y="78.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="479.94" y="74.00" width="54.25" height="28.00" fill="white" />
+      <text x="507.07" y="88.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-step/git_workflow_td.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 213.84 525.00" style="max-width: 213.84px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 227.84 525.00" style="max-width: 227.84px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -36,8 +36,8 @@
       <text x="87.36" y="250.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="55.34" y="396.00" width="64.04" height="28.00" fill="white" />
       <text x="87.36" y="410.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="151.59" y="246.71" width="54.25" height="28.00" fill="white" />
-      <text x="178.72" y="260.71" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="165.59" y="244.71" width="54.25" height="28.00" fill="white" />
+      <text x="192.72" y="258.71" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/http_request.svg
+++ b/tests/svg-snapshots/flowchart-step/http_request.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 509.28 679.75" style="max-width: 509.28px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 523.28 679.75" style="max-width: 523.28px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -47,8 +47,8 @@
       <text x="98.92" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="318.77" y="441.25" width="28.45" height="28.00" fill="white" />
       <text x="332.99" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <rect x="375.02" y="309.64" width="126.27" height="28.00" fill="white" />
-      <text x="438.15" y="323.64" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <rect x="389.02" y="307.64" width="126.27" height="28.00" fill="white" />
+      <text x="452.15" y="321.64" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-step/inline_label_flowchart.svg
@@ -116,8 +116,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="278.22" y="543.17" width="25.80" height="28.00" fill="white" />
-      <text x="291.12" y="557.17" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="276.22" y="600.27" width="25.80" height="28.00" fill="white" />
+      <text x="289.12" y="614.27" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <rect x="599.90" y="600.27" width="32.90" height="28.00" fill="white" />
       <text x="616.35" y="614.27" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <rect x="429.87" y="889.48" width="40.90" height="28.00" fill="white" />
@@ -126,12 +126,12 @@
       <text x="719.16" y="879.07" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <rect x="617.27" y="1587.95" width="25.80" height="28.00" fill="white" />
       <text x="630.17" y="1601.95" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <rect x="523.44" y="1525.55" width="32.90" height="28.00" fill="white" />
-      <text x="539.89" y="1539.55" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="38.35" y="427.79" width="24.90" height="28.00" fill="white" />
-      <text x="50.80" y="441.79" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="262.60" y="477.79" width="40.88" height="28.00" fill="white" />
-      <text x="283.04" y="491.79" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="554.90" y="1528.84" width="32.90" height="28.00" fill="white" />
+      <text x="571.35" y="1542.84" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="77.14" y="402.29" width="24.90" height="28.00" fill="white" />
+      <text x="89.59" y="416.29" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="264.60" y="461.79" width="40.88" height="28.00" fill="white" />
+      <text x="285.04" y="475.79" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
       <rect x="728.95" y="1389.30" width="42.68" height="28.00" fill="white" />
       <text x="750.29" y="1403.30" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>

--- a/tests/svg-snapshots/flowchart-step/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-step/label_clamp_bt_review.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 110.69 294.00" style="max-width: 110.69px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 106.24 294.00" style="max-width: 106.24px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-step/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-step/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 81.52" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 79.33" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-17.31)">
+  <g transform="translate(0.00,-19.50)">
     <g class="edgePaths">
       <path d="M209.12,35.50 L184.12,35.50 L184.12,54.50 L102.23,54.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,73.50 L110.23,73.50 L102.23,73.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-step/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-step/labeled_edges.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 366.52 569.48" style="max-width: 366.52px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 380.52 569.48" style="max-width: 380.52px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -41,10 +41,10 @@
       <text x="95.27" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
       <rect x="51.57" y="429.26" width="32.90" height="28.00" fill="white" />
       <text x="68.02" y="443.26" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="214.22" y="370.71" width="25.80" height="28.00" fill="white" />
-      <text x="227.12" y="384.71" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <rect x="318.52" y="268.39" width="40.00" height="28.00" fill="white" />
-      <text x="338.52" y="282.39" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="169.70" y="409.98" width="25.80" height="28.00" fill="white" />
+      <text x="182.60" y="423.98" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="332.52" y="266.39" width="40.00" height="28.00" fill="white" />
+      <text x="352.52" y="280.39" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-step/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 280.37 318.00" style="max-width: 280.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 216.89 318.00" style="max-width: 216.89px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M30.62,62.00 L30.62,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M61.00,256.00 L61.00,78.00 L66.67,78.00 L66.67,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-step/multi_edge_labeled.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 132.06 334.00" style="max-width: 132.06px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 121.39 334.00" style="max-width: 121.39px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(26.24,0.00)">
+  <g transform="translate(15.57,0.00)">
     <g class="edgePaths">
       <path d="M16.91,62.00 L16.91,100.00 L8.00,100.00 L8.00,118.00 L44.24,118.00 L44.24,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M71.58,62.00 L71.58,118.00 L71.58,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-step/three_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-step/three_parallel_labels.svg
@@ -21,8 +21,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="-9.35" y="99.00" width="34.70" height="28.00" fill="white" />
-      <text x="8.00" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
+      <rect x="-9.35" y="70.50" width="34.70" height="28.00" fill="white" />
+      <text x="8.00" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
       <rect x="45.35" y="94.75" width="32.90" height="28.00" fill="white" />
       <text x="61.80" y="108.75" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
       <rect x="66.90" y="126.75" width="44.47" height="28.00" fill="white" />

--- a/tests/svg-snapshots/flowchart-straight/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart-straight/ci_pipeline.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 174.00" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 177.50" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M129.36,87.00 L175.36,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M274.94,87.00 L320.94,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -44,10 +44,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="849.32" y="42.02" width="59.59" height="28.00" fill="white" />
-      <text x="879.12" y="56.02" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
-      <rect x="837.76" y="103.98" width="82.72" height="28.00" fill="white" />
-      <text x="879.12" y="117.98" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
+      <rect x="832.65" y="4.50" width="59.59" height="28.00" fill="white" />
+      <text x="862.45" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="832.65" y="108.50" width="82.72" height="28.00" fill="white" />
+      <text x="874.01" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/cjk_labels.svg
+++ b/tests/svg-snapshots/flowchart-straight/cjk_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 196.00" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 199.50" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M100.00,59.00 L121.29,50.49" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M233.00,49.00 L347.03,35.47" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -30,10 +30,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="270.01" y="28.24" width="40.00" height="28.00" fill="white" />
-      <text x="290.01" y="42.24" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
-      <rect x="270.41" y="78.79" width="40.00" height="28.00" fill="white" />
-      <text x="290.41" y="92.79" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
+      <rect x="259.50" y="4.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
+      <rect x="259.50" y="63.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="77.50" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
       <rect x="165.50" y="160.00" width="40.00" height="28.00" fill="white" />
       <text x="185.50" y="174.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
     </g>

--- a/tests/svg-snapshots/flowchart-straight/compat_class_annotation.svg
+++ b/tests/svg-snapshots/flowchart-straight/compat_class_annotation.svg
@@ -29,10 +29,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="49.27" y="256.68" width="35.57" height="28.00" fill="white" />
-      <text x="67.05" y="270.68" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="127.83" y="256.68" width="28.45" height="28.00" fill="white" />
-      <text x="142.06" y="270.68" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="25.99" y="235.86" width="35.57" height="28.00" fill="white" />
+      <text x="43.78" y="249.86" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="151.11" y="235.86" width="28.45" height="28.00" fill="white" />
+      <text x="165.33" y="249.86" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/compat_directive.svg
+++ b/tests/svg-snapshots/flowchart-straight/compat_directive.svg
@@ -29,10 +29,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="79.05" y="255.36" width="35.57" height="28.00" fill="#333333" />
-      <text x="96.84" y="269.36" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">Yes</text>
-      <rect x="175.87" y="255.36" width="28.45" height="28.00" fill="#333333" />
-      <text x="190.09" y="269.36" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">No</text>
+      <rect x="49.11" y="235.86" width="35.57" height="28.00" fill="#333333" />
+      <text x="66.90" y="249.86" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">Yes</text>
+      <rect x="205.80" y="235.86" width="28.45" height="28.00" fill="#333333" />
+      <text x="220.03" y="249.86" text-anchor="middle" dominant-baseline="middle" fill="#cccccc">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/compat_kitchen_sink.svg
+++ b/tests/svg-snapshots/flowchart-straight/compat_kitchen_sink.svg
@@ -35,10 +35,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="84.27" y="277.49" width="40.91" height="28.00" fill="#ffffff" />
-      <text x="104.73" y="291.49" text-anchor="middle" dominant-baseline="middle" fill="#333333">valid</text>
-      <rect x="180.41" y="277.49" width="53.36" height="28.00" fill="#ffffff" />
-      <text x="207.09" y="291.49" text-anchor="middle" dominant-baseline="middle" fill="#333333">invalid</text>
+      <rect x="53.56" y="259.88" width="40.91" height="28.00" fill="#ffffff" />
+      <text x="74.01" y="273.88" text-anchor="middle" dominant-baseline="middle" fill="#333333">valid</text>
+      <rect x="211.12" y="259.88" width="53.36" height="28.00" fill="#ffffff" />
+      <text x="237.80" y="273.88" text-anchor="middle" dominant-baseline="middle" fill="#333333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/complex.svg
+++ b/tests/svg-snapshots/flowchart-straight/complex.svg
@@ -57,14 +57,14 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="341.58" y="232.86" width="40.91" height="28.00" fill="white" />
-      <text x="362.03" y="246.86" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <rect x="166.00" y="237.09" width="53.36" height="28.00" fill="white" />
-      <text x="192.68" y="251.09" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="326.91" y="250.32" width="40.91" height="28.00" fill="white" />
+      <text x="347.36" y="264.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
+      <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
       <rect x="514.54" y="130.54" width="32.90" height="28.00" fill="white" />
       <text x="530.98" y="144.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="324.05" y="578.11" width="25.80" height="28.00" fill="white" />
-      <text x="336.95" y="592.11" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="340.02" y="596.91" width="25.80" height="28.00" fill="white" />
+      <text x="352.92" y="610.91" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart-straight/compound_backward_cross_boundary.svg
@@ -69,24 +69,24 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="166.97" y="208.98" width="61.37" height="28.00" fill="white" />
-      <text x="197.65" y="222.98" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
-      <rect x="294.16" y="204.12" width="51.59" height="28.00" fill="white" />
-      <text x="319.96" y="218.12" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
-      <rect x="236.03" y="482.90" width="40.02" height="28.00" fill="white" />
-      <text x="256.04" y="496.90" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
-      <rect x="295.78" y="438.76" width="69.38" height="28.00" fill="white" />
-      <text x="330.46" y="452.76" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
-      <rect x="163.97" y="434.05" width="41.78" height="28.00" fill="white" />
-      <text x="184.86" y="448.05" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
+      <rect x="177.68" y="201.00" width="61.37" height="28.00" fill="white" />
+      <text x="208.37" y="215.00" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
+      <rect x="288.63" y="201.00" width="51.59" height="28.00" fill="white" />
+      <text x="314.43" y="215.00" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
+      <rect x="217.03" y="488.09" width="40.02" height="28.00" fill="white" />
+      <text x="237.04" y="502.09" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="325.36" y="432.09" width="69.38" height="28.00" fill="white" />
+      <text x="360.05" y="446.09" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
+      <rect x="91.63" y="432.09" width="41.78" height="28.00" fill="white" />
+      <text x="112.52" y="446.09" text-anchor="middle" dominant-baseline="middle" fill="#333">write</text>
       <rect x="213.48" y="737.61" width="47.12" height="28.00" fill="white" />
       <text x="237.04" y="751.61" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
       <rect x="286.10" y="692.60" width="24.90" height="28.00" fill="white" />
       <text x="298.55" y="706.60" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="194.84" y="945.62" width="73.82" height="28.00" fill="white" />
-      <text x="231.75" y="959.62" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
-      <rect x="330.47" y="735.92" width="40.00" height="28.00" fill="white" />
-      <text x="350.47" y="749.92" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="200.13" y="917.11" width="73.82" height="28.00" fill="white" />
+      <text x="237.04" y="931.11" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="324.47" y="733.92" width="40.00" height="28.00" fill="white" />
+      <text x="344.47" y="747.92" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart-straight/crossing_minimize.svg
@@ -57,14 +57,14 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="341.58" y="232.86" width="40.91" height="28.00" fill="white" />
-      <text x="362.03" y="246.86" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <rect x="166.00" y="237.09" width="53.36" height="28.00" fill="white" />
-      <text x="192.68" y="251.09" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="326.91" y="250.32" width="40.91" height="28.00" fill="white" />
+      <text x="347.36" y="264.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
+      <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
       <rect x="514.54" y="130.54" width="32.90" height="28.00" fill="white" />
       <text x="530.98" y="144.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="324.05" y="578.11" width="25.80" height="28.00" fill="white" />
-      <text x="336.95" y="592.11" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="340.02" y="596.91" width="25.80" height="28.00" fill="white" />
+      <text x="352.92" y="610.91" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/decision.svg
+++ b/tests/svg-snapshots/flowchart-straight/decision.svg
@@ -30,10 +30,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="50.21" y="292.11" width="35.57" height="28.00" fill="white" />
-      <text x="68.00" y="306.11" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="150.12" y="281.14" width="28.45" height="28.00" fill="white" />
-      <text x="164.35" y="295.14" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="42.45" y="267.87" width="35.57" height="28.00" fill="white" />
+      <text x="60.23" y="281.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="132.80" y="267.87" width="28.45" height="28.00" fill="white" />
+      <text x="147.03" y="281.87" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart-straight/flowchart_code_flow.svg
@@ -686,12 +686,12 @@
       <text x="9389.78" y="464.41" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
       <rect x="9541.38" y="419.91" width="190.67" height="28.00" fill="white" />
       <text x="9636.72" y="433.91" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
-      <rect x="9272.96" y="717.44" width="35.57" height="28.00" fill="white" />
-      <text x="9290.75" y="731.44" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9125.04" y="714.20" width="35.57" height="28.00" fill="white" />
+      <text x="9142.83" y="728.20" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="9371.99" y="734.90" width="35.57" height="28.00" fill="white" />
       <text x="9389.78" y="748.90" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="9477.76" y="702.84" width="35.57" height="28.00" fill="white" />
-      <text x="9495.54" y="716.84" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9618.94" y="714.20" width="35.57" height="28.00" fill="white" />
+      <text x="9636.72" y="728.20" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="360.42" y="1608.82" width="131.59" height="28.00" fill="white" />
       <text x="426.21" y="1622.82" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>

--- a/tests/svg-snapshots/flowchart-straight/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-straight/git_workflow.svg
@@ -36,8 +36,8 @@
       <text x="492.56" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="751.95" y="21.00" width="64.04" height="28.00" fill="white" />
       <text x="783.97" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="481.94" y="62.00" width="54.25" height="28.00" fill="white" />
-      <text x="509.07" y="76.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="479.94" y="56.00" width="54.25" height="28.00" fill="white" />
+      <text x="507.07" y="70.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/http_request.svg
+++ b/tests/svg-snapshots/flowchart-straight/http_request.svg
@@ -43,10 +43,10 @@
     <g class="edgeLabels">
       <rect x="200.17" y="101.00" width="113.81" height="28.00" fill="white" />
       <text x="257.08" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Request</text>
-      <rect x="141.72" y="437.93" width="35.57" height="28.00" fill="white" />
-      <text x="159.51" y="451.93" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="292.81" y="444.58" width="28.45" height="28.00" fill="white" />
-      <text x="307.04" y="458.58" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="81.13" y="441.25" width="35.57" height="28.00" fill="white" />
+      <text x="98.92" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="280.81" y="459.25" width="28.45" height="28.00" fill="white" />
+      <text x="295.04" y="473.25" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
       <rect x="371.02" y="307.64" width="126.27" height="28.00" fill="white" />
       <text x="434.15" y="321.64" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>

--- a/tests/svg-snapshots/flowchart-straight/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart-straight/inline_label_flowchart.svg
@@ -116,22 +116,22 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="362.44" y="626.61" width="25.80" height="28.00" fill="white" />
-      <text x="375.34" y="640.61" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <rect x="541.51" y="643.33" width="32.90" height="28.00" fill="white" />
-      <text x="557.96" y="657.33" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="499.64" y="900.44" width="40.90" height="28.00" fill="white" />
-      <text x="520.09" y="914.44" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
-      <rect x="652.68" y="904.01" width="49.80" height="28.00" fill="white" />
-      <text x="677.58" y="918.01" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
-      <rect x="620.65" y="1565.66" width="25.80" height="28.00" fill="white" />
-      <text x="633.55" y="1579.66" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <rect x="509.16" y="1546.27" width="32.90" height="28.00" fill="white" />
-      <text x="525.61" y="1560.27" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="256.63" y="616.77" width="25.80" height="28.00" fill="white" />
+      <text x="269.53" y="630.77" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="545.17" y="642.27" width="32.90" height="28.00" fill="white" />
+      <text x="561.62" y="656.27" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="512.88" y="916.48" width="40.90" height="28.00" fill="white" />
+      <text x="533.33" y="930.48" text-anchor="middle" dominant-baseline="middle" fill="#333">sync</text>
+      <rect x="642.86" y="916.48" width="49.80" height="28.00" fill="white" />
+      <text x="667.76" y="930.48" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
+      <rect x="622.54" y="1572.25" width="25.80" height="28.00" fill="white" />
+      <text x="635.43" y="1586.25" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="518.55" y="1558.34" width="32.90" height="28.00" fill="white" />
+      <text x="535.00" y="1572.34" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <rect x="77.14" y="402.29" width="24.90" height="28.00" fill="white" />
       <text x="89.59" y="416.29" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="258.31" y="444.69" width="40.88" height="28.00" fill="white" />
-      <text x="278.75" y="458.69" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="185.56" y="402.29" width="40.88" height="28.00" fill="white" />
+      <text x="206.01" y="416.29" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
       <rect x="685.57" y="1399.66" width="42.68" height="28.00" fill="white" />
       <text x="706.91" y="1413.66" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>

--- a/tests/svg-snapshots/flowchart-straight/label_spacing.svg
+++ b/tests/svg-snapshots/flowchart-straight/label_spacing.svg
@@ -24,10 +24,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="54.15" y="99.26" width="40.91" height="28.00" fill="white" />
-      <text x="74.61" y="113.26" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
-      <rect x="106.50" y="99.26" width="53.36" height="28.00" fill="white" />
-      <text x="133.18" y="113.26" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
+      <rect x="22.88" y="70.50" width="40.91" height="28.00" fill="white" />
+      <text x="43.34" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
+      <rect x="137.77" y="70.50" width="53.36" height="28.00" fill="white" />
+      <text x="164.45" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart-straight/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart-straight/labeled_edges.svg
@@ -37,12 +37,12 @@
     <g class="edgeLabels">
       <rect x="74.46" y="101.00" width="64.91" height="28.00" fill="white" />
       <text x="106.92" y="115.00" text-anchor="middle" dominant-baseline="middle" fill="#333">initialize</text>
-      <rect x="65.17" y="249.11" width="73.82" height="28.00" fill="white" />
-      <text x="102.08" y="263.11" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
-      <rect x="59.73" y="435.12" width="32.90" height="28.00" fill="white" />
-      <text x="76.18" y="449.12" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="169.52" y="426.60" width="25.80" height="28.00" fill="white" />
-      <text x="182.42" y="440.60" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="62.34" y="248.50" width="73.82" height="28.00" fill="white" />
+      <text x="99.25" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
+      <rect x="62.79" y="440.48" width="32.90" height="28.00" fill="white" />
+      <text x="79.24" y="454.48" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="169.70" y="409.98" width="25.80" height="28.00" fill="white" />
+      <text x="182.60" y="423.98" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <rect x="314.52" y="266.39" width="40.00" height="28.00" fill="white" />
       <text x="334.52" y="280.39" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>

--- a/tests/svg-snapshots/flowchart-straight/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-straight/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 277.04 318.00" style="max-width: 277.04px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 219.22 318.00" style="max-width: 219.22px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M30.62,62.00 L30.62,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M47.69,256.00 L63.34,159.00 L48.33,65.95" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart/backward_label_asymmetric_markers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 225.88 246.00" style="max-width: 225.88px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 198.86 246.00" style="max-width: 198.86px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart/backward_loop_lr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 200.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 214.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -51,10 +51,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="1089.70" y="168.00" width="33.78" height="28.00" fill="white" />
-      <text x="1106.59" y="182.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
-      <rect x="1365.07" y="125.00" width="43.57" height="28.00" fill="white" />
-      <text x="1386.86" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
+      <rect x="1087.70" y="178.00" width="33.78" height="28.00" fill="white" />
+      <text x="1104.59" y="192.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Fail</text>
+      <rect x="1354.57" y="108.50" width="43.57" height="28.00" fill="white" />
+      <text x="1376.36" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">Pass</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/ci_pipeline.svg
+++ b/tests/svg-snapshots/flowchart/ci_pipeline.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 174.00" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1121.15 177.50" style="max-width: 1121.15px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M129.36,87.00 L175.36,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M274.94,87.00 L320.94,87.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -44,10 +44,10 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="828.71" y="21.00" width="59.59" height="28.00" fill="white" />
-      <text x="858.51" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
-      <rect x="817.15" y="125.00" width="82.72" height="28.00" fill="white" />
-      <text x="858.51" y="139.00" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
+      <rect x="832.65" y="4.50" width="59.59" height="28.00" fill="white" />
+      <text x="862.45" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">staging</text>
+      <rect x="832.65" y="108.50" width="82.72" height="28.00" fill="white" />
+      <text x="874.01" y="122.50" text-anchor="middle" dominant-baseline="middle" fill="#333">production</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/cjk_labels.svg
+++ b/tests/svg-snapshots/flowchart/cjk_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 200.00" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 451.00 217.50" style="max-width: 451.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,0.00)">
+  <g transform="translate(0.00,3.50)">
     <g class="edgePaths">
       <path d="M100.00,54.32 L121.00,54.32" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M233.00,30.00 L248.70,30.00 Q251.20,30.00 251.20,32.50 L251.20,32.50 Q251.20,35.00 253.70,35.00 L347.00,35.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
@@ -30,12 +30,12 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="267.50" y="21.00" width="40.00" height="28.00" fill="white" />
-      <text x="287.50" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
-      <rect x="244.00" y="106.00" width="40.00" height="28.00" fill="white" />
-      <text x="264.00" y="120.00" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
-      <rect x="167.50" y="164.00" width="40.00" height="28.00" fill="white" />
-      <text x="187.50" y="178.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
+      <rect x="259.50" y="4.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="18.50" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
+      <rect x="259.50" y="63.50" width="40.00" height="28.00" fill="white" />
+      <text x="279.50" y="77.50" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
+      <rect x="165.50" y="178.00" width="40.00" height="28.00" fill="white" />
+      <text x="185.50" y="192.00" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/complex.svg
+++ b/tests/svg-snapshots/flowchart/complex.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 559.43 737.41" style="max-width: 559.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 573.43 737.41" style="max-width: 573.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -61,10 +61,10 @@
       <text x="443.07" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <rect x="518.54" y="132.54" width="32.90" height="28.00" fill="white" />
-      <text x="534.98" y="146.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="284.77" y="516.65" width="25.80" height="28.00" fill="white" />
-      <text x="297.67" y="530.65" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="532.54" y="130.54" width="32.90" height="28.00" fill="white" />
+      <text x="548.98" y="144.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="441.29" y="554.91" width="25.80" height="28.00" fill="white" />
+      <text x="454.19" y="568.91" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/compound_backward_cross_boundary.svg
+++ b/tests/svg-snapshots/flowchart/compound_backward_cross_boundary.svg
@@ -73,8 +73,8 @@
       <text x="133.06" y="184.50" text-anchor="middle" dominant-baseline="middle" fill="#333">request</text>
       <rect x="319.38" y="231.75" width="51.59" height="28.00" fill="white" />
       <text x="345.18" y="245.75" text-anchor="middle" dominant-baseline="middle" fill="#333">health</text>
-      <rect x="260.97" y="487.59" width="40.02" height="28.00" fill="white" />
-      <text x="280.98" y="501.59" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
+      <rect x="217.03" y="488.09" width="40.02" height="28.00" fill="white" />
+      <text x="237.04" y="502.09" text-anchor="middle" dominant-baseline="middle" fill="#333">read</text>
       <rect x="325.36" y="432.09" width="69.38" height="28.00" fill="white" />
       <text x="360.05" y="446.09" text-anchor="middle" dominant-baseline="middle" fill="#333">fast path</text>
       <rect x="91.63" y="432.09" width="41.78" height="28.00" fill="white" />
@@ -83,8 +83,8 @@
       <text x="237.04" y="671.11" text-anchor="middle" dominant-baseline="middle" fill="#333">result</text>
       <rect x="347.60" y="748.09" width="24.90" height="28.00" fill="white" />
       <text x="360.05" y="762.09" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="197.00" y="945.61" width="73.82" height="28.00" fill="white" />
-      <text x="233.91" y="959.61" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
+      <rect x="200.13" y="917.11" width="73.82" height="28.00" fill="white" />
+      <text x="237.04" y="931.11" text-anchor="middle" dominant-baseline="middle" fill="#333">response</text>
       <rect x="328.47" y="716.09" width="40.00" height="28.00" fill="white" />
       <text x="348.47" y="730.09" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>

--- a/tests/svg-snapshots/flowchart/crossing_minimize.svg
+++ b/tests/svg-snapshots/flowchart/crossing_minimize.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 559.43 737.41" style="max-width: 559.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 573.43 737.41" style="max-width: 573.43px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -61,10 +61,10 @@
       <text x="443.07" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">valid</text>
       <rect x="127.90" y="232.32" width="53.36" height="28.00" fill="white" />
       <text x="154.58" y="246.32" text-anchor="middle" dominant-baseline="middle" fill="#333">invalid</text>
-      <rect x="518.54" y="132.54" width="32.90" height="28.00" fill="white" />
-      <text x="534.98" y="146.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="284.77" y="516.65" width="25.80" height="28.00" fill="white" />
-      <text x="297.67" y="530.65" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="532.54" y="130.54" width="32.90" height="28.00" fill="white" />
+      <text x="548.98" y="144.54" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="441.29" y="554.91" width="25.80" height="28.00" fill="white" />
+      <text x="454.19" y="568.91" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/decision.svg
+++ b/tests/svg-snapshots/flowchart/decision.svg
@@ -32,8 +32,8 @@
     <g class="edgeLabels">
       <rect x="42.45" y="267.87" width="35.57" height="28.00" fill="white" />
       <text x="60.23" y="281.87" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="177.61" y="242.34" width="28.45" height="28.00" fill="white" />
-      <text x="191.84" y="256.34" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
+      <rect x="132.80" y="267.87" width="28.45" height="28.00" fill="white" />
+      <text x="147.03" y="281.87" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/flowchart_code_flow.svg
+++ b/tests/svg-snapshots/flowchart/flowchart_code_flow.svg
@@ -686,12 +686,12 @@
       <text x="9389.78" y="464.41" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart/</text>
       <rect x="9541.38" y="450.41" width="190.67" height="28.00" fill="white" />
       <text x="9636.72" y="464.41" text-anchor="middle" dominant-baseline="middle" fill="#333">Checks /^\s*flowchart-elk/</text>
-      <rect x="9242.61" y="708.70" width="35.57" height="28.00" fill="white" />
-      <text x="9260.40" y="722.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9125.04" y="714.20" width="35.57" height="28.00" fill="white" />
+      <text x="9142.83" y="728.20" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="9371.99" y="734.90" width="35.57" height="28.00" fill="white" />
       <text x="9389.78" y="748.90" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
-      <rect x="9592.70" y="778.70" width="35.57" height="28.00" fill="white" />
-      <text x="9610.48" y="792.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
+      <rect x="9593.70" y="773.70" width="35.57" height="28.00" fill="white" />
+      <text x="9611.48" y="787.70" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="360.42" y="1608.82" width="131.59" height="28.00" fill="white" />
       <text x="426.21" y="1622.82" text-anchor="middle" dominant-baseline="middle" fill="#333">Preprocesses src</text>
     </g>

--- a/tests/svg-snapshots/flowchart/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 96.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 110.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -36,8 +36,8 @@
       <text x="492.56" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="751.95" y="21.00" width="64.04" height="28.00" fill="white" />
       <text x="783.97" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="481.94" y="64.00" width="54.25" height="28.00" fill="white" />
-      <text x="509.07" y="78.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="479.94" y="74.00" width="54.25" height="28.00" fill="white" />
+      <text x="507.07" y="88.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart/git_workflow_td.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 213.84 525.00" style="max-width: 213.84px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 227.84 525.00" style="max-width: 227.84px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -36,8 +36,8 @@
       <text x="87.36" y="250.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git commit</text>
       <rect x="55.34" y="396.00" width="64.04" height="28.00" fill="white" />
       <text x="87.36" y="410.00" text-anchor="middle" dominant-baseline="middle" fill="#333">git push</text>
-      <rect x="151.59" y="246.71" width="54.25" height="28.00" fill="white" />
-      <text x="178.72" y="260.71" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
+      <rect x="165.59" y="244.71" width="54.25" height="28.00" fill="white" />
+      <text x="192.72" y="258.71" text-anchor="middle" dominant-baseline="middle" fill="#333">git pull</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/http_request.svg
+++ b/tests/svg-snapshots/flowchart/http_request.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 509.28 679.75" style="max-width: 509.28px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 523.28 679.75" style="max-width: 523.28px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -47,8 +47,8 @@
       <text x="98.92" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">Yes</text>
       <rect x="318.77" y="441.25" width="28.45" height="28.00" fill="white" />
       <text x="332.99" y="455.25" text-anchor="middle" dominant-baseline="middle" fill="#333">No</text>
-      <rect x="375.02" y="309.64" width="126.27" height="28.00" fill="white" />
-      <text x="438.15" y="323.64" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
+      <rect x="389.02" y="307.64" width="126.27" height="28.00" fill="white" />
+      <text x="452.15" y="321.64" text-anchor="middle" dominant-baseline="middle" fill="#333">HTTP Response</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/inline_label_flowchart.svg
+++ b/tests/svg-snapshots/flowchart/inline_label_flowchart.svg
@@ -116,8 +116,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="278.22" y="543.17" width="25.80" height="28.00" fill="white" />
-      <text x="291.12" y="557.17" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="276.22" y="600.27" width="25.80" height="28.00" fill="white" />
+      <text x="289.12" y="614.27" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
       <rect x="599.90" y="600.27" width="32.90" height="28.00" fill="white" />
       <text x="616.35" y="614.27" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
       <rect x="429.87" y="889.48" width="40.90" height="28.00" fill="white" />
@@ -126,12 +126,12 @@
       <text x="719.16" y="879.07" text-anchor="middle" dominant-baseline="middle" fill="#333">async</text>
       <rect x="617.27" y="1587.95" width="25.80" height="28.00" fill="white" />
       <text x="630.17" y="1601.95" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <rect x="523.44" y="1525.55" width="32.90" height="28.00" fill="white" />
-      <text x="539.89" y="1539.55" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="38.35" y="427.79" width="24.90" height="28.00" fill="white" />
-      <text x="50.80" y="441.79" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
-      <rect x="262.60" y="477.79" width="40.88" height="28.00" fill="white" />
-      <text x="283.04" y="491.79" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
+      <rect x="554.90" y="1528.84" width="32.90" height="28.00" fill="white" />
+      <text x="571.35" y="1542.84" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
+      <rect x="77.14" y="402.29" width="24.90" height="28.00" fill="white" />
+      <text x="89.59" y="416.29" text-anchor="middle" dominant-baseline="middle" fill="#333">hit</text>
+      <rect x="264.60" y="461.79" width="40.88" height="28.00" fill="white" />
+      <text x="285.04" y="475.79" text-anchor="middle" dominant-baseline="middle" fill="#333">miss</text>
       <rect x="728.95" y="1389.30" width="42.68" height="28.00" fill="white" />
       <text x="750.29" y="1403.30" text-anchor="middle" dominant-baseline="middle" fill="#333">warn</text>
     </g>

--- a/tests/svg-snapshots/flowchart/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart/label_clamp_bt_review.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 110.69 294.00" style="max-width: 110.69px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 106.24 294.00" style="max-width: 106.24px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 81.52" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 79.33" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-17.31)">
+  <g transform="translate(0.00,-19.50)">
     <g class="edgePaths">
       <path d="M209.12,35.50 L189.12,35.50 Q184.12,35.50 184.12,40.50 L184.12,49.50 Q184.12,54.50 179.12,54.50 L102.23,54.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,73.50 L184.12,73.50 L102.23,73.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart/labeled_edges.svg
+++ b/tests/svg-snapshots/flowchart/labeled_edges.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 366.52 569.48" style="max-width: 366.52px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 380.52 569.48" style="max-width: 380.52px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -41,10 +41,10 @@
       <text x="95.27" y="262.50" text-anchor="middle" dominant-baseline="middle" fill="#333">configure</text>
       <rect x="51.57" y="429.26" width="32.90" height="28.00" fill="white" />
       <text x="68.02" y="443.26" text-anchor="middle" dominant-baseline="middle" fill="#333">yes</text>
-      <rect x="214.22" y="370.71" width="25.80" height="28.00" fill="white" />
-      <text x="227.12" y="384.71" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
-      <rect x="318.52" y="268.39" width="40.00" height="28.00" fill="white" />
-      <text x="338.52" y="282.39" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="169.70" y="409.98" width="25.80" height="28.00" fill="white" />
+      <text x="182.60" y="423.98" text-anchor="middle" dominant-baseline="middle" fill="#333">no</text>
+      <rect x="332.52" y="266.39" width="40.00" height="28.00" fill="white" />
+      <text x="352.52" y="280.39" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/flowchart/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 280.37 318.00" style="max-width: 280.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 216.89 318.00" style="max-width: 216.89px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M30.62,62.00 L30.62,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M61.00,256.00 L61.00,80.83 Q61.00,78.00 63.84,78.00 L63.84,78.00 Q66.67,78.00 66.67,75.17 L66.67,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart/multi_edge_labeled.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 132.06 334.00" style="max-width: 132.06px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 121.39 334.00" style="max-width: 121.39px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(26.24,0.00)">
+  <g transform="translate(15.57,0.00)">
     <g class="edgePaths">
       <path d="M16.91,62.00 L16.91,95.55 Q16.91,100.00 12.45,100.00 L12.45,100.00 Q8.00,100.00 8.00,104.45 L8.00,113.00 Q8.00,118.00 13.00,118.00 L39.24,118.00 Q44.24,118.00 44.24,123.00 L44.24,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M71.58,62.00 L71.58,118.00 L71.58,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart/three_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart/three_parallel_labels.svg
@@ -21,8 +21,8 @@
       </g>
     </g>
     <g class="edgeLabels">
-      <rect x="-9.35" y="99.00" width="34.70" height="28.00" fill="white" />
-      <text x="8.00" y="113.00" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
+      <rect x="-9.35" y="70.50" width="34.70" height="28.00" fill="white" />
+      <text x="8.00" y="84.50" text-anchor="middle" dominant-baseline="middle" fill="#333">one</text>
       <rect x="45.35" y="94.75" width="32.90" height="28.00" fill="white" />
       <text x="61.80" y="108.75" text-anchor="middle" dominant-baseline="middle" fill="#333">two</text>
       <rect x="66.90" y="126.75" width="44.47" height="28.00" fill="white" />

--- a/tests/svg-snapshots/state/cjk_labels.svg
+++ b/tests/svg-snapshots/state/cjk_labels.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 222.00 507.00" style="max-width: 222.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 236.00 507.00" style="max-width: 236.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -45,10 +45,10 @@
       <text x="69.00" y="166.50" text-anchor="middle" dominant-baseline="middle" fill="#333">提交</text>
       <rect x="18.50" y="300.00" width="40.00" height="28.00" fill="white" />
       <text x="38.50" y="314.00" text-anchor="middle" dominant-baseline="middle" fill="#333">成功</text>
-      <rect x="114.87" y="280.56" width="40.00" height="28.00" fill="white" />
-      <text x="134.87" y="294.56" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
-      <rect x="174.00" y="193.50" width="40.00" height="28.00" fill="white" />
-      <text x="194.00" y="207.50" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
+      <rect x="85.00" y="269.50" width="40.00" height="28.00" fill="white" />
+      <text x="105.00" y="283.50" text-anchor="middle" dominant-baseline="middle" fill="#333">失败</text>
+      <rect x="188.00" y="191.50" width="40.00" height="28.00" fill="white" />
+      <text x="208.00" y="205.50" text-anchor="middle" dominant-baseline="middle" fill="#333">重试</text>
     </g>
   </g>
 </svg>

--- a/tests/svg-snapshots/state/concurrent_three.svg
+++ b/tests/svg-snapshots/state/concurrent_three.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 584.81 520.00" style="max-width: 584.81px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 569.53 520.00" style="max-width: 569.53px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/state/transitions.svg
+++ b/tests/svg-snapshots/state/transitions.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 234.14 507.00" style="max-width: 234.14px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 248.14 507.00" style="max-width: 248.14px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
@@ -45,10 +45,10 @@
       <text x="77.47" y="166.50" text-anchor="middle" dominant-baseline="middle" fill="#333">submit</text>
       <rect x="5.66" y="294.38" width="72.92" height="28.00" fill="white" />
       <text x="42.12" y="308.38" text-anchor="middle" dominant-baseline="middle" fill="#333">complete</text>
-      <rect x="130.70" y="287.56" width="28.45" height="28.00" fill="white" />
-      <text x="144.92" y="301.56" text-anchor="middle" dominant-baseline="middle" fill="#333">fail</text>
-      <rect x="183.80" y="191.28" width="40.00" height="28.00" fill="white" />
-      <text x="203.80" y="205.28" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
+      <rect x="104.58" y="269.50" width="28.45" height="28.00" fill="white" />
+      <text x="118.81" y="283.50" text-anchor="middle" dominant-baseline="middle" fill="#333">fail</text>
+      <rect x="197.80" y="189.28" width="40.00" height="28.00" fill="white" />
+      <text x="217.80" y="203.28" text-anchor="middle" dominant-baseline="middle" fill="#333">retry</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- remove the SVG singleton label-anchor revalidation fallback and trust `label_geometry.center` whenever lane geometry is present
- share SVG edge-label placement resolution between label rendering and bounds so lane-shifted labels expand the viewBox instead of clipping
- update SVG pipeline regression coverage and refresh flowchart/state SVG snapshots for the new anchor positions and canvas bounds

## Validation
- `just check`
- translated-viewBox scan: 0 edge-label background rects exceed checked-in SVG viewBoxes
