### PR TITLE
fix: render multi-line labels on diamond and borderless text nodes

### DIFF
--- a/src/render/graph/text/shape.rs
+++ b/src/render/graph/text/shape.rs
@@ -226,12 +226,11 @@ pub fn render_node(
 ) -> NodeBounds {
     let (width, height) = node_dimensions(node, direction);
     let label = &node.label;
-    let label_len = display_width(label);
     let style = ResolvedTextNodeStyle::from_node(node);
 
     match categorize_shape(node.shape) {
         ShapeCategory::Diamond => {
-            render_diamond(canvas, x, y, width, label_len, label, charset, style);
+            render_diamond(canvas, x, y, width, height, label, charset, style);
         }
         ShapeCategory::Box { corners, modifier } => {
             let corners = match corners {
@@ -253,7 +252,7 @@ pub fn render_node(
             );
         }
         ShapeCategory::Borderless => {
-            render_borderless(canvas, x, y, width, height, label, style);
+            render_borderless(canvas, x, y, width, label, style);
         }
         ShapeCategory::Glyph(kind) => {
             if label.trim().is_empty() {
@@ -486,23 +485,28 @@ fn render_shadow_box(
 }
 
 /// Render a borderless text block (label only).
+///
+/// Each label line gets its own row, centered on `width`. There is no border to
+/// preserve here, so rows are driven by the label rather than by the measured
+/// height (which `grid_node_dimensions` derives from the same line count).
 fn render_borderless(
     canvas: &mut Canvas,
     x: usize,
     y: usize,
     width: usize,
-    height: usize,
     label: &str,
     style: ResolvedTextNodeStyle,
 ) {
-    let mid_y = y + height / 2;
-    let label_len = display_width(label);
-    if label_len == 0 {
-        return;
+    for (row, line) in label.split('\n').enumerate() {
+        let line_len = display_width(line);
+        if line_len == 0 {
+            continue;
+        }
+        let row_y = y + row;
+        let label_start = x + width.saturating_sub(line_len) / 2;
+        canvas.write_str(label_start, row_y, line);
+        merge_text_fg(canvas, label_start, row_y, line, style.color);
     }
-    let label_start = x + (width - label_len) / 2;
-    canvas.write_str(label_start, mid_y, label);
-    merge_text_fg(canvas, label_start, mid_y, label, style.color);
 }
 
 /// Render a bar (fork/join), perpendicular to flow direction.
@@ -566,13 +570,22 @@ fn render_glyph(
 /// < Christmas >
 /// └───────────┘
 /// ```
+///
+/// Multi-line labels (from `<br>`) get one content row per line, so the drawn
+/// shape fills exactly the box `grid_node_dimensions` measured:
+/// ```text
+/// ┌────────────────────┐
+/// < Is the cache warm? >
+/// <  Check the index   >
+/// └────────────────────┘
+/// ```
 #[allow(clippy::too_many_arguments)]
 fn render_diamond(
     canvas: &mut Canvas,
     x: usize,
     y: usize,
     width: usize,
-    label_len: usize,
+    height: usize,
     label: &str,
     charset: &CharSet,
     style: ResolvedTextNodeStyle,
@@ -587,19 +600,27 @@ fn render_diamond(
     canvas.set(x + width - 1, y, charset.corner_tr);
     merge_fg(canvas, x + width - 1, y, style.stroke);
 
-    // Middle row with label and angle brackets
-    let mid_y = y + 1;
-    canvas.set(x, mid_y, '<');
-    merge_fg(canvas, x, mid_y, style.stroke);
-    merge_bg_span(canvas, x + 1, x + width - 1, mid_y, style.fill);
-    let label_start = x + (width - label_len) / 2;
-    canvas.write_str(label_start, mid_y, label);
-    merge_text_fg(canvas, label_start, mid_y, label, style.color);
-    canvas.set(x + width - 1, mid_y, '>');
-    merge_fg(canvas, x + width - 1, mid_y, style.stroke);
+    // Content rows: one per label line, each centered on its own width.
+    // Rows are driven by `height` rather than by the line count so the shape
+    // stays rectangular even if the two ever disagree.
+    let lines: Vec<&str> = label.split('\n').collect();
+    for row in 0..height.saturating_sub(2) {
+        let row_y = y + 1 + row;
+        let line = lines.get(row).copied().unwrap_or("");
+        merge_bg_span(canvas, x + 1, x + width - 1, row_y, style.fill);
+        let label_start = x + width.saturating_sub(display_width(line)) / 2;
+        canvas.write_str(label_start, row_y, line);
+        merge_text_fg(canvas, label_start, row_y, line, style.color);
+        // Brackets last: an over-wide line loses characters rather than
+        // destroying the shape's sides.
+        canvas.set(x, row_y, '<');
+        merge_fg(canvas, x, row_y, style.stroke);
+        canvas.set(x + width - 1, row_y, '>');
+        merge_fg(canvas, x + width - 1, row_y, style.stroke);
+    }
 
     // Bottom border
-    let bot_y = y + 2;
+    let bot_y = y + height - 1;
     canvas.set(x, bot_y, charset.corner_bl);
     merge_fg(canvas, x, bot_y, style.stroke);
     for dx in 1..width - 1 {
@@ -721,6 +742,82 @@ mod tests {
         assert!(output.contains("┌──────────┐"));
         assert!(output.contains("< Decision >"));
         assert!(output.contains("└──────────┘"));
+    }
+
+    #[test]
+    fn render_diamond_multi_line_label_fills_measured_rows() {
+        let mut canvas = Canvas::new(30, 8);
+        let node = Node::new("B")
+            .with_label("Is the cache warm?\nCheck the index")
+            .with_shape(Shape::Diamond);
+        let charset = CharSet::unicode();
+
+        let bounds = render_node(&mut canvas, &node, 1, 1, &charset, Direction::TopDown);
+
+        // Width is the widest line + 4; height is one row per line + 2 borders,
+        // matching what `grid_node_dimensions` reserved for the node.
+        assert_eq!(bounds.width, 22);
+        assert_eq!(bounds.height, 4);
+
+        let output = canvas.to_string();
+        assert!(output.contains("┌────────────────────┐"), "{output}");
+        assert!(output.contains("< Is the cache warm? >"), "{output}");
+        assert!(output.contains("<  Check the index   >"), "{output}");
+        assert!(output.contains("└────────────────────┘"), "{output}");
+    }
+
+    #[test]
+    fn render_diamond_narrow_multi_line_label_keeps_borders_intact() {
+        // Lines short enough that the old centering arithmetic did not
+        // underflow, but the whole label was still written into one row,
+        // overwriting the `<` bracket and the row below it.
+        let mut canvas = Canvas::new(16, 8);
+        let node = Node::new("B")
+            .with_label("abc\nabc")
+            .with_shape(Shape::Diamond);
+        let charset = CharSet::unicode();
+
+        render_node(&mut canvas, &node, 1, 1, &charset, Direction::TopDown);
+
+        let output = canvas.to_string();
+        assert!(output.contains("┌─────┐"), "{output}");
+        assert_eq!(output.matches("< abc >").count(), 2, "{output}");
+        assert!(output.contains("└─────┘"), "{output}");
+    }
+
+    #[test]
+    fn render_hexagon_multi_line_label_fills_measured_rows() {
+        let mut canvas = Canvas::new(20, 8);
+        let node = Node::new("H")
+            .with_label("Retry?\nGive up")
+            .with_shape(Shape::Hexagon);
+        let charset = CharSet::unicode();
+
+        let bounds = render_node(&mut canvas, &node, 1, 1, &charset, Direction::TopDown);
+
+        assert_eq!(bounds.height, 4);
+
+        let output = canvas.to_string();
+        assert!(output.contains("< Retry?  >"), "{output}");
+        assert!(output.contains("< Give up >"), "{output}");
+    }
+
+    #[test]
+    fn render_borderless_multi_line_label_centers_every_line() {
+        let mut canvas = Canvas::new(20, 6);
+        let node = Node::new("N")
+            .with_label("Hello there\nWorld")
+            .with_shape(Shape::TextBlock);
+        let charset = CharSet::unicode();
+
+        let bounds = render_node(&mut canvas, &node, 1, 1, &charset, Direction::TopDown);
+
+        assert_eq!(bounds.width, 11);
+        assert_eq!(bounds.height, 2);
+
+        let output = canvas.to_string();
+        assert!(output.contains("Hello there"), "{output}");
+        assert!(output.contains("   World"), "{output}");
     }
 
     #[test]

--- a/tests/fixtures/flowchart/br_line_breaks_bracketed.mmd
+++ b/tests/fixtures/flowchart/br_line_breaks_bracketed.mmd
@@ -1,0 +1,4 @@
+graph TD
+    A[Start] --> B{Is the cache warm?<br/>Check the index}
+    B --> C{{Retry?<br/>Give up}}
+    C --> D@{ shape: text, label: "Hello there<br/>World again" }

--- a/tests/integration_full.rs
+++ b/tests/integration_full.rs
@@ -83,6 +83,48 @@ fn font_metrics_profiles_do_not_change_terminal_output() {
     }
 }
 
+/// A `<br/>` inside a diamond/hexagon label used to underflow the text
+/// renderer's centering arithmetic (panic in debug, dropped label in release).
+#[test]
+fn multi_line_labels_render_inside_bracketed_shapes() {
+    let cases = [
+        (
+            "{Is the cache warm?<br/>Check the index}",
+            ["< Is the cache warm? >", "<  Check the index   >"],
+        ),
+        ("{{Retry?<br/>Give up}}", ["< Retry?  >", "< Give up >"]),
+    ];
+
+    for (shape, expected_rows) in cases {
+        let input = format!("flowchart TD\n    A[Start] --> B{shape}\n");
+        for format in [OutputFormat::Text, OutputFormat::Ascii] {
+            let output = render_diagram(&input, format, &RenderConfig::default())
+                .unwrap_or_else(|e| panic!("{shape} should render as {format:?}: {e}"));
+            for row in expected_rows {
+                assert!(
+                    output.contains(row),
+                    "{format:?} output for {shape} is missing {row:?}:\n{output}"
+                );
+            }
+        }
+    }
+}
+
+/// The borderless (`shape: text`) node shares the diamond's centering path and
+/// underflowed the same way on a multi-line label.
+#[test]
+fn multi_line_label_renders_inside_borderless_node() {
+    let input =
+        "flowchart TD\n    A@{ shape: text, label: \"Hello there<br/>World again\" } --> B[x]\n";
+
+    for format in [OutputFormat::Text, OutputFormat::Ascii] {
+        let output = render_diagram(input, format, &RenderConfig::default())
+            .unwrap_or_else(|e| panic!("borderless node should render as {format:?}: {e}"));
+        assert!(output.contains("Hello there"), "{format:?}:\n{output}");
+        assert!(output.contains("World again"), "{format:?}:\n{output}");
+    }
+}
+
 fn render_flowchart_svg(input: &str) -> String {
     render_diagram(input, OutputFormat::Svg, &RenderConfig::default()).expect("should render svg")
 }

--- a/tests/snapshots/flowchart/br_line_breaks_bracketed.txt
+++ b/tests/snapshots/flowchart/br_line_breaks_bracketed.txt
@@ -1,0 +1,23 @@
+       ┌───────┐
+       │ Start │
+       └───────┘
+           │
+           │
+           ▼
+┌────────────────────┐
+< Is the cache warm? >
+<  Check the index   >
+└────────────────────┘
+           │
+           │
+           ▼
+      ┌─────────┐
+      < Retry?  >
+      < Give up >
+      └─────────┘
+           │
+           │
+           │
+           ▼
+      Hello there
+      World again

--- a/tests/svg-snapshots/flowchart-basis/br_line_breaks_bracketed.svg
+++ b/tests/svg-snapshots/flowchart-basis/br_line_breaks_bracketed.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 232.73 562.73" style="max-width: 232.73px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+  <defs>
+    <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
+      <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
+    </marker>
+  </defs>
+  <g transform="translate(0.00,0.00)">
+    <g class="edgePaths">
+      <path d="M116.36,62.00 L116.36,64.78 C116.36,67.56 116.36,73.11 116.36,78.67 C116.36,84.22 116.36,89.78 116.36,94.67 C116.36,99.56 116.36,103.78 116.36,105.89 L116.36,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,328.73 L116.36,331.50 C116.36,334.28 116.36,339.84 116.36,345.39 C116.36,350.95 116.36,356.50 116.36,361.39 C116.36,366.28 116.36,370.50 116.36,372.62 L116.36,374.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,456.73 L116.36,459.50 C116.36,462.28 116.36,467.84 116.36,473.39 C116.36,478.95 116.36,484.50 116.36,489.39 C116.36,494.28 116.36,498.50 116.36,500.62 L116.36,502.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+    </g>
+    <g class="nodes">
+      <g class="node default" id="A" data-id="A" data-look="classic">
+        <rect x="69.47" y="8.00" width="93.79" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Start</text>
+      </g>
+      <g class="node default" id="B" data-id="B" data-look="classic">
+        <polygon points="116.36,112.00 224.73,220.36 116.36,328.73 8.00,220.36" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="208.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Is the cache warm?</text>
+        <text x="116.36" y="232.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Check the index</text>
+      </g>
+      <g class="node default" id="C" data-id="C" data-look="classic">
+        <polygon points="73.53,378.73 159.19,378.73 187.74,417.73 159.19,456.73 73.53,456.73 44.98,417.73" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="405.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Retry?</text>
+        <text x="116.36" y="429.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Give up</text>
+      </g>
+      <g class="node default" id="D" data-id="D" data-look="classic">
+        <text x="116.36" y="518.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Hello there</text>
+        <text x="116.36" y="542.73" text-anchor="middle" dominant-baseline="middle" fill="#333">World again</text>
+      </g>
+    </g>
+    <g class="edgeLabels">
+    </g>
+  </g>
+</svg>

--- a/tests/svg-snapshots/flowchart-curved-step/br_line_breaks_bracketed.svg
+++ b/tests/svg-snapshots/flowchart-curved-step/br_line_breaks_bracketed.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 232.73 562.73" style="max-width: 232.73px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+  <defs>
+    <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
+      <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
+    </marker>
+  </defs>
+  <g transform="translate(0.00,0.00)">
+    <g class="edgePaths">
+      <path d="M116.36,62.00 L116.36,64.78 C116.36,67.56 116.36,73.11 116.36,78.11 C116.36,83.11 116.36,87.56 116.36,92.44 C116.36,97.33 116.36,102.67 116.36,105.33 L116.36,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,328.73 L116.36,331.50 C116.36,334.28 116.36,339.84 116.36,344.84 C116.36,349.84 116.36,354.28 116.36,359.17 C116.36,364.06 116.36,369.39 116.36,372.06 L116.36,374.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,456.73 L116.36,459.50 C116.36,462.28 116.36,467.84 116.36,472.84 C116.36,477.84 116.36,482.28 116.36,487.17 C116.36,492.06 116.36,497.39 116.36,500.06 L116.36,502.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+    </g>
+    <g class="nodes">
+      <g class="node default" id="A" data-id="A" data-look="classic">
+        <rect x="69.47" y="8.00" width="93.79" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Start</text>
+      </g>
+      <g class="node default" id="B" data-id="B" data-look="classic">
+        <polygon points="116.36,112.00 224.73,220.36 116.36,328.73 8.00,220.36" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="208.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Is the cache warm?</text>
+        <text x="116.36" y="232.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Check the index</text>
+      </g>
+      <g class="node default" id="C" data-id="C" data-look="classic">
+        <polygon points="73.53,378.73 159.19,378.73 187.74,417.73 159.19,456.73 73.53,456.73 44.98,417.73" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="405.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Retry?</text>
+        <text x="116.36" y="429.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Give up</text>
+      </g>
+      <g class="node default" id="D" data-id="D" data-look="classic">
+        <text x="116.36" y="518.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Hello there</text>
+        <text x="116.36" y="542.73" text-anchor="middle" dominant-baseline="middle" fill="#333">World again</text>
+      </g>
+    </g>
+    <g class="edgeLabels">
+    </g>
+  </g>
+</svg>

--- a/tests/svg-snapshots/flowchart-polyline/br_line_breaks_bracketed.svg
+++ b/tests/svg-snapshots/flowchart-polyline/br_line_breaks_bracketed.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 232.73 562.73" style="max-width: 232.73px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+  <defs>
+    <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
+      <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
+    </marker>
+  </defs>
+  <g transform="translate(0.00,0.00)">
+    <g class="edgePaths">
+      <path d="M116.36,62.00 L116.36,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,328.73 L116.36,374.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,456.73 L116.36,502.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+    </g>
+    <g class="nodes">
+      <g class="node default" id="A" data-id="A" data-look="classic">
+        <rect x="69.47" y="8.00" width="93.79" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Start</text>
+      </g>
+      <g class="node default" id="B" data-id="B" data-look="classic">
+        <polygon points="116.36,112.00 224.73,220.36 116.36,328.73 8.00,220.36" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="208.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Is the cache warm?</text>
+        <text x="116.36" y="232.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Check the index</text>
+      </g>
+      <g class="node default" id="C" data-id="C" data-look="classic">
+        <polygon points="73.53,378.73 159.19,378.73 187.74,417.73 159.19,456.73 73.53,456.73 44.98,417.73" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="405.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Retry?</text>
+        <text x="116.36" y="429.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Give up</text>
+      </g>
+      <g class="node default" id="D" data-id="D" data-look="classic">
+        <text x="116.36" y="518.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Hello there</text>
+        <text x="116.36" y="542.73" text-anchor="middle" dominant-baseline="middle" fill="#333">World again</text>
+      </g>
+    </g>
+    <g class="edgeLabels">
+    </g>
+  </g>
+</svg>

--- a/tests/svg-snapshots/flowchart-smooth-step/br_line_breaks_bracketed.svg
+++ b/tests/svg-snapshots/flowchart-smooth-step/br_line_breaks_bracketed.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 232.73 562.73" style="max-width: 232.73px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+  <defs>
+    <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
+      <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
+    </marker>
+  </defs>
+  <g transform="translate(0.00,0.00)">
+    <g class="edgePaths">
+      <path d="M116.36,62.00 L116.36,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,328.73 L116.36,374.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,456.73 L116.36,502.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+    </g>
+    <g class="nodes">
+      <g class="node default" id="A" data-id="A" data-look="classic">
+        <rect x="69.47" y="8.00" width="93.79" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Start</text>
+      </g>
+      <g class="node default" id="B" data-id="B" data-look="classic">
+        <polygon points="116.36,112.00 224.73,220.36 116.36,328.73 8.00,220.36" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="208.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Is the cache warm?</text>
+        <text x="116.36" y="232.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Check the index</text>
+      </g>
+      <g class="node default" id="C" data-id="C" data-look="classic">
+        <polygon points="73.53,378.73 159.19,378.73 187.74,417.73 159.19,456.73 73.53,456.73 44.98,417.73" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="405.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Retry?</text>
+        <text x="116.36" y="429.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Give up</text>
+      </g>
+      <g class="node default" id="D" data-id="D" data-look="classic">
+        <text x="116.36" y="518.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Hello there</text>
+        <text x="116.36" y="542.73" text-anchor="middle" dominant-baseline="middle" fill="#333">World again</text>
+      </g>
+    </g>
+    <g class="edgeLabels">
+    </g>
+  </g>
+</svg>

--- a/tests/svg-snapshots/flowchart-step/br_line_breaks_bracketed.svg
+++ b/tests/svg-snapshots/flowchart-step/br_line_breaks_bracketed.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 232.73 562.73" style="max-width: 232.73px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+  <defs>
+    <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
+      <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
+    </marker>
+  </defs>
+  <g transform="translate(0.00,0.00)">
+    <g class="edgePaths">
+      <path d="M116.36,62.00 L116.36,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,328.73 L116.36,374.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,456.73 L116.36,502.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+    </g>
+    <g class="nodes">
+      <g class="node default" id="A" data-id="A" data-look="classic">
+        <rect x="69.47" y="8.00" width="93.79" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Start</text>
+      </g>
+      <g class="node default" id="B" data-id="B" data-look="classic">
+        <polygon points="116.36,112.00 224.73,220.36 116.36,328.73 8.00,220.36" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="208.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Is the cache warm?</text>
+        <text x="116.36" y="232.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Check the index</text>
+      </g>
+      <g class="node default" id="C" data-id="C" data-look="classic">
+        <polygon points="73.53,378.73 159.19,378.73 187.74,417.73 159.19,456.73 73.53,456.73 44.98,417.73" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="405.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Retry?</text>
+        <text x="116.36" y="429.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Give up</text>
+      </g>
+      <g class="node default" id="D" data-id="D" data-look="classic">
+        <text x="116.36" y="518.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Hello there</text>
+        <text x="116.36" y="542.73" text-anchor="middle" dominant-baseline="middle" fill="#333">World again</text>
+      </g>
+    </g>
+    <g class="edgeLabels">
+    </g>
+  </g>
+</svg>

--- a/tests/svg-snapshots/flowchart-straight/br_line_breaks_bracketed.svg
+++ b/tests/svg-snapshots/flowchart-straight/br_line_breaks_bracketed.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 232.73 562.73" style="max-width: 232.73px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+  <defs>
+    <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
+      <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
+    </marker>
+  </defs>
+  <g transform="translate(0.00,0.00)">
+    <g class="edgePaths">
+      <path d="M116.36,62.00 L116.36,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,328.73 L116.36,374.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,456.73 L116.36,502.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+    </g>
+    <g class="nodes">
+      <g class="node default" id="A" data-id="A" data-look="classic">
+        <rect x="69.47" y="8.00" width="93.79" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Start</text>
+      </g>
+      <g class="node default" id="B" data-id="B" data-look="classic">
+        <polygon points="116.36,112.00 224.73,220.36 116.36,328.73 8.00,220.36" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="208.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Is the cache warm?</text>
+        <text x="116.36" y="232.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Check the index</text>
+      </g>
+      <g class="node default" id="C" data-id="C" data-look="classic">
+        <polygon points="73.53,378.73 159.19,378.73 187.74,417.73 159.19,456.73 73.53,456.73 44.98,417.73" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="405.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Retry?</text>
+        <text x="116.36" y="429.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Give up</text>
+      </g>
+      <g class="node default" id="D" data-id="D" data-look="classic">
+        <text x="116.36" y="518.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Hello there</text>
+        <text x="116.36" y="542.73" text-anchor="middle" dominant-baseline="middle" fill="#333">World again</text>
+      </g>
+    </g>
+    <g class="edgeLabels">
+    </g>
+  </g>
+</svg>

--- a/tests/svg-snapshots/flowchart/br_line_breaks_bracketed.svg
+++ b/tests/svg-snapshots/flowchart/br_line_breaks_bracketed.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" viewBox="0 0 232.73 562.73" style="max-width: 232.73px; background-color: transparent;" font-family="&quot;trebuchet ms&quot;, verdana, arial, sans-serif" font-size="16.00">
+  <defs>
+    <marker id="arrowhead" viewBox="0 0 10.00 10.00" refX="5.00" refY="5.00" markerWidth="8.00" markerHeight="8.00" orient="auto-start-reverse" markerUnits="userSpaceOnUse">
+      <path d="M 0 0 L 10.00 5.00 L 0 10.00 z" fill="#333" />
+    </marker>
+  </defs>
+  <g transform="translate(0.00,0.00)">
+    <g class="edgePaths">
+      <path d="M116.36,62.00 L116.36,108.00" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,328.73 L116.36,374.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+      <path d="M116.36,456.73 L116.36,502.73" stroke="#333" stroke-width="1.00" fill="none" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrowhead)" />
+    </g>
+    <g class="nodes">
+      <g class="node default" id="A" data-id="A" data-look="classic">
+        <rect x="69.47" y="8.00" width="93.79" height="54.00" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="35.00" text-anchor="middle" dominant-baseline="middle" fill="#333">Start</text>
+      </g>
+      <g class="node default" id="B" data-id="B" data-look="classic">
+        <polygon points="116.36,112.00 224.73,220.36 116.36,328.73 8.00,220.36" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="208.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Is the cache warm?</text>
+        <text x="116.36" y="232.36" text-anchor="middle" dominant-baseline="middle" fill="#333">Check the index</text>
+      </g>
+      <g class="node default" id="C" data-id="C" data-look="classic">
+        <polygon points="73.53,378.73 159.19,378.73 187.74,417.73 159.19,456.73 73.53,456.73 44.98,417.73" fill="white" stroke="#333" stroke-width="1.00" stroke-linejoin="round" />
+        <text x="116.36" y="405.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Retry?</text>
+        <text x="116.36" y="429.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Give up</text>
+      </g>
+      <g class="node default" id="D" data-id="D" data-look="classic">
+        <text x="116.36" y="518.73" text-anchor="middle" dominant-baseline="middle" fill="#333">Hello there</text>
+        <text x="116.36" y="542.73" text-anchor="middle" dominant-baseline="middle" fill="#333">World again</text>
+      </g>
+    </g>
+    <g class="edgeLabels">
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Closes #387.

## Problem

`render_diamond` drew a fixed three-row shape and wrote the whole label into its middle row as a single string, but the shape was sized from the label's *widest line*. For a two-line label of `n` chars per line, `width = n + 4` while `display_width(label) = 2n + 1`, so `width - label_len` underflowed once `n >= 4`:

| | debug | release |
|---|---|---|
| `n >= 4` | panic: `attempt to subtract with overflow` | label silently dropped, empty diamond |
| `n < 4` | label written across one row, destroying `<` and the row below | same |

`<br/>` in a decision node is ordinary Mermaid, so this was reachable from normal documents.

## Also fixed

`render_borderless` — the `shape: text` node — centers on the whole label the same way and panics identically. Not in the issue report, but it is the same defect in the same file:

```
flowchart TD
    A@{ shape: text, label: "Hello there<br/>World again" } --> B[x]
```

panicked at `shape.rs:503`.

## Fix

Both paths now render one row per label line, each centered on its own display width — matching what `grid_node_dimensions` already measured and what the box path has always done.

```
┌────────────────────┐
< Is the cache warm? >
<  Check the index   >
└────────────────────┘
```

Two hardening choices beyond the reported bug:

- the diamond drives its content rows from the **measured height** rather than the line count, so the shape stays rectangular even if the two ever disagree;
- brackets are drawn **after** the text, so an over-wide line loses characters instead of destroying the shape's sides.

## Verification

Written test-first: six tests reproduced both the panic and the sub-threshold corruption before any fix.

- 3241/3241 tests pass; `cargo xtask architecture check` clean
- New fixture `br_line_breaks_bracketed.mmd` covers diamond + hexagon + borderless through the text snapshot and all seven SVG snapshot sweeps
- **Regenerating text and SVG snapshots produced only the new files** — every existing snapshot is byte-identical, confirming single-line rendering is unchanged

## Note

`just lint` currently fails on `main` under clippy 1.97 (`question_mark` in three unrelated files). Those failures are pre-existing and are not touched here; they are addressed in a separate `chore` PR.
