### PR TITLE
chore: validate commit scope in commit-msg hook

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -50,6 +50,26 @@ if echo "$header" | grep -q '\.$'; then
     echo "error: commit subject must not end with a period"
     exit 1
 fi
+
+# Workaround for cocogitto/cocogitto#516: `cog verify` does not validate
+# scope against the configured `scopes` list. Fixed upstream in v7.0.0 via
+# cocogitto/cocogitto#541. Remove this block once mmdflux is on cog >= 7
+# (currently blocked on cocogitto/cocogitto#558). Single-line `scopes = [...]`
+# assumed; multi-line arrays would need a real TOML parser.
+scope=$(echo "$header" | sed -nE 's/^[a-z]+\(([^)]+)\)!?:.*/\1/p')
+if [ -n "$scope" ]; then
+    allowed=$(awk -F'=' '/^scopes[[:space:]]*=/ {
+        sub(/^.*=[[:space:]]*\[/, "")
+        sub(/\].*$/, "")
+        gsub(/[" ]/, "")
+        print
+    }' cog.toml)
+    if ! echo "$allowed" | tr ',' '\n' | grep -qx "$scope"; then
+        echo "error: scope '$scope' is not in cog.toml scopes list"
+        echo "  allowed: ${allowed:-<empty>}"
+        exit 1
+    fi
+fi
 '''
 
 [git_hooks.pre-push]

--- a/docs/mmds.md
+++ b/docs/mmds.md
@@ -284,7 +284,7 @@ Practical guidance:
   `--format svg`. Do not stage through MMDS.
 - If you want to drive a downstream graph renderer or adapter from a stable
   structural document with routing information, use MMDS — the Canonical
-  geometry is what you want for replay. See `examples/mmds/` for adapter
+  geometry is what you want for replay. See `examples/` for adapter
   patterns.
 - The persisted `metadata.bounds` and `subgraph.bounds` reflect the Canonical
   envelope; they are not a viewBox for the Visual SVG.


### PR DESCRIPTION
## Summary

`cog verify` in cocogitto 6.x does not validate the scope component of a conventional commit header against the configured `scopes` list (cocogitto/cocogitto#516). Fixed upstream in v7.0.0 by cocogitto/cocogitto#541, but mmdflux can't move to cog 7 yet because of the open cocogitto/cocogitto#558 monorepo `bump_order` regression.

Add an inline shell check to `[git_hooks.commit-msg]` that extracts the scope from the header (handling the optional breaking-change `!` marker) and rejects anything not in the `cog.toml` scopes list. Single-line `scopes = [...]` parsing via awk; multi-line arrays would need a real TOML parser. Unscoped commits (root crate, per the project convention) continue to pass through.

This avoids the round-trip cost of pushing a commit with an unrecognized scope and only finding out in CI. The block is tagged with the upstream issue references so the next person knows when it's safe to drop.

## Test plan

Exercised the snippet against six representative commit headers from outside the worktree (no actual commit needed):

| Header | Expected | Result |
|---|---|---|
| `docs(mmds): ...` (the original miss) | reject | reject |
| `feat(mmds-core): ...` | accept | accept |
| `docs: ...` (no scope, root crate) | accept | accept |
| `feat(wasm)!: ...` (breaking change) | accept | accept |
| `feat(typo)!: ...` (breaking change, bad scope) | reject | reject |
| `chore(version): ...` | accept | accept |

- [x] Six-case dry run passes.
- [x] `cog check HEAD~1..HEAD` clean on this commit.
- [ ] Contributors re-running `just setup-hooks` from the main repo (not from a worktree — `cog install-hook` chokes on worktree `.git` files) pick up the new hook automatically.

## Cleanup

Drop the marked block when both cocogitto/cocogitto#558 lands upstream and mmdflux moves to cog >= 7.