### PR TITLE
feat: route dynamic text metrics through MMDS browser path; fix MMDS replay subgraph rect

### DIFF
--- a/packages/mmds-browser-text-metrics/src/client.ts
+++ b/packages/mmds-browser-text-metrics/src/client.ts
@@ -11,6 +11,7 @@ import type {
 } from "./main-thread.js";
 import { mayNeedBrowserTextMetrics } from "./routing.js";
 import {
+  type DynamicRenderOutputFormat,
   isWorkerRequestMessage,
   PROTOCOL_VERSION,
   type WorkerBrowserTextMetricsDecision,
@@ -163,13 +164,14 @@ export function createMmdsBrowserTextMetricsClient(
   return {
     renderSvg(opts) {
       const seq = nextDynamicSeq++;
+      const format: DynamicRenderOutputFormat = opts.format ?? "svg";
       return new Promise<MmdsRenderResult>((resolve, reject) => {
         const mainThreadFallback = fallback
           ? () => fallback.renderSvg(opts)
           : undefined;
         const slot: PendingRender = {
           kind: "render",
-          format: "svg",
+          format,
           resolve,
           reject,
           mainThreadFallback,
@@ -197,7 +199,7 @@ export function createMmdsBrowserTextMetricsClient(
             type: "renderWithBrowserTextMetrics",
             seq,
             input: opts.input,
-            format: "svg",
+            format,
             configJson: opts.configJson ?? "{}",
             browserTextMetrics: opts.browserTextMetrics,
           },
@@ -272,7 +274,7 @@ export function createMmdsBrowserTextMetricsClient(
     },
     async renderAuto(opts) {
       if (
-        opts.format !== "svg" ||
+        (opts.format !== "svg" && opts.format !== "mmds") ||
         !mayNeedBrowserTextMetrics({
           input: opts.input,
           configJson: opts.configJson,
@@ -296,6 +298,7 @@ export function createMmdsBrowserTextMetricsClient(
         input: opts.input,
         configJson: opts.configJson,
         browserTextMetrics: decision.browserTextMetrics,
+        format: opts.format,
       });
     },
     terminate() {

--- a/packages/mmds-browser-text-metrics/src/main-thread.ts
+++ b/packages/mmds-browser-text-metrics/src/main-thread.ts
@@ -7,6 +7,7 @@ import {
   type PrepareMainThreadTextMetricsOptions,
 } from "./prepare.js";
 import { classifyWasmError } from "./wasm-classifier.js";
+import type { DynamicRenderOutputFormat } from "./worker-protocol.js";
 
 export type MmdsRenderFormat = "svg" | "text" | "ascii" | "mmds" | "mermaid";
 
@@ -22,6 +23,8 @@ export interface MmdsDynamicRenderOptions {
   input: string;
   browserTextMetrics: BrowserTextMetricsRequest;
   configJson?: string;
+  /** Defaults to "svg" so existing callers keep behavior. */
+  format?: DynamicRenderOutputFormat;
 }
 
 export interface MmdsStaticRenderOptions {
@@ -56,6 +59,7 @@ export function createMmdsMainThreadRenderer(
 
   return {
     async renderSvg(opts) {
+      const format: DynamicRenderOutputFormat = opts.format ?? "svg";
       const prepared = await prepareMetrics({
         request: opts.browserTextMetrics,
         environment: options.environment,
@@ -64,13 +68,13 @@ export function createMmdsMainThreadRenderer(
       const output = runWasm(() =>
         wasm.renderWithBrowserTextMetrics(
           opts.input,
-          "svg",
+          format,
           opts.configJson ?? "{}",
           prepared.metricsJson,
           prepared.measureText,
         ),
       );
-      return { output, format: "svg", source: "main-thread" };
+      return { output, format, source: "main-thread" };
     },
     async renderStatic(opts) {
       const wasm = await getWasmModule();

--- a/packages/mmds-browser-text-metrics/src/worker-protocol.ts
+++ b/packages/mmds-browser-text-metrics/src/worker-protocol.ts
@@ -3,6 +3,23 @@ export type WorkerProtocolVersion = typeof PROTOCOL_VERSION;
 
 export type WorkerOutputFormat = "text" | "ascii" | "svg" | "mmds" | "mermaid";
 
+/**
+ * Output formats served by the graph-family dynamic-metrics bridge. Text and
+ * mermaid renderers don't consume measured widths, so the renderer rejects
+ * them; the wire-level guard narrows here to surface drift early.
+ */
+export type DynamicRenderOutputFormat = "svg" | "mmds";
+
+const DYNAMIC_RENDER_FORMATS: ReadonlySet<string> = Object.freeze(
+  new Set<DynamicRenderOutputFormat>(["svg", "mmds"]),
+);
+
+export function isDynamicRenderOutputFormat(
+  value: unknown,
+): value is DynamicRenderOutputFormat {
+  return typeof value === "string" && DYNAMIC_RENDER_FORMATS.has(value);
+}
+
 // Minimal wire shape consumed by the worker handler. The full preflight
 // surface (with profile id, version, textStyles, etc.) lives in prepare.ts
 // and is structurally compatible.
@@ -63,7 +80,7 @@ export interface WorkerDynamicTextMetricsRenderRequestMessage {
   type: "renderWithBrowserTextMetrics";
   seq: number;
   input: string;
-  format: "svg";
+  format: DynamicRenderOutputFormat;
   configJson: string;
   browserTextMetrics: WorkerBrowserTextMetricsRequest;
 }
@@ -219,7 +236,7 @@ export function isWorkerRequestMessage(
     case "renderWithBrowserTextMetrics":
       return (
         typeof v.input === "string" &&
-        v.format === "svg" &&
+        isDynamicRenderOutputFormat(v.format) &&
         typeof v.configJson === "string" &&
         isObjectWithBrowserTextMetrics(v.browserTextMetrics)
       );

--- a/packages/mmds-browser-text-metrics/test/worker-protocol.test.ts
+++ b/packages/mmds-browser-text-metrics/test/worker-protocol.test.ts
@@ -100,7 +100,21 @@ describe("worker-protocol", () => {
     ).toBe(false);
   });
 
-  it("rejects renderWithBrowserTextMetrics with non-svg format or bad metrics", () => {
+  it("accepts renderWithBrowserTextMetrics with mmds format", () => {
+    expect(
+      isWorkerRequestMessage({
+        version: 1,
+        type: "renderWithBrowserTextMetrics",
+        seq: 1,
+        input: "x",
+        format: "mmds",
+        configJson: "{}",
+        browserTextMetrics: { fontFamily: "Inter" },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects renderWithBrowserTextMetrics with non-graph format or bad metrics", () => {
     expect(
       isWorkerRequestMessage({
         version: 1,

--- a/src/main.rs
+++ b/src/main.rs
@@ -762,7 +762,11 @@ fn main() -> io::Result<()> {
     }
 
     // Collect and print warnings to stderr (unless --quiet).
+    // MMDS JSON input is not Mermaid source — skip the Mermaid validator,
+    // which would otherwise complain "Strict parsing would reject this input:
+    // expected header" on every JSON document.
     if !cli.quiet
+        && !mmdflux::mmds::is_mmds_input(&input)
         && let Some(instance) = default_registry().create(diagram_id)
     {
         let warnings = instance.validation_warnings(&input);

--- a/src/mmds/hydrate.rs
+++ b/src/mmds/hydrate.rs
@@ -775,7 +775,12 @@ fn build_subgraph_geometry(
                 subgraph.id.clone(),
                 SubgraphGeometry {
                     id: subgraph.id.clone(),
-                    rect: FRect::new(center_x, center_y, width, height),
+                    rect: FRect::new(
+                        center_x - width / 2.0,
+                        center_y - height / 2.0,
+                        width,
+                        height,
+                    ),
                     title: subgraph.title.clone(),
                     depth: diagram.subgraph_depth(&subgraph.id),
                 },
@@ -801,10 +806,15 @@ fn derive_subgraph_center_and_extent(
         let Some(placed) = nodes.get(&node.id) else {
             continue;
         };
-        let left = placed.rect.x - placed.rect.width / 2.0;
-        let right = placed.rect.x + placed.rect.width / 2.0;
-        let top = placed.rect.y - placed.rect.height / 2.0;
-        let bottom = placed.rect.y + placed.rect.height / 2.0;
+        // PositionedNode.rect uses FRect top-left semantics (see
+        // build_positioned_nodes); the previous version of this function
+        // shifted by ±width/2 as if rect.x/y were centers, which collapsed
+        // the bbox onto the children's top-left corner and propagated to
+        // the cluster rect during SVG replay.
+        let left = placed.rect.x;
+        let right = placed.rect.x + placed.rect.width;
+        let top = placed.rect.y;
+        let bottom = placed.rect.y + placed.rect.height;
         min_x = min_x.min(left);
         max_x = max_x.max(right);
         min_y = min_y.min(top);

--- a/src/runtime/dynamic_text_metrics.rs
+++ b/src/runtime/dynamic_text_metrics.rs
@@ -630,7 +630,7 @@ pub fn resolve_browser_text_metrics_request(
     format: OutputFormat,
     config: &RenderConfig,
 ) -> Result<BrowserTextMetricsDecision, RenderError> {
-    if !matches!(format, OutputFormat::Svg) {
+    if !matches!(format, OutputFormat::Svg | OutputFormat::Mmds) {
         return Ok(browser_text_metrics_not_required());
     }
     if config.graph_text_style.is_some() {
@@ -1365,6 +1365,26 @@ mod tests {
             profile_id: None,
             profile_version: None,
         }
+    }
+
+    #[test]
+    fn browser_metrics_request_resolves_multi_font_graph_styles_for_mmds() {
+        let decision = resolve_browser_text_metrics_request(
+            multi_font_mermaid_input(),
+            OutputFormat::Mmds,
+            &RenderConfig::default(),
+        )
+        .expect("resolver should accept mmds graph input");
+
+        assert!(decision.required);
+        let request = decision.browser_text_metrics.expect("metrics request");
+        assert!(
+            request
+                .text_styles
+                .iter()
+                .any(|style| style.font_family == "Verdana"),
+            "mmds resolver should surface Verdana style"
+        );
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1511,6 +1511,20 @@ fn cli_renders_positioned_mmds_to_svg() {
 }
 
 #[test]
+fn cli_mmds_input_does_not_emit_mermaid_strict_warning() {
+    // The Mermaid strict-mode validator must not fire on MMDS JSON input;
+    // every JSON document looks like a missing `flowchart`/`graph` header
+    // to that validator, so the warning was a false positive on every
+    // MMDS → SVG (or any) CLI invocation.
+    mmdflux()
+        .args(["--format", "svg"])
+        .write_stdin(include_str!("fixtures/mmds/positioned/routed-basic.json"))
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Strict parsing would reject").not());
+}
+
+#[test]
 fn cli_mmds_includes_defaults_block_and_omits_default_edge_fields() {
     let assert = mmdflux()
         .args(["--format", "mmds"])

--- a/tests/mmds_json.rs
+++ b/tests/mmds_json.rs
@@ -3456,6 +3456,76 @@ flowchart TD
 }
 
 #[test]
+fn mmds_replay_subgraph_rect_contains_children() {
+    // MMDS subgraph.bounds carries width/height only; the replay derives the
+    // top-left from children. Passing the children-derived center to
+    // FRect::new (which treats x/y as top-left) shifts the cluster off its
+    // children by half the bounds, leaving children floating outside the
+    // cluster border (the symptom that surfaced via CLI MMDS replay of a
+    // styled-subgraph document).
+    let input = "\
+flowchart TD
+    subgraph G[Outer]
+        A[Inner] --> B[Leaf]
+    end
+";
+    let mmds = render_json(input);
+    let replay_svg = render_mmds_input(&mmds, OutputFormat::Svg, RenderConfig::default());
+
+    let cluster = parse_first_rect_after(&replay_svg, "class=\"cluster");
+    let node_a = parse_first_rect_after(&replay_svg, "id=\"A\"");
+    let node_b = parse_first_rect_after(&replay_svg, "id=\"B\"");
+    assert!(
+        rect_contains(&cluster, &node_a) && rect_contains(&cluster, &node_b),
+        "subgraph rect must contain its children after MMDS replay.\n\
+         cluster: {cluster:?}\nnode A: {node_a:?}\nnode B: {node_b:?}\n\nreplay SVG:\n{replay_svg}",
+    );
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SvgRect {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+}
+
+fn parse_first_rect_after(svg: &str, anchor: &str) -> SvgRect {
+    let anchor_start = svg
+        .find(anchor)
+        .unwrap_or_else(|| panic!("missing anchor {anchor:?} in SVG"));
+    let after_anchor = &svg[anchor_start..];
+    let rect_start = after_anchor
+        .find("<rect ")
+        .unwrap_or_else(|| panic!("no rect after anchor {anchor:?}"));
+    let rect_chunk = &after_anchor[rect_start..rect_start + 200];
+    let extract = |attr: &str| -> f64 {
+        let needle = format!("{attr}=\"");
+        let start = rect_chunk
+            .find(&needle)
+            .unwrap_or_else(|| panic!("missing attr {attr} in {rect_chunk}"))
+            + needle.len();
+        let end = rect_chunk[start..]
+            .find('"')
+            .unwrap_or_else(|| panic!("unterminated attr {attr}"));
+        rect_chunk[start..start + end].parse().unwrap()
+    };
+    SvgRect {
+        x: extract("x"),
+        y: extract("y"),
+        width: extract("width"),
+        height: extract("height"),
+    }
+}
+
+fn rect_contains(outer: &SvgRect, inner: &SvgRect) -> bool {
+    outer.x <= inner.x
+        && outer.y <= inner.y
+        && outer.x + outer.width >= inner.x + inner.width
+        && outer.y + outer.height >= inner.y + inner.height
+}
+
+#[test]
 fn mmds_hydrate_no_class_names_field_yields_empty_vec() {
     // Legacy MMDS predating classNames must hydrate cleanly to an empty Vec.
     let input = "\

--- a/tests/svg-snapshots/mmds/routed-basic.svg
+++ b/tests/svg-snapshots/mmds/routed-basic.svg
@@ -1,14 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 196.00 236.00" style="max-width: 196.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 196.00 196.00" style="max-width: 196.00px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
   <defs>
     <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
       <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
     </marker>
   </defs>
-  <g transform="translate(8.00,-12.00)">
+  <g transform="translate(38.00,-12.00)">
     <g class="clusters">
       <g class="cluster" id="sg1" data-id="sg1" data-look="classic">
-        <rect class="subgraph" x="0.00" y="120.00" width="180.00" height="120.00" fill="none" stroke="#888" stroke-width="1.00" />
-        <text x="90.00" y="124.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">Group</text>
+        <rect class="subgraph" x="-30.00" y="80.00" width="180.00" height="120.00" fill="none" stroke="#888" stroke-width="1.00" />
+        <text x="60.00" y="84.00" text-anchor="middle" dominant-baseline="hanging" fill="#333">Group</text>
       </g>
     </g>
     <g class="edgePaths">

--- a/web/src/dynamic-svg-routing.test.ts
+++ b/web/src/dynamic-svg-routing.test.ts
@@ -85,6 +85,7 @@ describe("renderPlaygroundRequest", () => {
       input: "graph TD\nA[Regular]-->B\nstyle A font-family:Verdana",
       configJson: "{}",
       browserTextMetrics: expect.objectContaining({ defaultStyle: "s0" }),
+      format: "svg",
     });
     expect(client.render).not.toHaveBeenCalled();
   });
@@ -130,6 +131,7 @@ describe("renderPlaygroundRequest", () => {
       input: request.input,
       configJson: "{}",
       browserTextMetrics: expect.objectContaining({ defaultStyle: "s0" }),
+      format: "svg",
     });
     expect(client.render).not.toHaveBeenCalled();
   });
@@ -233,7 +235,8 @@ describe("renderPlaygroundRequest", () => {
 
   it.each([
     "text",
-    "mmds",
+    "ascii",
+    "mermaid",
   ] as const)("routes %s without resolving browser metrics", async (format) => {
     const client = renderClientFixture();
 
@@ -249,6 +252,82 @@ describe("renderPlaygroundRequest", () => {
       seq: 3,
       input: "graph TD\nA-->B",
       format,
+      configJson: "{}",
+    });
+    expect(client.renderWithBrowserTextMetrics).not.toHaveBeenCalled();
+  });
+
+  it("routes required browser metrics through dynamic render for MMDS", async () => {
+    const client = renderClientFixture({
+      resolveBrowserTextMetricsRequest: vi.fn(async () => ({
+        required: true,
+        browserTextMetrics: {
+          defaultStyle: "s0",
+          textStyles: [
+            {
+              id: "s0",
+              fontFamily: "Verdana",
+              fontSize: 8,
+              lineHeight: 12,
+              fontStyle: "normal",
+              fontWeight: "400",
+            },
+          ],
+        },
+      })),
+      renderWithBrowserTextMetrics: vi.fn(
+        async (request: BrowserTextMetricsRenderRequest) => ({
+          seq: request.seq,
+          format: "mmds" as const,
+          output: '{"version":2}',
+        }),
+      ),
+    });
+
+    await expect(
+      renderPlaygroundRequest(client, {
+        seq: 11,
+        input: "graph TD\nA[Regular]-->B\nstyle A font-family:Verdana",
+        format: "mmds",
+        configJson: "{}",
+      }),
+    ).resolves.toEqual({
+      seq: 11,
+      format: "mmds",
+      output: '{"version":2}',
+    });
+
+    expect(client.resolveBrowserTextMetricsRequest).toHaveBeenCalledWith({
+      seq: 11,
+      input: "graph TD\nA[Regular]-->B\nstyle A font-family:Verdana",
+      format: "mmds",
+      configJson: "{}",
+    });
+    expect(client.renderWithBrowserTextMetrics).toHaveBeenCalledWith({
+      seq: 11,
+      input: "graph TD\nA[Regular]-->B\nstyle A font-family:Verdana",
+      format: "mmds",
+      configJson: "{}",
+      browserTextMetrics: expect.objectContaining({ defaultStyle: "s0" }),
+    });
+    expect(client.render).not.toHaveBeenCalled();
+  });
+
+  it("routes MMDS without font hints through static render", async () => {
+    const client = renderClientFixture();
+
+    await renderPlaygroundRequest(client, {
+      seq: 12,
+      input: "graph TD\nA-->B",
+      format: "mmds",
+      configJson: "{}",
+    });
+
+    expect(client.resolveBrowserTextMetricsRequest).not.toHaveBeenCalled();
+    expect(client.render).toHaveBeenCalledWith({
+      seq: 12,
+      input: "graph TD\nA-->B",
+      format: "mmds",
       configJson: "{}",
     });
     expect(client.renderWithBrowserTextMetrics).not.toHaveBeenCalled();

--- a/web/src/main.test.ts
+++ b/web/src/main.test.ts
@@ -201,6 +201,7 @@ describe("renderApp", () => {
         input: expect.any(String),
         configJson: expect.any(String),
         browserTextMetrics: expect.objectContaining({ defaultStyle: "s0" }),
+        format: "svg",
       });
       expect(render).not.toHaveBeenCalled();
       expect(root.querySelector("[data-preview-output]")?.textContent).toBe(

--- a/web/src/services/dynamic-svg-routing.ts
+++ b/web/src/services/dynamic-svg-routing.ts
@@ -1,4 +1,5 @@
 import { mayNeedBrowserTextMetrics } from "@mmds/browser-text-metrics/routing";
+import { isDynamicRenderOutputFormat } from "@mmds/browser-text-metrics/worker-protocol";
 import type {
   RenderRequest,
   RenderResponse,
@@ -9,7 +10,10 @@ export async function renderPlaygroundRequest(
   client: RenderWorkerClient,
   request: RenderRequest,
 ): Promise<RenderResponse> {
-  if (request.format !== "svg" || !mayNeedBrowserTextMetrics(request)) {
+  if (
+    !isDynamicRenderOutputFormat(request.format) ||
+    !mayNeedBrowserTextMetrics(request)
+  ) {
     return client.render(request);
   }
 
@@ -30,5 +34,6 @@ export async function renderPlaygroundRequest(
     input: request.input,
     configJson: request.configJson,
     browserTextMetrics: decision.browserTextMetrics,
+    format: request.format,
   });
 }

--- a/web/src/services/render-client.ts
+++ b/web/src/services/render-client.ts
@@ -1,6 +1,7 @@
 import type { BrowserTextMetricsRequest } from "@mmds/browser-text-metrics";
 import type { MmdsMainThreadRenderer } from "@mmds/browser-text-metrics/main-thread";
 import {
+  type DynamicRenderOutputFormat,
   PROTOCOL_VERSION,
   type WorkerBrowserTextMetricsDecision,
   type WorkerOutputFormat,
@@ -26,6 +27,8 @@ export interface BrowserTextMetricsRenderRequest {
   input: string;
   configJson?: string;
   browserTextMetrics: BrowserTextMetricsRequest;
+  /** Defaults to "svg". Set to "mmds" for dynamic-profile MMDS output. */
+  format?: DynamicRenderOutputFormat;
 }
 
 export interface BrowserTextMetricsDecisionRequest {
@@ -226,6 +229,7 @@ export function createRenderWorkerClient(
     },
     renderWithBrowserTextMetrics: (request) => {
       const currentSeq = request.seq;
+      const format: DynamicRenderOutputFormat = request.format ?? "svg";
 
       return new Promise<RenderResponse>((resolve, reject) => {
         const mainThreadFallback = mainThreadRenderer
@@ -234,10 +238,11 @@ export function createRenderWorkerClient(
                 input: request.input,
                 browserTextMetrics: request.browserTextMetrics,
                 configJson: request.configJson ?? "{}",
+                format,
               });
               return {
                 seq: request.seq,
-                format: "svg",
+                format: result.format,
                 output: result.output,
               };
             }
@@ -253,7 +258,7 @@ export function createRenderWorkerClient(
           type: "renderWithBrowserTextMetrics",
           seq: currentSeq,
           input: request.input,
-          format: "svg",
+          format,
           configJson: request.configJson ?? "{}",
           browserTextMetrics: request.browserTextMetrics,
         };


### PR DESCRIPTION
## Summary

- **Dynamic MMDS bridge**: widen `resolve_browser_text_metrics_request` to accept `OutputFormat::Mmds` so the playground can request browser-measured styles for MMDS output (previously it short-circuited to "not required" for everything that wasn't SVG).
- **Worker protocol**: introduce `DynamicRenderOutputFormat` ("svg" | "mmds") with a guard. The `renderWithBrowserTextMetrics` message and `MmdsDynamicRenderOptions` now carry the format through the worker, the main-thread fallback, and back into the result. The existing `renderSvg` surface stays source-compatible because the field defaults to "svg".
- **Playground routing**: `renderPlaygroundRequest` and `render-client.ts` forward the format so MMDS-with-font-hints reaches the dynamic worker instead of the static path.
- **Subgraph rect fix**: piping a real styled-subgraph MMDS document through the CLI exposed a latent bug in `build_subgraph_geometry`: `PositionedNode.rect.x`/`y` were treated as centers (they are top-left), and the resulting children-bbox midpoint was passed to `FRect::new` (also top-left). The cluster rect rendered off its children. Replace the bbox computation with top-left semantics for both axes and the cluster origin, and regenerate the affected snapshot.
- **Mermaid strict-mode false positive on MMDS input**: the CLI ran the flowchart validator on every input, so MMDS JSON triggered `"Strict parsing would reject this input: expected header"` on every invocation. Skip the validator when the input is MMDS JSON.

Closes #307.

## Test plan

- [x] `cargo nextest run` — 3219 tests pass, including new `mmds_replay_subgraph_rect_contains_children` (Red → Green), `cli_mmds_input_does_not_emit_mermaid_strict_warning`, and `browser_metrics_request_resolves_multi_font_graph_styles_for_mmds`.
- [x] `just lint` / `just architecture-check`.
- [x] `npm test` in `packages/mmds-browser-text-metrics` (174 tests).
- [x] `npx vitest run` in `web` (97 tests).
- [x] Manual browser test via Chrome DevTools MCP: Dynamic Fonts example switched to MMDS tab now emits a document with `metricsProfile.source = "dynamic"` and per-style measurements for Verdana / Courier New / Times New Roman / Georgia.
- [x] CLI replay of the same dynamic-fonts MMDS document via `cargo run -- doc.json --format svg` now renders the subgraph rect at `(8, 8)` with size `232 × 419.5` (matches the document's geometry), and stderr is silent.
- [x] SVG path still renders without regression.

## Follow-up

Text/ASCII MMDS replay of a dynamic-profile document still fails (`requires a matching provider`) because the text-grid renderer doesn't yet read the persisted `org.mmdflux.text-measurements.v1` extension in place of a live provider. Tracked separately (matches deferred #308).