### PR TITLE
fix: include rendered svg labels in bounds

### DIFF
--- a/src/internal_tests/svg_render_pipeline.rs
+++ b/src/internal_tests/svg_render_pipeline.rs
@@ -6308,6 +6308,22 @@ mod plan_0145_q9_red {
         let failures = svg_viewbox_contains_rects(&svg);
         assert!(failures.is_empty(), "viewBox violations: {failures:?}");
     }
+
+    #[test]
+    fn svg_viewbox_covers_git_workflow_lr_backward_label() {
+        let input = load_flowchart_fixture("git_workflow.mmd");
+        let svg = render_svg_default(&input);
+        let failures = svg_viewbox_contains_rects(&svg);
+        assert!(failures.is_empty(), "viewBox violations: {failures:?}");
+    }
+
+    #[test]
+    fn svg_viewbox_covers_git_workflow_td_backward_label() {
+        let input = load_flowchart_fixture("git_workflow_td.mmd");
+        let svg = render_svg_default(&input);
+        let failures = svg_viewbox_contains_rects(&svg);
+        assert!(failures.is_empty(), "viewBox violations: {failures:?}");
+    }
 }
 
 mod sibling_subgraph_label_placement {

--- a/src/render/graph/svg/bounds.rs
+++ b/src/render/graph/svg/bounds.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use super::labels::{fallback_label_position, precomputed_label_positions};
+use super::labels::resolve_edge_label;
 use super::{Point, Rect};
 use crate::graph::geometry::GraphGeometry;
 use crate::graph::measure::{
@@ -57,6 +57,7 @@ pub(super) fn compute_svg_bounds(
     metrics: &dyn TextMetricsProvider,
     self_edge_paths: &HashMap<usize, Vec<Point>>,
     rendered_edge_paths: &HashMap<usize, Vec<Point>>,
+    override_nodes: &HashMap<String, String>,
 ) -> SvgBounds {
     let mut bounds = SvgBounds::new();
 
@@ -109,8 +110,6 @@ pub(super) fn compute_svg_bounds(
         }
     }
 
-    let label_positions = precomputed_label_positions(geom);
-
     for edge in diagram.edges.iter() {
         if edge.stroke == Stroke::Invisible {
             continue;
@@ -118,42 +117,25 @@ pub(super) fn compute_svg_bounds(
         let Some(label) = edge.label.as_ref() else {
             continue;
         };
-        let edge_idx = edge.index;
-        // Use precomputed label positions only when the edge was NOT re-routed.
-        // Re-routed edges (e.g. backward edges with channel detours) have their
-        // labels placed on the rendered path, which can differ from the
-        // precomputed geometry position.
-        let use_precomputed = edge.from_subgraph.is_none()
-            && edge.to_subgraph.is_none()
-            && !rendered_edge_paths.contains_key(&edge.index);
-
-        // Prefer label_geometry.rect when precomputed positions would be used.
-        // label_geometry is the authoritative source populated by the routing
-        // label-lane pass; it carries both center and padded rect.
-        // TODO: remove precomputed/revalidate fallback once label_lanes
-        // populates label_geometry for all edges.
-        let layout_edge = geom.edges.iter().find(|e| e.index == edge_idx);
-        if let Some(g) = layout_edge.and_then(|e| e.label_geometry.as_ref())
-            && use_precomputed
-        {
-            bounds.update_rect(&g.rect);
-            continue;
-        }
-
-        let position = if use_precomputed {
-            label_positions.get(&edge_idx).copied()
-        } else {
-            None
-        }
-        .or_else(|| fallback_label_position(geom, edge_idx, self_edge_paths, rendered_edge_paths));
-        let Some(point) = position else {
+        let Some(resolved_label) = resolve_edge_label(
+            diagram,
+            edge,
+            geom,
+            self_edge_paths,
+            rendered_edge_paths,
+            override_nodes,
+        ) else {
             continue;
         };
-        let style = edge_text_style_key(metrics, edge);
-        let (w, h) = edge_label_dimensions_for_provider_and_style(metrics, &style, label);
+        let (w, h) = if let Some(g) = resolved_label.geometry {
+            (g.rect.width, g.rect.height)
+        } else {
+            let style = edge_text_style_key(metrics, edge);
+            edge_label_dimensions_for_provider_and_style(metrics, &style, label)
+        };
         let rect = Rect {
-            x: point.x - w / 2.0,
-            y: point.y - h / 2.0,
+            x: resolved_label.center.x - w / 2.0,
+            y: resolved_label.center.y - h / 2.0,
             width: w,
             height: h,
         };
@@ -227,6 +209,7 @@ mod tests {
         let (diagram, mut geom) = minimal_labeled_edge_fixtures();
         let metrics = default_proportional_text_metrics();
         let empty_map = HashMap::new();
+        let empty_overrides = HashMap::new();
 
         // Set label_geometry with a rect far outside the normal layout bounds.
         geom.edges[0].label_geometry = Some(EdgeLabelGeometry {
@@ -238,7 +221,14 @@ mod tests {
             compartment_size: 1,
         });
 
-        let bounds = compute_svg_bounds(&diagram, &geom, &metrics, &empty_map, &empty_map);
+        let bounds = compute_svg_bounds(
+            &diagram,
+            &geom,
+            &metrics,
+            &empty_map,
+            &empty_map,
+            &empty_overrides,
+        );
         let (min_x, min_y, max_x, max_y) = bounds.finalize(200.0, 200.0);
 
         // The bounds must include the label_geometry rect (490..510, 495..505).

--- a/src/render/graph/svg/labels.rs
+++ b/src/render/graph/svg/labels.rs
@@ -7,14 +7,19 @@ use super::text::{
     render_text_centered_with_wrap,
 };
 use super::{GraphSvgPalette, Point, dynamic_css_attrs};
-use crate::graph::geometry::GraphGeometry;
+use crate::graph::geometry::{EdgeLabelGeometry, GraphGeometry};
 use crate::graph::measure::{GraphTextStyleKey, TextMetricsProvider, edge_text_style_key};
 use crate::graph::routing::compute_end_label_positions;
-use crate::graph::{Graph, Stroke};
+use crate::graph::{Edge, Graph, Stroke};
 use crate::render::svg::SvgWriter;
 
 const LABEL_ANCHOR_REVALIDATION_MAX_DISTANCE: f64 = 2.0;
 const LABEL_POINT_EPS: f64 = 0.000_001;
+
+pub(super) struct ResolvedEdgeLabel<'a> {
+    pub(super) center: Point,
+    pub(super) geometry: Option<&'a EdgeLabelGeometry>,
+}
 
 fn revalidate_svg_label_anchor(candidate: Point, rendered_path: Option<&[Point]>) -> Point {
     let Some(path) = rendered_path else {
@@ -112,7 +117,6 @@ pub(super) fn render_edge_labels(
     scale: f64,
     palette: &GraphSvgPalette,
 ) {
-    let label_positions = precomputed_label_positions(geom);
     let dynamic_attrs = dynamic_css_attrs(
         palette.dynamic_css,
         "graph-edge-text",
@@ -138,77 +142,17 @@ pub(super) fn render_edge_labels(
         let Some(label) = edge.label.as_ref() else {
             continue;
         };
-        let edge_idx = edge.index;
-        let cross_boundary = if edge.from_subgraph.is_none() && edge.to_subgraph.is_none() {
-            let from_override = override_nodes.get(&edge.from);
-            let to_override = override_nodes.get(&edge.to);
-            matches!(
-                (from_override, to_override),
-                (Some(a), Some(b)) if a != b
-            ) || matches!(
-                (from_override, to_override),
-                (Some(_), None) | (None, Some(_))
-            )
-        } else {
-            false
-        };
-        let use_precomputed =
-            edge.from_subgraph.is_none() && edge.to_subgraph.is_none() && !cross_boundary;
-
-        // Prefer label_geometry.center (populated by the routing label-lane pass)
-        // over the precomputed label_position when available. Falls through to
-        // fallback + revalidation when label_geometry is None.
-        // TODO: remove precomputed/revalidate fallback once label_lanes
-        // populates label_geometry for all edges.
-        let layout_edge = geom.edges.iter().find(|e| e.index == edge_idx);
-        let label_geom = layout_edge.and_then(|e| e.label_geometry.as_ref());
-        // The lane-assignment pass writes `label_geometry` with either
-        // `track != 0` (numerical displacement) or `compartment_size > 1`
-        // (coordinated placement inside a multi-edge group, even when the
-        // member happens to sit on track 0 relative to the shared anchor).
-        // For either signal, trust the center directly — re-validating
-        // would snap the coordinated label back to this edge's own path
-        // midpoint and undo the shared-anchor placement. For singleton
-        // track-0 edges (`compartment_size == 1`), the center is just the
-        // engine-supplied label_position, which can be off-path due to
-        // upstream side-adjustment passes; keep the revalidation fallback
-        // so those labels render attached to their edge.
-        //
-        // Exception: labels crossing between sibling subgraphs intentionally
-        // use the compound label-dummy slot, even when they are not lane-
-        // shifted. Re-validating those against a rendered direct path can snap
-        // them from the inter-sibling gap back to a child boundary.
-        let sibling_compound_center = label_geom
-            .filter(|_| edge_crosses_sibling_subgraphs(diagram, geom, edge))
-            .map(|g| g.center);
-        let lane_shifted_center = label_geom
-            .filter(|g| (g.track != 0 || g.compartment_size > 1) && use_precomputed)
-            .map(|g| g.center);
-        let position = if let Some(center) = sibling_compound_center.or(lane_shifted_center) {
-            Some(center)
-        } else {
-            let candidate = if use_precomputed {
-                label_geom
-                    .map(|g| g.center)
-                    .or_else(|| label_positions.get(&edge_idx).copied())
-            } else {
-                None
-            }
-            .or_else(|| {
-                fallback_label_position(geom, edge_idx, self_edge_paths, rendered_edge_paths)
-            });
-            candidate.map(|candidate| {
-                revalidate_svg_label_anchor(
-                    candidate,
-                    rendered_edge_paths
-                        .get(&edge_idx)
-                        .map(|path| path.as_slice()),
-                )
-            })
-        };
-        let Some(point) = position else {
+        let Some(resolved_label) = resolve_edge_label(
+            diagram,
+            edge,
+            geom,
+            self_edge_paths,
+            rendered_edge_paths,
+            override_nodes,
+        ) else {
             continue;
         };
+        let layout_edge = geom.edges.iter().find(|e| e.index == edge.index);
         // Prefer the post-lane re-wrap output when the routing pass decided
         // to narrow this edge's label. Falling back to
         // `edge.wrapped_label_lines` (pre-engine wrap) when no re-wrap
@@ -230,8 +174,8 @@ pub(super) fn render_edge_labels(
         render_text_centered_with_wrap(
             writer,
             Point {
-                x: point.x * scale,
-                y: point.y * scale,
+                x: resolved_label.center.x * scale,
+                y: resolved_label.center.y * scale,
             },
             label,
             wrap_lines,
@@ -244,7 +188,9 @@ pub(super) fn render_edge_labels(
                 background: Some(BackgroundStyle {
                     fill: bg_style.fill,
                     extra_attrs: bg_style.extra_attrs,
-                    size: label_geom.map(|g| (g.rect.width, g.rect.height)),
+                    size: resolved_label
+                        .geometry
+                        .map(|g| (g.rect.width, g.rect.height)),
                 }),
             },
         );
@@ -318,6 +264,80 @@ pub(super) fn render_edge_labels(
     writer.end_group();
 }
 
+pub(super) fn resolve_edge_label<'a>(
+    diagram: &Graph,
+    edge: &Edge,
+    geom: &'a GraphGeometry,
+    self_edge_paths: &HashMap<usize, Vec<Point>>,
+    rendered_edge_paths: &HashMap<usize, Vec<Point>>,
+    override_nodes: &HashMap<String, String>,
+) -> Option<ResolvedEdgeLabel<'a>> {
+    let edge_idx = edge.index;
+    let cross_boundary = if edge.from_subgraph.is_none() && edge.to_subgraph.is_none() {
+        let from_override = override_nodes.get(&edge.from);
+        let to_override = override_nodes.get(&edge.to);
+        matches!(
+            (from_override, to_override),
+            (Some(a), Some(b)) if a != b
+        ) || matches!(
+            (from_override, to_override),
+            (Some(_), None) | (None, Some(_))
+        )
+    } else {
+        false
+    };
+    let use_precomputed =
+        edge.from_subgraph.is_none() && edge.to_subgraph.is_none() && !cross_boundary;
+
+    let layout_edge = geom.edges.iter().find(|e| e.index == edge_idx);
+    let label_geom = layout_edge.and_then(|e| e.label_geometry.as_ref());
+    // The lane-assignment pass writes `label_geometry` with either
+    // `track != 0` (numerical displacement) or `compartment_size > 1`
+    // (coordinated placement inside a multi-edge group, even when the
+    // member happens to sit on track 0 relative to the shared anchor).
+    // For either signal, trust the center directly — re-validating would snap
+    // coordinated labels back to this edge's own path midpoint and undo the
+    // shared-anchor placement. For singleton track-0 edges, keep revalidation:
+    // those centers can drift from the rendered SVG path.
+    //
+    // Exception: labels crossing between sibling subgraphs intentionally use
+    // the compound label-dummy slot, even when they are not lane-shifted.
+    let sibling_compound_center = label_geom
+        .filter(|_| edge_crosses_sibling_subgraphs(diagram, geom, edge))
+        .map(|g| g.center);
+    let lane_shifted_center = label_geom
+        .filter(|g| (g.track != 0 || g.compartment_size > 1) && use_precomputed)
+        .map(|g| g.center);
+    if let Some(center) = sibling_compound_center.or(lane_shifted_center) {
+        return Some(ResolvedEdgeLabel {
+            center,
+            geometry: label_geom,
+        });
+    }
+
+    let candidate = if use_precomputed {
+        label_geom
+            .map(|g| g.center)
+            .or_else(|| layout_edge.and_then(|e| e.label_position))
+    } else {
+        None
+    }
+    .or_else(|| fallback_label_position(geom, edge_idx, self_edge_paths, rendered_edge_paths));
+
+    let center = candidate.map(|candidate| {
+        revalidate_svg_label_anchor(
+            candidate,
+            rendered_edge_paths
+                .get(&edge_idx)
+                .map(|path| path.as_slice()),
+        )
+    })?;
+    Some(ResolvedEdgeLabel {
+        center,
+        geometry: label_geom,
+    })
+}
+
 fn edge_crosses_sibling_subgraphs(
     diagram: &Graph,
     geom: &GraphGeometry,
@@ -388,50 +408,14 @@ pub(super) fn fallback_label_position(
     None
 }
 
-pub(super) fn precomputed_label_positions(geom: &GraphGeometry) -> HashMap<usize, Point> {
-    geom.edges
-        .iter()
-        .filter_map(|edge| edge.label_position.map(|point| (edge.index, point)))
-        .collect()
-}
-
-/// Resolve the label center for a given edge index, preferring
-/// `label_geometry.center` when present, falling back to `label_position`
-/// (precomputed by the layout engine), then to path-based midpoint fallbacks.
-// TODO: once label_lanes populates label_geometry for all edges, the
-// precomputed/fallback paths may be simplified.
-#[cfg(test)]
-fn resolve_edge_label_center(
-    geom: &GraphGeometry,
-    edge_index: usize,
-    self_edge_paths: &HashMap<usize, Vec<Point>>,
-    rendered_edge_paths: &HashMap<usize, Vec<Point>>,
-) -> Option<Point> {
-    // Prefer label_geometry.center (populated by the routing label-lane pass).
-    if let Some(layout_edge) = geom.edges.iter().find(|e| e.index == edge_index)
-        && let Some(g) = &layout_edge.label_geometry
-    {
-        return Some(g.center);
-    }
-
-    // Fall back to precomputed label_position from the layout engine.
-    let label_positions = precomputed_label_positions(geom);
-    if let Some(&pos) = label_positions.get(&edge_index) {
-        return Some(pos);
-    }
-
-    // Final fallback: path-based midpoint.
-    fallback_label_position(geom, edge_index, self_edge_paths, rendered_edge_paths)
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
 
     use super::{Point, revalidate_svg_label_anchor, svg_path_midpoint};
-    use crate::graph::Direction;
     use crate::graph::geometry::{EdgeLabelGeometry, EdgeLabelSide, GraphGeometry, LayoutEdge};
     use crate::graph::space::{FPoint, FRect};
+    use crate::graph::{Direction, Edge, Graph};
 
     #[test]
     fn revalidate_svg_label_anchor_keeps_nearby_anchor() {
@@ -498,6 +482,12 @@ mod tests {
         }
     }
 
+    fn minimal_labeled_edge() -> Edge {
+        let mut edge = Edge::new("A", "B").with_label("yes");
+        edge.index = 0;
+        edge
+    }
+
     #[test]
     fn svg_labels_uses_label_geometry_center_when_present() {
         let mut geom = minimal_geom_with_labeled_edge();
@@ -513,12 +503,22 @@ mod tests {
             compartment_size: 1,
         });
 
-        // resolve_edge_label_center should prefer label_geometry.center.
-        let center = super::resolve_edge_label_center(&geom, 0, &empty_map, &empty_map);
+        // With no rendered path available, the resolved label remains at the
+        // geometry center.
+        let empty_overrides = HashMap::new();
+        let center = super::resolve_edge_label(
+            &Graph::new(Direction::TopDown),
+            &minimal_labeled_edge(),
+            &geom,
+            &empty_map,
+            &empty_map,
+            &empty_overrides,
+        )
+        .map(|label| label.center);
         assert_eq!(
             center,
             Some(FPoint::new(123.0, 456.0)),
-            "must prefer label_geometry.center when present"
+            "must use label_geometry.center when no rendered path can revalidate it"
         );
     }
 
@@ -526,9 +526,18 @@ mod tests {
     fn svg_labels_falls_back_to_label_position_when_no_label_geometry() {
         let geom = minimal_geom_with_labeled_edge();
         let empty_map: HashMap<usize, Vec<Point>> = HashMap::new();
+        let empty_overrides = HashMap::new();
 
         // label_geometry is None, so it should fall back to precomputed label_position.
-        let center = super::resolve_edge_label_center(&geom, 0, &empty_map, &empty_map);
+        let center = super::resolve_edge_label(
+            &Graph::new(Direction::TopDown),
+            &minimal_labeled_edge(),
+            &geom,
+            &empty_map,
+            &empty_map,
+            &empty_overrides,
+        )
+        .map(|label| label.center);
         assert_eq!(
             center,
             Some(FPoint::new(50.0, 50.0)),

--- a/src/render/graph/svg/mod.rs
+++ b/src/render/graph/svg/mod.rs
@@ -249,6 +249,7 @@ fn render_svg_with_geometry_context(
         metrics,
         &self_edge_paths,
         &prepared_edges.paths,
+        context.override_nodes,
     );
     let padding = options.diagram_padding;
     let (min_x, min_y, max_x, max_y) = bounds.finalize(geom.bounds.width, geom.bounds.height);

--- a/tests/svg-snapshots/flowchart-basis/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-basis/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 92.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 98.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-basis/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-basis/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 116.00" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 113.91" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-2.50)">
+  <g transform="translate(0.00,-4.59)">
     <g class="edgePaths">
       <path d="M209.12,39.31 L201.54,36.76 L195.47,34.72 C189.40,32.67 177.26,28.59 174.36,26.54 C171.46,24.50 177.79,24.50 168.59,27.33 C159.39,30.16 134.66,35.83 122.29,38.66 L109.92,41.49 L102.13,43.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,67.27 L201.43,69.45 L192.56,71.95 C183.69,74.46 165.96,79.48 163.08,81.99 C160.19,84.50 172.16,84.50 165.78,81.67 C159.39,78.84 134.66,73.17 122.29,70.34 L109.92,67.51 L102.13,65.72" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-basis/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-basis/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 277.04 318.00" style="max-width: 277.04px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 219.22 318.00" style="max-width: 219.22px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M43.34,62.00 L43.34,70.00 L43.34,72.83 C43.34,75.67 43.34,81.33 43.34,93.33 C43.34,105.33 43.34,123.67 43.34,149.83 C43.34,176.00 43.34,210.00 43.34,227.00 L43.34,244.00 L43.34,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M47.69,256.00 L48.96,248.10 L51.36,233.25 C53.76,218.40 58.55,188.70 58.65,159.66 C58.76,130.62 54.18,102.23 51.89,88.04 L49.60,73.85 L48.33,65.95" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-curved-step/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/backward_label_asymmetric_markers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 225.88 246.00" style="max-width: 225.88px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 198.86 246.00" style="max-width: 198.86px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-curved-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/backward_loop_lr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 200.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 214.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-curved-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 96.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 110.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-curved-step/git_workflow_td.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/git_workflow_td.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 213.84 525.00" style="max-width: 213.84px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 218.27 525.00" style="max-width: 218.27px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-curved-step/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/label_clamp_bt_review.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 110.69 294.00" style="max-width: 110.69px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 106.24 294.00" style="max-width: 106.24px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-curved-step/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 81.52" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 79.33" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-17.31)">
+  <g transform="translate(0.00,-19.50)">
     <g class="edgePaths">
       <path d="M209.12,35.50 L209.12,39.31 L204.96,39.31 C200.79,39.31 192.46,39.31 188.29,41.84 C184.12,44.37 184.12,49.44 184.12,51.97 L184.12,54.50 L102.23,54.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,73.50 L209.12,67.27 L193.98,67.27 C178.83,67.27 148.53,67.27 133.38,68.31 C118.23,69.35 118.23,71.42 118.23,72.46 L118.23,73.50 L102.23,73.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-curved-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 280.37 318.00" style="max-width: 280.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 216.89 318.00" style="max-width: 216.89px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M43.34,62.00 L43.34,126.67 L43.34,132.06 C43.34,137.44 43.34,148.22 43.34,159.00 C43.34,169.78 43.34,180.56 43.34,185.94 L43.34,191.33 L43.34,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M61.00,256.00 L61.00,86.00 L61.48,86.00 C61.95,86.00 62.89,86.00 63.84,86.00 C64.78,86.00 65.73,86.00 66.20,86.00 L66.67,86.00 L66.67,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-curved-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/multi_edge_labeled.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 132.06 334.00" style="max-width: 132.06px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 121.39 334.00" style="max-width: 121.39px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(26.24,0.00)">
+  <g transform="translate(15.57,0.00)">
     <g class="edgePaths">
       <path d="M16.91,62.00 L16.91,100.00 L21.46,100.00 C26.02,100.00 35.13,100.00 39.69,103.00 C44.24,106.00 44.24,112.00 44.24,115.00 L44.24,118.00 L44.24,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M71.58,62.00 L71.58,71.33 C71.58,80.67 71.58,99.33 71.58,116.33 C71.58,133.33 71.58,148.67 71.58,156.33 L71.58,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-curved-step/three_parallel_labels.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/three_parallel_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 136.71 230.00" style="max-width: 136.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 110.25 230.00" style="max-width: 110.25px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(17.35,0.00)">
+  <g transform="translate(-9.11,0.00)">
     <g class="edgePaths">
       <path d="M34.46,62.00 L34.46,92.50 L34.46,94.62 C34.46,96.75 34.46,101.00 34.46,105.25 C34.46,109.50 34.46,113.75 34.46,115.88 L34.46,118.00 L34.46,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M61.80,62.00 L61.80,97.33 L61.80,100.28 C61.80,103.22 61.80,109.11 61.80,115.00 C61.80,120.89 61.80,126.78 61.80,129.72 L61.80,132.67 L61.80,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-polyline/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-polyline/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 92.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 98.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-polyline/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-polyline/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 116.00" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 113.91" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-2.50)">
+  <g transform="translate(0.00,-4.59)">
     <g class="edgePaths">
       <path d="M209.12,39.31 L165.12,24.50 L184.12,24.50 L102.13,43.28" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,67.27 L148.23,84.50 L184.12,84.50 L102.13,65.72" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-polyline/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-polyline/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 277.04 318.00" style="max-width: 277.04px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 219.22 318.00" style="max-width: 219.22px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M43.34,62.00 L43.34,87.00 L43.34,142.00 L43.34,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M47.69,256.00 L63.34,159.00 L48.33,65.95" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-smooth-step/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/backward_label_asymmetric_markers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 225.88 246.00" style="max-width: 225.88px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 198.86 246.00" style="max-width: 198.86px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-smooth-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/backward_loop_lr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 200.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 204.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-smooth-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 96.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 100.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-smooth-step/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/label_clamp_bt_review.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 110.69 294.00" style="max-width: 110.69px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 106.24 294.00" style="max-width: 106.24px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-smooth-step/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 81.52" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 79.33" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-17.31)">
+  <g transform="translate(0.00,-19.50)">
     <g class="edgePaths">
       <path d="M209.12,35.50 L189.12,35.50 Q184.12,35.50 184.12,40.50 L184.12,49.50 Q184.12,54.50 179.12,54.50 L102.23,54.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,73.50 L184.12,73.50 L102.23,73.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-smooth-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 280.37 318.00" style="max-width: 280.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 216.89 318.00" style="max-width: 216.89px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M30.62,62.00 L30.62,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M61.00,256.00 L61.00,80.83 Q61.00,78.00 63.84,78.00 L63.84,78.00 Q66.67,78.00 66.67,75.17 L66.67,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-smooth-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/multi_edge_labeled.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 132.06 334.00" style="max-width: 132.06px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 121.39 334.00" style="max-width: 121.39px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(26.24,0.00)">
+  <g transform="translate(15.57,0.00)">
     <g class="edgePaths">
       <path d="M16.91,62.00 L16.91,95.55 Q16.91,100.00 12.45,100.00 L12.45,100.00 Q8.00,100.00 8.00,104.45 L8.00,113.00 Q8.00,118.00 13.00,118.00 L39.24,118.00 Q44.24,118.00 44.24,123.00 L44.24,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M71.58,62.00 L71.58,118.00 L71.58,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-step/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart-step/backward_label_asymmetric_markers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 225.88 246.00" style="max-width: 225.88px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 198.86 246.00" style="max-width: 198.86px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-step/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart-step/backward_loop_lr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 200.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 204.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-step/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-step/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 96.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 100.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-step/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart-step/label_clamp_bt_review.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 110.69 294.00" style="max-width: 110.69px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 106.24 294.00" style="max-width: 106.24px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-step/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart-step/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 81.52" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 79.33" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-17.31)">
+  <g transform="translate(0.00,-19.50)">
     <g class="edgePaths">
       <path d="M209.12,35.50 L184.12,35.50 L184.12,54.50 L102.23,54.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,73.50 L110.23,73.50 L102.23,73.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-step/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-step/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 280.37 318.00" style="max-width: 280.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 216.89 318.00" style="max-width: 216.89px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M30.62,62.00 L30.62,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M61.00,256.00 L61.00,78.00 L66.67,78.00 L66.67,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-step/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart-step/multi_edge_labeled.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 132.06 334.00" style="max-width: 132.06px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 121.39 334.00" style="max-width: 121.39px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(26.24,0.00)">
+  <g transform="translate(15.57,0.00)">
     <g class="edgePaths">
       <path d="M16.91,62.00 L16.91,100.00 L8.00,100.00 L8.00,118.00 L44.24,118.00 L44.24,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M71.58,62.00 L71.58,118.00 L71.58,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart-straight/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart-straight/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 92.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 98.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart-straight/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart-straight/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 277.04 318.00" style="max-width: 277.04px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 219.22 318.00" style="max-width: 219.22px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M30.62,62.00 L30.62,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M47.69,256.00 L63.34,159.00 L48.33,65.95" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart/backward_label_asymmetric_markers.svg
+++ b/tests/svg-snapshots/flowchart/backward_label_asymmetric_markers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 225.88 246.00" style="max-width: 225.88px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 198.86 246.00" style="max-width: 198.86px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart/backward_loop_lr.svg
+++ b/tests/svg-snapshots/flowchart/backward_loop_lr.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 200.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1636.83 204.00" style="max-width: 1636.83px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart/git_workflow.svg
+++ b/tests/svg-snapshots/flowchart/git_workflow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 96.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 1021.71 100.00" style="max-width: 1021.71px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart/label_clamp_bt_review.svg
+++ b/tests/svg-snapshots/flowchart/label_clamp_bt_review.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 110.69 294.00" style="max-width: 110.69px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 106.24 294.00" style="max-width: 106.24px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />

--- a/tests/svg-snapshots/flowchart/label_clamp_rl_review.svg
+++ b/tests/svg-snapshots/flowchart/label_clamp_rl_review.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 81.52" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 307.37 79.33" style="max-width: 307.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(0.00,-17.31)">
+  <g transform="translate(0.00,-19.50)">
     <g class="edgePaths">
       <path d="M209.12,35.50 L189.12,35.50 Q184.12,35.50 184.12,40.50 L184.12,49.50 Q184.12,54.50 179.12,54.50 L102.23,54.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M209.12,73.50 L184.12,73.50 L102.23,73.50" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart/long_reciprocal_labels.svg
+++ b/tests/svg-snapshots/flowchart/long_reciprocal_labels.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 280.37 318.00" style="max-width: 280.37px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 216.89 318.00" style="max-width: 216.89px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(75.39,0.00)">
+  <g transform="translate(56.27,0.00)">
     <g class="edgePaths">
       <path d="M30.62,62.00 L30.62,252.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M61.00,256.00 L61.00,80.83 Q61.00,78.00 63.84,78.00 L63.84,78.00 Q66.67,78.00 66.67,75.17 L66.67,66.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/flowchart/multi_edge_labeled.svg
+++ b/tests/svg-snapshots/flowchart/multi_edge_labeled.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 132.06 334.00" style="max-width: 132.06px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 121.39 334.00" style="max-width: 121.39px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(26.24,0.00)">
+  <g transform="translate(15.57,0.00)">
     <g class="edgePaths">
       <path d="M16.91,62.00 L16.91,95.55 Q16.91,100.00 12.45,100.00 L12.45,100.00 Q8.00,100.00 8.00,104.45 L8.00,113.00 Q8.00,118.00 13.00,118.00 L39.24,118.00 Q44.24,118.00 44.24,123.00 L44.24,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
       <path d="M71.58,62.00 L71.58,118.00 L71.58,164.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />

--- a/tests/svg-snapshots/state/concurrent_three.svg
+++ b/tests/svg-snapshots/state/concurrent_three.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 584.81 520.00" style="max-width: 584.81px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 569.53 520.00" style="max-width: 569.53px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />


### PR DESCRIPTION
## Summary
- share SVG edge-label resolution between rendering and bounds so viewBox sizing includes the actual emitted label position
- preserve SVG label-anchor revalidation for singleton label geometry instead of trusting every `label_geometry.center`
- add LR/TD git workflow viewBox regression coverage and refresh affected SVG snapshots

## Validation
- `cargo nextest run -E 'test(git_workflow_direct_routed_svg_keeps_git_pull_label_attached) + test(git_workflow_td_direct_routed_svg_keeps_git_pull_label_attached) + test(svg_viewbox_covers_git_workflow_lr_backward_label) + test(svg_viewbox_covers_git_workflow_td_backward_label)'`
- `GENERATE_SVG_SNAPSHOTS=1 cargo nextest run -E 'test(svg_snapshot_all_fixtures)'`
- `GENERATE_STATE_SVG_SNAPSHOTS=1 cargo nextest run --test compliance_state -E 'test(state_svg_snapshots)'`
- `just check`
